### PR TITLE
Electron modules revamping for mc15

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -258,7 +258,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
     }
 
     //
-    // Creat the name of the weight
+    // Create the name of the weight
     //   template:  SYSNAME_BTag_SF
     //
     std::string sfName = m_decor;

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -68,6 +68,7 @@ EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
 {
 
   if ( !m_configName.empty() ) {
+    
     Info("configure()", "Configuing ElectronEfficiencyCorrector Interface. User configuration read from : %s ", m_configName.c_str());
 
     m_configName = gSystem->ExpandPathName( m_configName.c_str() );
@@ -77,16 +78,15 @@ EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug", false);
+    
     // input container to be read from TEvent or TStore
     m_inContainerName         = config->GetValue("InputContainer",  "");
-    m_outContainerName        = config->GetValue("OutputContainer", "");
 
     // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");  // this is the name of the vector of names of the systematically varied containers produced by the
-  			             				              // upstream algo (e.g., the SC containers with calibration systematics)		   
-    m_systName		      = config->GetValue("SystName" , "" );                                        // if running systs - the name of the systematic (default: no syst)    
-    m_outputSystNames         = config->GetValue("OutputSystNames",  "ElectronEfficiencyCorrector_Syst"); // the name of vector<float> with the string names for systematically varied SFs (first component: nominal SF) 
-    m_systVal 		      = config->GetValue("SystVal" , 0. );                                         // if running systs - the value ( +/- 1 )
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  ""); 
+    m_systName		      = config->GetValue("SystName" , "" );                                       
+    m_outputSystNames         = config->GetValue("OutputSystNames",  "ElectronEfficiencyCorrector_Syst"); 
+    m_systVal 		      = config->GetValue("SystVal" , 0. );                                        
     m_runAllSyst              = (m_systName.find("All") != std::string::npos);
     // file(s) containing corrections
     m_corrFileName1           = config->GetValue("CorrectionFileName1" , "" );
@@ -103,8 +103,6 @@ EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
     Error("configure()", "InputContainer is empty!");
     return EL::StatusCode::FAILURE;
   }
-
-  m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -1,11 +1,11 @@
-/******************************************
+/*****************************************************
  *
  * Interface to CP Electron Efficiency Correction Tool.
  *
  * M. Milesi (marco.milesi@cern.ch)
  *
  *
- ******************************************/
+ *****************************************************/
 
 // c++ include(s):
 #include <iostream>
@@ -46,14 +46,10 @@ ClassImp(ElectronEfficiencyCorrector)
 ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () {
 }
 
-ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string name, std::string configName,
-	std::string systName, float systVal) :
+ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector ( std::string name, std::string configName ) :
   Algorithm(),
   m_name(name),
   m_configName(configName),
-  m_systName(systName),       // if running systs - the name of the systematic
-  m_systVal(systVal),         // if running systs - the value ( +/- 1 )
-  m_runSysts(false),          // gets set later is syst applies to this tool
   m_asgElectronEfficiencyCorrectionTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
@@ -71,7 +67,7 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string name, st
 EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
 {
 
-  if(!m_configName.empty()){
+  if ( !m_configName.empty() ) {
     Info("configure()", "Configuing ElectronEfficiencyCorrector Interface. User configuration read from : %s ", m_configName.c_str());
 
     m_configName = gSystem->ExpandPathName( m_configName.c_str() );
@@ -85,22 +81,22 @@ EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
     m_inContainerName         = config->GetValue("InputContainer",  "");
     m_outContainerName        = config->GetValue("OutputContainer", "");
 
-    // name of algo input container comes from - only if running on systematics
-    m_inputAlgo               = config->GetValue("InputAlgo",  "");
-    m_outputAlgo              = config->GetValue("OutputAlgo", "ElectronCollection_CalibCorr_Algo");
-
     // Systematics stuff
-    m_systName		    = config->GetValue("SystName" , "" );      // default: no syst
-    m_systVal 		    = config->GetValue("SystVal" , 0. );
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");  // this is the name of the vector of names of the systematically varied containers produced by the
+  			             				              // upstream algo (e.g., the SC containers with calibration systematics)		   
+    m_systName		      = config->GetValue("SystName" , "" );                                        // if running systs - the name of the systematic (default: no syst)    
+    m_outputSystNames         = config->GetValue("OutputSystNames",  "ElectronEfficiencyCorrector_Syst"); // the name of vector<float> with the string names for systematically varied SFs (first component: nominal SF) 
+    m_systVal 		      = config->GetValue("SystVal" , 0. );                                         // if running systs - the value ( +/- 1 )
+    m_runAllSyst              = (m_systName.find("All") != std::string::npos);
     // file(s) containing corrections
     m_corrFileName1           = config->GetValue("CorrectionFileName1" , "" );
     //m_corrFileName2         = config->GetValue("CorrectionFileName2" , "" );
 
-
     config->Print();
+    
     Info("configure()", "ElectronEfficiencyCorrector Interface succesfully configured! ");
 
-    delete config;config = nullptr;
+    delete config; config = nullptr;
   }
 
   if ( m_inContainerName.empty() ) {
@@ -207,8 +203,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   // Convert into a simple list
   m_systList = CP::make_systematics_vector(recSysts);
 
-  if ( !m_systList.empty() ) { m_runSysts = true; }
-
   if ( m_debug ) {
     for ( const auto& syst_it : m_systList ) {
       Info("initialize()"," available systematic: %s", (syst_it.name()).c_str());
@@ -236,74 +230,52 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
   m_numEvent++;
 
   // initialise containers
-  const xAOD::ElectronContainer* correctedElectrons = nullptr;
-  ConstDataVector<xAOD::ElectronContainer>* correctedElectronsCDV = nullptr;
+  const xAOD::ElectronContainer* inputElectrons = nullptr;
 
-  // if m_inputAlgo = "" --> input comes from xAOD, or just running one collection,
+  // if m_inputAlgoSystNames = "" --> input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
-  if ( m_inputAlgo.empty() ) {
+  
+  // Declare a counter, initialised to 0 
+  // For the systematically varied input containers, we won't store again the vector with efficiency systs in TStore ( it will be always the same!)
+  unsigned int countInputCont(0);
+  
+  if ( m_inputAlgoSystNames.empty() ) {
 
-        RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(correctedElectrons, m_inContainerName, m_event, m_store, m_debug) ,"");
-    	correctedElectronsCDV = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-    	correctedElectronsCDV->reserve( correctedElectrons->size() );
+        RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, m_debug) ,"");
 
 	// decorate electrons w/ SF
-	this->executeSF( correctedElectrons );
-
-	// save pointers in ConstDataVector
-    	RETURN_CHECK( "ElectronCalibrator::execute()", HelperFunctions::makeSubsetCont(correctedElectrons, correctedElectronsCDV, "", ToolName::CORRECTOR), "");
-    	// add container to TStore
-    	RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_store->record( correctedElectronsCDV, m_outContainerName), "Failed to store container.");
+	this->executeSF( inputElectrons, countInputCont );
 
   } else {
-  // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo
+  // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo. This is the case of calibrators: one different SC 
+  // for each calibration syst applied
 
 	// get vector of string giving the syst names of the upstream algo m_inputAlgo (rememeber: 1st element is a blank string: nominal case!)
         std::vector<std::string>* systNames(nullptr);
-        RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, m_debug) ,"");
-
-    	// prepare a vector of the names of CDV containers
-    	// must be a pointer to be recorded in TStore
-    	// for now just copy the one you just retrieved in it!
-    	std::vector<std::string>* vecOutContainerNames = new std::vector< std::string >(*systNames);
-
-    	// just to check everything is fine
-    	if ( m_debug ) {
-    	  Info("execute()","output vector already contains systematics:" );
-    	  for (auto it : *vecOutContainerNames) {
-    	    Info("execute()" ,"\t %s ", it.c_str());
-    	  }
-    	}
+        RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_debug) ,"");
 
     	// loop over systematic sets available
     	for ( auto systName : *systNames ) {
 
-           RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(correctedElectrons, m_inContainerName+systName, m_event, m_store, m_debug) ,"");
-    	   // create ConstDataVector to be eventually stored in TStore
-    	   correctedElectronsCDV = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-    	   correctedElectronsCDV->reserve( correctedElectrons->size() );
+           RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName+systName, m_event, m_store, m_debug) ,"");
 
     	   if ( m_debug ){
     	     unsigned int idx(0);
-    	     for ( auto el : *(correctedElectrons) ) {
+    	     for ( auto el : *(inputElectrons) ) {
     	       Info( "execute", "Input electron %i, pt = %.2f GeV ", idx, (el->pt() * 1e-3) );
     	       ++idx;
     	     }
     	   }
 
 	   // decorate electrons w/ SF- there will be a decoration w/ different name for each syst!
-	   this->executeSF( correctedElectrons );
+	   this->executeSF( inputElectrons, countInputCont );
 
-    	   // save pointers in ConstDataVector
-    	   RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", HelperFunctions::makeSubsetCont(correctedElectrons, correctedElectronsCDV, "", ToolName::CORRECTOR), "");
-    	   // add container to TStore
-    	   RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_store->record( correctedElectronsCDV, m_outContainerName+systName), "Failed to store container.");
-
+	   // increment counter
+	   ++countInputCont;
+	   
     	} // close loop on systematic sets available from upstream algo
 
-        // save list of systs that should be considered down stream
-        RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_store->record( vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
-  }
+   }
 
   // look what do we have in TStore
   if ( m_debug ) { m_store->print(); }
@@ -366,21 +338,30 @@ EL::StatusCode ElectronEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronContainer* correctedElectrons  )
+EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronContainer* inputElectrons, unsigned int countSyst  )
 {
 
-  // loop over available systematics for this tool - remember syst == EMPTY_STRING --> baseline
+  //
+  // Every electron gets decorated with a vector<double> of SFs, one for each syst.
+  // We create this vector<string> with the SF syst names, so that we know which component corresponds to.
+  // This vector is eventually stored in TStore
+  //
+  std::vector< std::string >* sysVariationNames = new std::vector< std::string >;
+
+  // loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   for ( const auto& syst_it : m_systList ) {
 
-    // appends syst name to decoration
+    //
+    // Create the name of the SF weight to be recorded
+    //   template:  SYSNAME_ElEff_SF
+    //
+    std::string sfName = "ElEff_SF";
     if ( !syst_it.name().empty() ) {
-      RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_asgElectronEfficiencyCorrectionTool->setProperty("ResultPrefix",syst_it.name()), "Failed to set property ResultPrefix" );
+       std::string prepend = syst_it.name() + "_";
+       sfName.insert( 0, prepend );
     }
-
-    // if not running systematics (i.e., syst name is "") or running on one syst only, skip directly all other syst
-    //if(!(syst_it.name() == "All")){
-    //  if( syst_it.name() != m_systName ) { continue; }
-    //}
+    if(m_debug) Info("execute()", "SF decoration name is: %s", sfName.c_str());
+    sysVariationNames->push_back(sfName);
 
     // apply syst
     if ( m_asgElectronEfficiencyCorrectionTool->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
@@ -391,8 +372,15 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
     // and now apply efficiency SF!
     unsigned int idx(0);
-    double SF(0);
-    for ( auto el_itr : *(correctedElectrons) ) {
+    for ( auto el_itr : *(inputElectrons) ) {
+
+       //
+       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* electron)
+       //
+       SG::AuxElement::Decorator< std::vector<double> > sfVec( m_outputSystNames );
+       if ( !sfVec.isAvailable( *el_itr ) ) {
+	 sfVec( *el_itr ) = std::vector<double>();
+       }
 
        if ( m_debug ) { Info( "execute", "Checking electron %i, pt = %.2f GeV ", idx, (el_itr->pt() * 1e-3) ); }
        ++idx;
@@ -412,22 +400,36 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
          if ( m_debug ) { Info( "execute", "Apply SF: skipping electron %i, is outside |eta| acceptance", idx); }
          continue;
        }
-
+     
+       //
+       // obtain efficiency SF
+       //
+       double SF(0.0);
        if ( m_asgElectronEfficiencyCorrectionTool->getEfficiencyScaleFactor( *el_itr, SF ) != CP::CorrectionCode::Ok ) {
          Error( "execute()", "Problem in getEfficiencyScaleFactor");
          return EL::StatusCode::FAILURE;
-       }
-       // apply SF as decoration for this electron
-       if ( m_asgElectronEfficiencyCorrectionTool->applyEfficiencyScaleFactor( *el_itr ) != CP::CorrectionCode::Ok ) {
-         Error( "execute()", "Problem in applyEfficiencyScaleFactor");
-         return EL::StatusCode::FAILURE;
-       }
-
-       if ( m_debug ) { Info( "execute", "===>>> Resulting SF (from get function) %f, (from apply function) %f", SF, el_itr->auxdata< float >("SF")); }
+       }   
+       //
+       // Add it to decoration vector
+       //
+       sfVec( *el_itr ).push_back(SF);
+       
+       if ( m_debug ) { Info( "execute", "===>>> Resulting SF: %f for systematic: %s ", SF, syst_it.name().c_str()); }
 
     } // close electron loop
 
   }  // close loop on systematics
+ 
+  //
+  // add list of efficiency systematics names to TStore
+  //
+  // NB: we need to make sure that this is not pushed more than once in TStore!
+  // This will be the case when this executeSF() function gets called for every syst varied input container,
+  // e.g. the different SC containers w/ calibration systematics upstream.  
+  //
+  // Use the counter defined in execute() to check this is done only once
+  //
+  if ( countSyst == 0 ) { RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_store->record( sysVariationNames, m_outputSystNames), "Failed to record vector of systematic names" ); }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -196,6 +196,8 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* ev
 
 void HelpTreeBase::AddMuons(const std::string detailStr) {
 
+  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
+
   m_muInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr );
 
   // always
@@ -332,7 +334,9 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
  ********************/
 
 void HelpTreeBase::AddElectrons(const std::string detailStr) {
-
+  
+  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
+  
   m_elInfoSwitch = new HelperClasses::ElectronInfoSwitch( detailStr );
 
   // always
@@ -343,6 +347,18 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_phi", &m_el_phi);
     m_tree->Branch("el_eta", &m_el_eta);
     m_tree->Branch("el_m",   &m_el_m);
+  }
+
+  if ( m_elInfoSwitch->m_isolation ) {
+    m_tree->Branch("",  &m_el_isIsolated);
+  }
+  
+  if ( m_elInfoSwitch->m_PID ) {
+    m_tree->Branch("",  &m_el_LHVeryLoose);
+    m_tree->Branch("",  &m_el_LHLoose);
+    m_tree->Branch("",  &m_el_LHMedium);
+    m_tree->Branch("",  &m_el_LHTight);
+    m_tree->Branch("",  &m_el_LHVeryTight);
   }
 
   if ( m_elInfoSwitch->m_trackparams ) {
@@ -392,6 +408,27 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       m_el_eta.push_back( (el_itr)->eta() );
       m_el_phi.push_back( (el_itr)->phi() );
       m_el_m.push_back  ( (el_itr)->m() / m_units );
+    }
+  
+    if ( m_elInfoSwitch->m_isolation ) {
+      static SG::AuxElement::Accessor<char> isIsoAcc ("isIsolated");
+      if ( isIsoAcc.isAvailable( *el_itr ) ) { m_el_isIsolated.push_back( isIsoAcc( *el_itr ) ); } else { m_el_isIsolated.push_back( -1 ); }
+    }
+    
+    if ( m_elInfoSwitch->m_PID ) {
+      
+      static SG::AuxElement::Accessor<char> isLHVeryLooseAcc ("isLHVeryLoose");
+      static SG::AuxElement::Accessor<char> isLHLooseAcc ("isLHLoose");
+      static SG::AuxElement::Accessor<char> isLHMediumAcc ("isLHMedium");
+      static SG::AuxElement::Accessor<char> isLHTightAcc ("isLHTight");
+      static SG::AuxElement::Accessor<char> isLHVeryTightAcc ("isLHVeryTight");
+      
+      if ( isLHVeryLooseAcc.isAvailable( *el_itr ) ) { m_el_LHVeryLoose.push_back( isLHVeryLooseAcc( *el_itr ) ); } else { m_el_LHVeryLoose.push_back( -1 ); }
+      if ( isLHLooseAcc.isAvailable( *el_itr ) )     { m_el_LHLoose.push_back( isLHLooseAcc( *el_itr ) );         } else { m_el_LHLoose.push_back( -1 ); }
+      if ( isLHMediumAcc.isAvailable( *el_itr ) )    { m_el_LHMedium.push_back( isLHMediumAcc( *el_itr ) );       } else { m_el_LHMedium.push_back( -1 ); }
+      if ( isLHTightAcc.isAvailable( *el_itr ) )     { m_el_LHTight.push_back( isLHTightAcc( *el_itr ) );         } else { m_el_LHTight.push_back( -1 ); }
+      if ( isLHVeryTightAcc.isAvailable( *el_itr ) ) { m_el_LHVeryTight.push_back( isLHVeryTightAcc( *el_itr ) ); } else { m_el_LHVeryTight.push_back( -1 ); }
+    
     }
 
     if ( m_elInfoSwitch->m_trackparams ) {
@@ -1183,8 +1220,10 @@ void HelpTreeBase::ClearMuons() {
     m_muon_trknTRTHits.clear();
     m_muon_trknTRTHoles.clear();
     m_muon_trknBLayerHits.clear();
-    //m_muon_trknInnermostPixLayHits.clear();
-    //m_muon_trkPixdEdX.clear();
+    if ( !m_DC14 ) {
+      m_muon_trknInnermostPixLayHits.clear();
+      m_muon_trkPixdEdX.clear();
+    }
   }
 
 }
@@ -1198,6 +1237,18 @@ void HelpTreeBase::ClearElectrons() {
     m_el_eta.clear();
     m_el_phi.clear();
     m_el_m.clear();
+  }
+
+  if ( m_elInfoSwitch->m_isolation ) {
+    m_el_isIsolated.clear();
+  }
+  
+  if ( m_elInfoSwitch->m_PID ) {
+    m_el_LHVeryLoose.clear();
+    m_el_LHLoose.clear();
+    m_el_LHMedium.clear();
+    m_el_LHTight.clear();
+    m_el_LHVeryTight.clear();
   }
 
   if ( m_elInfoSwitch->m_trackparams ) {
@@ -1220,8 +1271,10 @@ void HelpTreeBase::ClearElectrons() {
     m_el_trknTRTHits.clear();
     m_el_trknTRTHoles.clear();
     m_el_trknBLayerHits.clear();
-    //m_el_trknInnermostPixLayHits.clear();
-    //m_el_trkPixdEdX.clear();
+    if ( !m_DC14 ) {    
+      m_el_trknInnermostPixLayHits.clear();
+      m_el_trkPixdEdX.clear();    
+    }
   }
 
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -20,7 +20,7 @@
 #pragma link C++ class vector<float>+;
 #endif
 
-HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const float units, bool debug):
+HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const float units, bool debug, bool DC14):
   m_eventInfoSwitch(0),
   m_muInfoSwitch(0),
   m_elInfoSwitch(0),
@@ -31,6 +31,7 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
 
   m_units = units;
   m_debug = debug;
+  m_DC14  = DC14;
   m_tree = tree;
   m_tree->SetDirectory( file );
   Info("HelpTreeBase()", "HelpTreeBase setup");
@@ -227,8 +228,10 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
     m_tree->Branch("muon_trknTRTHits",   &m_muon_trknTRTHits);
     m_tree->Branch("muon_trknTRTHoles",  &m_muon_trknTRTHoles);
     m_tree->Branch("muon_trknBLayerHits",&m_muon_trknBLayerHits);
-    //m_tree->Branch("muon_trknInnermostPixLayHits",  &m_muon_trknInnermostPixLayHits);
-    //m_tree->Branch("muon_trkPixdEdX",  &m_muon_trkPixdEdX);
+    if ( !m_DC14 ) {
+      m_tree->Branch("muon_trknInnermostPixLayHits",  &m_muon_trknInnermostPixLayHits);
+      m_tree->Branch("muon_trkPixdEdX",    &m_muon_trkPixdEdX);
+    }
   }
 
   this->AddMuonsUser();
@@ -297,8 +300,10 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       	trk->summaryValue( nTRTHits,     xAOD::numberOfTRTHits );
       	trk->summaryValue( nTRTHoles,    xAOD::numberOfTRTHoles );
         trk->summaryValue( nBLayerHits,  xAOD::numberOfBLayerHits );
-        //trk->summaryValue( nInnermostPixLayHits, xAOD::numberOfInnermostPixelLayerHits );
-        //trk->summaryValue( pixdEdX,   xAOD::pixeldEdx);
+        if ( !m_DC14 ) {
+	  trk->summaryValue( nInnermostPixLayHits, xAOD::numberOfInnermostPixelLayerHits );
+          trk->summaryValue( pixdEdX,   xAOD::pixeldEdx);
+        }
       }
       m_muon_trknSiHits.push_back( nPixHits + nSCTHits );
       m_muon_trknPixHits.push_back( nPixHits );
@@ -308,8 +313,10 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       m_muon_trknTRTHits.push_back( nTRTHits );
       m_muon_trknTRTHoles.push_back( nTRTHoles );
       m_muon_trknBLayerHits.push_back( nBLayerHits );
-      //m_muon_trknInnermostPixLayHits.push_back( nInnermostPixLayHits );
-      //m_muon_trkPixdEdX.push_back( pixdEdX );
+      if ( !m_DC14 ) {
+        m_muon_trknInnermostPixLayHits.push_back( nInnermostPixLayHits );
+        m_muon_trkPixdEdX.push_back( pixdEdX );
+      }
     }
 
     this->FillMuonsUser(muon_itr);
@@ -358,8 +365,10 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_trknTRTHits",   &m_el_trknTRTHits);
     m_tree->Branch("el_trknTRTHoles",  &m_el_trknTRTHoles);
     m_tree->Branch("el_trknBLayerHits",&m_el_trknBLayerHits);
-    //m_tree->Branch("el_trknInnermostPixLayHits",  &m_el_trknInnermostPixLayHits);
-    //m_tree->Branch("el_trkPixdEdX",    &m_el_trkPixdEdX);
+    if ( !m_DC14 ) {
+      m_tree->Branch("el_trknInnermostPixLayHits",  &m_el_trknInnermostPixLayHits);
+      m_tree->Branch("el_trkPixdEdX",    &m_el_trkPixdEdX);
+    }
   }
 
   this->AddElectronsUser();
@@ -429,8 +438,10 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
         trk->summaryValue( nTRTHits,  xAOD::numberOfTRTHits );
         trk->summaryValue( nTRTHoles, xAOD::numberOfTRTHoles );
         trk->summaryValue( nBLayerHits,  xAOD::numberOfBLayerHits );
-        //trk->summaryValue( nInnermostPixLayHits, xAOD::numberOfInnermostPixelLayerHits );
-        //trk->summaryValue( pixdEdX,   xAOD::pixeldEdx);
+	if ( !m_DC14 ) {
+          trk->summaryValue( nInnermostPixLayHits, xAOD::numberOfInnermostPixelLayerHits );
+          trk->summaryValue( pixdEdX,   xAOD::pixeldEdx);
+        }
       }
       m_el_trknSiHits.push_back( nPixHits + nSCTHits );
       m_el_trknPixHits.push_back( nPixHits );
@@ -440,8 +451,10 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       m_el_trknTRTHits.push_back( nTRTHits );
       m_el_trknTRTHoles.push_back( nTRTHoles );
       m_el_trknBLayerHits.push_back( nBLayerHits );
-      //m_el_trknInnermostPixLayHits.push_back( nInnermostPixLayHits );
-      //m_el_trkPixdEdX.push_back( pixdEdX );
+      if ( !m_DC14 ) {
+        m_el_trknInnermostPixLayHits.push_back( nInnermostPixLayHits );
+        m_el_trkPixdEdX.push_back( pixdEdX );
+      }
     }
 
     this->FillElectronsUser(el_itr);
@@ -542,9 +555,11 @@ void HelpTreeBase::AddJets(const std::string detailStr)
   }
 
   if( m_jetInfoSwitch->m_flavTag ) {
-    m_tree->Branch("jet_SV0",           &m_jet_sv0);
-    m_tree->Branch("jet_SV1",           &m_jet_sv1);
-    m_tree->Branch("jet_IP3D",          &m_jet_ip3d);
+    if ( !m_DC14 ) {
+      m_tree->Branch("jet_SV0",           &m_jet_sv0);
+      m_tree->Branch("jet_SV1",           &m_jet_sv1);
+      m_tree->Branch("jet_IP3D",          &m_jet_ip3d);
+    }
     m_tree->Branch("jet_SV1IP3D",       &m_jet_sv1ip3d);
     m_tree->Branch("jet_MV1",           &m_jet_mv1);
     m_tree->Branch("jet_MV2c00",        &m_jet_mv2c00);
@@ -867,9 +882,11 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation ) {
 
     if ( m_jetInfoSwitch->m_flavTag) {
       const xAOD::BTagging * myBTag = jet_itr->btagging();
-      m_jet_sv0.push_back(     myBTag -> SV0_significance3D()       );
-      m_jet_sv1.push_back(     myBTag -> SV1_loglikelihoodratio()   );
-      m_jet_ip3d.push_back(    myBTag -> IP3D_loglikelihoodratio()  );
+      if ( !m_DC14 ) {
+        m_jet_sv0.push_back(     myBTag -> SV0_significance3D()       );
+        m_jet_sv1.push_back(     myBTag -> SV1_loglikelihoodratio()   );
+        m_jet_ip3d.push_back(    myBTag -> IP3D_loglikelihoodratio()  );
+      }
       m_jet_sv1ip3d.push_back( myBTag -> SV1plusIP3D_discriminant() );
       m_jet_mv1.push_back(     myBTag -> MV1_discriminant()         );
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -107,6 +107,8 @@ namespace HelperClasses{
 
   void ElectronInfoSwitch::initialize(){
     m_kinematic     = parse("kinematic");
+    m_isolation     = parse("isolation");
+    m_PID           = parse("PID");
     m_trackparams   = parse("trackparams");
     m_trackhitcont  = parse("trackhitcont");
   }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -77,7 +77,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
 
   // get the file we created already
   TFile* treeFile = wk()->getOutputFile ("tree");
-  m_helpTree = new HelpTreeBase( m_event, outTree, treeFile, 1e3, m_debug );
+  m_helpTree = new HelpTreeBase( m_event, outTree, treeFile, 1e3, m_debug, m_DC14 );
   // tell the tree to go into the file
   outTree->SetDirectory( treeFile );
   // uncomment if want to add to same file as ouput histograms
@@ -118,6 +118,10 @@ EL::StatusCode TreeAlgo :: configure ()
     m_jetContainerName        = config->GetValue("JetContainerName",        "");
     m_fatJetContainerName     = config->GetValue("FatJetContainerName",     "");
     m_tauContainerName        = config->GetValue("TauContainerName",        "");
+    
+    // DC14 switch for little things that need to happen to run
+    // for those samples with the corresponding packages
+    m_DC14                    = config->GetValue("DC14", false);
 
     Info("configure()", "Loaded in configuration values");
 

--- a/data/bjetEffCorr.config
+++ b/data/bjetEffCorr.config
@@ -6,6 +6,6 @@ TaggerName              MV1
 BTagMedium              True
 UseDevelopmentFile      True
 ConeFlavourLabel        True
-# leave this field blank if not running on syst or running on all syst
+# leave this field blank if not running on syst. Otherwise, specify syst name. When running on all systs, use "All"
 SystName		
 ## last option must be followed by a new line ##

--- a/data/electronCalib.config
+++ b/data/electronCalib.config
@@ -1,5 +1,32 @@
-InputContainer		ElectronCollection
-OutputContainer		ElectronCollection_Calib
-OutputAlgo              ElectronCollection_Calib_Algo
-Debug			False
+InputContainer		Electrons
+OutputContainer		Electrons_Calib
+# ------------------------------------------------------------------------- #
+#
+# This is the vector<string> w/ names of the systematically varied 
+# containers coming from the upstream algo (e.g., the SC containers with 
+# calibration systematics), which will be processed by this module.
+#
+# If left blank, it means there's no upstream algo making SC w/ systematics.
+# This is the case when processing straight from the original xAOD/DxAOD 
+#		   
+# ------------------------------------------------------------------------- #
+InputAlgoSystNames	
+# ------------------------------------------------------------------------------ #
+#
+# This is the vector<string> of the systematically varied containers (SCs) 
+# created by by this algorithm, if any.
+# This will need to be the InputAlgoSystNames of the first downstream algorithm!
+#
+# ------------------------------------------------------------------------------ #
+OutputAlgoSystNames     ElectronCalibrator_Syst
+#------------------------------------------------------------------------------------------------------------------ #
+# Leave this field blank if not running on syst. Otherwise, specify syst name. When running on all systs, use "All"
+#------------------------------------------------------------------------------------------------------------------ #
+SystName
+#-------------------------------------------- #
+# Choose number and sign of sigma variations
+#-------------------------------------------- #
+SystVal
+# ------------------------------------------- #
+Debug			True
 ## last option must be followed by a new line ##

--- a/data/electronEffCorr.config
+++ b/data/electronEffCorr.config
@@ -1,8 +1,15 @@
 InputContainer		ElectronCollection_Calib
 OutputContainer		ElectronCollection_CalibCorr
-InputAlgo		ElectronCollection_Calib_Algo
-OutputAlgo 		ElectronCollection_CalibCorr_Algo
-Debug			False
+Debug			True
 CorrectionFileName1	$ROOTCOREBIN/data/ElectronEfficiencyCorrection/efficiencySF.offline.Loose.2012.8TeV.rel17p2.v07.root
 #CorrectionFileName2
+# ------------------------------- #
+# this is the name of the vector of names of the systematically varied 
+# containers produced by the upstream algo 
+# (e.g., the SC containers with calibration systematics)		   
+# ------------------------------- #
+InputAlgoSystNames	ElectronCollection_Calib_Algo
+# leave this field blank if not running on syst. Otherwise, specify syst name. When running on all systs, use "All"
+SystName		
+OutputSystNames		ElectronEfficiencyCorrector_Syst
 ## last option must be followed by a new line ##

--- a/data/electronEffCorr.config
+++ b/data/electronEffCorr.config
@@ -1,15 +1,34 @@
-InputContainer		ElectronCollection_Calib
-OutputContainer		ElectronCollection_CalibCorr
+InputContainer		Electrons_Calib
+#----------------------------------------------------------------------- #
 Debug			True
+#-----------------------------------------------------------------------
 CorrectionFileName1	$ROOTCOREBIN/data/ElectronEfficiencyCorrection/efficiencySF.offline.Loose.2012.8TeV.rel17p2.v07.root
-#CorrectionFileName2
-# ------------------------------- #
-# this is the name of the vector of names of the systematically varied 
-# containers produced by the upstream algo 
-# (e.g., the SC containers with calibration systematics)		   
-# ------------------------------- #
-InputAlgoSystNames	ElectronCollection_Calib_Algo
-# leave this field blank if not running on syst. Otherwise, specify syst name. When running on all systs, use "All"
+##CorrectionFileName2
+# ------------------------------------------------------------------------- #
+#
+# This is the vector of strings w/ names of the systematically varied 
+# containers coming from the upstream algo (e.g., the SC containers with 
+# calibration systematics), which will be processed by this module.
+#
+# If left blank, it means there's no upstream algo making SC w/ systematics.
+# This is the case when processing straight from the original xAOD/DxAOD 
+#		   
+# ------------------------------------------------------------------------- #
+InputAlgoSystNames	ElectronCalibrator_Syst
+#------------------------------------------------------------------------------------------------ #
+#
+# Leave this field blank if not running systematics on this module. Otherwise, specify syst name.
+# When running on all systs, use "All" option.
+#
+#------------------------------------------------------------------------------------------------ #
 SystName		
+#------------------------------------------------------------------------------------------ #
+#
+# This is the vector<string> w/ the names for systematically varied SFs made by this module
+# (first component: empty string). There is a 1:1 correspondence w/ the vector<float>
+# containing the SFs which decorates each particle (first component: nominal SF)
+#
+#------------------------------------------------------------------------------------------ #
 OutputSystNames		ElectronEfficiencyCorrector_Syst
+#----------------------------------------------------------------------- #
 ## last option must be followed by a new line ##

--- a/data/electronSelect_signal.config
+++ b/data/electronSelect_signal.config
@@ -1,32 +1,91 @@
-InputContainer          ElectronCollection_CalibCorr
+InputContainer          Electrons_Calib
+OutputContainer         Electrons_Signal
 DecorateSelectedObjects True
 CreateSelectedContainer True
-OutputContainer         ElectronCollection_Signal
-InputAlgo		
-OutputAlgo		
-Debug			False
+# ------------------------------------------------------------------------- #
+Debug			True
+# ------------------------------------------------------------------------- #
+#
+# This is the vector<string> w/ names of the systematically varied 
+# containers coming from the upstream algo (e.g., the SC containers with 
+# calibration systematics), which will be processed by this module.
+#
+# If left blank, it means there's no upstream algo making SC w/ systematics.
+# This is the case when processing straight from the original xAOD/DxAOD 
+#		   
+# ------------------------------------------------------------------------- #
+InputAlgoSystNames	ElectronCalibrator_Syst
+# ------------------------------------------------------------------------------ #
+#
+# This is the vector<string> of the systematically varied containers (SCs) 
+# created by by this algorithm, if any.
+# This will need to be the InputAlgoSystNames of the first downstream algorithm!
+#
+# ------------------------------------------------------------------------------ #
+OutputAlgoSystNames		
+# -------------------------------------------------------------------------------------------- #
+PassMin                 0
 pTMin                   10e3
 etaMax			2.47
 VetoCrack		True
 d0sigMax		5.0
 z0sinthetaMax		1.5
-# Where to find config files? 
+# -------------------------------------------------------------------------------------------- #
+#
+# Wondering where to find config files for particle ID? 
 #    See:
 #        https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EGammaIdentificationRun2 
 #    and 
 #        http://atlas.web.cern.ch/Atlas/GROUPS/DATABASE/GroupData/ElectronPhotonSelectorTools
-ConfDirPID		mc15_20150224
-# likelihood-based PID WPs: VeryLoose, Loose, Medium, Tight, VeryTight, LooseRelaxed (see ElectronPhotonSelectorTools/​TElectronLikelihoodTool.h)
+#
+# -------------------------------------------------------------------------------------------- #
+ConfDirPID		mc15_20150518
+# ------------------------------------------------------------------------------------------------------------------------------------------- #
+#
+# Supported likelihood-based PID WPs: VeryLoose, Loose, Medium, Tight, VeryTight (see ElectronPhotonSelectorTools/TElectronLikelihoodTool.h)
+#
+# ------------------------------------------------------------------------------------------------------------------------------------------- #
 DoLHPIDCut		True
-LHPID			Loose
-LHOperatingPoint        ElectronLikelihoodLooseOfflineConfig2015.conf
+LHOperatingPoint	Medium
+LHConfigYear	        2015
+# -------------------------------------------------------------------------------------------- #
 DoCutBasedPIDCut	False
 CutBasedOperatingPoint  ElectronIsEMLooseSelectorCutDefs2012.conf  
-PassMin                 0
+# ---------------------------------------------------------- #
 DoIsolationCut		False
-UseRelativeIso		True
+# -------------------------------------------------------------------------------------- #
+#
+# Isolation WP definitions are defined in:
+# https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ElectronIsolationSelectionTool
+# A "CutBasedDC14" WP is available to apply DC14 and Run1-style isolation
+#
+# -------------------------------------------------------------------------------------- #
+IsolationWP		Loose
+# ---------------------------------- #
+#
+# The following options are relevant 
+# for "UserDefined" WP only
+#
+# ---------------------------------- #
+CaloIsoEfficiency	0.1*x+83
+TrackIsoEfficiency	98
+# ---------------------------------- #
+#
+# The following options are relevant 
+# for "UserDefined" OR "CutBasedDC14" WP 
+# only
+#
+# ---------------------------------- #
 CaloBasedIsoType	topoetcone20
+TrackBasedIsoType	ptvarcone20
+# ---------------------------------- #
+#
+# The following options are relevant 
+# for "CutBasedDC14" WP only
+#
+# ---------------------------------- #
+UseRelativeIso		True
 CaloBasedIsoCut         0.05
-TrackBasedIsoType	ptcone20
 TrackBasedIsoCut        0.05
+# -------------------------------------------------------------------------------------------- #
 ## last option must be followed by a new line ##

--- a/data/tree.config
+++ b/data/tree.config
@@ -1,8 +1,9 @@
-MuonContainerName	Muons_Signal
-ElectronContainerName	ElectronCollection_Signal
-JetContainerName      	AntiKt4EMTopoJets_Signal
+#MuonContainerName	Muons_Signal
+ElectronContainerName	Electrons_Signal
+#JetContainerName      	AntiKt4EMTopoJets_Signal
 Debug			False
+SameHistsOutDir		False
 EventDetailStr		"pileup"
 MuonDetailStr		"kinematic trackparams trackhitcont"
-ElectronDetailStr	"kinematic trackparams trackhitcont"
+ElectronDetailStr	"kinematic isolation PID trackparams trackhitcont"
 JetDetailStr          	"kinematic energy"

--- a/util/test_multiAlgo.cxx
+++ b/util/test_multiAlgo.cxx
@@ -124,7 +124,7 @@ int main( int argc, char* argv[] ) {
   job.algsAdd( electronCalib );
   job.algsAdd( electronEffCorr );
   //job.algsAdd( muonSelect_signal );
-  //job.algsAdd( electronSelect_signal );
+  job.algsAdd( electronSelect_signal );
   //job.algsAdd( jetSelect_signal );
   //job.algsAdd( bjetSelect_signal );
   //job.algsAdd( bjetEffCorr_btag );
@@ -134,7 +134,7 @@ int main( int argc, char* argv[] ) {
   //job.algsAdd( jetHistsAlgo_truth );
   //job.algsAdd( overlapRemoval );
   //job.algsAdd( jk_AntiKt10LC );
-  //job.algsAdd( out_tree );
+  job.algsAdd( out_tree );
 
   // Run the job using the local/direct driver:
   EL::DirectDriver driver;

--- a/util/test_multiAlgo.cxx
+++ b/util/test_multiAlgo.cxx
@@ -93,10 +93,10 @@ int main( int argc, char* argv[] ) {
 
   JetCalibrator* jetCalib                       = new JetCalibrator(        "jetCalib_AntiKt4TopoEM",   localDataDir+"jetCalib_AntiKt4TopoEMCalib.config");
   MuonCalibrator* muonCalib                     = new MuonCalibrator(       "muonCalib",                localDataDir+"muonCalib.config");
-  ElectronCalibrator* electronCalib             = new ElectronCalibrator(   "electronCalib",            localDataDir+"electronCalib.config" /*, "All"*/ );
+  ElectronCalibrator* electronCalib             = new ElectronCalibrator(   "electronCalib",            localDataDir+"electronCalib.config" );
 
-  MuonEfficiencyCorrector*      muonEffCorr     = new MuonEfficiencyCorrector(       "muonEfficiencyCorrector",                localDataDir+"muonEffCorr.config");
-  ElectronEfficiencyCorrector*  electronEffCorr = new ElectronEfficiencyCorrector(   "electronEfficiencyCorrector",            localDataDir+"electronEffCorr.config"/*, "All"*/);
+  MuonEfficiencyCorrector*      muonEffCorr     = new MuonEfficiencyCorrector(       "muonEfficiencyCorrector",      localDataDir+"muonEffCorr.config");
+  ElectronEfficiencyCorrector*  electronEffCorr = new ElectronEfficiencyCorrector(   "electronEfficiencyCorrector",  localDataDir+"electronEffCorr.config");
 
   MuonSelector* muonSelect_signal               = new MuonSelector(         "muonSelect_signal",        localDataDir+"muonSelect_signal.config");
   ElectronSelector* electronSelect_signal       = new ElectronSelector(     "electronSelect_signal",    localDataDir+"electronSelect_signal.config");
@@ -121,8 +121,8 @@ int main( int argc, char* argv[] ) {
   //job.algsAdd( jetCalib );
   //job.algsAdd( muonCalib );
   //job.algsAdd( muonEffCorr );
-  //job.algsAdd( electronCalib );
-  //job.algsAdd( electronEffCorr );
+  job.algsAdd( electronCalib );
+  job.algsAdd( electronEffCorr );
   //job.algsAdd( muonSelect_signal );
   //job.algsAdd( electronSelect_signal );
   //job.algsAdd( jetSelect_signal );

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -33,16 +33,19 @@ public:
   std::string m_inContainerName;
   std::string m_outContainerName;
 
-  std::string m_inputAlgo;
-  std::string m_outputAlgo;
-
   // sort after calibration
   bool    m_sort;
 
+  
   // systematics
-  std::string m_systName;
-  float m_systVal;
+  std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
+  			             // upstream algo (e.g., the SC containers with calibration systematics)		   
+  std::string m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers produced by THIS
+  				     // algo ( these will be the m_inputAlgoSystNames of the algo downstream
+  std::string m_systName;            
+  float m_systVal;                   
   bool m_runSysts;
+  bool m_runAllSyst;                 
 
 private:
   xAOD::TEvent *m_event;  //!
@@ -69,7 +72,7 @@ public:
 
   // this is a standard constructor
   ElectronCalibrator ();
-  ElectronCalibrator (std::string name, std::string configName, std::string systName = "", float systVal = 0);
+  ElectronCalibrator (std::string name, std::string configName);
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -34,7 +34,6 @@ public:
 
   // configuration variables
   std::string m_inContainerName;
-  std::string m_outContainerName;
 
   // systematics
   std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -26,6 +26,7 @@ class ElectronEfficiencyCorrector : public EL::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
+  
   std::string m_name;
   std::string m_configName;
 
@@ -34,22 +35,25 @@ public:
   // configuration variables
   std::string m_inContainerName;
   std::string m_outContainerName;
-  std::string m_inputAlgo;               // input type - from xAOD or from xAODAnaHelpers Algo output
-  std::string m_outputAlgo;
 
   // systematics
-  std::string m_systName;
-  float m_systVal;
-  std::string m_corrFileName1;
+  std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
+  			             // upstream algo (e.g., the SC containers with calibration systematics)		   
+  bool m_runAllSyst;                 
+  std::string m_systName;            
+  std::string m_outputSystNames;      
+  float m_systVal;                   
+  std::string m_corrFileName1;       
+  //std::string m_corrFileName2;      
 
 private:
+  
   xAOD::TEvent *m_event;  //!
   xAOD::TStore *m_store;  //!
   int m_numEvent;         //!
   int m_numObject;        //!
   std::string m_outAuxContainerName;
 
-  bool m_runSysts;
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
@@ -58,14 +62,16 @@ private:
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker
   // node (done by the //!)
+
 public:
+
   // Tree *myTree; //!
-  // TH1 *myHist; //!
+  // TH1 *myHist;  //!
 
 
   // this is a standard constructor
   ElectronEfficiencyCorrector ();
-  ElectronEfficiencyCorrector (std::string name, std::string configName, std::string systName = "", float systVal = 0);
+  ElectronEfficiencyCorrector ( std::string name, std::string configName );
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);
@@ -80,7 +86,7 @@ public:
 
   // these are the functions not inherited from Algorithm
   virtual EL::StatusCode configure ();
-  virtual EL::StatusCode executeSF (  const xAOD::ElectronContainer* correctedElectrons  );
+  virtual EL::StatusCode executeSF (  const xAOD::ElectronContainer* inputElectrons, unsigned int countSyst  );
 
   // this is needed to distribute the algorithm to the workers
   ClassDef(ElectronEfficiencyCorrector, 1);

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -13,12 +13,15 @@
 #include "xAODEgamma/ElectronContainer.h"
 #include "xAODTracking/Vertex.h"
 
+// package include(s):
+#include "xAODAnaHelpers/ParticlePIDManager.h"
+
 // ROOT include(s):
 #include "TH1D.h"
 
 // external tools include(s):
 #include "ElectronPhotonSelectorTools/AsgElectronIsEMSelector.h"
-#include "ElectronPhotonSelectorTools/AsgElectronLikelihoodTool.h"
+#include "ElectronIsolationSelection/IsolationSelectionTool.h"
 #include "ElectronIsolationSelection/ElectronIsolationSelectionTool.h"
 
 class ElectronSelector : public EL::Algorithm
@@ -38,8 +41,8 @@ public:
   std::string    m_inContainerName;          // input container name
   std::string    m_outContainerName;         // output container name
   std::string    m_outAuxContainerName;      // output auxiliary container name
-  std::string    m_inputAlgo;                // input type - from xAOD or from xAODAnaHelpers Algo output
-  std::string    m_outputAlgo;
+  std::string    m_inputAlgoSystNames;
+  std::string    m_outputAlgoSystNames;
   bool       	 m_decorateSelectedObjects;  // decorate selected objects? defaul passSel
   bool       	 m_createSelectedContainer;  // fill using SG::VIEW_ELEMENTS to be light weight
   int        	 m_nToProcess;  	     // look at n objects
@@ -60,7 +63,7 @@ public:
   
   // likelihood-based PID
   bool           m_doLHPIDcut;
-  std::string    m_LHPID;
+  std::string    m_LHConfigYear;
   std::string    m_LHOperatingPoint;
 
   // cut-based PID
@@ -69,6 +72,9 @@ public:
 
   // isolation
   bool           m_doIsolation;
+  std::string    m_IsoWP;
+  std::string    m_CaloIsoEff;
+  std::string    m_TrackIsoEff;
   bool           m_useRelativeIso;
   std::string    m_CaloBasedIsoType;
   float          m_CaloBasedIsoCut;
@@ -94,9 +100,13 @@ private:
   int   m_cutflow_bin;      //!
 
   // tools
-  AsgElectronIsEMSelector            *m_asgElectronIsEMSelector ;       //!
-  AsgElectronLikelihoodTool          *m_asgElectronLikelihoodTool;      //!
-  CP::ElectronIsolationSelectionTool *m_electronIsolationSelectionTool; //!
+  AsgElectronIsEMSelector            *m_asgElectronIsEMSelector ;             //!
+  CP::IsolationSelectionTool         *m_IsolationSelectionTool;               //! /* MC15 tool for isolation*/
+  CP::ElectronIsolationSelectionTool *m_ElectronIsolationSelectionTool;       //! /* DC14 tool for isolation*/
+
+  
+  // PID manager(s)
+  LikelihoodPIDManager               *m_el_LH_PIDManager; //!
 
   std::vector<std::string> m_passKeys;  //!
   std::vector<std::string> m_failKeys;  //!

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -37,10 +37,6 @@ public:
   HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, bool DC14 = false );
   virtual ~HelpTreeBase() {;}
 
- // virtual void setDebugMode(  bool debug ){
- //   m_debug = debug;
- // } 
-
   void AddEvent    (const std::string detailStr = "");
   void AddMuons    (const std::string detailStr = "");
   void AddElectrons(const std::string detailStr = "");
@@ -293,6 +289,12 @@ protected:
   std::vector<float> m_el_phi;
   std::vector<float> m_el_eta;
   std::vector<float> m_el_m;
+  std::vector<int>   m_el_isIsolated;
+  std::vector<int>   m_el_LHVeryLoose;
+  std::vector<int>   m_el_LHLoose;
+  std::vector<int>   m_el_LHMedium;
+  std::vector<int>   m_el_LHTight;
+  std::vector<int>   m_el_LHVeryTight;
  
   // track parameters
   std::vector<float> m_el_trkd0;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -34,7 +34,7 @@ class HelpTreeBase {
 
 public:
 
-  HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false );
+  HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, bool DC14 = false );
   virtual ~HelpTreeBase() {;}
 
  // virtual void setDebugMode(  bool debug ){
@@ -117,6 +117,7 @@ protected:
   int m_units; //For MeV to GeV conversion in output
   
   bool m_debug;
+  bool m_DC14;
 
   // event
   int m_runNumber;
@@ -281,8 +282,8 @@ protected:
   std::vector<int> m_muon_trknTRTHits;
   std::vector<int> m_muon_trknTRTHoles;
   std::vector<int> m_muon_trknBLayerHits; 
-  //std::vector<int> m_muon_trknInnermostPixLayHits; // not available ?
-  //std::vector<float> m_muon_trkPixdEdX; // not available ?
+  std::vector<int> m_muon_trknInnermostPixLayHits; // not available in DC14
+  std::vector<float> m_muon_trkPixdEdX;            // not available in DC14
 
   // electrons
   int m_nel;
@@ -312,8 +313,8 @@ protected:
   std::vector<int> m_el_trknTRTHits;
   std::vector<int> m_el_trknTRTHoles;
   std::vector<int> m_el_trknBLayerHits; 
-  //std::vector<int> m_el_trknInnermostPixLayHits; // not available ?
-  //std::vector<float> m_el_trkPixdEdX; // not available ?
+  std::vector<int> m_el_trknInnermostPixLayHits; // not available in DC14
+  std::vector<float> m_el_trkPixdEdX;            // not available in DC14
 
   // taus
   int m_ntau;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -79,6 +79,8 @@ namespace HelperClasses {
 
   struct ElectronInfoSwitch : InfoSwitch {
     bool m_kinematic;
+    bool m_isolation;
+    bool m_PID;
     bool m_trackparams;
     bool m_trackhitcont;
     void initialize();

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -1,0 +1,111 @@
+#ifndef xAODAnaHelpers_ParticlePIDManager_H
+#define xAODAnaHelpers_ParticlePIDManager_H
+
+// package include(s):
+#include "xAODAnaHelpers/HelperClasses.h"
+#include "xAODAnaHelpers/HelperFunctions.h"
+
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+#include <xAODAnaHelpers/tools/ReturnCheckConfig.h>
+
+#include "AsgTools/StatusCode.h"
+
+#include "ElectronPhotonSelectorTools/AsgElectronLikelihoodTool.h"
+
+
+class LikelihoodPIDManager
+{
+   public: 
+     LikelihoodPIDManager ();
+     LikelihoodPIDManager (std::string WP) :
+        m_asgElectronLikelihoodTool_VeryLoose(nullptr),
+	m_asgElectronLikelihoodTool_Loose(nullptr),    
+	m_asgElectronLikelihoodTool_Medium(nullptr),   
+	m_asgElectronLikelihoodTool_Tight(nullptr),    
+	m_asgElectronLikelihoodTool_VeryTight(nullptr)
+     {
+	m_selectedWP = WP;
+        
+        /*  fill the multimap with WPs and corresponding tools */
+	std::pair < std::string, AsgElectronLikelihoodTool* > veryloose = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
+        m_allWPs.insert(veryloose);
+	std::pair < std::string, AsgElectronLikelihoodTool* > loose = std::make_pair( std::string("Loose"), m_asgElectronLikelihoodTool_Loose );
+        m_allWPs.insert(loose);
+	std::pair < std::string, AsgElectronLikelihoodTool* > medium = std::make_pair( std::string("Medium"), m_asgElectronLikelihoodTool_Medium );
+        m_allWPs.insert(medium);
+	std::pair < std::string, AsgElectronLikelihoodTool* > tight = std::make_pair( std::string("Tight"), m_asgElectronLikelihoodTool_Tight );
+        m_allWPs.insert(tight);
+	std::pair < std::string, AsgElectronLikelihoodTool* > verytight = std::make_pair( std::string("VeryTight"), m_asgElectronLikelihoodTool_VeryTight );
+        m_allWPs.insert(verytight);
+
+     };
+     
+     ~LikelihoodPIDManager()
+     {
+     	if ( m_asgElectronLikelihoodTool_VeryLoose ) { delete m_asgElectronLikelihoodTool_VeryLoose; m_asgElectronLikelihoodTool_VeryLoose = nullptr; }
+     	if ( m_asgElectronLikelihoodTool_Loose )     { delete m_asgElectronLikelihoodTool_Loose; m_asgElectronLikelihoodTool_Loose = nullptr; }
+     	if ( m_asgElectronLikelihoodTool_Medium )    { delete m_asgElectronLikelihoodTool_Medium; m_asgElectronLikelihoodTool_Medium = nullptr; }
+     	if ( m_asgElectronLikelihoodTool_Tight )     { delete m_asgElectronLikelihoodTool_Tight; m_asgElectronLikelihoodTool_Tight = nullptr; }
+     	if ( m_asgElectronLikelihoodTool_VeryTight ) { delete m_asgElectronLikelihoodTool_VeryTight; m_asgElectronLikelihoodTool_VeryTight = nullptr; }       
+     };
+     
+     
+     StatusCode setupLHTools( std::string confDir, std::string year ) {
+     
+        HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
+        unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
+       
+        /*  
+	/
+	/ By converting the string to the corresponding LikeEnum, we can exploit the ordering of the enum itself 
+	/ ( see ElectronPhotonID/ElectronPhotonSelectorTools/trunk/ElectronPhotonSelectorTools/TElectronLikelihoodTool.h for definition)
+	/ to initialise ONLY the tools with WP tighter (or equal) the selected one.
+	/ The selected WP will be used to cut loose electrons in the selector, the tighter WPs to decorate! 
+	/
+	*/       
+	for ( auto it : (m_allWPs) ) {
+
+	    /* instantiate tools (do it for all) */
+            it.second =  new AsgElectronLikelihoodTool( (it.first).c_str() );
+            
+            HelperClasses::EnumParser<LikeEnum::Menu>  itWP_parser;
+            unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
+            
+            /* if this WP is looser than user's WP, skip to next */
+            if ( itWP_enum < selectedWP_enum ) { continue; }
+        
+            /* configure and initialise only tools with (WP >= selectedWP) */
+            it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */
+	    RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->setProperty("primaryVertexContainer", "PrimaryVertices"), "Failed to set primaryVertexContainer property");
+	    std::string config_string = confDir + "ElectronLikelihood" + it.first + "OfflineConfig" + year + ".conf";
+            RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
+	    RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->initialize(), "Failed to initialize tool." );
+            
+	    /* copy map element into container of valid tools for later usage */
+	    m_validWPs.insert( it );
+	    
+        }
+	
+	return StatusCode::SUCCESS;
+     
+     };
+     
+     /* returns a map containing only the tools w/ (WP >= selected WP) */
+     std::multimap< std::string, AsgElectronLikelihoodTool* > getValidLHTools() { return m_validWPs; };
+     
+   private:   
+     
+     std::string m_selectedWP;
+     std::multimap<std::string, AsgElectronLikelihoodTool*> m_allWPs;
+     std::multimap<std::string, AsgElectronLikelihoodTool*> m_validWPs;
+     
+
+     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLoose;  
+     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose;	 
+     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Medium;	 
+     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Tight;	 
+     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryTight;  
+
+};
+
+#endif

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -19,6 +19,9 @@ public:
   const std::string m_name;
   std::string m_configName;
 
+  // choose whether the tree gets saved in the same directory as output histograms
+  bool m_outHistDir;                   //!
+ 
   // holds bools that control which branches are filled
   std::string m_evtDetailStr;	       //!
   std::string m_muDetailStr;	       //!

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -35,6 +35,7 @@ public:
   std::string m_tauContainerName;      //!
 
   bool m_debug;                        //!
+  bool m_DC14;                         //!
 
 private:
   xAOD::TEvent *m_event;               //!
@@ -45,8 +46,8 @@ private:
 public:
 
   // this is a standard constructor
-  TreeAlgo ();                                           //!
-  TreeAlgo (std::string name, std::string configName);   //!
+  TreeAlgo ();                                              //!
+  TreeAlgo (std::string name, std::string configName);      //!
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);           //!


### PR DESCRIPTION
-) Updated electron isolation tool interface to cope with 2.3.X CP tool version.
-) In ElectronEfficiencyCorrector, decorate with vector<double>  of SFs (nominal+syst) each electron
-) Create ParticlePIDManager.h, containing classes that manage multiple instances of CP tools for Particle ID (for now only electron LH tool). An instance of such classes becomes a data member of the Selectors, and allows particle selection for a given WP plus automatically provides decorations for WPs equal or tighter to the one selected. 
-) Using such decorations, electrons ID (and isolation) branches are now available from HelpTreeBase using switches.