### PR TITLE
Cut-based electron PID manager and bugfixes- commit 48e67c641c071cabc4e367090955d55c46304caf

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -349,15 +349,18 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
   }
 
   if ( m_elInfoSwitch->m_isolation ) {
-    m_tree->Branch("",  &m_el_isIsolated);
+    m_tree->Branch("el_isIsolated",  &m_el_isIsolated);
   }
   
   if ( m_elInfoSwitch->m_PID ) {
-    m_tree->Branch("",  &m_el_LHVeryLoose);
-    m_tree->Branch("",  &m_el_LHLoose);
-    m_tree->Branch("",  &m_el_LHMedium);
-    m_tree->Branch("",  &m_el_LHTight);
-    m_tree->Branch("",  &m_el_LHVeryTight);
+    m_tree->Branch("el_LHVeryLoose",  &m_el_LHVeryLoose);
+    m_tree->Branch("el_LHLoose",      &m_el_LHLoose);
+    m_tree->Branch("el_LHMedium",     &m_el_LHMedium);
+    m_tree->Branch("el_LHTight",      &m_el_LHTight);
+    m_tree->Branch("el_LHVeryTight",  &m_el_LHVeryTight);
+    m_tree->Branch("el_IsEMLoose",    &m_el_IsEMLoose);
+    m_tree->Branch("el_IsEMMedium",   &m_el_IsEMMedium);
+    m_tree->Branch("el_IsEMTight",    &m_el_IsEMTight);
   }
 
   if ( m_elInfoSwitch->m_trackparams ) {
@@ -416,18 +419,25 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
     
     if ( m_elInfoSwitch->m_PID ) {
       
-      static SG::AuxElement::Accessor<char> isLHVeryLooseAcc ("isLHVeryLoose");
-      static SG::AuxElement::Accessor<char> isLHLooseAcc ("isLHLoose");
-      static SG::AuxElement::Accessor<char> isLHMediumAcc ("isLHMedium");
-      static SG::AuxElement::Accessor<char> isLHTightAcc ("isLHTight");
-      static SG::AuxElement::Accessor<char> isLHVeryTightAcc ("isLHVeryTight");
+      static SG::AuxElement::Accessor<char> LHVeryLooseAcc ("LHVeryLoose");
+      static SG::AuxElement::Accessor<char> LHLooseAcc ("LHLoose");
+      static SG::AuxElement::Accessor<char> LHMediumAcc ("LHMedium");
+      static SG::AuxElement::Accessor<char> LHTightAcc ("LHTight");
+      static SG::AuxElement::Accessor<char> LHVeryTightAcc ("LHVeryTight");
+
+      static SG::AuxElement::Accessor<char> EMLooseAcc ("Loose");
+      static SG::AuxElement::Accessor<char> EMMediumAcc ("Medium");
+      static SG::AuxElement::Accessor<char> EMTightAcc ("Tight");
+
+      if ( LHVeryLooseAcc.isAvailable( *el_itr ) ) { m_el_LHVeryLoose.push_back( LHVeryLooseAcc( *el_itr ) ); } else { m_el_LHVeryLoose.push_back( -1 ); }
+      if ( LHLooseAcc.isAvailable( *el_itr ) )     { m_el_LHLoose.push_back( LHLooseAcc( *el_itr ) );         } else { m_el_LHLoose.push_back( -1 ); }
+      if ( LHMediumAcc.isAvailable( *el_itr ) )    { m_el_LHMedium.push_back( LHMediumAcc( *el_itr ) );       } else { m_el_LHMedium.push_back( -1 ); }
+      if ( LHTightAcc.isAvailable( *el_itr ) )     { m_el_LHTight.push_back( LHTightAcc( *el_itr ) );         } else { m_el_LHTight.push_back( -1 ); }
+      if ( LHVeryTightAcc.isAvailable( *el_itr ) ) { m_el_LHVeryTight.push_back( LHVeryTightAcc( *el_itr ) ); } else { m_el_LHVeryTight.push_back( -1 ); }
       
-      if ( isLHVeryLooseAcc.isAvailable( *el_itr ) ) { m_el_LHVeryLoose.push_back( isLHVeryLooseAcc( *el_itr ) ); } else { m_el_LHVeryLoose.push_back( -1 ); }
-      if ( isLHLooseAcc.isAvailable( *el_itr ) )     { m_el_LHLoose.push_back( isLHLooseAcc( *el_itr ) );         } else { m_el_LHLoose.push_back( -1 ); }
-      if ( isLHMediumAcc.isAvailable( *el_itr ) )    { m_el_LHMedium.push_back( isLHMediumAcc( *el_itr ) );       } else { m_el_LHMedium.push_back( -1 ); }
-      if ( isLHTightAcc.isAvailable( *el_itr ) )     { m_el_LHTight.push_back( isLHTightAcc( *el_itr ) );         } else { m_el_LHTight.push_back( -1 ); }
-      if ( isLHVeryTightAcc.isAvailable( *el_itr ) ) { m_el_LHVeryTight.push_back( isLHVeryTightAcc( *el_itr ) ); } else { m_el_LHVeryTight.push_back( -1 ); }
-    
+      if ( EMLooseAcc.isAvailable( *el_itr ) )         { m_el_IsEMLoose.push_back( EMLooseAcc( *el_itr ) );   } else { m_el_IsEMLoose.push_back( -1 ); }
+      if ( EMMediumAcc.isAvailable( *el_itr ) )        { m_el_IsEMMedium.push_back( EMMediumAcc( *el_itr ) ); } else { m_el_IsEMMedium.push_back( -1 ); }
+      if ( EMTightAcc.isAvailable( *el_itr ) )         { m_el_IsEMTight.push_back( EMTightAcc( *el_itr ) );   } else { m_el_IsEMTight.push_back( -1 ); }
     }
 
     if ( m_elInfoSwitch->m_trackparams ) {
@@ -1248,6 +1258,9 @@ void HelpTreeBase::ClearElectrons() {
     m_el_LHMedium.clear();
     m_el_LHTight.clear();
     m_el_LHVeryTight.clear();
+    m_el_IsEMLoose.clear();
+    m_el_IsEMMedium.clear();
+    m_el_IsEMTight.clear();
   }
 
   if ( m_elInfoSwitch->m_trackparams ) {

--- a/data/electronCalib.config
+++ b/data/electronCalib.config
@@ -1,5 +1,5 @@
-InputContainer		Electrons
-OutputContainer		Electrons_Calib
+InputContainer Electrons
+OutputContainer	Electrons_Calib
 # ------------------------------------------------------------------------- #
 #
 # This is the vector<string> w/ names of the systematically varied 
@@ -18,7 +18,7 @@ InputAlgoSystNames
 # This will need to be the InputAlgoSystNames of the first downstream algorithm!
 #
 # ------------------------------------------------------------------------------ #
-OutputAlgoSystNames     ElectronCalibrator_Syst
+OutputAlgoSystNames ElectronCalibrator_Syst
 #------------------------------------------------------------------------------------------------------------------ #
 # Leave this field blank if not running on syst. Otherwise, specify syst name. When running on all systs, use "All"
 #------------------------------------------------------------------------------------------------------------------ #
@@ -28,5 +28,5 @@ SystName
 #-------------------------------------------- #
 SystVal
 # ------------------------------------------- #
-Debug			True
+Debug False
 ## last option must be followed by a new line ##

--- a/data/electronEffCorr.config
+++ b/data/electronEffCorr.config
@@ -1,8 +1,8 @@
-InputContainer		Electrons_Calib
+InputContainer Electrons_Calib
 #----------------------------------------------------------------------- #
-Debug			True
+Debug False
 #-----------------------------------------------------------------------
-CorrectionFileName1	$ROOTCOREBIN/data/ElectronEfficiencyCorrection/efficiencySF.offline.Loose.2012.8TeV.rel17p2.v07.root
+CorrectionFileName1 $ROOTCOREBIN/data/ElectronEfficiencyCorrection/efficiencySF.offline.Loose.2012.8TeV.rel17p2.v07.root
 ##CorrectionFileName2
 # ------------------------------------------------------------------------- #
 #
@@ -14,7 +14,7 @@ CorrectionFileName1	$ROOTCOREBIN/data/ElectronEfficiencyCorrection/efficiencySF.
 # This is the case when processing straight from the original xAOD/DxAOD 
 #		   
 # ------------------------------------------------------------------------- #
-InputAlgoSystNames	ElectronCalibrator_Syst
+InputAlgoSystNames ElectronCalibrator_Syst
 #------------------------------------------------------------------------------------------------ #
 #
 # Leave this field blank if not running systematics on this module. Otherwise, specify syst name.
@@ -29,6 +29,6 @@ SystName
 # containing the SFs which decorates each particle (first component: nominal SF)
 #
 #------------------------------------------------------------------------------------------ #
-OutputSystNames		ElectronEfficiencyCorrector_Syst
+OutputSystNames ElectronEfficiencyCorrector_Syst
 #----------------------------------------------------------------------- #
 ## last option must be followed by a new line ##

--- a/data/electronSelect_signal.config
+++ b/data/electronSelect_signal.config
@@ -1,9 +1,9 @@
-InputContainer          Electrons_Calib
-OutputContainer         Electrons_Signal
+InputContainer Electrons_Calib
+OutputContainer Electrons_Signal
 DecorateSelectedObjects True
 CreateSelectedContainer True
 # ------------------------------------------------------------------------- #
-Debug			True
+Debug False
 # ------------------------------------------------------------------------- #
 #
 # This is the vector<string> w/ names of the systematically varied 
@@ -14,7 +14,7 @@ Debug			True
 # This is the case when processing straight from the original xAOD/DxAOD 
 #		   
 # ------------------------------------------------------------------------- #
-InputAlgoSystNames	ElectronCalibrator_Syst
+InputAlgoSystNames ElectronCalibrator_Syst
 # ------------------------------------------------------------------------------ #
 #
 # This is the vector<string> of the systematically varied containers (SCs) 
@@ -24,12 +24,12 @@ InputAlgoSystNames	ElectronCalibrator_Syst
 # ------------------------------------------------------------------------------ #
 OutputAlgoSystNames		
 # -------------------------------------------------------------------------------------------- #
-PassMin                 0
-pTMin                   10e3
-etaMax			2.47
-VetoCrack		True
-d0sigMax		5.0
-z0sinthetaMax		1.5
+PassMin 0
+pTMin 10e3
+etaMax 2.47
+VetoCrack True
+d0sigMax 5.0
+z0sinthetaMax 1.5
 # -------------------------------------------------------------------------------------------- #
 #
 # Wondering where to find config files for particle ID? 
@@ -39,20 +39,25 @@ z0sinthetaMax		1.5
 #        http://atlas.web.cern.ch/Atlas/GROUPS/DATABASE/GroupData/ElectronPhotonSelectorTools
 #
 # -------------------------------------------------------------------------------------------- #
-ConfDirPID		mc15_20150518
+ConfDirPID mc15_20150224
 # ------------------------------------------------------------------------------------------------------------------------------------------- #
 #
 # Supported likelihood-based PID WPs: VeryLoose, Loose, Medium, Tight, VeryTight (see ElectronPhotonSelectorTools/TElectronLikelihoodTool.h)
 #
 # ------------------------------------------------------------------------------------------------------------------------------------------- #
-DoLHPIDCut		True
-LHOperatingPoint	Medium
-LHConfigYear	        2015
+DoLHPIDCut False
+LHOperatingPoint Medium
+LHConfigYear 2012
 # -------------------------------------------------------------------------------------------- #
-DoCutBasedPIDCut	False
-CutBasedOperatingPoint  ElectronIsEMLooseSelectorCutDefs2012.conf  
+#
+# Supported cut-based PID WPs: IsEMLoose, IsEMMedium, IsEMTight (see http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Reconstruction/egamma/egammaEvent/egammaEvent/egammaPIDdefs.h)
+#
+# ------------------------------------------------------------------------------------------------------------------------------------------- #
+DoCutBasedPIDCut True
+CutBasedOperatingPoint IsEMMedium
+CutBasedConfigYear 2012
 # ---------------------------------------------------------- #
-DoIsolationCut		False
+DoIsolationCut False
 # -------------------------------------------------------------------------------------- #
 #
 # Isolation WP definitions are defined in:
@@ -60,15 +65,15 @@ DoIsolationCut		False
 # A "CutBasedDC14" WP is available to apply DC14 and Run1-style isolation
 #
 # -------------------------------------------------------------------------------------- #
-IsolationWP		Loose
+IsolationWP Loose
 # ---------------------------------- #
 #
 # The following options are relevant 
 # for "UserDefined" WP only
 #
 # ---------------------------------- #
-CaloIsoEfficiency	0.1*x+83
-TrackIsoEfficiency	98
+CaloIsoEfficiency 0.1*x+83
+TrackIsoEfficiency 98
 # ---------------------------------- #
 #
 # The following options are relevant 
@@ -76,16 +81,16 @@ TrackIsoEfficiency	98
 # only
 #
 # ---------------------------------- #
-CaloBasedIsoType	topoetcone20
-TrackBasedIsoType	ptvarcone20
+CaloBasedIsoType topoetcone20
+TrackBasedIsoType ptvarcone20
 # ---------------------------------- #
 #
 # The following options are relevant 
 # for "CutBasedDC14" WP only
 #
 # ---------------------------------- #
-UseRelativeIso		True
-CaloBasedIsoCut         0.05
-TrackBasedIsoCut        0.05
+UseRelativeIso True
+CaloBasedIsoCut  0.05
+TrackBasedIsoCut 0.05
 # -------------------------------------------------------------------------------------------- #
 ## last option must be followed by a new line ##

--- a/util/test_multiAlgo.cxx
+++ b/util/test_multiAlgo.cxx
@@ -80,6 +80,9 @@ int main( int argc, char* argv[] ) {
   // For Trigger
   job.options()->setString( EL::Job::optXaodAccessMode, EL::Job::optXaodAccessMode_branch );
 
+  // Select max number of events
+  //job.options()->setDouble (EL::Job::optMaxEvents, 1000);
+
   std::string localDataDir = "$ROOTCOREBIN/data/xAODAnaHelpers/";
 
   BasicEventSelection* baseEventSel             = new BasicEventSelection();

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -12,7 +12,6 @@
 #include "TH1D.h"
 
 // external tools include(s):
-#include "ElectronPhotonSelectorTools/AsgElectronIsEMSelector.h"
 #include "ElectronIsolationSelection/IsolationSelectionTool.h"
 #include "ElectronIsolationSelection/ElectronIsolationSelectionTool.h"
 
@@ -58,6 +57,7 @@ public:
 
   // cut-based PID
   bool           m_doCutBasedPIDcut;
+  std::string    m_CutBasedConfigYear;
   std::string    m_CutBasedOperatingPoint;
 
   // isolation
@@ -87,13 +87,12 @@ private:
   int   m_cutflow_bin;      //!
 
   // tools
-  AsgElectronIsEMSelector            *m_asgElectronIsEMSelector ;             //!
   CP::IsolationSelectionTool         *m_IsolationSelectionTool;               //! /* MC15 tool for isolation*/
   CP::ElectronIsolationSelectionTool *m_ElectronIsolationSelectionTool;       //! /* DC14 tool for isolation*/
 
-  
   // PID manager(s)
-  LikelihoodPIDManager               *m_el_LH_PIDManager; //!
+  ElectronLHPIDManager               *m_el_LH_PIDManager;       //!
+  ElectronCutBasedPIDManager         *m_el_CutBased_PIDManager; //!
 
   std::vector<std::string> m_passKeys;  //!
   std::vector<std::string> m_failKeys;  //!

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -289,12 +289,19 @@ protected:
   std::vector<float> m_el_phi;
   std::vector<float> m_el_eta;
   std::vector<float> m_el_m;
+  
+  // isolation
   std::vector<int>   m_el_isIsolated;
+  
+  // PID
   std::vector<int>   m_el_LHVeryLoose;
   std::vector<int>   m_el_LHLoose;
   std::vector<int>   m_el_LHMedium;
   std::vector<int>   m_el_LHTight;
   std::vector<int>   m_el_LHVeryTight;
+  std::vector<int>   m_el_IsEMLoose;
+  std::vector<int>   m_el_IsEMMedium;
+  std::vector<int>   m_el_IsEMTight;
  
   // track parameters
   std::vector<float> m_el_trkd0;

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -11,13 +11,21 @@
 #include "AsgTools/StatusCode.h"
 
 #include "ElectronPhotonSelectorTools/AsgElectronLikelihoodTool.h"
+#include "ElectronPhotonSelectorTools/AsgElectronIsEMSelector.h"
+#include "ElectronPhotonSelectorTools/egammaPIDdefs.h"
 
+// EDM include(s):
+#include "xAODEgamma/ElectronContainer.h"
+#include "xAODEgamma/Electron.h"
 
-class LikelihoodPIDManager
+// C++ include(s)
+#include <string>
+
+class ElectronLHPIDManager
 {
    public: 
-     LikelihoodPIDManager ();
-     LikelihoodPIDManager (std::string WP) :
+     ElectronLHPIDManager ();
+     ElectronLHPIDManager (std::string WP) :
         m_asgElectronLikelihoodTool_VeryLoose(nullptr),
 	m_asgElectronLikelihoodTool_Loose(nullptr),    
 	m_asgElectronLikelihoodTool_Medium(nullptr),   
@@ -37,10 +45,9 @@ class LikelihoodPIDManager
         m_allWPs.insert(tight);
 	std::pair < std::string, AsgElectronLikelihoodTool* > verytight = std::make_pair( std::string("VeryTight"), m_asgElectronLikelihoodTool_VeryTight );
         m_allWPs.insert(verytight);
-
      };
      
-     ~LikelihoodPIDManager()
+     ~ElectronLHPIDManager()
      {
      	if ( m_asgElectronLikelihoodTool_VeryLoose ) { delete m_asgElectronLikelihoodTool_VeryLoose; m_asgElectronLikelihoodTool_VeryLoose = nullptr; }
      	if ( m_asgElectronLikelihoodTool_Loose )     { delete m_asgElectronLikelihoodTool_Loose; m_asgElectronLikelihoodTool_Loose = nullptr; }
@@ -50,7 +57,7 @@ class LikelihoodPIDManager
      };
      
      
-     StatusCode setupLHTools( std::string confDir, std::string year ) {
+     StatusCode setupTools( std::string confDir, std::string year ) {
      
         HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
         unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
@@ -76,10 +83,10 @@ class LikelihoodPIDManager
         
             /* configure and initialise only tools with (WP >= selectedWP) */
             it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */
-	    RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->setProperty("primaryVertexContainer", "PrimaryVertices"), "Failed to set primaryVertexContainer property");
+	    RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("primaryVertexContainer", "PrimaryVertices"), "Failed to set primaryVertexContainer property");
 	    std::string config_string = confDir + "ElectronLikelihood" + it.first + "OfflineConfig" + year + ".conf";
-            RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
-	    RETURN_CHECK( "ParticlePIDManager::setupLHTools()", it.second->initialize(), "Failed to initialize tool." );
+            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
+	    RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->initialize(), "Failed to initialize tool." );
             
 	    /* copy map element into container of valid tools for later usage */
 	    m_validWPs.insert( it );
@@ -90,8 +97,24 @@ class LikelihoodPIDManager
      
      };
      
+     /* set default values for decorations (do it for all WPs) */
+     StatusCode setDecorations( const xAOD::Electron* electron ) {
+       
+       for ( auto it : (m_allWPs) ) { 
+         const std::string defaultDecorWP =  "LH" + it.first;  
+         electron->auxdecor<char>(defaultDecorWP) = -1;
+       }
+
+       return StatusCode::SUCCESS;
+     }  
+     
+     const std::string getSelectedWP ( ) { return m_selectedWP; }  
+	
+     /* returns a map containing all the tools  */
+     std::multimap< std::string, AsgElectronLikelihoodTool* > getTools() { return m_allWPs; };
+     
      /* returns a map containing only the tools w/ (WP >= selected WP) */
-     std::multimap< std::string, AsgElectronLikelihoodTool* > getValidLHTools() { return m_validWPs; };
+     std::multimap< std::string, AsgElectronLikelihoodTool* > getValidTools() { return m_validWPs; };
      
    private:   
      
@@ -108,4 +131,126 @@ class LikelihoodPIDManager
 
 };
 
+class ElectronCutBasedPIDManager
+{
+   public: 
+     ElectronCutBasedPIDManager ();
+     ElectronCutBasedPIDManager (std::string WP) :
+	m_asgElectronIsEMSelector_Loose(nullptr),    
+	m_asgElectronIsEMSelector_Medium(nullptr),   
+	m_asgElectronIsEMSelector_Tight(nullptr)    
+     {
+	m_selectedWP = WP;
+	
+        /*  fill the multimap with WPs and corresponding tools. Use an ordered index to reflect the tightness order (0: loosest WP, ...) */
+	std::pair < std::string, AsgElectronIsEMSelector* > loose = std::make_pair( std::string("IsEMLoose"), m_asgElectronIsEMSelector_Loose );
+        m_allWPs.insert( loose );
+	std::pair < std::string, AsgElectronIsEMSelector* > medium = std::make_pair( std::string("IsEMMedium"), m_asgElectronIsEMSelector_Medium );
+        m_allWPs.insert( medium );
+	std::pair < std::string, AsgElectronIsEMSelector* > tight = std::make_pair( std::string("IsEMTight"), m_asgElectronIsEMSelector_Tight );
+        m_allWPs.insert( tight );
+     };
+     
+     ~ElectronCutBasedPIDManager()
+     {
+     	if ( m_asgElectronIsEMSelector_Loose )     { delete m_asgElectronIsEMSelector_Loose; m_asgElectronIsEMSelector_Loose = nullptr; }
+     	if ( m_asgElectronIsEMSelector_Medium )    { delete m_asgElectronIsEMSelector_Medium; m_asgElectronIsEMSelector_Medium = nullptr; }
+     	if ( m_asgElectronIsEMSelector_Tight )     { delete m_asgElectronIsEMSelector_Tight; m_asgElectronIsEMSelector_Tight = nullptr; }
+     };
+     
+     
+     StatusCode setupTools( std::string confDir, std::string year ) {
+     
+        HelperClasses::EnumParser<egammaPID::PID> selectedWP_parser;
+        unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
+       
+        /*  
+	/
+	/ By converting the string to the corresponding egammaPID, we can exploit the ordering of the enum itself 
+	/ ( see ElectronPhotonID/ElectronPhotonSelectorTools/trunk/ElectronPhotonSelectorTools/TElectronIsEMSelector.h for definition)
+	/ to initialise ONLY the tools with WP tighter (or equal) the selected one.
+	/ The selected WP will be used to cut loose electrons in the selector, the tighter WPs to decorate! 
+	/
+	/ egammaPID enums :http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Reconstruction/egamma/egammaEvent/egammaEvent/egammaPIDdefs.h
+	/
+	*/       
+	
+	for ( auto it : (m_allWPs) ) {
+
+	    /* instantiate tools (do it for all) */
+            it.second =  new AsgElectronIsEMSelector( (it.first).c_str() );
+           
+            HelperClasses::EnumParser<egammaPID::PID>  itWP_parser;
+            unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
+            
+            /* if this WP is looser than user's WP, skip to next */
+            if ( itWP_enum < selectedWP_enum ) { continue; }
+
+            /* configure and initialise only tools with (WP >= selectedWP) */
+
+            it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */	    
+	    std::string config_string = confDir + "Electron" + it.first + "SelectorCutDefs" + year + ".conf";
+            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
+    	    /* set the bitmask only for samples with 2012 config */
+    	    if ( year == "2012" )  {
+    	      unsigned int EMMask = 999;
+    	      if ( (it.first).find("IsEMLoose") != std::string::npos ) {
+    		EMMask = egammaPID::ElectronLoosePP;
+    	      } else if ( (it.first).find("IsEMMedium") != std::string::npos ) {
+    		EMMask = egammaPID::ElectronMediumPP;
+    	      } else if ( (it.first).find("IsEMTight") != std::string::npos ) {
+    		EMMask = egammaPID::ElectronTightPP;
+    	      } else {
+    		Error("initialize()", "Unavailable electron cut-based PID bitmask for this operating point!");
+    		return EL::StatusCode::FAILURE;
+    	      }
+    	      RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("isEMMask", EMMask ), "Failed to set isEMMask property");
+    	    }
+            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->initialize(), "Failed to initialize tool." );
+            
+	    /* copy map element into container of valid tools for later usage */
+	    m_validWPs.insert( it );
+	    
+        }
+	
+	return StatusCode::SUCCESS;
+     
+     };
+     
+     /* set default values for decorations (do it for all WPs) */
+     StatusCode setDecorations( const xAOD::Electron* electron ) {
+       
+       for ( auto it : (m_allWPs) ) { 
+         std::string defaultDecorWP = it.first;  
+	 defaultDecorWP.erase(0,4);
+         electron->auxdecor<char>(defaultDecorWP) = -1;
+       }
+       
+       return StatusCode::SUCCESS;
+	
+     }
+
+     const std::string getSelectedWP ( ) { return m_selectedWP; }  
+     
+     /* returns a map containing all the tools */
+     std::multimap< std::string, AsgElectronIsEMSelector* > getTools() { return m_allWPs; };
+    
+     /* returns a map containing only the tools w/ (WP >= selected WP) */
+     std::multimap< std::string, AsgElectronIsEMSelector* > getValidTools() { return m_validWPs; };
+     
+   private:   
+     
+     std::string m_selectedWP;
+     
+     std::multimap<std::string, AsgElectronIsEMSelector*> m_allWPs;
+     std::multimap<std::string, AsgElectronIsEMSelector*> m_validWPs;
+
+     AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Loose;	 
+     AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Medium;	 
+     AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Tight;	 
+
+};
+
 #endif
+
+


### PR DESCRIPTION
-) Added electron cut-based PID manager class in:
      xAODAnaHelpers/ParticlePIDManager.h
-) Fixed bug in ElectronSelector and ParticlePIDManager : all the PID decorations MUST be initialised to a dummy value!
-) Added nMaxEvents option in:
      util/test_multiAlgo.cxx