### PR TITLE
Remove histInitialize, Added jet cleaning decisions

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -210,13 +210,6 @@ EL::StatusCode ElectronSelector :: histInitialize ()
 
   Info("histInitialize()", "Calling histInitialize");
 
-  if ( m_useCutFlow ) {
-    TFile *file     = wk()->getOutputFile ("cutflow");
-    m_cutflowHist  = (TH1D*)file->Get("cutflow");
-    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
-    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
-    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-  }
 
   return EL::StatusCode::SUCCESS;
 }
@@ -260,6 +253,14 @@ EL::StatusCode ElectronSelector :: initialize ()
   // input events.
 
   Info("initialize()", "Initializing ElectronSelector Interface... ");
+
+  if ( m_useCutFlow ) {
+    TFile *file     = wk()->getOutputFile ("cutflow");
+    m_cutflowHist  = (TH1D*)file->Get("cutflow");
+    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
+    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
+    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
+  }
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -551,6 +552,12 @@ EL::StatusCode ElectronSelector :: finalize ()
   if ( m_IsolationSelectionTool )         { delete m_IsolationSelectionTool; m_IsolationSelectionTool = nullptr; }
   if ( m_ElectronIsolationSelectionTool ) { delete m_ElectronIsolationSelectionTool; m_ElectronIsolationSelectionTool = nullptr; }
 
+  if ( m_useCutFlow ) {
+    Info("finalize()", "Filling cutflow");
+    m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
+    m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
+  }
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -571,11 +578,6 @@ EL::StatusCode ElectronSelector :: histFinalize ()
 
   Info("histFinalize()", "Calling histFinalize");
 
-  if ( m_useCutFlow ) {
-    Info("histFinalize()", "Filling cutflow");
-    m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
-    m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
-  }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -37,7 +37,7 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   m_DC14  = DC14;
   m_tree = tree;
   m_tree->SetDirectory( file );
-  Info("HelpTreeBase()", "HelpTreeBase setup");
+  if(m_debug) Info("HelpTreeBase()", "HelpTreeBase setup");
 
 }
 
@@ -53,7 +53,7 @@ void HelpTreeBase::Fill() {
 
 void HelpTreeBase::AddEvent( const std::string detailStr ) {
 
-  Info("AddEvent()", "Adding event variables: %s", detailStr.c_str());
+  if(m_debug)  Info("AddEvent()", "Adding event variables: %s", detailStr.c_str());
 
   m_eventInfoSwitch = new HelperClasses::EventInfoSwitch( detailStr );
 
@@ -198,7 +198,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* ev
  ********************/
 void HelpTreeBase::AddTrigger( const std::string detailStr ) {
 
-  Info("AddTrigger()", "Adding trigger variables: %s", detailStr.c_str());
+  if(m_debug) Info("AddTrigger()", "Adding trigger variables: %s", detailStr.c_str());
 
   m_trigInfoSwitch = new HelperClasses::TriggerInfoSwitch( detailStr );
 
@@ -208,7 +208,7 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
     m_tree->Branch("passL1",          &m_passL1,       "passL1/I"      );
     m_tree->Branch("passHLT",         &m_passHLT,      "passHLT/I"     );
   }
-  
+
   // Detailed trigger infoformation related to the menu (might be useful)
   // This is useful for using this database: https://atlas-trigconf.cern.ch/
   if ( m_trigInfoSwitch->m_menuKeys ) {
@@ -216,13 +216,13 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
     m_tree->Branch("L1PSKey",         &m_L1PSKey,      "L1PSKey/I"   );
     m_tree->Branch("HLTPSKey",        &m_HLTPSKey,     "HLTPSKey/I"  );
   }
-  
+
   // Trigger Decision for each and every trigger in a vector
   if ( m_trigInfoSwitch->m_allTriggers ) {
     m_tree->Branch("allTriggers",      &m_allTriggers    );   // vector of strings for trigger names
     m_tree->Branch("allTriggerDec",    &m_allTriggerDec  );   // vector of integer for trigger decisions
   }
-  
+
   this->AddTriggerUser();
 }
 
@@ -239,12 +239,12 @@ void HelpTreeBase::FillTrigger( TrigConf::xAODConfigTool* trigConfTool, Trig::Tr
   if ( m_trigInfoSwitch->m_basic ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_basic"); }
-  
+
     m_passAny = trigDecTool->isPassed(".*");
     m_passL1  = trigDecTool->isPassed("L1_.*");
     m_passHLT = trigDecTool->isPassed("HLT_.*");
   }
-    
+
   // If detailed menu information about the configuration keys, turn this on.
   // This is useful for using this database: https://atlas-trigconf.cern.ch/
   if ( m_trigInfoSwitch->m_menuKeys ) {
@@ -255,7 +255,7 @@ void HelpTreeBase::FillTrigger( TrigConf::xAODConfigTool* trigConfTool, Trig::Tr
     m_L1PSKey   = trigConfTool->lvl1PrescaleKey();
     m_HLTPSKey  = trigConfTool->hltPrescaleKey();
   }
-  
+
   // If super detailed information about each and every trigger is desired, use this
   // to build a vector of strings (trigger names) and decisions (integers or booleans)
   if ( m_trigInfoSwitch->m_allTriggers ) {
@@ -267,28 +267,28 @@ void HelpTreeBase::FillTrigger( TrigConf::xAODConfigTool* trigConfTool, Trig::Tr
     auto chainGroup = trigDecTool->getChainGroup(trigs);
     for (auto &trigName : chainGroup->getListOfTriggers()) {
       auto trigChain = trigDecTool->getChainGroup( trigName );
-      
+
       m_allTriggers.push_back   ( trigName );
       m_allTriggerDec.push_back ( trigChain->isPassed() );
     }
   }
-  
+
 }
 
 // Clear Trigger
 void HelpTreeBase::ClearTrigger() {
-  
+
   m_passAny = -1;
   m_passL1  = -1;
   m_passHLT = -1;
-  
+
   m_masterKey = 0;
   m_L1PSKey   = 0;
   m_HLTPSKey  = 0;
-  
+
   m_allTriggers.clear();
   m_allTriggerDec.clear();
-  
+
 }
 
 /*********************
@@ -311,7 +311,7 @@ void HelpTreeBase::ClearJetTrigger(  ) { }
 
 void HelpTreeBase::AddMuons(const std::string detailStr) {
 
-  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
+  if(m_debug)  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
   m_muInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr );
 
@@ -449,9 +449,9 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
  ********************/
 
 void HelpTreeBase::AddElectrons(const std::string detailStr) {
-  
-  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
-  
+
+  if(m_debug)  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
+
   m_elInfoSwitch = new HelperClasses::ElectronInfoSwitch( detailStr );
 
   // always
@@ -467,7 +467,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
   if ( m_elInfoSwitch->m_isolation ) {
     m_tree->Branch("el_isIsolated",  &m_el_isIsolated);
   }
-  
+
   if ( m_elInfoSwitch->m_PID ) {
     m_tree->Branch("el_LHVeryLoose",  &m_el_LHVeryLoose);
     m_tree->Branch("el_LHLoose",      &m_el_LHLoose);
@@ -527,14 +527,14 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       m_el_phi.push_back( (el_itr)->phi() );
       m_el_m.push_back  ( (el_itr)->m() / m_units );
     }
-  
+
     if ( m_elInfoSwitch->m_isolation ) {
       static SG::AuxElement::Accessor<char> isIsoAcc ("isIsolated");
       if ( isIsoAcc.isAvailable( *el_itr ) ) { m_el_isIsolated.push_back( isIsoAcc( *el_itr ) ); } else { m_el_isIsolated.push_back( -1 ); }
     }
-    
+
     if ( m_elInfoSwitch->m_PID ) {
-      
+
       static SG::AuxElement::Accessor<char> LHVeryLooseAcc ("LHVeryLoose");
       static SG::AuxElement::Accessor<char> LHLooseAcc ("LHLoose");
       static SG::AuxElement::Accessor<char> LHMediumAcc ("LHMedium");
@@ -550,7 +550,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       if ( LHMediumAcc.isAvailable( *el_itr ) )    { m_el_LHMedium.push_back( LHMediumAcc( *el_itr ) );       } else { m_el_LHMedium.push_back( -1 ); }
       if ( LHTightAcc.isAvailable( *el_itr ) )     { m_el_LHTight.push_back( LHTightAcc( *el_itr ) );         } else { m_el_LHTight.push_back( -1 ); }
       if ( LHVeryTightAcc.isAvailable( *el_itr ) ) { m_el_LHVeryTight.push_back( LHVeryTightAcc( *el_itr ) ); } else { m_el_LHVeryTight.push_back( -1 ); }
-      
+
       if ( EMLooseAcc.isAvailable( *el_itr ) )         { m_el_IsEMLoose.push_back( EMLooseAcc( *el_itr ) );   } else { m_el_IsEMLoose.push_back( -1 ); }
       if ( EMMediumAcc.isAvailable( *el_itr ) )        { m_el_IsEMMedium.push_back( EMMediumAcc( *el_itr ) ); } else { m_el_IsEMMedium.push_back( -1 ); }
       if ( EMTightAcc.isAvailable( *el_itr ) )         { m_el_IsEMTight.push_back( EMTightAcc( *el_itr ) );   } else { m_el_IsEMTight.push_back( -1 ); }
@@ -634,7 +634,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 void HelpTreeBase::AddJets(const std::string detailStr)
 {
 
-  Info("AddJets()", "Adding jet variables: %s", detailStr.c_str());
+  if(m_debug) Info("AddJets()", "Adding jet variables: %s", detailStr.c_str());
 
   m_jetInfoSwitch = new HelperClasses::JetInfoSwitch( detailStr );
 
@@ -664,6 +664,10 @@ void HelpTreeBase::AddJets(const std::string detailStr)
     m_tree->Branch("jet_LeadingClusterSecondLambda",    &m_jet_LeadingClusterSecondLambda  	  );
     m_tree->Branch("jet_LeadingClusterCenterLambda",    &m_jet_LeadingClusterCenterLambda  	  );
     m_tree->Branch("jet_LeadingClusterSecondR",         &m_jet_LeadingClusterSecondR  	      );
+    m_tree->Branch("jet_clean_VeryLooseBad",            &m_jet_clean_VeryLooseBad             );
+    m_tree->Branch("jet_clean_LooseBad",                &m_jet_clean_LooseBad                 );
+    m_tree->Branch("jet_clean_MediumBad",               &m_jet_clean_MediumBad                );
+    m_tree->Branch("jet_clean_TightBad",                &m_jet_clean_TightBad                 );
   }
 
   if ( m_jetInfoSwitch->m_energy ) {
@@ -892,6 +896,26 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation ) {
       if ( leadClusSecondR.isAvailable( *jet_itr ) ) {
         m_jet_LeadingClusterSecondR.push_back( leadClusSecondR( *jet_itr ) );
       } else { m_jet_LeadingClusterSecondR.push_back( -999 ); }
+
+      static SG::AuxElement::ConstAccessor<char> clean_VeryLooseBad ("clean_VeryLooseBad");
+      if ( clean_VeryLooseBad.isAvailable( *jet_itr ) ) {
+        m_jet_clean_VeryLooseBad.push_back( clean_VeryLooseBad( *jet_itr ) );
+      } else { m_jet_clean_VeryLooseBad.push_back( -1 ); }
+
+      static SG::AuxElement::ConstAccessor<char> clean_LooseBad ("clean_LooseBad");
+      if ( clean_LooseBad.isAvailable( *jet_itr ) ) {
+        m_jet_clean_LooseBad.push_back( clean_LooseBad( *jet_itr ) );
+      } else { m_jet_clean_LooseBad.push_back( -1 ); }
+
+      static SG::AuxElement::ConstAccessor<char> clean_MediumBad ("clean_MediumBad");
+      if ( clean_MediumBad.isAvailable( *jet_itr ) ) {
+        m_jet_clean_MediumBad.push_back( clean_MediumBad( *jet_itr ) );
+      } else { m_jet_clean_MediumBad.push_back( -1 ); }
+
+      static SG::AuxElement::ConstAccessor<char> clean_TightBad ("clean_TightBad");
+      if ( clean_TightBad.isAvailable( *jet_itr ) ) {
+        m_jet_clean_TightBad.push_back( clean_TightBad( *jet_itr ) );
+      } else { m_jet_clean_TightBad.push_back( -1 ); }
 
     } // clean
 
@@ -1491,7 +1515,7 @@ void HelpTreeBase::ClearElectrons() {
   if ( m_elInfoSwitch->m_isolation ) {
     m_el_isIsolated.clear();
   }
-  
+
   if ( m_elInfoSwitch->m_PID ) {
     m_el_LHVeryLoose.clear();
     m_el_LHLoose.clear();
@@ -1523,9 +1547,9 @@ void HelpTreeBase::ClearElectrons() {
     m_el_trknTRTHits.clear();
     m_el_trknTRTHoles.clear();
     m_el_trknBLayerHits.clear();
-    if ( !m_DC14 ) {    
+    if ( !m_DC14 ) {
       m_el_trknInnermostPixLayHits.clear();
-      m_el_trkPixdEdX.clear();    
+      m_el_trkPixdEdX.clear();
     }
   }
 
@@ -1557,6 +1581,10 @@ void HelpTreeBase::ClearJets() {
     m_jet_LeadingClusterSecondLambda.clear();
     m_jet_LeadingClusterCenterLambda.clear();
     m_jet_LeadingClusterSecondR.clear();
+    m_jet_clean_VeryLooseBad.clear();
+    m_jet_clean_LooseBad.clear();
+    m_jet_clean_MediumBad.clear();
+    m_jet_clean_TightBad.clear();
   }
 
   // energy

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -900,22 +900,22 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation ) {
       static SG::AuxElement::ConstAccessor<char> clean_VeryLooseBad ("clean_VeryLooseBad");
       if ( clean_VeryLooseBad.isAvailable( *jet_itr ) ) {
         m_jet_clean_VeryLooseBad.push_back( clean_VeryLooseBad( *jet_itr ) );
-      } else { m_jet_clean_VeryLooseBad.push_back( -1 ); }
+      } else { m_jet_clean_VeryLooseBad.push_back( -999 ); }
 
       static SG::AuxElement::ConstAccessor<char> clean_LooseBad ("clean_LooseBad");
       if ( clean_LooseBad.isAvailable( *jet_itr ) ) {
         m_jet_clean_LooseBad.push_back( clean_LooseBad( *jet_itr ) );
-      } else { m_jet_clean_LooseBad.push_back( -1 ); }
+      } else { m_jet_clean_LooseBad.push_back( -999 ); }
 
       static SG::AuxElement::ConstAccessor<char> clean_MediumBad ("clean_MediumBad");
       if ( clean_MediumBad.isAvailable( *jet_itr ) ) {
         m_jet_clean_MediumBad.push_back( clean_MediumBad( *jet_itr ) );
-      } else { m_jet_clean_MediumBad.push_back( -1 ); }
+      } else { m_jet_clean_MediumBad.push_back( -999 ); }
 
       static SG::AuxElement::ConstAccessor<char> clean_TightBad ("clean_TightBad");
       if ( clean_TightBad.isAvailable( *jet_itr ) ) {
         m_jet_clean_TightBad.push_back( clean_TightBad( *jet_itr ) );
-      } else { m_jet_clean_TightBad.push_back( -1 ); }
+      } else { m_jet_clean_TightBad.push_back( -999 ); }
 
     } // clean
 
@@ -1182,7 +1182,6 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation ) {
           e.  push_back( constit->e() / m_units  );
         }
       }
-      xAOD::JetConstituentVector vec = jet_itr->getConstituents();
       m_jet_numConstituents.push_back( jet_itr->numConstituents() );
       m_jet_constit_pt. push_back( pt  );
       m_jet_constit_eta.push_back( eta );

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -32,17 +32,6 @@ EL::StatusCode JetHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-  // needed here and not in initalize since this is called first
-  Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
-  if ( this->configure() == EL::StatusCode::FAILURE ) {
-    Error("histInitialize()", "%s failed to properly configure. Exiting.", m_name.c_str() );
-    return EL::StatusCode::FAILURE;
-  } else {
-    Info("histInitialize()", "Succesfully configured! ");
-  }
-
-  // only running 1 collection
-  if(m_inputAlgo.empty()) { AddHists( "" ); }
 
   return EL::StatusCode::SUCCESS;
 }
@@ -95,6 +84,18 @@ EL::StatusCode JetHistsAlgo :: changeInput (bool /*firstFile*/) { return EL::Sta
 EL::StatusCode JetHistsAlgo :: initialize ()
 {
   Info("initialize()", m_name.c_str());
+
+  // needed here and not in initalize since this is called first
+  Info("histInitialize()", "Attempting to configure using: %s", m_configName.c_str());
+  if ( this->configure() == EL::StatusCode::FAILURE ) {
+    Error("histInitialize()", "%s failed to properly configure. Exiting.", m_name.c_str() );
+    return EL::StatusCode::FAILURE;
+  } else {
+    Info("histInitialize()", "Succesfully configured! ");
+  }
+
+  // only running 1 collection
+  if(m_inputAlgo.empty()) { AddHists( "" ); }
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
   return EL::StatusCode::SUCCESS;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -205,13 +205,6 @@ EL::StatusCode JetSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  if ( m_useCutFlow ) {
-    TFile *file = wk()->getOutputFile ("cutflow");
-    m_cutflowHist  = (TH1D*)file->Get("cutflow");
-    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
-    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
-    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-  }
 
   return EL::StatusCode::SUCCESS;
 }
@@ -253,6 +246,14 @@ EL::StatusCode JetSelector :: initialize ()
   // doesn't get called if no events are processed.  So any objects
   // you create here won't be available in the output if you have no
   // input events.
+  Info("initialize()", "Calling initialize");
+  if ( m_useCutFlow ) {
+    TFile *file = wk()->getOutputFile ("cutflow");
+    m_cutflowHist  = (TH1D*)file->Get("cutflow");
+    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
+    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
+    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
+  }
 
   if ( this->configure() == EL::StatusCode::FAILURE ) {
     Error("initialize()", "Failed to properly configure. Exiting." );

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -192,14 +192,6 @@ EL::StatusCode MuonSelector :: histInitialize ()
 
   Info("histInitialize()", "Calling histInitialize");
 
-  if ( m_useCutFlow ) {
-    TFile *file = wk()->getOutputFile ("cutflow");
-    m_cutflowHist  = (TH1D*)file->Get("cutflow");
-    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
-    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
-    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-  }
-
   return EL::StatusCode::SUCCESS;
 }
 
@@ -242,6 +234,14 @@ EL::StatusCode MuonSelector :: initialize ()
   // input events.
 
   Info("initialize()", "Initializing MuonSelector Interface... ");
+
+  if ( m_useCutFlow ) {
+    TFile *file = wk()->getOutputFile ("cutflow");
+    m_cutflowHist  = (TH1D*)file->Get("cutflow");
+    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
+    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
+    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
+  }
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -412,6 +412,12 @@ EL::StatusCode MuonSelector :: finalize ()
 
   if ( m_muonSelectionTool ) { delete m_muonSelectionTool; m_muonSelectionTool = nullptr; }
 
+  if ( m_useCutFlow ) {
+    Info("histFinalize()", "Filling cutflow");
+    m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
+    m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
+  }
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -431,12 +437,6 @@ EL::StatusCode MuonSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
-  if ( m_useCutFlow ) {
-    Info("histFinalize()", "Filling cutflow");
-    m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
-    m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
-  }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -138,13 +138,6 @@ EL::StatusCode TrackSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  if(m_useCutFlow) {
-    TFile *file = wk()->getOutputFile ("cutflow");
-    m_cutflowHist  = (TH1D*)file->Get("cutflow");
-    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
-    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
-    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-  }
 
   return EL::StatusCode::SUCCESS;
 }
@@ -186,6 +179,14 @@ EL::StatusCode TrackSelector :: initialize ()
   // doesn't get called if no events are processed.  So any objects
   // you create here won't be available in the output if you have no
   // input events.
+
+  if(m_useCutFlow) {
+    TFile *file = wk()->getOutputFile ("cutflow");
+    m_cutflowHist  = (TH1D*)file->Get("cutflow");
+    m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
+    m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
+    m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
+  }
 
   if ( this->configure() == EL::StatusCode::FAILURE ) {
     Error("initialize()", "Failed to properly configure. Exiting." );

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -44,6 +44,8 @@ class BasicEventSelection : public xAH::Algorithm
     TrigConf::xAODConfigTool*    m_trigConfTool;  //!
     Trig::TrigDecisionTool*      m_trigDecTool;   //!
 
+    bool m_isMC;      //!
+
     int m_eventCounter;     //!
 
     // read from MetaData

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -209,10 +209,10 @@ protected:
   std::vector<float> m_jet_LeadingClusterSecondLambda;
   std::vector<float> m_jet_LeadingClusterCenterLambda;
   std::vector<float> m_jet_LeadingClusterSecondR;
-  std::vector<char> m_jet_clean_VeryLooseBad;
-  std::vector<char> m_jet_clean_LooseBad;
-  std::vector<char> m_jet_clean_MediumBad;
-  std::vector<char> m_jet_clean_TightBad;
+  std::vector<int> m_jet_clean_VeryLooseBad;
+  std::vector<int> m_jet_clean_LooseBad;
+  std::vector<int> m_jet_clean_MediumBad;
+  std::vector<int> m_jet_clean_TightBad;
 
   // energy
   std::vector<float> m_jet_HECf;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -6,7 +6,7 @@
  * need to be added by the user
  *
  * Gabriel Facini ( gabriel.facini@cern.ch ), Marco Milesi (marco.milesi@cern.ch)
- * 
+ *
  *
  ***************************************************/
 
@@ -53,7 +53,7 @@ public:
   void AddJets        (const std::string detailStr = "");
   void AddFatJets     (const std::string detailStr = "");
   void AddTaus        (const std::string detailStr = "");
-  
+
 
   // control which branches are filled
   HelperClasses::EventInfoSwitch*      m_eventInfoSwitch;
@@ -64,7 +64,7 @@ public:
   HelperClasses::JetInfoSwitch*        m_jetInfoSwitch;
   HelperClasses::JetInfoSwitch*        m_fatJetInfoSwitch;
   HelperClasses::TauInfoSwitch*        m_tauInfoSwitch;
-  
+
 
   void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event = 0 );
   void FillTrigger( TrigConf::xAODConfigTool* trigConfTool, Trig::TrigDecisionTool* trigDecTool, std::string trigs = ".*" );
@@ -86,42 +86,42 @@ public:
 
   bool writeTo( TFile *file );
 
-  virtual void AddEventUser(const std::string detailStr = "")      { 
-    Info("AddEventUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+  virtual void AddEventUser(const std::string detailStr = "")      {
+    if(m_debug) Info("AddEventUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
-  virtual void AddTriggerUser(const std::string detailStr = "")      { 
-    Info("AddTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+  virtual void AddTriggerUser(const std::string detailStr = "")      {
+    if(m_debug) Info("AddTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
-  virtual void AddJetTriggerUser(const std::string detailStr = "")      { 
-    Info("AddTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+  virtual void AddJetTriggerUser(const std::string detailStr = "")      {
+    if(m_debug) Info("AddTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
   virtual void AddMuonsUser(const std::string detailStr = "")      {
-    Info("AddMuonsUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+    if(m_debug) Info("AddMuonsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
   virtual void AddElectronsUser(const std::string detailStr = "")  {
-    Info("AddElectronsUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+    if(m_debug) Info("AddElectronsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
   virtual void AddJetsUser(const std::string detailStr = "")       {
-    Info("AddJetsUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+    if(m_debug) Info("AddJetsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
   virtual void AddTausUser(const std::string detailStr = "")       {
-    Info("AddTausUser","Empty function called from HelpTreeBase %s",detailStr.c_str()); 
-    return; 
+    if(m_debug) Info("AddTausUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    return;
   };
-  
+
   virtual void ClearEventUser()     { return; };
   virtual void ClearTriggerUser()   { return; };
   virtual void ClearMuonsUser()     { return; };
   virtual void ClearElectronsUser() { return; };
   virtual void ClearJetsUser() 	    { return; };
   virtual void ClearTausUser() 	    { return; };
-  
+
 
   virtual void FillEventUser( const xAOD::EventInfo* /*eventInfo*/ )        { return; };
   virtual void FillMuonsUser( const xAOD::Muon* /*muon*/ )                  { return; };
@@ -129,17 +129,17 @@ public:
   virtual void FillJetsUser( const xAOD::Jet* /*jet*/ )                     { return; };
   virtual void FillFatJetsUser( const xAOD::Jet* /*fatJet*/ )               { return; };
   virtual void FillTausUser( const xAOD::TauJet* /*tau*/ )                  { return; };
-  
+
   virtual void FillTriggerUser( TrigConf::xAODConfigTool* /* trigConfTool */, Trig::TrigDecisionTool* /* trigDecTool */ )      { return; };
   virtual void FillJetTriggerUser( TrigConf::xAODConfigTool* /* trigConfTool */, Trig::TrigDecisionTool* /* trigDecTool */ )   { return; };
-  
+
 
 protected:
 
   TTree* m_tree;
 
   int m_units; //For MeV to GeV conversion in output
-  
+
   bool m_debug;
   bool m_DC14;
 
@@ -170,7 +170,7 @@ protected:
   //float m_pdf2;
   float m_xf1;
   float m_xf2;
-  
+
   // trigger
   int m_passAny;
   int m_passL1;
@@ -180,7 +180,7 @@ protected:
   unsigned int m_HLTPSKey;
   std::vector<std::string> m_allTriggers;
   std::vector<int> m_allTriggerDec;
-  
+
   // jet trigger
 
   // jets
@@ -209,6 +209,10 @@ protected:
   std::vector<float> m_jet_LeadingClusterSecondLambda;
   std::vector<float> m_jet_LeadingClusterCenterLambda;
   std::vector<float> m_jet_LeadingClusterSecondR;
+  std::vector<char> m_jet_clean_VeryLooseBad;
+  std::vector<char> m_jet_clean_LooseBad;
+  std::vector<char> m_jet_clean_MediumBad;
+  std::vector<char> m_jet_clean_TightBad;
 
   // energy
   std::vector<float> m_jet_HECf;
@@ -319,13 +323,13 @@ protected:
 
   // muons
   int m_nmuon;
-  
+
   // kinematics
   std::vector<float> m_muon_pt;
   std::vector<float> m_muon_eta;
   std::vector<float> m_muon_phi;
   std::vector<float> m_muon_m;
-  
+
   // track parameters
   std::vector<float> m_muon_trkd0;
   std::vector<float> m_muon_trkd0sig;
@@ -335,7 +339,7 @@ protected:
   std::vector<float> m_muon_trktheta;
   std::vector<float> m_muon_trkcharge;
   std::vector<float> m_muon_trkqOverP;
-  
+
   // track hit content
   std::vector<int> m_muon_trknSiHits;
   std::vector<int> m_muon_trknPixHits;
@@ -344,22 +348,22 @@ protected:
   std::vector<int> m_muon_trknSCTHoles;
   std::vector<int> m_muon_trknTRTHits;
   std::vector<int> m_muon_trknTRTHoles;
-  std::vector<int> m_muon_trknBLayerHits; 
+  std::vector<int> m_muon_trknBLayerHits;
   std::vector<int> m_muon_trknInnermostPixLayHits; // not available in DC14
   std::vector<float> m_muon_trkPixdEdX;            // not available in DC14
 
   // electrons
   int m_nel;
-  
+
   // kinematics
   std::vector<float> m_el_pt;
   std::vector<float> m_el_phi;
   std::vector<float> m_el_eta;
   std::vector<float> m_el_m;
-  
+
   // isolation
   std::vector<int>   m_el_isIsolated;
-  
+
   // PID
   std::vector<int>   m_el_LHVeryLoose;
   std::vector<int>   m_el_LHLoose;
@@ -369,7 +373,7 @@ protected:
   std::vector<int>   m_el_IsEMLoose;
   std::vector<int>   m_el_IsEMMedium;
   std::vector<int>   m_el_IsEMTight;
- 
+
   // track parameters
   std::vector<float> m_el_trkd0;
   std::vector<float> m_el_trkd0sig;
@@ -379,7 +383,7 @@ protected:
   std::vector<float> m_el_trktheta;
   std::vector<float> m_el_trkcharge;
   std::vector<float> m_el_trkqOverP;
-  
+
   // track hit content
   std::vector<int> m_el_trknSiHits;
   std::vector<int> m_el_trknPixHits;
@@ -388,13 +392,13 @@ protected:
   std::vector<int> m_el_trknSCTHoles;
   std::vector<int> m_el_trknTRTHits;
   std::vector<int> m_el_trknTRTHoles;
-  std::vector<int> m_el_trknBLayerHits; 
+  std::vector<int> m_el_trknBLayerHits;
   std::vector<int> m_el_trknInnermostPixLayHits; // not available in DC14
   std::vector<float> m_el_trkPixdEdX;            // not available in DC14
 
   // taus
   int m_ntau;
-  
+
   // kinematics
   std::vector<float> m_tau_pt;
   std::vector<float> m_tau_eta;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -32,7 +32,8 @@ public:
   std::string m_calibConfigAFII;        //!
   std::string m_calibConfig;            //!
   std::string m_calibSequence;          //!
-  std::string m_jetCalibCutLevel;   //!
+  std::string m_jetCalibCutLevel;       //!
+  bool m_saveAllCleanDecisions;         //!
   std::string m_uncertConfig;           //!
   // sort after calibration
   bool    m_sort;                   //!
@@ -55,9 +56,12 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  JetCalibrationTool    * m_jetCalibration; //!
-  JetCleaningTool       * m_jetCleaning;    //!
-  JetUncertaintiesTool  * m_jetUncert;      //!
+  JetCalibrationTool       * m_jetCalibration; //!
+  JetCleaningTool          * m_jetCleaning;    //!
+  std::vector<std::string>  m_decisionNames;    //!
+  std::vector< JetCleaningTool* > m_allJetCleaningTools;   //!
+
+  JetUncertaintiesTool     * m_jetUncert;      //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
Everything moved out of histInitialize and into initialize to allow for m_isMC and other meta-data checking.  Nothing should be used in histInitialize from here on out.  Also added option to save all cleaning decisions into the output tree.

/cc @gfacini @mmilesi @kratsg