### PR TITLE
Streamablize it all.

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -44,6 +44,27 @@ BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
 
   Info("BJetEfficiencyCorrector()", "Calling constructor");
 
+  // read flags set from .config file
+  m_debug                   = false;
+  m_inContainerName         = "";
+  m_systName                = "";      // default: no syst
+  m_outputSystName          = "BJetEfficiency_Algo";
+
+  // configuration of the bjet eff tool
+  m_corrFileName           = "2014-Winter-8TeV-MC12-CDI.root";
+  m_jetAuthor              = "AntiKt4TopoEMJVF0_5";
+  m_taggerName             = "MV1";
+  m_useDevelopmentFile     = true;
+  m_coneFlavourLabel       = true;
+
+  // Btag quality
+  m_btag_veryloose          = false;
+  m_btag_loose              = false;
+  m_btag_medium             = false;
+  m_btag_tight              = false;
+
+  m_decor                   = "BTag_SF";
+
 }
 
 
@@ -57,29 +78,29 @@ EL::StatusCode  BJetEfficiencyCorrector :: configure ()
     //
     // read flags set from .config file
     //
-    m_debug                   = config->GetValue("Debug" , false );
-    m_inContainerName         = config->GetValue("InputContainer",  "");
-    m_systName                = config->GetValue("SystName" ,       "" );      // default: no syst
-    m_outputSystName          = config->GetValue("OutputSystName",  "BJetEfficiency_Algo");
+    m_debug                   = config->GetValue("Debug" , m_debug );
+    m_inContainerName         = config->GetValue("InputContainer", m_inContainerName.c_str());
+    m_systName                = config->GetValue("SystName" ,       m_systName.c_str() );      // default: no syst
+    m_outputSystName          = config->GetValue("OutputSystName",  m_outputSystName.c_str() );
 
     //
     // configuration of the bjet eff tool
     //
-    m_corrFileName           = config->GetValue("CorrectionFileName", "2014-Winter-8TeV-MC12-CDI.root" );
-    m_jetAuthor              = config->GetValue("JetAuthor",          "AntiKt4TopoEMJVF0_5" );
-    m_taggerName             = config->GetValue("TaggerName",         "MV1" );
-    m_useDevelopmentFile     = config->GetValue("UseDevelopmentFile", true );
-    m_coneFlavourLabel       = config->GetValue("ConeFlavourLabel",   true );
+    m_corrFileName           = config->GetValue("CorrectionFileName", m_corrFileName.c_str() );
+    m_jetAuthor              = config->GetValue("JetAuthor",          m_jetAuthor.c_str() );
+    m_taggerName             = config->GetValue("TaggerName",         m_taggerName.c_str() );
+    m_useDevelopmentFile     = config->GetValue("UseDevelopmentFile", m_useDevelopmentFile);
+    m_coneFlavourLabel       = config->GetValue("ConeFlavourLabel",   m_coneFlavourLabel);
 
     //
     // Btag quality
     //
-    m_btag_veryloose          = config->GetValue("BTagVeryLoose",   false);
-    m_btag_loose              = config->GetValue("BTagLoose",       false);
-    m_btag_medium             = config->GetValue("BTagMedium",      false);
-    m_btag_tight              = config->GetValue("BTagTight",       false);
+    m_btag_veryloose          = config->GetValue("BTagVeryLoose",   m_btag_veryloose);
+    m_btag_loose              = config->GetValue("BTagLoose",       m_btag_loose);
+    m_btag_medium             = config->GetValue("BTagMedium",      m_btag_medium);
+    m_btag_tight              = config->GetValue("BTagTight",       m_btag_tight);
 
-    m_decor                   = config->GetValue("DecorationName", "BTag_SF");
+    m_decor                   = config->GetValue("DecorationName", m_decor.c_str());
 
     config->Print();
     Info("configure()", "BJetEfficiencyCorrector Interface succesfully configured! ");

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -55,6 +55,22 @@ ElectronCalibrator :: ElectronCalibrator () :
 
   Info("ElectronCalibrator()", "Calling constructor");
 
+  // read debug flag from .config file
+  m_debug                   = false;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+  m_outContainerName        = "";
+
+  // Systematics stuff
+  m_inputAlgoSystNames      = "";
+  m_outputAlgoSystNames     = "ElectronCalibrator_Syst";
+  m_runSysts                = false; // gets set later is syst applies to this tool
+  m_systName		      = "";
+  m_systVal 		      = 0.;
+
+  m_sort                    = true;
+
 }
 
 
@@ -68,20 +84,20 @@ EL::StatusCode  ElectronCalibrator :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug", false);
+    m_debug                   = config->GetValue("Debug", m_debug);
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
 
    // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");
-    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", "ElectronCalibrator_Syst");
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", m_outputAlgoSystNames.c_str());
     m_runSysts                = false; // gets set later is syst applies to this tool
-    m_systName		      = config->GetValue("SystName" , "" );
-    m_systVal 		      = config->GetValue("SystVal" , 0. );
+    m_systName		      = config->GetValue("SystName" , m_systName.c_str() );
+    m_systVal 		      = config->GetValue("SystVal" , m_systVal );
     m_runAllSyst              = (m_systName.find("All") != std::string::npos);
 
-    m_sort                    = config->GetValue("Sort",  true);
+    m_sort                    = config->GetValue("Sort", m_sort);
 
     config->Print();
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -54,6 +54,21 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
 
   Info("ElectronEfficiencyCorrector()", "Calling constructor");
 
+  // read debug flag from .config file
+  m_debug                   = false;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+
+  // Systematics stuff
+  m_inputAlgoSystNames      = "";
+  m_systName		      = "";
+  m_outputSystNames         = "ElectronEfficiencyCorrector_Syst";
+  m_systVal 		      = 0.;
+
+  // file(s) containing corrections
+  m_corrFileName1           = "";
+
 }
 
 
@@ -67,19 +82,19 @@ EL::StatusCode  ElectronEfficiencyCorrector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug", false);
+    m_debug                   = config->GetValue("Debug", m_debug);
 
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");
-    m_systName		      = config->GetValue("SystName" , "" );
-    m_outputSystNames         = config->GetValue("OutputSystNames",  "ElectronEfficiencyCorrector_Syst");
-    m_systVal 		      = config->GetValue("SystVal" , 0. );
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_systName		      = config->GetValue("SystName" , m_systName.c_str());
+    m_outputSystNames         = config->GetValue("OutputSystNames",  m_outputSystNames.c_str());
+    m_systVal 		      = config->GetValue("SystVal" , m_systVal);
     m_runAllSyst              = (m_systName.find("All") != std::string::npos);
     // file(s) containing corrections
-    m_corrFileName1           = config->GetValue("CorrectionFileName1" , "" );
+    m_corrFileName1           = config->GetValue("CorrectionFileName1" , m_corrFileName1.c_str());
     //m_corrFileName2         = config->GetValue("CorrectionFileName2" , "" );
 
     config->Print();

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -60,6 +60,70 @@ ElectronSelector :: ElectronSelector () :
   // initialize().
 
   Info("ElectronSelector()", "Calling constructor");
+
+  // read debug flag from .config file
+  m_debug                   = false;
+  m_useCutFlow              = true;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+
+  // Systematics stuff
+  m_inputAlgoSystNames      = "";
+  m_outputAlgoSystNames     = "ElectronSelector_Syst";
+
+
+  // decorate selected objects that pass the cuts
+  m_decorateSelectedObjects = true;
+  // additional functionality : create output container of selected objects
+  //                            using the SG::View_Element option
+  //                            decorrating and output container should not be mutually exclusive
+  m_createSelectedContainer = false;
+  // if requested, a new container is made using the SG::View_Element option
+  m_outContainerName        = "";
+
+  // if only want to look at a subset of object
+  m_nToProcess              = -1;
+
+  // configurable cuts
+  m_pass_max                = -1;
+  m_pass_min                = -1;
+  m_pT_max                  = 1e8;
+  m_pT_min                  = 1e8;
+  m_eta_max                 = 1e8;
+  m_vetoCrack               = true;
+  m_d0_max                  = 1e8;
+  m_d0sig_max     	      = 1e8;
+  m_z0sintheta_max          = 1e8;
+
+  m_doAuthorCut             = true;
+  m_doOQCut                 = true;
+
+  m_confDirPID              = "mc15_20150224";
+  // likelihood-based PID
+  m_doLHPIDcut              = false;
+  m_LHOperatingPoint        = "Loose";
+  m_LHConfigYear            = "2015";
+
+  // cut-based PID
+  m_doCutBasedPIDcut        = false;
+  m_CutBasedOperatingPoint  = "IsEMLoose";
+  m_CutBasedConfigYear      = "2012";
+
+  // isolation stuff
+  m_doIsolation             = false;
+  m_IsoWP		            = "Tight";
+  m_CaloIsoEff              = "0.1*x+90";  // only if isolation WP is "UserDefined"
+  m_TrackIsoEff             = "98";        // only if isolation WP is "UserDefined"
+  m_useRelativeIso          = true;
+  m_CaloBasedIsoType        = "topoetcone20";
+  m_CaloBasedIsoCut         = 0.05;
+  m_TrackBasedIsoType       = "ptvarcone20";
+  m_TrackBasedIsoCut        = 0.05;
+
+  m_passAuxDecorKeys        = "";
+  m_failAuxDecorKeys        = "";
+
 }
 
 ElectronSelector::~ElectronSelector() {}
@@ -73,67 +137,67 @@ EL::StatusCode  ElectronSelector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug" ,      false);
-    m_useCutFlow              = config->GetValue("UseCutFlow",  true);
+    m_debug                   = config->GetValue("Debug" ,      m_debug);
+    m_useCutFlow              = config->GetValue("UseCutFlow",  m_useCutFlow);
 
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");
-    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", "ElectronSelector_Syst");
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", m_outputAlgoSystNames.c_str());
 
 
     // decorate selected objects that pass the cuts
-    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", true);
+    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     // additional functionality : create output container of selected objects
     //                            using the SG::View_Element option
     //                            decorrating and output container should not be mutually exclusive
-    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", false);
+    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", m_createSelectedContainer);
     // if requested, a new container is made using the SG::View_Element option
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
 
     // if only want to look at a subset of object
-    m_nToProcess              = config->GetValue("NToProcess", -1);
+    m_nToProcess              = config->GetValue("NToProcess", m_nToProcess);
 
     // configurable cuts
-    m_pass_max                = config->GetValue("PassMax", -1);
-    m_pass_min                = config->GetValue("PassMin", -1);
-    m_pT_max                  = config->GetValue("pTMax",  1e8);
-    m_pT_min                  = config->GetValue("pTMin",  1e8);
-    m_eta_max                 = config->GetValue("etaMax", 1e8);
-    m_vetoCrack               = config->GetValue("VetoCrack", true);
-    m_d0_max                  = config->GetValue("d0Max", 1e8);
-    m_d0sig_max     	      = config->GetValue("d0sigMax", 1e8);
-    m_z0sintheta_max          = config->GetValue("z0sinthetaMax", 1e8);
+    m_pass_max                = config->GetValue("PassMax", m_pass_max);
+    m_pass_min                = config->GetValue("PassMin", m_pass_min);
+    m_pT_max                  = config->GetValue("pTMax",  m_pT_max);
+    m_pT_min                  = config->GetValue("pTMin",  m_pT_min);
+    m_eta_max                 = config->GetValue("etaMax", m_eta_max);
+    m_vetoCrack               = config->GetValue("VetoCrack", m_vetoCrack);
+    m_d0_max                  = config->GetValue("d0Max", m_d0_max);
+    m_d0sig_max     	      = config->GetValue("d0sigMax", m_d0sig_max);
+    m_z0sintheta_max          = config->GetValue("z0sinthetaMax", m_z0sintheta_max);
 
-    m_doAuthorCut             = config->GetValue("DoAuthorCut", true);
-    m_doOQCut                 = config->GetValue("DoOQCut", true);
+    m_doAuthorCut             = config->GetValue("DoAuthorCut", m_doAuthorCut);
+    m_doOQCut                 = config->GetValue("DoOQCut", m_doOQCut);
 
-    m_confDirPID              = config->GetValue("ConfDirPID", "mc15_20150224");
+    m_confDirPID              = config->GetValue("ConfDirPID", m_confDirPID.c_str());
     // likelihood-based PID
-    m_doLHPIDcut              = config->GetValue("DoLHPIDCut", false);
-    m_LHOperatingPoint        = config->GetValue("LHOperatingPoint", "Loose");
-    m_LHConfigYear            = config->GetValue("LHConfigYear", "2015");
+    m_doLHPIDcut              = config->GetValue("DoLHPIDCut", m_doLHPIDcut);
+    m_LHOperatingPoint        = config->GetValue("LHOperatingPoint", m_LHOperatingPoint.c_str());
+    m_LHConfigYear            = config->GetValue("LHConfigYear", m_LHConfigYear.c_str());
 
     // cut-based PID
-    m_doCutBasedPIDcut        = config->GetValue("DoCutBasedPIDCut", false);
-    m_CutBasedOperatingPoint  = config->GetValue("CutBasedOperatingPoint", "IsEMLoose");
-    m_CutBasedConfigYear      = config->GetValue("CutBasedConfigYear", "2012");
+    m_doCutBasedPIDcut        = config->GetValue("DoCutBasedPIDCut", m_doCutBasedPIDcut);
+    m_CutBasedOperatingPoint  = config->GetValue("CutBasedOperatingPoint", m_CutBasedOperatingPoint.c_str());
+    m_CutBasedConfigYear      = config->GetValue("CutBasedConfigYear", m_CutBasedConfigYear.c_str());
 
     // isolation stuff
-    m_doIsolation             = config->GetValue("DoIsolationCut"    ,  false);
-    m_IsoWP		      = config->GetValue("IsolationWP"       ,  "Tight");
-    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  "0.1*x+90");  // only if isolation WP is "UserDefined"
-    m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  "98");        // only if isolation WP is "UserDefined"
-    m_useRelativeIso          = config->GetValue("UseRelativeIso"    ,  true );
-    m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  "topoetcone20");
-    m_CaloBasedIsoCut         = config->GetValue("CaloBasedIsoCut"   ,  0.05 );
-    m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  "ptvarcone20");
-    m_TrackBasedIsoCut        = config->GetValue("TrackBasedIsoCut"  ,  0.05 );
+    m_doIsolation             = config->GetValue("DoIsolationCut"    ,  m_doIsolation);
+    m_IsoWP		      = config->GetValue("IsolationWP"       ,  m_IsoWP.c_str());
+    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());  // only if isolation WP is "UserDefined"
+    m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  m_TrackIsoEff.c_str());        // only if isolation WP is "UserDefined"
+    m_useRelativeIso          = config->GetValue("UseRelativeIso"    ,  m_useRelativeIso);
+    m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  m_CaloBasedIsoType.c_str());
+    m_CaloBasedIsoCut         = config->GetValue("CaloBasedIsoCut"   ,  m_CaloBasedIsoCut);
+    m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  m_TrackBasedIsoType.c_str());
+    m_TrackBasedIsoCut        = config->GetValue("TrackBasedIsoCut"  ,  m_TrackBasedIsoCut);
 
-    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", "");
-    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", "");
+    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", m_passAuxDecorKeys.c_str());
+    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", m_failAuxDecorKeys.c_str());
 
     config->Print();
 

--- a/Root/JERShifter.cxx
+++ b/Root/JERShifter.cxx
@@ -49,6 +49,16 @@ JERShifter :: JERShifter ()
   // called on both the submission and the worker node.  Most of your
   // initialization code will go into histInitialize() and
   // initialize().
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName = "";
+
+  // output container to be put into TStore
+  m_outContainerName  	= "";
+
+  m_jetAlgo             = "";
+  m_debug                   = false;
+
 }
 
 
@@ -68,13 +78,13 @@ EL::StatusCode JERShifter :: setupJob (EL::Job& job)
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // input container to be read from TEvent or TStore
-    m_inContainerName = config->GetValue("InputContainer",  "");
+    m_inContainerName = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // output container to be put into TStore
-    m_outContainerName  	= config->GetValue("OutputContainer", "");
+    m_outContainerName  	= config->GetValue("OutputContainer", m_outContainerName.c_str());
 
-    m_jetAlgo             = config->GetValue("JetAlgorithm",    "");
-    m_debug                   = config->GetValue("Debug" ,           false );
+    m_jetAlgo             = config->GetValue("JetAlgorithm",    m_jetAlgo.c_str());
+    m_debug                   = config->GetValue("Debug" ,           m_debug);
 
     delete config;
   }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -55,6 +55,40 @@ JetCalibrator :: JetCalibrator () :
 
   Info("JetCalibrator()", "Calling constructor");
 
+
+  // read debug flag from .config file
+  m_debug                   = false;
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+
+  // DC14 switch for little things that need to happen to run
+  // for those samples with the corresponding packages
+  m_DC14                    = false;
+
+  // CONFIG parameters for JetCalibrationTool
+  m_jetAlgo                 = "";
+  m_outputAlgo              = "";
+
+  // when running data "_Insitu" is appended to this string
+  m_calibSequence           = "JetArea_Residual_Origin_EtaJES_GSC";
+  m_calibConfigFullSim      = "JES_MC15Prerecommendation_April2015.config";
+  m_calibConfigAFII         = "JES_Prerecommendation2015_AFII_Apr2015.config";
+  m_calibConfigData         = "JES_MC15Prerecommendation_April2015.config";
+
+  // CONFIG parameters for JetCleaningTool
+  m_jetCalibCutLevel        = "MediumBad";
+  m_saveAllCleanDecisions   = false;
+
+  // CONFIG parameters for JetUncertaintiesTool
+  m_uncertConfig            = "";
+  // calibrator uses TopoEM or TopoLC while the uncertainity tool uses EMTopo and LCTopo
+  // calibrator should switch at some point
+  // "fix" the name here so the user never knows the difference
+
+  // shallow copies are made with this output container name
+  m_outContainerName        = "";
+  m_sort                    = true;
+
 }
 
 EL::StatusCode  JetCalibrator :: configure ()
@@ -67,38 +101,37 @@ EL::StatusCode  JetCalibrator :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug" , false );
+    m_debug                   = config->GetValue("Debug" , m_debug);
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // DC14 switch for little things that need to happen to run
     // for those samples with the corresponding packages
-    m_DC14                    = config->GetValue("DC14", false);
+    m_DC14                    = config->GetValue("DC14", m_DC14);
 
     // CONFIG parameters for JetCalibrationTool
-    m_jetAlgo                 = config->GetValue("JetAlgorithm",    "");
-    m_outputAlgo              = config->GetValue("OutputAlgo",      "");
+    m_jetAlgo                 = config->GetValue("JetAlgorithm", m_jetAlgo.c_str());
+    m_outputAlgo              = config->GetValue("OutputAlgo",   m_outputAlgo.c_str());
 
     // when running data "_Insitu" is appended to this string
-    m_calibSequence           = config->GetValue("CalibSequence",           "JetArea_Residual_Origin_EtaJES_GSC");
-    m_calibConfigFullSim      = config->GetValue("configNameFullSim",       "JES_MC15Prerecommendation_April2015.config");
-    m_calibConfigAFII         = config->GetValue("configNameAFII",          "JES_Prerecommendation2015_AFII_Apr2015.config");
-    m_calibConfigData         = config->GetValue("configNameData",          "JES_MC15Prerecommendation_April2015.config");
-    //m_calibConfigData         = config->GetValue("configNameData",          "JES_Full2012dataset_May2014.config");
+    m_calibSequence           = config->GetValue("CalibSequence",           m_calibSequence.c_str());
+    m_calibConfigFullSim      = config->GetValue("configNameFullSim",       m_calibConfigFullSim.c_str());
+    m_calibConfigAFII         = config->GetValue("configNameAFII",          m_calibConfigAFII.c_str());
+    m_calibConfigData         = config->GetValue("configNameData",          m_calibConfigData.c_str());
 
     // CONFIG parameters for JetCleaningTool
-    m_jetCalibCutLevel        = config->GetValue("JetCalibCutLevel",        "MediumBad");
-    m_saveAllCleanDecisions   = config->GetValue("SaveAllCleanDecisions",  false);
+    m_jetCalibCutLevel        = config->GetValue("JetCalibCutLevel",        m_jetCalibCutLevel.c_str());
+    m_saveAllCleanDecisions   = config->GetValue("SaveAllCleanDecisions",   m_saveAllCleanDecisions);
 
     // CONFIG parameters for JetUncertaintiesTool
-    m_uncertConfig            = config->GetValue("JetUncertConfig", "");
+    m_uncertConfig            = config->GetValue("JetUncertConfig", m_uncertConfig.c_str());
     // calibrator uses TopoEM or TopoLC while the uncertainity tool uses EMTopo and LCTopo
     // calibrator should switch at some point
     // "fix" the name here so the user never knows the difference
 
     // shallow copies are made with this output container name
-    m_outContainerName        = config->GetValue("OutputContainer", "");
-    m_sort                    = config->GetValue("Sort",          true);
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
+    m_sort                    = config->GetValue("Sort",            m_sort);
 
     config->Print();
     Info("configure()", "JetCalibrator Interface succesfully configured! ");

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -18,7 +18,16 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetHistsAlgo)
 
-JetHistsAlgo :: JetHistsAlgo () {}
+JetHistsAlgo :: JetHistsAlgo () {
+  m_inContainerName         = "";
+  // which plots will be turned on
+  m_detailStr               = "";
+  // name of algo input container comes from - only if
+  m_inputAlgo               = "";
+
+  m_debug                   = false;
+
+}
 
 EL::StatusCode JetHistsAlgo :: setupJob (EL::Job& job)
 {
@@ -54,13 +63,13 @@ EL::StatusCode JetHistsAlgo :: configure ()
     // the file exists, use TEnv to read it off
     TEnv* config = new TEnv(getConfig(true).c_str());
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
     // which plots will be turned on
-    m_detailStr               = config->GetValue("DetailStr",       "");
+    m_detailStr               = config->GetValue("DetailStr",       m_detailStr.c_str());
     // name of algo input container comes from - only if
-    m_inputAlgo               = config->GetValue("InputAlgo",       "");
+    m_inputAlgo               = config->GetValue("InputAlgo",       m_inputAlgo.c_str());
 
-    m_debug                   = config->GetValue("Debug" ,           false );
+    m_debug                   = config->GetValue("Debug" ,           m_debug);
 
     Info("configure()", "Loaded in configuration values");
 

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -56,6 +56,60 @@ JetSelector :: JetSelector () :
   // initialization code will go into histInitialize() and
   // initialize().
   Info("JetSelector()", "Calling constructor");
+
+  // read debug flag from .config file
+  m_debug         = false;
+  m_useCutFlow    = true;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+
+  // name of algo input container comes from - only if running on syst
+  m_inputAlgo               = "";
+  m_outputAlgo              = "";
+
+  // decorate selected objects that pass the cuts
+  m_decorateSelectedObjects = true;
+  // additional functionality : create output container of selected objects
+  //                            using the SG::VIEW_ELEMENTS option
+  //                            decorating and output container should not be mutually exclusive
+  m_createSelectedContainer = false;
+  // if requested, a new container is made using the SG::VIEW_ELEMENTS option
+  m_outContainerName        = "";
+  // if only want to look at a subset of object
+  m_nToProcess              = -1;
+
+  // cuts
+  m_cleanJets               = true;
+  m_cleanEvtLeadJets        = 0; // indepedent of previous switch
+  m_pass_max                = -1;
+  m_pass_min                = -1;
+  m_pT_max                  = 1e8;
+  m_pT_min                  = 1e8;
+  m_eta_max                 = 1e8;
+  m_eta_min                 = 1e8;
+  m_detEta_max              = 1e8;
+  m_detEta_min              = 1e8;
+  m_mass_max                = 1e8;
+  m_mass_min                = 1e8;
+  m_rapidity_max            = 1e8;
+  m_rapidity_min            = 1e8;
+  m_truthLabel 	      = -1;
+
+  m_doJVF 		      = false;
+  m_pt_max_JVF 	      = 50e3;
+  m_eta_max_JVF 	      = 2.4;
+  m_JVFCut 		      = 0.5;
+
+  // Btag quality
+  m_btag_veryloose          = false;
+  m_btag_loose              = false;
+  m_btag_medium             = false;
+  m_btag_tight              = false;
+
+  m_passAuxDecorKeys        = "";
+  m_failAuxDecorKeys        = "";
+
 }
 
 EL::StatusCode  JetSelector :: configure ()
@@ -66,57 +120,57 @@ EL::StatusCode  JetSelector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug         = config->GetValue("Debug" ,      false );
-    m_useCutFlow    = config->GetValue("UseCutFlow",  true);
+    m_debug         = config->GetValue("Debug" ,      m_debug);
+    m_useCutFlow    = config->GetValue("UseCutFlow",  m_useCutFlow);
 
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // name of algo input container comes from - only if running on syst
-    m_inputAlgo               = config->GetValue("InputAlgo",   "");
-    m_outputAlgo              = config->GetValue("OutputAlgo",  "");
+    m_inputAlgo               = config->GetValue("InputAlgo",   m_inputAlgo.c_str());
+    m_outputAlgo              = config->GetValue("OutputAlgo",  m_outputAlgo.c_str());
 
     // decorate selected objects that pass the cuts
-    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", true);
+    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     // additional functionality : create output container of selected objects
     //                            using the SG::VIEW_ELEMENTS option
     //                            decorating and output container should not be mutually exclusive
-    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", false);
+    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", m_createSelectedContainer);
     // if requested, a new container is made using the SG::VIEW_ELEMENTS option
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
     // if only want to look at a subset of object
-    m_nToProcess              = config->GetValue("NToProcess", -1);
+    m_nToProcess              = config->GetValue("NToProcess", m_nToProcess);
 
     // cuts
-    m_cleanJets               = config->GetValue("CleanJets",  true);
-    m_cleanEvtLeadJets        = config->GetValue("CleanEventWithLeadJets", 0); // indepedent of previous switch
-    m_pass_max                = config->GetValue("PassMax",      -1);
-    m_pass_min                = config->GetValue("PassMin",      -1);
-    m_pT_max                  = config->GetValue("pTMax",       1e8);
-    m_pT_min                  = config->GetValue("pTMin",       1e8);
-    m_eta_max                 = config->GetValue("etaMax",      1e8);
-    m_eta_min                 = config->GetValue("etaMin",      1e8);
-    m_detEta_max              = config->GetValue("detEtaMax",   1e8);
-    m_detEta_min              = config->GetValue("detEtaMin",   1e8);
-    m_mass_max                = config->GetValue("massMax",     1e8);
-    m_mass_min                = config->GetValue("massMin",     1e8);
-    m_rapidity_max            = config->GetValue("rapidityMax", 1e8);
-    m_rapidity_min            = config->GetValue("rapidityMin", 1e8);
-    m_truthLabel 	      = config->GetValue("TruthLabel",   -1);
+    m_cleanJets               = config->GetValue("CleanJets",  m_cleanJets);
+    m_cleanEvtLeadJets        = config->GetValue("CleanEventWithLeadJets", m_cleanEvtLeadJets); // indepedent of previous switch
+    m_pass_max                = config->GetValue("PassMax",      m_pass_max);
+    m_pass_min                = config->GetValue("PassMin",      m_pass_min);
+    m_pT_max                  = config->GetValue("pTMax",       m_pT_max);
+    m_pT_min                  = config->GetValue("pTMin",       m_pT_min);
+    m_eta_max                 = config->GetValue("etaMax",      m_eta_max);
+    m_eta_min                 = config->GetValue("etaMin",      m_eta_min);
+    m_detEta_max              = config->GetValue("detEtaMax",   m_detEta_max);
+    m_detEta_min              = config->GetValue("detEtaMin",   m_detEta_min);
+    m_mass_max                = config->GetValue("massMax",     m_mass_max);
+    m_mass_min                = config->GetValue("massMin",     m_mass_min);
+    m_rapidity_max            = config->GetValue("rapidityMax", m_rapidity_max);
+    m_rapidity_min            = config->GetValue("rapidityMin", m_rapidity_min);
+    m_truthLabel 	      = config->GetValue("TruthLabel",   m_truthLabel);
 
-    m_doJVF 		      = config->GetValue("DoJVF",       false);
-    m_pt_max_JVF 	      = config->GetValue("pTMaxJVF",    50e3);
-    m_eta_max_JVF 	      = config->GetValue("etaMaxJVF",   2.4);
-    m_JVFCut 		      = config->GetValue("JVFCut",      0.5);
+    m_doJVF 		      = config->GetValue("DoJVF",       m_doJVF);
+    m_pt_max_JVF 	      = config->GetValue("pTMaxJVF",    m_pt_max_JVF);
+    m_eta_max_JVF 	      = config->GetValue("etaMaxJVF",   m_eta_max_JVF);
+    m_JVFCut 		      = config->GetValue("JVFCut",      m_JVFCut);
 
     // Btag quality
-    m_btag_veryloose          = config->GetValue("BTagVeryLoose",   false);
-    m_btag_loose              = config->GetValue("BTagLoose",       false);
-    m_btag_medium             = config->GetValue("BTagMedium",      false);
-    m_btag_tight              = config->GetValue("BTagTight",       false);
+    m_btag_veryloose          = config->GetValue("BTagVeryLoose",   m_btag_veryloose);
+    m_btag_loose              = config->GetValue("BTagLoose",       m_btag_loose);
+    m_btag_medium             = config->GetValue("BTagMedium",      m_btag_medium);
+    m_btag_tight              = config->GetValue("BTagTight",       m_btag_tight);
 
-    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", "");
-    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", "");
+    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", m_passAuxDecorKeys.c_str());
+    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", m_failAuxDecorKeys.c_str());
 
     config->Print();
     Info("configure()", "JetSelector Interface succesfully configured! ");

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -54,11 +54,27 @@ MuonCalibrator :: MuonCalibrator () :
 
   Info("MuonCalibrator()", "Calling constructor");
 
+  // read debug flag from .config file
+  m_debug                   = false;
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+  m_outContainerName        = "";
+
+  m_sort                    = true;
+
+  // Systematics stuff
+  m_inputAlgoSystNames      = "";
+  m_outputAlgoSystNames     = "MuonCalibrator_Syst";
+  m_systName		      = "";
+  m_systVal 		      = 0.;
+
+  m_sort                    = false;
+
 }
 
 EL::StatusCode  MuonCalibrator :: configure ()
 {
-  
+
   if ( !getConfig().empty() ) {
 
     Info("configure()", "Configuing MuonCalibrator Interface. User configuration read from : %s ", getConfig().c_str());
@@ -66,22 +82,22 @@ EL::StatusCode  MuonCalibrator :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug", false);
+    m_debug                   = config->GetValue("Debug", m_debug);
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
 
-    m_sort                    = config->GetValue("Sort",  true);
+    m_sort                    = config->GetValue("Sort",  m_sort);
 
     // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");
-    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", "MuonCalibrator_Syst");
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", m_outputAlgoSystNames.c_str());
     m_runSysts                = false; // gets set later is syst applies to this tool
-    m_systName		      = config->GetValue("SystName" , "" );
-    m_systVal 		      = config->GetValue("SystVal" , 0. );
+    m_systName		      = config->GetValue("SystName" , m_systName.c_str());
+    m_systVal 		      = config->GetValue("SystVal" , m_systVal);
     m_runAllSyst              = (m_systName.find("All") != std::string::npos);
 
-    m_sort                    = config->GetValue("Sort",  false);
+    m_sort                    = config->GetValue("Sort",  m_sort);
 
     config->Print();
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -54,6 +54,31 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
 
   Info("MuonEfficiencyCorrector()", "Calling constructor");
 
+  // Read debug flag from .config file
+  m_debug                      = false;
+
+  // Input container to be read from TEvent or TStore
+  m_inContainerName            = "";
+
+  // Efficiency SF
+  m_WorkingPoint               = "Loose";
+  m_DataPeriod                 = "2015";
+
+  // Trigger SF
+  m_year                       = 2015;
+  m_runNumber                  = 900000;
+  m_SingleMuTrig               = "HLT_mu20_iloose_L1MU15";
+  m_SinglePlusDiMuTrig         = "mu20_iloose_L1MU15_or_mu50_or_2mu14";
+
+  // Systematics stuff
+  m_inputAlgoSystNames         = "";
+  m_systNameEff		           = "";
+  m_systNameTrig		       = "";
+  m_outputSystNamesEff         = "MuonEfficiencyCorrector_EffSyst";
+  m_outputSystNamesTrig        = "MuonEfficiencyCorrector_TrigSyst";
+  m_systValEff 		           = 0.;
+  m_systValTrig 		       = 0.;
+
 }
 
 
@@ -67,32 +92,32 @@ EL::StatusCode  MuonEfficiencyCorrector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // Read debug flag from .config file
-    m_debug                      = config->GetValue("Debug", false);
+    m_debug                      = config->GetValue("Debug", m_debug);
 
     // Input container to be read from TEvent or TStore
-    m_inContainerName            = config->GetValue("InputContainer",  "");
+    m_inContainerName            = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // Efficiency SF
-    m_WorkingPoint               = config->GetValue("WorkingPoint", "Loose" );
-    m_DataPeriod                 = config->GetValue("DataPeriod",   "2015" );
+    m_WorkingPoint               = config->GetValue("WorkingPoint", m_WorkingPoint.c_str());
+    m_DataPeriod                 = config->GetValue("DataPeriod",   m_DataPeriod.c_str());
 
     // Trigger SF
-    m_year                       = config->GetValue("year", 2015);
-    m_runNumber                  = config->GetValue("runNumber", 900000);
-    m_SingleMuTrig               = config->GetValue("SingleMuTrig", "HLT_mu20_iloose_L1MU15");
-    m_SinglePlusDiMuTrig         = config->GetValue("SinglePlusDiMuTrig", "mu20_iloose_L1MU15_or_mu50_or_2mu14");
-    
+    m_year                       = config->GetValue("year", m_year);
+    m_runNumber                  = config->GetValue("runNumber", m_runNumber);
+    m_SingleMuTrig               = config->GetValue("SingleMuTrig", m_SingleMuTrig.c_str());
+    m_SinglePlusDiMuTrig         = config->GetValue("SinglePlusDiMuTrig", m_SinglePlusDiMuTrig.c_str());
+
     // Systematics stuff
-    m_inputAlgoSystNames         = config->GetValue("InputAlgoSystNames",  "");
-    m_systNameEff		 = config->GetValue("SystNameEff" , "" );
-    m_systNameTrig		 = config->GetValue("SystNameTrig" , "" );
-    m_outputSystNamesEff         = config->GetValue("OutputSystNamesEff",  "MuonEfficiencyCorrector_EffSyst");
-    m_outputSystNamesTrig        = config->GetValue("OutputSystNamesTrig",  "MuonEfficiencyCorrector_TrigSyst");
-    m_systValEff 		 = config->GetValue("SystValEff" , 0. );
-    m_systValTrig 		 = config->GetValue("SystValTrig" , 0. );
+    m_inputAlgoSystNames         = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_systNameEff		 = config->GetValue("SystNameEff" , m_systNameEff.c_str());
+    m_systNameTrig		 = config->GetValue("SystNameTrig" , m_systNameTrig.c_str());
+    m_outputSystNamesEff         = config->GetValue("OutputSystNamesEff",  m_outputSystNamesEff.c_str());
+    m_outputSystNamesTrig        = config->GetValue("OutputSystNamesTrig", m_outputSystNamesTrig.c_str());
+    m_systValEff 		 = config->GetValue("SystValEff" , m_systValEff);
+    m_systValTrig 		 = config->GetValue("SystValTrig" , m_systValTrig);
     m_runAllSystEff              = (m_systNameEff.find("All") != std::string::npos);
     m_runAllSystTrig             = (m_systNameTrig.find("All") != std::string::npos);
-  
+
     config->Print();
 
     Info("configure()", "ElectronEfficiencyCorrector Interface succesfully configured! ");
@@ -193,11 +218,11 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonEffSFTool->setProperty("WorkingPoint", m_WorkingPoint ),"Failed to set Working Point property of MuonEfficiencyScaleFactors");
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonEffSFTool->setProperty("DataPeriod", m_DataPeriod ),"Failed to set DataPeriod property of MuonEfficiencyScaleFactors");
   // test audit trail
-  RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonEffSFTool->setProperty("doAudit", false),"Failed to set doAudit property of MuonEfficiencyScaleFactors"); 
+  RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonEffSFTool->setProperty("doAudit", false),"Failed to set doAudit property of MuonEfficiencyScaleFactors");
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonEffSFTool->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors");
 
   // Get a list of affecting systematics
-  if ( m_debug ) { 
+  if ( m_debug ) {
     CP::SystematicSet affectSystsEff = m_MuonEffSFTool->affectingSystematics();
     // Convert into a simple list
     std::vector<CP::SystematicSet> affectSystEffList = CP::make_systematics_vector(affectSystsEff);
@@ -230,7 +255,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_MuonTrigSFTool->initialize(), "Failed to properly initialize MuonTriggerScaleFactors");
 
   // Get a list of affecting systematics
-  if ( m_debug ) { 
+  if ( m_debug ) {
     CP::SystematicSet affectSystsTrig = m_MuonTrigSFTool->affectingSystematics();
     // Convert into a simple list
     std::vector<CP::SystematicSet> affectSystTrigList = CP::make_systematics_vector(affectSystsTrig);
@@ -531,10 +556,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
   //
   // Use the counter defined in execute() to check this is done only once
   //
-  if ( countSyst == 0 ) { 
+  if ( countSyst == 0 ) {
 
-    RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( sysVariationNamesEff, m_outputSystNamesEff), "Failed to record vector of systematic names for efficiency SF" ); 
-    RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig), "Failed to record vector of systematic names for trigger SF" ); 
+    RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( sysVariationNamesEff, m_outputSystNamesEff), "Failed to record vector of systematic names for efficiency SF" );
+    RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig), "Failed to record vector of systematic names for trigger SF" );
 
   }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -55,6 +55,56 @@ MuonSelector :: MuonSelector () :
   // initialize().
 
   Info("MuonSelector()", "Calling constructor");
+
+  // read debug flag from .config file
+  m_debug                   = false;
+  m_useCutFlow              = true;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName         = "";
+
+  // Systematics stuff
+  m_inputAlgoSystNames      = "";
+  m_outputAlgoSystNames     = "MuonSelector_Syst";
+
+
+  // decorate selected objects that pass the cuts
+  m_decorateSelectedObjects = true;
+  // additional functionality : create output container of selected objects
+  //                            using the SG::View_Element option
+  //                            decorrating and output container should not be mutually exclusive
+  m_createSelectedContainer = false;
+  // if requested, a new container is made using the SG::View_Element option
+  m_outContainerName        = "";
+
+  // if only want to look at a subset of object
+  m_nToProcess              = -1;
+
+  // configurable cuts
+  m_muonType                = "";
+  m_pass_max                = -1;
+  m_pass_min                = -1;
+  m_pT_max                  = 1e8;
+  m_pT_min                  = 1e8;
+  m_eta_max                 = 1e8;
+  m_d0_max                  = 1e8;
+  m_d0sig_max     	        = 1e8;
+  m_z0sintheta_max          = 1e8;
+
+  // isolation stuff
+  m_doIsolation             = false;
+  m_IsoWP		            = "Tight";
+  m_CaloIsoEff              = "0.1*x+90";  // only if isolation WP is "UserDefined"
+  m_TrackIsoEff             = "98";        // only if isolation WP is "UserDefined"
+  m_useRelativeIso          = true;
+  m_CaloBasedIsoType        = "topoetcone20";
+  m_CaloBasedIsoCut         = 0.05;
+  m_TrackBasedIsoType       = "ptvarcone30";
+  m_TrackBasedIsoCut        = 0.05;
+
+  m_passAuxDecorKeys        = "";
+  m_failAuxDecorKeys        = "";
+
 }
 
 MuonSelector::~MuonSelector() {}
@@ -69,56 +119,56 @@ EL::StatusCode  MuonSelector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug                   = config->GetValue("Debug" ,      false);
-    m_useCutFlow              = config->GetValue("UseCutFlow",  true);
+    m_debug                   = config->GetValue("Debug" ,      m_debug);
+    m_useCutFlow              = config->GetValue("UseCutFlow",  m_useCutFlow);
 
     // input container to be read from TEvent or TStore
-    m_inContainerName         = config->GetValue("InputContainer",  "");
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // Systematics stuff
-    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  "");
-    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", "MuonSelector_Syst");
+    m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
+    m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", m_outputAlgoSystNames.c_str());
 
 
     // decorate selected objects that pass the cuts
-    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", true);
+    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     // additional functionality : create output container of selected objects
     //                            using the SG::View_Element option
     //                            decorrating and output container should not be mutually exclusive
-    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", false);
+    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", m_createSelectedContainer);
     // if requested, a new container is made using the SG::View_Element option
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
 
     // if only want to look at a subset of object
-    m_nToProcess              = config->GetValue("NToProcess", -1);
+    m_nToProcess              = config->GetValue("NToProcess", m_nToProcess);
 
     // configurable cuts
-    std::string muonQuality   = config->GetValue("MuonQuality", "Medium"); 
+    std::string muonQuality   = config->GetValue("MuonQuality", "Medium");
     HelperClasses::EnumParser<xAOD::Muon::Quality> muQualityParser;
     m_muonQuality             = static_cast<int>( muQualityParser.parseEnum(muonQuality) );
-    m_muonType                = config->GetValue("MuonType", ""); 
-    m_pass_max                = config->GetValue("PassMax", -1);
-    m_pass_min                = config->GetValue("PassMin", -1);
-    m_pT_max                  = config->GetValue("pTMax",  1e8);
-    m_pT_min                  = config->GetValue("pTMin",  1e8);
-    m_eta_max                 = config->GetValue("etaMax", 1e8);
-    m_d0_max                  = config->GetValue("d0Max", 1e8);
-    m_d0sig_max     	      = config->GetValue("d0sigMax", 1e8);
-    m_z0sintheta_max          = config->GetValue("z0sinthetaMax", 1e8);
+    m_muonType                = config->GetValue("MuonType", m_muonType.c_str());
+    m_pass_max                = config->GetValue("PassMax", m_pass_max);
+    m_pass_min                = config->GetValue("PassMin", m_pass_min);
+    m_pT_max                  = config->GetValue("pTMax",  m_pT_max);
+    m_pT_min                  = config->GetValue("pTMin",  m_pT_min);
+    m_eta_max                 = config->GetValue("etaMax", m_eta_max);
+    m_d0_max                  = config->GetValue("d0Max", m_d0_max);
+    m_d0sig_max     	      = config->GetValue("d0sigMax", m_d0sig_max);
+    m_z0sintheta_max          = config->GetValue("z0sinthetaMax", m_z0sintheta_max);
 
     // isolation stuff
-    m_doIsolation             = config->GetValue("DoIsolationCut"    ,  false);
-    m_IsoWP		      = config->GetValue("IsolationWP"       ,  "Tight");
-    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  "0.1*x+90");  // only if isolation WP is "UserDefined"
-    m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  "98");        // only if isolation WP is "UserDefined"
-    m_useRelativeIso          = config->GetValue("UseRelativeIso"    ,  true );
-    m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  "topoetcone20");
-    m_CaloBasedIsoCut         = config->GetValue("CaloBasedIsoCut"   ,  0.05 );
-    m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  "ptvarcone30");
-    m_TrackBasedIsoCut        = config->GetValue("TrackBasedIsoCut"  ,  0.05 );
+    m_doIsolation             = config->GetValue("DoIsolationCut"    ,  m_doIsolation);
+    m_IsoWP		      = config->GetValue("IsolationWP"       ,  m_CaloIsoEff.c_str());
+    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());  // only if isolation WP is "UserDefined"
+    m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  m_TrackIsoEff.c_str());        // only if isolation WP is "UserDefined"
+    m_useRelativeIso          = config->GetValue("UseRelativeIso"    ,  m_useRelativeIso);
+    m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  m_CaloBasedIsoType.c_str());
+    m_CaloBasedIsoCut         = config->GetValue("CaloBasedIsoCut"   ,  m_CaloBasedIsoCut);
+    m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  m_TrackBasedIsoType.c_str());
+    m_TrackBasedIsoCut        = config->GetValue("TrackBasedIsoCut"  ,  m_TrackBasedIsoCut);
 
-    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", "");
-    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", "");
+    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", m_passAuxDecorKeys.c_str());
+    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", m_failAuxDecorKeys.c_str());
 
     config->Print();
 
@@ -276,7 +326,7 @@ EL::StatusCode MuonSelector :: initialize ()
   m_muonSelectionTool->msg().setLevel( MSG::ERROR); // VERBOSE
 
   // set eta and quality requirements in order to accept the muon - ID tracks required by default
-  RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MaxEta",    static_cast<double>(m_eta_max)), "Failed to set MaxEta property");  RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MuQuality", m_muonQuality), "Failed to set MuQuality property" ); 
+  RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MaxEta",    static_cast<double>(m_eta_max)), "Failed to set MaxEta property");  RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MuQuality", m_muonQuality), "Failed to set MuQuality property" );
   RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->initialize(), "Failed to properly initialize the Muon Selection Tool");
 
   // isolation tool for muons not available in DC14
@@ -625,15 +675,15 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
     // get the selected quality level
     HelperClasses::EnumParser<xAOD::Muon::Quality> muQualityParser;
     int selected_quality = static_cast<int>( muTypeParser.parseEnum(m_muonQuality) )
-   
-    // NB: please note the ordering of the enum items! 
+
+    // NB: please note the ordering of the enum items!
     // http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Event/xAOD/xAODMuon/xAODMuon/versions/Muon_v1.h
     if ( quality > selected_quality ) {
       if ( m_debug ) { Info("PassCuts()", "Muon quality: %i - min. required: %i . Failed", quality, selected_quality); }
       return 0;
     }
 
-  } 
+  }
   */
 
   // type
@@ -647,7 +697,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
   // isolation
   static SG::AuxElement::Decorator< char > isIsoDecor("isIsolated");
-  bool passIso(false); 
+  bool passIso(false);
   if (  m_IsoWP == "CutBasedDC14" ) {
 
     HelperClasses::EnumParser<xAOD::Iso::IsolationType> isoParser;
@@ -690,7 +740,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
     return 0;
   }
 
-  int this_quality     = static_cast<int>( m_muonSelectionTool->getQuality( *muon ) );     
+  int this_quality     = static_cast<int>( m_muonSelectionTool->getQuality( *muon ) );
   isVeryLooseQDecor( *muon ) = ( this_quality == static_cast<int>(xAOD::Muon::VeryLoose) ) ? 1 : 0;
   isLooseQDecor( *muon )     = ( this_quality == static_cast<int>(xAOD::Muon::Loose) )     ? 1 : 0;
   isMediumQDecor( *muon )    = ( this_quality == static_cast<int>(xAOD::Muon::Medium) )    ? 1 : 0;

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -61,6 +61,46 @@ OverlapRemover :: OverlapRemover () :
 
   Info("OverlapRemover()", "Calling constructor");
 
+  // read debug flag from .config file
+  m_debug         = false;
+  // input container(s) to be read from TEvent or TStore
+
+  /* Muons */
+  m_inContainerName_Muons       = "";
+  m_inputAlgoMuons              = "";  // name of vector<string> of syst retrieved from TStore
+  m_outputAlgoMuons             = "MuonCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
+  /* Electrons */
+  m_inContainerName_Electrons   = "";
+  m_inputAlgoElectrons          = "";  // name of vector<string> of syst retrieved from TStore
+  m_outputAlgoElectrons         = "ElectronCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
+  /* Jets */
+  m_inContainerName_Jets        = "";
+  m_inputAlgoJets               = "";  // name of vector<string> of syst retrieved from TStore
+  m_outputAlgoJets              = "JetCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
+  /* Photons */
+  m_inContainerName_Photons     = "";
+  /* Taus */
+  m_inContainerName_Taus        = "";
+
+  // decorate selected objects that pass the cuts
+  m_decorateSelectedObjects     = true;
+  // additional functionality : create output container of selected objects
+  //                            using the SG::View_Element option
+  //                            decorating and output container should not be mutually exclusive
+  m_createSelectedContainers    = false;
+
+  m_useSelected = false;
+
+  m_outContainerName_Electrons  = "";
+
+  m_outContainerName_Muons      = "";
+
+  m_outContainerName_Jets       = "";
+
+  m_outContainerName_Photons    = "";
+
+  m_outContainerName_Taus       = "";
+
 }
 
 EL::StatusCode  OverlapRemover :: configure ()
@@ -73,44 +113,44 @@ EL::StatusCode  OverlapRemover :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug         = config->GetValue("Debug" , false );
+    m_debug         = config->GetValue("Debug" , m_debug);
     // input container(s) to be read from TEvent or TStore
 
     /* Muons */
-    m_inContainerName_Muons       = config->GetValue("InputContainerMuons",  "");
-    m_inputAlgoMuons              = config->GetValue("InputAlgoMuons",  "");  // name of vector<string> of syst retrieved from TStore
-    m_outputAlgoMuons             = config->GetValue("OutputAlgoMuons", "MuonCollection_OR_Algo");    // name of vector<string> of syst pushed in TStore
+    m_inContainerName_Muons       = config->GetValue("InputContainerMuons",  m_inContainerName_Muons.c_str());
+    m_inputAlgoMuons              = config->GetValue("InputAlgoMuons",  m_inputAlgoMuons.c_str());  // name of vector<string> of syst retrieved from TStore
+    m_outputAlgoMuons             = config->GetValue("OutputAlgoMuons", m_outputAlgoMuons.c_str());    // name of vector<string> of syst pushed in TStore
     /* Electrons */
-    m_inContainerName_Electrons   = config->GetValue("InputContainerElectrons",  "");
-    m_inputAlgoElectrons          = config->GetValue("InputAlgoElectrons",  "");  // name of vector<string> of syst retrieved from TStore
-    m_outputAlgoElectrons         = config->GetValue("OutputAlgoElectrons", "ElectronCollection_OR_Algo");    // name of vector<string> of syst pushed in TStore
+    m_inContainerName_Electrons   = config->GetValue("InputContainerElectrons",  m_inContainerName_Electrons.c_str());
+    m_inputAlgoElectrons          = config->GetValue("InputAlgoElectrons",  m_inputAlgoElectrons.c_str());  // name of vector<string> of syst retrieved from TStore
+    m_outputAlgoElectrons         = config->GetValue("OutputAlgoElectrons", m_outputAlgoElectrons.c_str());    // name of vector<string> of syst pushed in TStore
     /* Jets */
-    m_inContainerName_Jets        = config->GetValue("InputContainerJets",  "");
-    m_inputAlgoJets               = config->GetValue("InputAlgoJets",  "");  // name of vector<string> of syst retrieved from TStore
-    m_outputAlgoJets              = config->GetValue("OutputAlgoJets", "JetCollection_OR_Algo");    // name of vector<string> of syst pushed in TStore
+    m_inContainerName_Jets        = config->GetValue("InputContainerJets",  m_inContainerName_Jets.c_str());
+    m_inputAlgoJets               = config->GetValue("InputAlgoJets",  m_inputAlgoJets.c_str());  // name of vector<string> of syst retrieved from TStore
+    m_outputAlgoJets              = config->GetValue("OutputAlgoJets", m_outputAlgoJets.c_str());    // name of vector<string> of syst pushed in TStore
     /* Photons */
-    m_inContainerName_Photons     = config->GetValue("InputContainerPhotons",  "");
+    m_inContainerName_Photons     = config->GetValue("InputContainerPhotons",  m_inContainerName_Photons.c_str());
     /* Taus */
-    m_inContainerName_Taus        = config->GetValue("InputContainerTaus",  "");
+    m_inContainerName_Taus        = config->GetValue("InputContainerTaus",  m_inContainerName_Taus.c_str());
 
     // decorate selected objects that pass the cuts
-    m_decorateSelectedObjects     = config->GetValue("DecorateSelectedObjects", true);
+    m_decorateSelectedObjects     = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     // additional functionality : create output container of selected objects
     //                            using the SG::View_Element option
     //                            decorating and output container should not be mutually exclusive
-    m_createSelectedContainers    = config->GetValue("CreateSelectedContainers", false);
+    m_createSelectedContainers    = config->GetValue("CreateSelectedContainers", m_createSelectedContainers);
 
-    m_useSelected = config->GetValue("UseSelected", false);
+    m_useSelected = config->GetValue("UseSelected", m_useSelected);
 
-    m_outContainerName_Electrons  = config->GetValue("OutputContainerElectrons", "");
+    m_outContainerName_Electrons  = config->GetValue("OutputContainerElectrons", m_outContainerName_Electrons.c_str());
 
-    m_outContainerName_Muons      = config->GetValue("OutputContainerMuons", "");
+    m_outContainerName_Muons      = config->GetValue("OutputContainerMuons", m_outContainerName_Muons.c_str());
 
-    m_outContainerName_Jets       = config->GetValue("OutputContainerJets", "");
+    m_outContainerName_Jets       = config->GetValue("OutputContainerJets", m_outContainerName_Jets.c_str());
 
-    m_outContainerName_Photons    = config->GetValue("OutputContainerPhotons", "");
+    m_outContainerName_Photons    = config->GetValue("OutputContainerPhotons", m_outContainerName_Photons.c_str());
 
-    m_outContainerName_Taus       = config->GetValue("OutputContainerTaus", "");
+    m_outContainerName_Taus       = config->GetValue("OutputContainerTaus", m_outContainerName_Taus.c_str());
 
     config->Print();
     Info("configure()", "OverlapRemover Interface succesfully configured! ");

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -19,6 +19,10 @@ ClassImp(TrackHistsAlgo)
 TrackHistsAlgo :: TrackHistsAlgo () :
   m_plots(nullptr)
 {
+  m_inContainerName         = "";
+  m_detailStr               = "";
+  m_debug                   = false;
+
 }
 
 EL::StatusCode TrackHistsAlgo :: setupJob (EL::Job& job)
@@ -62,9 +66,9 @@ EL::StatusCode TrackHistsAlgo :: configure ()
     //  If Container Name is already set dont read it from the config
     //   (Allows to pass as argument in setup script)
     //
-    m_inContainerName         = config->GetValue("InputContainer",  "");
-    m_detailStr               = config->GetValue("DetailStr",       "");
-    m_debug                   = config->GetValue("Debug" ,           false );
+    m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
+    m_detailStr               = config->GetValue("DetailStr",       m_detailStr.c_str());
+    m_debug                   = config->GetValue("Debug" ,          m_debug);
 
     Info("configure()", "Loaded in configuration values");
 

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -34,6 +34,45 @@ TrackSelector :: TrackSelector () :
   // initialization code will go into histInitialize() and
   // initialize().
   Info("TrackSelector()", "Calling constructor");
+
+  // read debug flag from .config file
+  m_debug         = false;
+  m_useCutFlow    = true;
+
+  // input container to be read from TEvent or TStore
+  m_inContainerName  = "";
+
+  // decorate selected objects that pass the cuts
+  m_decorateSelectedObjects = true;
+  // additional functionality : create output container of selected objects
+  //                            using the SG::VIEW_ELEMENTS option
+  //                            decorating and output container should not be mutually exclusive
+  m_createSelectedContainer = false;
+  // if requested, a new container is made using the SG::VIEW_ELEMENTS option
+  m_outContainerName        = "";
+  // if only want to look at a subset of object
+  m_nToProcess              = -1;
+
+  // cuts
+  m_pass_max                = -1;
+  m_pass_min                = -1;
+  m_pT_max                  = 1e8;
+  m_pT_min                  = 1e8;
+  m_eta_max                 = 1e8;
+  m_eta_min                 = 1e8;
+  m_d0_max                  = 1e8;
+  m_z0_max                  = 1e8;
+  m_z0sinT_max              = 1e8;
+  m_nBL_min                 = 1e8;
+  m_nSi_min                 = 1e8;
+  m_nPixHoles_max           = 1e8;
+  m_chi2NdofCut_max         = 1e8;
+  m_chi2Prob_max            = 1e8;
+
+  m_passAuxDecorKeys        = "";
+
+  m_failAuxDecorKeys        = "";
+
 }
 
 EL::StatusCode  TrackSelector :: configure ()
@@ -44,42 +83,42 @@ EL::StatusCode  TrackSelector :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
 
     // read debug flag from .config file
-    m_debug         = config->GetValue("Debug" ,      false );
-    m_useCutFlow    = config->GetValue("UseCutFlow",  true);
+    m_debug         = config->GetValue("Debug" ,      m_debug);
+    m_useCutFlow    = config->GetValue("UseCutFlow",  m_useCutFlow);
 
     // input container to be read from TEvent or TStore
-    m_inContainerName  = config->GetValue("InputContainer",  "");
+    m_inContainerName  = config->GetValue("InputContainer",  m_inContainerName.c_str());
 
     // decorate selected objects that pass the cuts
-    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", true);
+    m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     // additional functionality : create output container of selected objects
     //                            using the SG::VIEW_ELEMENTS option
     //                            decorating and output container should not be mutually exclusive
-    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", false);
+    m_createSelectedContainer = config->GetValue("CreateSelectedContainer", m_createSelectedContainer);
     // if requested, a new container is made using the SG::VIEW_ELEMENTS option
-    m_outContainerName        = config->GetValue("OutputContainer", "");
+    m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
     // if only want to look at a subset of object
-    m_nToProcess              = config->GetValue("NToProcess", -1);
+    m_nToProcess              = config->GetValue("NToProcess", m_nToProcess);
 
     // cuts
-    m_pass_max                = config->GetValue("PassMax",       -1);
-    m_pass_min                = config->GetValue("PassMin",       -1);
-    m_pT_max                  = config->GetValue("pTMax",        1e8);
-    m_pT_min                  = config->GetValue("pTMin",        1e8);
-    m_eta_max                 = config->GetValue("etaMax",       1e8);
-    m_eta_min                 = config->GetValue("etaMin",       1e8);
-    m_d0_max                  = config->GetValue("d0Max",        1e8);
-    m_z0_max                  = config->GetValue("z0Max",        1e8);
-    m_z0sinT_max              = config->GetValue("z0SinTMax",    1e8);
-    m_nBL_min                 = config->GetValue("nBLMin",       1e8);
-    m_nSi_min                 = config->GetValue("nSiMin",       1e8);
-    m_nPixHoles_max           = config->GetValue("nPixHolesMax", 1e8);
-    m_chi2NdofCut_max         = config->GetValue("chi2NdofMax",  1e8);
-    m_chi2Prob_max            = config->GetValue("chi2ProbMax",  1e8);
+    m_pass_max                = config->GetValue("PassMax",      m_pass_max);
+    m_pass_min                = config->GetValue("PassMin",      m_pass_min);
+    m_pT_max                  = config->GetValue("pTMax",        m_pT_max);
+    m_pT_min                  = config->GetValue("pTMin",        m_pT_min);
+    m_eta_max                 = config->GetValue("etaMax",       m_eta_max);
+    m_eta_min                 = config->GetValue("etaMin",       m_eta_min);
+    m_d0_max                  = config->GetValue("d0Max",        m_d0_max);
+    m_z0_max                  = config->GetValue("z0Max",        m_z0_max);
+    m_z0sinT_max              = config->GetValue("z0SinTMax",    m_z0sinT_max);
+    m_nBL_min                 = config->GetValue("nBLMin",       m_nBL_min);
+    m_nSi_min                 = config->GetValue("nSiMin",       m_nSi_min);
+    m_nPixHoles_max           = config->GetValue("nPixHolesMax", m_nPixHoles_max);
+    m_chi2NdofCut_max         = config->GetValue("chi2NdofMax",  m_chi2NdofCut_max);
+    m_chi2Prob_max            = config->GetValue("chi2ProbMax",  m_chi2Prob_max);
 
-    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", "");
+    m_passAuxDecorKeys        = config->GetValue("PassDecorKeys", m_passAuxDecorKeys.c_str());
 
-    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", "");
+    m_failAuxDecorKeys        = config->GetValue("FailDecorKeys", m_failAuxDecorKeys.c_str());
 
     config->Print();
     Info("configure()", "TrackSelector Interface succesfully configured! ");

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -24,6 +24,30 @@ TreeAlgo :: TreeAlgo () :
   m_helpTree(nullptr)
 {
   this->SetName("TreeAlgo"); // needed if you want to retrieve this algo with wk()->getAlg(ALG_NAME) downstream
+
+  m_evtDetailStr            = "";
+  m_trigDetailStr           = "";
+  m_jetTrigDetailStr        = "";
+  m_muDetailStr             = "";
+  m_elDetailStr             = "";
+  m_jetDetailStr            = "";
+  m_fatJetDetailStr         = "";
+  m_tauDetailStr            = "";
+
+  m_debug                   = false;
+
+  m_outHistDir              = false;
+
+  m_muContainerName         = "";
+  m_elContainerName         = "";
+  m_jetContainerName        = "";
+  m_fatJetContainerName     = "";
+  m_tauContainerName        = "";
+
+  // DC14 switch for little things that need to happen to run
+  // for those samples with the corresponding packages
+  m_DC14                    = false;
+
 }
 
 EL::StatusCode TreeAlgo :: setupJob (EL::Job& job)
@@ -99,28 +123,28 @@ EL::StatusCode TreeAlgo :: configure ()
 
     // the file exists, use TEnv to read it off
     TEnv* config = new TEnv(getConfig(true).c_str());
-    m_evtDetailStr            = config->GetValue("EventDetailStr",       "");
-    m_trigDetailStr           = config->GetValue("TrigDetailStr",        "");
-    m_jetTrigDetailStr        = config->GetValue("JetTrigDetailStr",     "");
-    m_muDetailStr             = config->GetValue("MuonDetailStr",        "");
-    m_elDetailStr             = config->GetValue("ElectronDetailStr",    "");
-    m_jetDetailStr            = config->GetValue("JetDetailStr",         "");
-    m_fatJetDetailStr         = config->GetValue("FatJetDetailStr",      "");
-    m_tauDetailStr            = config->GetValue("TauDetailStr",         "");
+    m_evtDetailStr            = config->GetValue("EventDetailStr",       m_evtDetailStr.c_str());
+    m_trigDetailStr           = config->GetValue("TrigDetailStr",        m_trigDetailStr.c_str());
+    m_jetTrigDetailStr        = config->GetValue("JetTrigDetailStr",     m_jetTrigDetailStr.c_str());
+    m_muDetailStr             = config->GetValue("MuonDetailStr",        m_muDetailStr.c_str());
+    m_elDetailStr             = config->GetValue("ElectronDetailStr",    m_elDetailStr.c_str());
+    m_jetDetailStr            = config->GetValue("JetDetailStr",         m_jetDetailStr.c_str());
+    m_fatJetDetailStr         = config->GetValue("FatJetDetailStr",      m_fatJetDetailStr.c_str());
+    m_tauDetailStr            = config->GetValue("TauDetailStr",         m_tauDetailStr.c_str());
 
-    m_debug                   = config->GetValue("Debug" ,           false );
+    m_debug                   = config->GetValue("Debug" ,           m_debug);
 
-    m_outHistDir              = config->GetValue("SameHistsOutDir",  false );
+    m_outHistDir              = config->GetValue("SameHistsOutDir",  m_outHistDir);
 
-    m_muContainerName         = config->GetValue("MuonContainerName",       "");
-    m_elContainerName         = config->GetValue("ElectronContainerName",   "");
-    m_jetContainerName        = config->GetValue("JetContainerName",        "");
-    m_fatJetContainerName     = config->GetValue("FatJetContainerName",     "");
-    m_tauContainerName        = config->GetValue("TauContainerName",        "");
+    m_muContainerName         = config->GetValue("MuonContainerName",       m_muContainerName.c_str());
+    m_elContainerName         = config->GetValue("ElectronContainerName",   m_elContainerName.c_str());
+    m_jetContainerName        = config->GetValue("JetContainerName",        m_jetContainerName.c_str());
+    m_fatJetContainerName     = config->GetValue("FatJetContainerName",     m_fatJetContainerName.c_str());
+    m_tauContainerName        = config->GetValue("TauContainerName",        m_tauContainerName.c_str());
 
     // DC14 switch for little things that need to happen to run
     // for those samples with the corresponding packages
-    m_DC14                    = config->GetValue("DC14", false);
+    m_DC14                    = config->GetValue("DC14", m_DC14);
 
     Info("configure()", "Loaded in configuration values");
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -20,7 +20,15 @@ ClassImp(Writer)
 
 
 
-Writer :: Writer () {}
+Writer :: Writer () {
+  m_outputLabel               = "";
+
+  m_jetContainerNamesStr      = "";
+  m_electronContainerNamesStr = "";
+  m_muonContainerNamesStr     = "";
+  m_debug                   = false;
+
+}
 
 EL::StatusCode Writer :: setupJob (EL::Job& job)
 {
@@ -43,12 +51,12 @@ EL::StatusCode Writer :: setupJob (EL::Job& job)
       return EL::StatusCode::FAILURE;
     }
 
-    m_outputLabel               = config->GetValue("OutputLabel"            , "");
+    m_outputLabel               = config->GetValue("OutputLabel"            , m_outputLabel);
 
-    m_jetContainerNamesStr      = config->GetValue("JetContainerNames"      , "");
-    m_electronContainerNamesStr = config->GetValue("ElectronContainerNames" , "");
-    m_muonContainerNamesStr     = config->GetValue("MuonContainerNames"     , "");
-    m_debug                   = config->GetValue("Debug",                 false);
+    m_jetContainerNamesStr      = config->GetValue("JetContainerNames"      , m_jetContainerNamesStr);
+    m_electronContainerNamesStr = config->GetValue("ElectronContainerNames" , m_electronContainerNamesStr);
+    m_muonContainerNamesStr     = config->GetValue("MuonContainerNames"     , m_muonContainerNamesStr);
+    m_debug                   = config->GetValue("Debug",                m_debug);
 
     delete config;
   }

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -19,24 +19,24 @@ class BJetEfficiencyCorrector : public xAH::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-  std::string m_inContainerName;     //!
+  std::string m_inContainerName;
 
   // systematics
-  bool m_runAllSyst;                 //!
-  std::string m_systName;            //!
-  std::string m_outputSystName;      //!
+  bool m_runAllSyst;
+  std::string m_systName;
+  std::string m_outputSystName;
 
   std::string m_corrFileName;
   std::string m_jetAuthor;
   std::string m_taggerName;
   bool        m_useDevelopmentFile;
   bool        m_coneFlavourLabel;
-  bool  m_btag_veryloose;            //!
-  bool  m_btag_loose;                //!
-  bool  m_btag_medium;               //!
-  bool  m_btag_tight;                //!
+  bool  m_btag_veryloose;
+  bool  m_btag_loose;
+  bool  m_btag_medium;
+  bool  m_btag_tight;
 
-  std::string m_decor;            //! The decoration key written to passing objects
+  std::string m_decor;            // The decoration key written to passing objects
 
 private:
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -25,25 +25,25 @@ class BasicEventSelection : public xAH::Algorithm
   // that way they can be set directly from CINT and python.
   public:
     // variables read in through configuration file
-    bool m_truthLevelOnly;  //!
+    bool m_truthLevelOnly;
     // GRL
-    bool m_applyGRL;        //!
-    std::string m_GRLxml;   //!
+    bool m_applyGRL;
+    std::string m_GRLxml;
     //PU Reweighting
-    bool m_doPUreweighting; //!
-    std::string m_triggerSelection; //!
-    bool m_cutOnTrigger;       //!
-    bool m_storeTrigDecisions; //!
-    bool m_storePassAny;       //!
-    bool m_storePassL1;        //!
-    bool m_storePassHLT;       //!
-    bool m_storeTrigKeys;      //!
+    bool m_doPUreweighting;
+    std::string m_triggerSelection;
+    bool m_cutOnTrigger;
+    bool m_storeTrigDecisions;
+    bool m_storePassAny;
+    bool m_storePassL1;
+    bool m_storePassHLT;
+    bool m_storeTrigKeys;
 
     std::string m_derivationName;
 
     // primary vertex
-    std::string m_vertexContainerName; //!
-    int m_PVNTrack;                //!
+    std::string m_vertexContainerName;
+    int m_PVNTrack;
 
   private:
     GoodRunsListSelectionTool*   m_grl;       //!
@@ -63,7 +63,7 @@ class BasicEventSelection : public xAH::Algorithm
     double m_MD_initialSumW;         //!
     double m_MD_finalSumW;	     //!
     double m_MD_initialSumWSquared;  //!
-    double m_MD_finalSumWSquared;    //! 
+    double m_MD_finalSumWSquared;    //!
 
     // cutflow
     TH1D* m_cutflowHist;    //!

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -19,24 +19,24 @@ class JetCalibrator : public xAH::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-  bool m_DC14;            //!
+  bool m_DC14;
 
   // configuration variables
-  std::string m_inContainerName;        //!
-  std::string m_outContainerName;       //!
+  std::string m_inContainerName;
+  std::string m_outContainerName;
 
-  std::string m_jetAlgo;                //!
-  std::string m_outputAlgo;             //!
-  std::string m_calibConfigData;        //!
-  std::string m_calibConfigFullSim;     //!
-  std::string m_calibConfigAFII;        //!
-  std::string m_calibConfig;            //!
-  std::string m_calibSequence;          //!
-  std::string m_jetCalibCutLevel;       //!
-  bool m_saveAllCleanDecisions;         //!
-  std::string m_uncertConfig;           //!
+  std::string m_jetAlgo;
+  std::string m_outputAlgo;
+  std::string m_calibConfigData;
+  std::string m_calibConfigFullSim;
+  std::string m_calibConfigAFII;
+  std::string m_calibConfig;
+  std::string m_calibSequence;
+  std::string m_jetCalibCutLevel;
+  bool m_saveAllCleanDecisions;
+  std::string m_uncertConfig;
   // sort after calibration
-  bool    m_sort;                   //!
+  bool    m_sort;
 
   // systematics
   bool m_runSysts;
@@ -45,8 +45,8 @@ private:
   int m_numEvent;         //!
   int m_numObject;        //!
 
-  bool m_isMC;
-  bool m_isFullSim;
+  bool m_isMC;            //!
+  bool m_isFullSim;       //!
 
   std::string m_jetUncertAlgo;          //!
 

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -16,45 +16,45 @@ class JetSelector : public xAH::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-  bool m_useCutFlow;             //!
+  bool m_useCutFlow;
 
   // configuration variables
-  std::string m_inContainerName;   //! input container name
-  std::string m_outContainerName;  //! output container name
-  std::string m_inputAlgo;         //! input type - from xAOD or from xAODAnaHelper Algo output
-  std::string m_outputAlgo;        //! output type - this is how the vector<string> w/ syst names will be saved in TStore
-  std::string m_decor;            //! The decoration key written to passing objects
-  bool m_decorateSelectedObjects; //! decorate selected objects? defaul passSel
-  bool m_createSelectedContainer; //! fill using SG::VIEW_ELEMENTS to be light weight
-  int m_nToProcess;               //! look at n objects
-  bool m_cleanJets;               //! require cleanJet decoration to not be set and false
-  int m_cleanEvtLeadJets;         //! kill event if any of the N leading jets are not clean
-  int m_pass_min;                 //! minimum number of objects passing cuts
-  int m_pass_max;                 //! maximum number of objects passing cuts
-  float m_pT_max;                 //! require pT < pt_max
-  float m_pT_min;                 //! require pT > pt_max
-  float m_eta_max;                //! require eta < eta_max
-  float m_eta_min;                //! require eta > eta_max
-  float m_detEta_max;             //! require detEta < detEta_max
-  float m_detEta_min;             //! require detEta > detEta_max
-  float m_mass_max;               //! require mass < mass_max
-  float m_mass_min;               //! require mass > mass_max
-  float m_rapidity_max;           //! require rapidity < rapidity_max
-  float m_rapidity_min;           //! require rapidity > rapidity_min
-  int   m_truthLabel;             //! require truth level on truth jets
+  std::string m_inContainerName;   // input container name
+  std::string m_outContainerName;  // output container name
+  std::string m_inputAlgo;         // input type - from xAOD or from xAODAnaHelper Algo output
+  std::string m_outputAlgo;        // output type - this is how the vector<string> w/ syst names will be saved in TStore
+  std::string m_decor;            // The decoration key written to passing objects
+  bool m_decorateSelectedObjects; // decorate selected objects? defaul passSel
+  bool m_createSelectedContainer; // fill using SG::VIEW_ELEMENTS to be light weight
+  int m_nToProcess;               // look at n objects
+  bool m_cleanJets;               // require cleanJet decoration to not be set and false
+  int m_cleanEvtLeadJets;         // kill event if any of the N leading jets are not clean
+  int m_pass_min;                 // minimum number of objects passing cuts
+  int m_pass_max;                 // maximum number of objects passing cuts
+  float m_pT_max;                 // require pT < pt_max
+  float m_pT_min;                 // require pT > pt_max
+  float m_eta_max;                // require eta < eta_max
+  float m_eta_min;                // require eta > eta_max
+  float m_detEta_max;             // require detEta < detEta_max
+  float m_detEta_min;             // require detEta > detEta_max
+  float m_mass_max;               // require mass < mass_max
+  float m_mass_min;               // require mass > mass_max
+  float m_rapidity_max;           // require rapidity < rapidity_max
+  float m_rapidity_min;           // require rapidity > rapidity_min
+  int   m_truthLabel;             // require truth level on truth jets
 
-  bool m_doJVF;                   //! check JVF
-  float m_pt_max_JVF;             //! max pT (JVF is a pileup cut)
-  float m_eta_max_JVF;            //! detector eta cut
-  float m_JVFCut;                 //! cut value
-  float m_btagCut;                //! btagging cuts, configured by the bools below
-  bool  m_btag_veryloose;         //!
-  bool  m_btag_loose;             //!
-  bool  m_btag_medium;            //!
-  bool  m_btag_tight;             //!
+  bool m_doJVF;                   // check JVF
+  float m_pt_max_JVF;             // max pT (JVF is a pileup cut)
+  float m_eta_max_JVF;            // detector eta cut
+  float m_JVFCut;                 // cut value
+  float m_btagCut;                // btagging cuts, configured by the bools below
+  bool  m_btag_veryloose;         //
+  bool  m_btag_loose;             //
+  bool  m_btag_medium;            //
+  bool  m_btag_tight;             //
 
-  std::string              m_passAuxDecorKeys;  //!
-  std::string              m_failAuxDecorKeys;  //!
+  std::string              m_passAuxDecorKeys;
+  std::string              m_failAuxDecorKeys;
 
 private:
   int m_numEvent;         //!

--- a/xAODAnaHelpers/TrackHistsAlgo.h
+++ b/xAODAnaHelpers/TrackHistsAlgo.h
@@ -14,7 +14,7 @@ public:
   std::string m_inContainerName;
 
   // configuration variables
-  std::string m_detailStr;        //!
+  std::string m_detailStr;
 
 private:
   TrackHists* m_plots; //!

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -15,23 +15,8 @@ class TrackSelector : public xAH::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-  int m_numEvent;         //!
-  int m_numObject;        //!
-  int m_numEventPass;     //!
-  int m_numObjectPass;    //!
 
-  std::string              m_passAuxDecorKeys;
-  std::string              m_failAuxDecorKeys;
-  std::vector<std::string> m_passKeys;
-  std::vector<std::string> m_failKeys;
-
-  // cutflow
   bool m_useCutFlow;            //!
-  TH1D* m_cutflowHist;          //!
-  TH1D* m_cutflowHistW;         //!
-  int   m_cutflow_bin;          //!
-
-private:
 
   // configuration variables
   std::string m_inContainerName;      // input container name
@@ -54,6 +39,23 @@ private:
   float m_chi2NdofCut_max;        // require chi2/ndof < chi2NdofCut_max
   float m_chi2Prob_max;           // require TMath::Prob(chi2,ndof) < chi2ProbMax
 
+  std::string              m_passAuxDecorKeys;
+  std::string              m_failAuxDecorKeys;
+
+private:
+
+  std::vector<std::string> m_passKeys;
+  std::vector<std::string> m_failKeys;
+
+  int m_numEvent;         //!
+  int m_numObject;        //!
+  int m_numEventPass;     //!
+  int m_numObjectPass;    //!
+
+  // cutflow
+  TH1D* m_cutflowHist;          //!
+  TH1D* m_cutflowHistW;         //!
+  int   m_cutflow_bin;          //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -14,30 +14,30 @@ class TreeAlgo : public xAH::Algorithm
   // that way they can be set directly from CINT and python.
 public:
   // choose whether the tree gets saved in the same directory as output histograms
-  bool m_outHistDir;                   //!
+  bool m_outHistDir;
 
   // holds bools that control which branches are filled
-  std::string m_evtDetailStr;	       //!
-  std::string m_trigDetailStr;	     //!
-  std::string m_jetTrigDetailStr;	   //!
-  std::string m_muDetailStr;	       //!
-  std::string m_elDetailStr;	       //!
-  std::string m_jetDetailStr;	       //!
-  std::string m_fatJetDetailStr;     //!
-  std::string m_tauDetailStr;        //!
+  std::string m_evtDetailStr;
+  std::string m_trigDetailStr;
+  std::string m_jetTrigDetailStr;
+  std::string m_muDetailStr;
+  std::string m_elDetailStr;
+  std::string m_jetDetailStr;
+  std::string m_fatJetDetailStr;
+  std::string m_tauDetailStr;
 
-  std::string m_evtContainerName;      //!
-  std::string m_muContainerName;       //!
-  std::string m_elContainerName;       //!
-  std::string m_jetContainerName;      //!
-  std::string m_fatJetContainerName;   //!
-  std::string m_tauContainerName;      //!
+  std::string m_evtContainerName;
+  std::string m_muContainerName;
+  std::string m_elContainerName;
+  std::string m_jetContainerName;
+  std::string m_fatJetContainerName;
+  std::string m_tauContainerName;
 
-  bool m_DC14;                         //!
+  bool m_DC14;
 
 private:
   HelpTreeBase* m_helpTree;            //!
-  
+
 public:
 
   // this is a standard constructor


### PR DESCRIPTION
This closes #32. All algorithms with public members are meant to be configurable from python, a macro script, or a TEnv config file. This requires that all members are streamable, but also set to default values

Note that the `test_multiAlgo` does not work with the skimmed mc15 file provided. Need to run something like

```
test_multiAlgo submitDir /share/t3data3/kratsg/xAODs/ mc15_13TeV.410000.PowhegPythiaEvtGen_P2012_ttbar_hdamp172p5_nonallhad.merge.AOD.e3698_s2608_s2183_r6630_r6264_tid05419191_00/ AOD.05419191._000003.pool.root.1
```

where you provide your own file.