### PR TITLE
ConfigName for GRID jobs.

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -29,11 +29,10 @@ xAH::Algorithm* xAH::Algorithm::setName(std::string name){
 xAH::Algorithm* xAH::Algorithm::setConfig(std::string configName){
   m_configName = configName;
   if ( !m_configName.empty() ) {
-    m_configName = gSystem->ExpandPathName( m_configName.c_str() );
     /* check if file exists
      https://root.cern.ch/root/roottalk/roottalk02/5332.html */
     FileStat_t fStats;
-    int fSuccess = gSystem->GetPathInfo(m_configName.c_str(), fStats);
+    int fSuccess = gSystem->GetPathInfo(xAH::Algorithm::getConfig(true).c_str(), fStats);
     if(fSuccess != 0){
       // could not find
       delete this;
@@ -41,6 +40,11 @@ xAH::Algorithm* xAH::Algorithm::setConfig(std::string configName){
     }
   }
   return this;
+}
+
+std::string xAH::Algorithm::getConfig(bool expand){
+  if(expand) return gSystem->ExpandPathName( m_configName.c_str() );
+  return m_configName;
 }
 
 xAH::Algorithm* xAH::Algorithm::setDebug(bool debug){

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -49,10 +49,10 @@ BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
 
 EL::StatusCode  BJetEfficiencyCorrector :: configure ()
 {
-  if(!m_configName.empty()){
-    Info("configure()", "Configuing BJetEfficiencyCorrector Interface. User configuration read from : %s ", m_configName.c_str());
+  if(!getConfig().empty()){
+    Info("configure()", "Configuing BJetEfficiencyCorrector Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     //
     // read flags set from .config file

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -65,9 +65,9 @@ BasicEventSelection :: BasicEventSelection () :
 EL::StatusCode BasicEventSelection :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
     // read in user configuration from text file
-    TEnv *config = new TEnv(m_configName.c_str());
+    TEnv *config = new TEnv(getConfig(true).c_str());
     if ( !config ) {
       Error("BasicEventSelection()", "Failed to initialize reading of config file. Exiting." );
       return EL::StatusCode::FAILURE;
@@ -195,7 +195,7 @@ EL::StatusCode BasicEventSelection :: histInitialize ()
   if ( m_triggerSelection.size() > 0 ) {
     m_cutflow_trigger  = m_cutflowHist->GetXaxis()->FindBin("Trigger");
   }
-  
+
   // do it again for the weighted cutflow hist
   m_cutflowHistW->GetXaxis()->FindBin("all");
   if(m_applyGRL)
@@ -340,7 +340,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
   // Trigger //
   if ( m_triggerSelection.size() > 0 ) {
-    
+
     m_trigConfTool = new TrigConf::xAODConfigTool( "xAODConfigTool" );
     RETURN_CHECK("BasicEventSelection::initialize()", m_trigConfTool->initialize(), "");
     ToolHandle< TrigConf::ITrigConfigTool > configHandle( m_trigConfTool );

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -61,11 +61,11 @@ ElectronCalibrator :: ElectronCalibrator () :
 EL::StatusCode  ElectronCalibrator :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
-    Info("configure()", "Configuing ElectronCalibrator Interface. User configuration read from : %s ", m_configName.c_str());
+    Info("configure()", "Configuing ElectronCalibrator Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug", false);

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -60,11 +60,11 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
 EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
-    Info("configure()", "Configuing ElectronEfficiencyCorrector Interface. User configuration read from : %s ", m_configName.c_str());
+    Info("configure()", "Configuing ElectronEfficiencyCorrector Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug", false);

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -66,11 +66,11 @@ ElectronSelector::~ElectronSelector() {}
 
 EL::StatusCode  ElectronSelector :: configure ()
 {
-  if ( !m_configName.empty() ) {
-    
-    Info("configure()", "Configuing ElectronSelector Interface. User configuration read from : %s ", m_configName.c_str());
+  if ( !getConfig().empty() ) {
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    Info("configure()", "Configuing ElectronSelector Interface. User configuration read from : %s ", getConfig().c_str());
+
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug" ,      false);
@@ -113,7 +113,7 @@ EL::StatusCode  ElectronSelector :: configure ()
     m_confDirPID              = config->GetValue("ConfDirPID", "mc15_20150224");
     // likelihood-based PID
     m_doLHPIDcut              = config->GetValue("DoLHPIDCut", false);
-    m_LHOperatingPoint        = config->GetValue("LHOperatingPoint", "Loose"); 
+    m_LHOperatingPoint        = config->GetValue("LHOperatingPoint", "Loose");
     m_LHConfigYear            = config->GetValue("LHConfigYear", "2015");
 
     // cut-based PID
@@ -297,8 +297,8 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   // initialise IsolationSelectionTool ( and ElectronIsolationTool, for DC14 )
 
-  std::string iso_tool_name = "ElectronIsolationSelectionTool_";  
-  if ( m_IsoWP != "CutBasedDC14" ) { iso_tool_name.erase(0,8); } 
+  std::string iso_tool_name = "ElectronIsolationSelectionTool_";
+  if ( m_IsoWP != "CutBasedDC14" ) { iso_tool_name.erase(0,8); }
   iso_tool_name += m_name;
 
   m_ElectronIsolationSelectionTool = new CP::ElectronIsolationSelectionTool( iso_tool_name.c_str() );
@@ -664,33 +664,33 @@ int ElectronSelector :: PassCuts( const xAOD::Electron* electron, const xAOD::Ve
   m_el_LH_PIDManager->setDecorations( electron );
 
   // retrieve only tools with WP >= selected WP, cut electrons if not satisfying selected WP, and decorate w/ tool decision all the others
-  
+
   typedef std::multimap< std::string, AsgElectronLikelihoodTool* > LHToolsMap;
   LHToolsMap myLHTools = m_el_LH_PIDManager->getValidTools();
-  
+
   if ( m_doLHPIDcut && !( ( myLHTools.find( m_LHOperatingPoint )->second )->accept( *electron ) ) ) {
       if ( m_debug ) { Info("PassCuts()", "Electron failed likelihood PID cut." ); }
       return 0;
   }
-  
+
   for ( auto it : (myLHTools) ) {
-    
+
     const std::string decorWP = it.second->getOperatingPointName( );
-    
+
     if ( m_debug ) { Info("PassCuts()", "Decorating electron with decison for LH WP : %s ", ( decorWP ).c_str() ); }
-    
+
     electron->auxdecor<char>(decorWP) = static_cast<char>( it.second->accept( *electron ) );
   }
 
   //
   // cut-based PID
   //
-  
+
   // set default values for *this* electron decorations
   m_el_CutBased_PIDManager->setDecorations( electron );
-  
+
   // retrieve only tools with WP >= selected WP, cut electrons if not satisfying selected WP, and decorate w/ tool decision all the others
-  
+
   typedef std::multimap< std::string, AsgElectronIsEMSelector* > CutBasedToolsMap;
   CutBasedToolsMap myCutBasedTools = m_el_CutBased_PIDManager->getValidTools();
 
@@ -700,11 +700,11 @@ int ElectronSelector :: PassCuts( const xAOD::Electron* electron, const xAOD::Ve
   }
 
   for ( auto it : (myCutBasedTools) ) {
-    
+
     const std::string decorWP = it.second->getOperatingPointName( );
-    
+
     if ( m_debug ) { Info("PassCuts()", "Decorating electron with decison for cut-based WP : %s ", ( decorWP ).c_str() ); }
-    
+
     electron->auxdecor<char>(decorWP) = static_cast<char>( it.second->accept( *electron ) );
   }
 

--- a/Root/JERShifter.cxx
+++ b/Root/JERShifter.cxx
@@ -64,8 +64,8 @@ EL::StatusCode JERShifter :: setupJob (EL::Job& job)
   job.useXAOD ();
   xAOD::Init( "JERShifter" ).ignore(); // call before opening first file
 
-  if(!m_configName.empty()){
-    TEnv* config = new TEnv(m_configName.c_str());
+  if(!getConfig().empty()){
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // input container to be read from TEvent or TStore
     m_inContainerName = config->GetValue("InputContainer",  "");

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -60,11 +60,11 @@ JetCalibrator :: JetCalibrator () :
 EL::StatusCode  JetCalibrator :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
-    Info("configure()", "Configuing JetCalibrator Interface. User configuration read from : %s ", m_configName.c_str());
+    Info("configure()", "Configuing JetCalibrator Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug" , false );

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -33,7 +33,7 @@ EL::StatusCode JetHistsAlgo :: histInitialize ()
 
   Info("histInitialize()", "%s", m_name.c_str() );
   // needed here and not in initalize since this is called first
-  Info("histInitialize()", "Attempting to configure using: %s", m_configName.c_str());
+  Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {
     Error("histInitialize()", "%s failed to properly configure. Exiting.", m_name.c_str() );
     return EL::StatusCode::FAILURE;
@@ -61,9 +61,9 @@ EL::StatusCode JetHistsAlgo::AddHists( std::string name ) {
 
 EL::StatusCode JetHistsAlgo :: configure ()
 {
-  if(!m_configName.empty()){
+  if(!getConfig().empty()){
     // the file exists, use TEnv to read it off
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
     // input container to be read from TEvent or TStore
     m_inContainerName         = config->GetValue("InputContainer",  "");
     // which plots will be turned on

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -60,10 +60,10 @@ JetSelector :: JetSelector () :
 
 EL::StatusCode  JetSelector :: configure ()
 {
-  if(!m_configName.empty()){
-    Info("configure()", "Configuing JetSelector Interface. User configuration read from : %s ", m_configName.c_str());
+  if(!getConfig().empty()){
+    Info("configure()", "Configuing JetSelector Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug         = config->GetValue("Debug" ,      false );

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -43,10 +43,10 @@ MuonCalibrator :: MuonCalibrator () :
 
 EL::StatusCode  MuonCalibrator :: configure ()
 {
-  if(!m_configName.empty()){
-    Info("configure()", "Configuing MuonCalibrator Interface. User configuration read from : %s ", m_configName.c_str());
+  if(!getConfig().empty()){
+    Info("configure()", "Configuing MuonCalibrator Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug", false);

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -60,11 +60,11 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
 EL::StatusCode  MuonEfficiencyCorrector :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
-    Info("configure()", "Configuing MuonEfficiencyCorrector Interface. User configuration read from : %s ", m_configName.c_str());
+    Info("configure()", "Configuing MuonEfficiencyCorrector Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug" , false );

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -61,11 +61,11 @@ MuonSelector::~MuonSelector() {}
 EL::StatusCode  MuonSelector :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
     Info("configure()", "Configuing MuonSelector Interface. User configuration read from : %s ", m_configName.c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug                   = config->GetValue("Debug" ,     false );

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -66,11 +66,11 @@ OverlapRemover :: OverlapRemover () :
 EL::StatusCode  OverlapRemover :: configure ()
 {
 
-  if ( !m_configName.empty() ) {
+  if ( !getConfig().empty() ) {
 
-    Info("configure()", "Configuing OverlapRemover Interface. User configuration read from : %s ", m_configName.c_str());
+    Info("configure()", "Configuing OverlapRemover Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug         = config->GetValue("Debug" , false );

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -36,7 +36,7 @@ EL::StatusCode TrackHistsAlgo :: histInitialize ()
 
   Info("histInitialize()", "%s", m_name.c_str() );
   // needed here and not in initalize since this is called first
-  Info("histInitialize()", "Attempting to configure using: %s", m_configName.c_str());
+  Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {
     Error("histInitialize()", "%s failed to properly configure. Exiting.", m_name.c_str() );
     return EL::StatusCode::FAILURE;
@@ -54,9 +54,9 @@ EL::StatusCode TrackHistsAlgo :: histInitialize ()
 
 EL::StatusCode TrackHistsAlgo :: configure ()
 {
-  if(!m_configName.empty()){
+  if(!getConfig().empty()){
     // the file exists, use TEnv to read it off
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     //
     //  If Container Name is already set dont read it from the config

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -38,10 +38,10 @@ TrackSelector :: TrackSelector () :
 
 EL::StatusCode  TrackSelector :: configure ()
 {
-  if(!m_configName.empty()){
-    Info("configure()", "Configuing TrackSelector Interface. User configuration read from : %s ", m_configName.c_str());
+  if(!getConfig().empty()){
+    Info("configure()", "Configuing TrackSelector Interface. User configuration read from : %s ", getConfig().c_str());
 
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
     m_debug         = config->GetValue("Debug" ,      false );

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -57,7 +57,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
 {
   Info("treeInitialize()", "%s", m_name.c_str() );
   // needed here and not in initalize since this is called first
-  Info("treeInitialize()", "Attempting to configure using: %s", m_configName.c_str());
+  Info("treeInitialize()", "Attempting to configure using: %s", getConfig().c_str());
 
   TTree * outTree = new TTree(m_name.c_str(),m_name.c_str());
   if ( !outTree ) {
@@ -82,7 +82,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
   if ( m_outHistDir ) {
     wk()->addOutput( outTree );
   }
-  
+
   // Trigger //
   Info("initialize()", "About to try to configure xAODConfigTool and TrigDecisionTool" );
   if ( !m_trigDetailStr.empty() || !m_jetTrigDetailStr.empty() ) {
@@ -100,7 +100,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
     RETURN_CHECK("TreeAlgo::initialize()", m_trigDecTool->initialize(), "");
 
   }
-  
+
 
   m_helpTree->AddEvent( m_evtDetailStr );
 
@@ -120,10 +120,10 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
 
 EL::StatusCode TreeAlgo :: configure ()
 {
-  if (!m_configName.empty()) {
-    
+  if (!getConfig().empty()) {
+
     // the file exists, use TEnv to read it off
-    TEnv* config = new TEnv(m_configName.c_str());
+    TEnv* config = new TEnv(getConfig(true).c_str());
     m_evtDetailStr            = config->GetValue("EventDetailStr",       "");
     m_trigDetailStr           = config->GetValue("TrigDetailStr",        "");
     m_jetTrigDetailStr        = config->GetValue("JetTrigDetailStr",     "");
@@ -142,7 +142,7 @@ EL::StatusCode TreeAlgo :: configure ()
     m_jetContainerName        = config->GetValue("JetContainerName",        "");
     m_fatJetContainerName     = config->GetValue("FatJetContainerName",     "");
     m_tauContainerName        = config->GetValue("TauContainerName",        "");
-    
+
     m_triggerSelection        = config->GetValue("TriggerSelection",        ".*");
 
     // DC14 switch for little things that need to happen to run
@@ -175,16 +175,16 @@ EL::StatusCode TreeAlgo :: execute ()
   const xAOD::Vertex* primaryVertex = HelperFunctions::getPrimaryVertex( vertices );
 
   m_helpTree->FillEvent( eventInfo, m_event );
-  
+
   // Fill trigger information
-  if ( !m_trigDetailStr.empty() )    {  
+  if ( !m_trigDetailStr.empty() )    {
     m_helpTree->FillTrigger( m_trigConfTool, m_trigDecTool, m_triggerSelection );
   }
-  
+
   // Fill jet trigger information
   if ( !m_jetTrigDetailStr.empty() ) {
     m_helpTree->FillJetTrigger( m_trigConfTool, m_trigDecTool );
-  } 
+  }
 
 
   // for the containers the were supplied, fill the appropriate vectors

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -35,11 +35,11 @@ EL::StatusCode Writer :: setupJob (EL::Job& job)
   job.useXAOD ();
   xAOD::Init( "Writer" ).ignore(); // call before opening first file
 
-  if(!m_configName.empty()){
-    TEnv* config = new TEnv(m_configName.c_str());
+  if(!getConfig().empty()){
+    TEnv* config = new TEnv(getConfig(true).c_str());
     if( !config ) {
       Error("Writer::setupJob()", "Failed to read config file!");
-      Error("Writer::setupJob()", "config name : %s",m_configName.c_str());
+      Error("Writer::setupJob()", "config name : %s",getConfig().c_str());
       return EL::StatusCode::FAILURE;
     }
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -20,6 +20,7 @@ namespace xAH {
 
         Algorithm* setName(std::string name);
         Algorithm* setConfig(std::string configName);
+        std::string getConfig(bool expand=false);
 
         Algorithm* setDebug(bool debug);
 


### PR DESCRIPTION
Do not expand the configName for grid jobs. Add a getConfig(expand=false) option to allow folks to grab the configuration filename if they need it.

/cc James Saxon reported this issue and this is a commit to fix it up. I'll merge when Jamie confirms it works.