### PR TITLE
flag to skip metadata stuff

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -125,6 +125,9 @@ EL::StatusCode BasicEventSelection :: configure ()
       m_PVNTrack            = config->GetValue("NTrackForPrimaryVertex",  m_PVNTrack); // harmonized cut
     }
 
+    // temp flag for derivations with broken meta data
+    m_useMetaData           = config->GetValue("UseMetaData", true);
+
     // Trigger
     m_triggerSelection           = config->GetValue("Trigger",            m_triggerSelection.c_str());
     m_cutOnTrigger               = config->GetValue("CutOnTrigger",       m_cutOnTrigger);
@@ -238,7 +241,7 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
   //check if file is from a DxAOD
   bool m_isDerivation = !MetaData->GetBranch("StreamAOD");
 
-  if ( m_isDerivation ) {
+  if ( m_isDerivation && m_useMetaData ) {
 
     // check for corruption
     const xAOD::CutBookkeeperContainer* incompleteCBC(nullptr);

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -31,6 +31,7 @@ class BasicEventSelection : public xAH::Algorithm
     std::string m_GRLxml;
     //PU Reweighting
     bool m_doPUreweighting;
+    bool m_useMetaData;
     std::string m_triggerSelection;
     bool m_cutOnTrigger;
     bool m_storeTrigDecisions;


### PR DESCRIPTION
There is an issue with MetaData corruption and CutBookkeepers in the Derivation Framework related to the move to release 20.1.5.  This flag is a temporary thing for those running on these derivations.  