### PR TITLE
Skeleton for MET recalculation, and order change in muon/electron selection

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -655,13 +655,6 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
   int oq      = static_cast<int>( electron->auxdata<uint32_t>("OQ") & 1446 );
 
-  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/InDetTrackingDC14
-
-  const xAOD::TrackParticle* tp  = electron->trackParticle();
-
-  float d0_significance = fabs( tp->d0() ) / sqrt(tp->definingParametersCovMatrix()(0,0) );
-  float z0sintheta      = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
-
   // author cut
   if ( m_doAuthorCut ) {
     if ( !( electron->author(xAOD::EgammaParameters::AuthorElectron) || electron->author(xAOD::EgammaParameters::AuthorAmbiguous) ) ) {
@@ -706,6 +699,13 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       }
     }
   }
+
+  // Tracking AFTER acceptance, in case of derivation reduction.
+  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/InDetTrackingDC14
+  const xAOD::TrackParticle* tp  = electron->trackParticle();
+  float d0_significance = fabs( tp->d0() ) / sqrt(tp->definingParametersCovMatrix()(0,0) );
+  float z0sintheta      = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
   // d0 cut
   if ( !( tp->d0() < m_d0_max ) ) {
       if ( m_debug ) { Info("PassCuts()", "Electron failed d0 cut."); }

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -14,6 +14,9 @@
 #include <xAODAnaHelpers/MuonCalibrator.h>
 /*#include <xAODAnaHelpers/GroomedFatJets.h>*/
 
+/* Missing Energy Reconstruction */
+#include <xAODAnaHelpers/METConstructor.h>
+
 /* Scale Factors */
 #include <xAODAnaHelpers/ElectronEfficiencyCorrector.h>
 #include <xAODAnaHelpers/MuonEfficiencyCorrector.h>
@@ -51,6 +54,8 @@
 #pragma link C++ class JetCalibrator+;
 #pragma link C++ class MuonCalibrator+;
 /*#pragma link C++ class GroomedFatJets+;*/
+
+#pragma link C++ class METConstructor+;
 
 #pragma link C++ class ElectronEfficiencyCorrector+;
 #pragma link C++ class MuonEfficiencyCorrector+;

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -1,0 +1,354 @@
+#include <iostream>
+
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+
+#include "xAODAnaHelpers/METConstructor.h"
+
+// top of file, outside of algorithm declaration
+// #include "METUtilities/METRebuilder.h"
+#include "METUtilities/METMaker.h"
+#include "METUtilities/CutsMETMaker.h"
+
+#include "xAODEgamma/PhotonContainer.h"
+#include "xAODEgamma/ElectronContainer.h"
+#include "xAODMuon/MuonContainer.h"
+#include "xAODTau/TauJetContainer.h"
+#include "xAODJet/JetContainer.h"
+
+#include "xAODCore/ShallowCopy.h"
+
+// #include "xAODMissingET/MissingET.h"
+#include "xAODMissingET/MissingETContainer.h"
+#include "xAODMissingET/MissingETAuxContainer.h"
+#include "xAODMissingET/MissingETComposition.h"
+#include "xAODMissingET/MissingETAssociationMap.h"
+  
+// #include "xAODParticleEvent/Particle.h"
+// #include "xAODParticleEvent/ParticleContainer.h"
+// #include "xAODParticleEvent/ParticleAuxContainer.h"
+
+#include "xAODAnaHelpers/HelperFunctions.h"
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+#include <xAODAnaHelpers/tools/ReturnCheckConfig.h>
+
+#include "TEnv.h"
+#include "TSystem.h"
+
+namespace xAOD {
+#ifndef XAODJET_JETCONTAINER_H 
+  class JetContainer;
+#endif
+#ifndef XAODJET_JET_H 
+  class Jet;
+#endif
+}
+
+using std::cout; using std::cerr; using std::endl;
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(METConstructor)
+
+
+METConstructor :: METConstructor () : m_metmaker(0) {}
+
+EL::StatusCode  METConstructor :: configure ()
+{
+  Info("configure()", "Configuing METConstructor Interface. User configuration read from : %s \n", getConfig(true).c_str());
+
+  getConfig(true) = gSystem->ExpandPathName( getConfig(true).c_str() );
+  // check if file exists
+  /* https://root.cern.ch/root/roottalk/roottalk02/5332.html */
+  FileStat_t fStats;
+  int fSuccess = gSystem->GetPathInfo(getConfig(true).c_str(), fStats);
+  if(fSuccess != 0){
+    Error("configure()", "Could not find the configuration file");
+    return EL::StatusCode::FAILURE;
+  }
+  Info("configure()", "Found configuration file");
+  
+  TEnv* config = new TEnv(getConfig(true).c_str());
+
+  // read debug flag from .config file
+  m_debug           = config->GetValue("Debug" , false );
+  m_referenceMETContainer = config->GetValue("Reference",       "MET_Reference_AntiKt4LCTopo");
+
+  m_mapName         = config->GetValue("MapName",         "METAssoc_AntiKt4LCTopo");
+  m_coreName        = config->GetValue("CoreName",        "MET_Core_AntiKt4LCTopo");
+  m_outputContainer = config->GetValue("OutputContainer", "NewRefFinal");
+
+  m_inputJets       = config->GetValue("InputJets",       "AntiKt4LCTopoJets");
+  m_inputElectrons  = config->GetValue("InputElectrons",  "Electrons_Calib");
+  m_inputPhotons    = config->GetValue("InputPhotons",    "Photons");
+  m_inputTaus       = config->GetValue("InputTaus",       "TauJets");
+  m_inputMuons      = config->GetValue("InputMuons",      "Muons");
+
+  m_doElectronCuts  = config->GetValue("ApplyElectronCuts", false);
+  m_doPhotonCuts    = config->GetValue("ApplyPhotonCuts",   false);
+  m_doTauCuts       = config->GetValue("ApplyTauCuts",      false);
+  m_doMuonCuts      = config->GetValue("ApplyMuonCuts",     false);
+
+  if( m_mapName.Length() == 0 ) {
+    Error("configure()", "MapName is empty!");
+    return EL::StatusCode::FAILURE;
+  }
+
+  config->Print();
+  Info("configure()", "METConstructor Interface succesfully configured! \n");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode METConstructor :: setupJob (EL::Job& job)
+{
+  // Here you put code that sets up the job on the submission object
+  // so that it is ready to work with your algorithm, e.g. you can
+  // request the D3PDReader service or add output files.  Any code you
+  // put here could instead also go into the submission script.  The
+  // sole advantage of putting it here is that it gets automatically
+  // activated/deactivated when you add/remove the algorithm from your
+  // job, which may or may not be of value to you.
+
+  Info("setupJob()", "Calling setupJob \n");
+
+  job.useXAOD ();
+  xAOD::Init( "METConstructor" ).ignore(); // call before opening first file
+  Info("setupJob()", "METConstructor Ready\n");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor :: histInitialize ()
+{
+  // Here you do everything that needs to be done at the very
+  // beginning on each worker node, e.g. create histograms and output
+  // trees.  This method gets called before any input files are
+  // connected.
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor :: fileExecute ()
+{
+  // Here you do everything that needs to be done exactly once for every
+  // single file, e.g. collect a list of all lumi-blocks processed
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor :: changeInput (bool /*firstFile*/)
+{
+  // Here you do everything you need to do when we change input files,
+  // e.g. resetting branch addresses on trees.  If you are using
+  // D3PDReader or a similar service this method is not needed.
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor :: initialize ()
+{
+  // Here you do everything that you need to do after the first input
+  // file has been connected and before the first event is processed,
+  // e.g. create additional histograms based on which variables are
+  // available in the input files.  You can also create all of your
+  // histograms and trees in here, but be aware that this method
+  // doesn't get called if no events are processed.  So any objects
+  // you create here won't be available in the output if you have no
+  // input events.
+
+  Info("initialize()", "Initializing METConstructor Interface... \n");
+
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+  m_store->print();
+
+  if ( this->configure() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed to properly configure. Exiting." );
+    return EL::StatusCode::FAILURE;
+  }
+
+  m_metmaker = new met::METMaker("METMaker");
+  if(m_metmaker->initialize().isFailure()){
+    Error("initialize()", "Failed to properly initialize. Exiting." );
+    return EL::StatusCode::FAILURE;
+  }
+
+  Info("initialize()", "METConstructor Interface %s succesfully initialized!", m_name.c_str());
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode METConstructor :: execute ()
+{
+  // Here you do everything that needs to be done on every single
+  // events, e.g. read input variables, apply cuts, and fill
+  // histograms and trees.  This is where most of your actual analysis
+  // code will go.
+
+  if(m_debug) Info("execute()", "Performing MET reconstruction... \n");
+
+
+  // Create a MissingETContainer with its aux store
+  xAOD::MissingETContainer* newMet = new xAOD::MissingETContainer();
+  RETURN_CHECK("METConstructor::execute()", m_store->record(newMet, m_outputContainer.Data()), "Failed to store MET output container.");
+
+  xAOD::MissingETAuxContainer* metAuxCont = new xAOD::MissingETAuxContainer();
+  RETURN_CHECK("METConstructor::execute()", m_store->record(metAuxCont, (m_outputContainer + "Aux.").Data()), "Failed to store MET output container.");
+  newMet->setStore(metAuxCont);
+
+
+  const xAOD::MissingETAssociationMap* metMap = 0;
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(metMap,  m_mapName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Map.");
+  metMap->resetObjSelectionFlags();
+
+  ///////////////////////
+  ////// ELECTRONS  /////
+  ///////////////////////
+  const xAOD::ElectronContainer* eleCont(0);
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+  if (m_doElectronCuts) { 
+    ConstDataVector<xAOD::ElectronContainer> metElectrons(SG::VIEW_ELEMENTS);
+    for (const auto& el : *eleCont) if (CutsMETMaker::accept(el)) metElectrons.push_back(el);
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefEle", xAOD::Type::Electron, newMet, metElectrons.asDataVector(), metMap), "Failed rebuilding electron component.");
+  } else {
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefEle", xAOD::Type::Electron, newMet, eleCont, metMap), "Failed rebuilding electron component.");
+  }
+
+
+  //////////////////////
+  //////  PHOTONS  /////
+  //////////////////////
+  const xAOD::PhotonContainer* phoCont(0);
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, m_debug), "Failed retrieving photon cont.");
+  if (m_doPhotonCuts) {
+    ConstDataVector<xAOD::PhotonContainer> metPhotons(SG::VIEW_ELEMENTS);
+    for (const auto& ph : *phoCont) if (CutsMETMaker::accept(ph)) metPhotons.push_back(ph);
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, metPhotons.asDataVector(), metMap), "Failed rebuilding photon component.");
+  } else {
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, phoCont, metMap), "Failed rebuilding photon component.");
+  }
+
+
+  ///////////////////
+  //////  TAUS  /////
+  ///////////////////
+  const xAOD::TauJetContainer* tauCont(0);
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, m_debug), "Failed retrieving tau cont.");
+  if (m_doTauCuts) {
+    ConstDataVector<xAOD::TauJetContainer> metTaus(SG::VIEW_ELEMENTS);
+    // for (const auto& tau : *tauCont) if (CutsMETMaker::accept(tau)) metTaus.push_back(tau);
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefTau", xAOD::Type::Tau, newMet, metTaus.asDataVector(), metMap), "Failed rebuilding tau component.");
+  } else {
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefTau", xAOD::Type::Tau, newMet, tauCont, metMap), "Failed rebuilding tau component.");
+  }
+
+
+  ////////////////////
+  //////  MUONS  /////
+  ////////////////////
+  const xAOD::MuonContainer* muonCont(0);
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data(), m_event, m_store, m_debug), "Failed retrieving muon cont.");
+  if (m_doMuonCuts) {
+    ConstDataVector<xAOD::MuonContainer> metMuons(SG::VIEW_ELEMENTS);
+    for (const auto& mu : *muonCont) if (CutsMETMaker::accept(mu)) metMuons.push_back(mu);
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("Muons", xAOD::Type::Muon, newMet, metMuons.asDataVector(), metMap), "Failed rebuilding muon component.");
+  } else {
+    RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("Muons", xAOD::Type::Muon, newMet, muonCont, metMap), "Failed rebuilding muon component.");
+  }
+
+
+  const xAOD::JetContainer* jetCont(0);
+  const xAOD::MissingETContainer* coreMet(0);
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_debug), "Failed retrieving jet cont.");
+  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Core.");
+  RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, false), "Failed to build jet/MET.");
+
+
+  RETURN_CHECK("METConstructor::execute()", m_metmaker->buildMETSum("FinalClus", newMet, MissingETBase::Source::LCTopo), "Failed to build FinalClus MET.");
+  RETURN_CHECK("METConstructor::execute()", m_metmaker->buildMETSum("FinalTrk",  newMet, MissingETBase::Source::Track),  "Failed to build FinalTrk MET.");
+
+
+  if (m_debug) {
+    const xAOD::MissingETContainer* oldMet(0);
+    RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(oldMet, m_referenceMETContainer.Data(), m_event, m_store, m_debug) ,"");
+    xAOD::MissingETContainer::const_iterator final(oldMet->find("FinalClus"));
+    xAOD::MissingETContainer::const_iterator newfinal(newMet->find("FinalClus"));
+    Info("execute()", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+    Info("execute()", "RefEle:    old=%8.f  new=%8.f", (*oldMet->find("RefEle")   )->met(), (*newMet->find("RefEle")   )->met());
+    Info("execute()", "RefGamma:  old=%8.f  new=%8.f", (*oldMet->find("RefGamma") )->met(), (*newMet->find("RefGamma") )->met());
+    Info("execute()", "RefTau:    old=%8.f  new=%8.f", (*oldMet->find("RefTau")   )->met(), (*newMet->find("RefTau")   )->met());
+    Info("execute()", "Muons:     old=%8.f  new=%8.f", (*oldMet->find("Muons")    )->met(), (*newMet->find("Muons")    )->met());
+    Info("execute()", "RefJet:    old=%8.f  new=%8.f", (*oldMet->find("RefJet")   )->met(), (*newMet->find("RefJet")   )->met());
+    Info("execute()", "SoftClus:  old=%8.f  new=%8.f", (*oldMet->find("SoftClus") )->met(), (*newMet->find("SoftClus") )->met());
+    Info("execute()", "FinalClus: old=%8.f  new=%8.f", (*oldMet->find("FinalClus"))->met(), (*newMet->find("FinalClus"))->met());
+    Info("execute()", "       >>>>> R=%.3f",          (*oldMet->find("FinalClus"))->met()/ (*newMet->find("FinalClus"))->met());
+  }
+
+  return EL::StatusCode::SUCCESS;
+
+}
+
+
+
+EL::StatusCode METConstructor :: postExecute ()
+{
+  // Here you do everything that needs to be done after the main event
+  // processing.  This is typically very rare, particularly in user
+  // code.  It is mainly used in implementing the NTupleSvc.
+
+  if(m_debug) Info("postExecute()", "Calling postExecute \n");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor::finalize()
+{
+  // This method is the mirror image of initialize(), meaning it gets
+  // called after the last event has been processed on the worker node
+  // and allows you to finish up any objects you created in
+  // initialize() before they are written to disk.  This is actually
+  // fairly rare, since this happens separately for each worker node.
+  // Most of the time you want to do your post-processing on the
+  // submission node after all your histogram outputs have been
+  // merged.  This is different from histFinalize() in that it only
+  // gets called on worker nodes that processed input events.
+
+  Info("finalize()", "Deleting tool instances... \n");
+
+  if (m_metmaker) {
+    delete m_metmaker;
+    m_metmaker = 0;
+  }
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode METConstructor :: histFinalize ()
+{
+  // This method is the mirror image of histInitialize(), meaning it
+  // gets called after the last event has been processed on the worker
+  // node and allows you to finish up any objects you created in
+  // histInitialize() before they are written to disk.  This is
+  // actually fairly rare, since this happens separately for each
+  // worker node.  Most of the time you want to do your
+  // post-processing on the submission node after all your histogram
+  // outputs have been merged.  This is different from finalize() in
+  // that it gets called on all worker nodes regardless of whether
+  // they processed input events.
+
+  Info("histFinalize()", "Calling histFinalize \n");
+
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -244,7 +244,7 @@ EL::StatusCode METConstructor :: execute ()
   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, m_debug), "Failed retrieving tau cont.");
   if (m_doTauCuts) {
     ConstDataVector<xAOD::TauJetContainer> metTaus(SG::VIEW_ELEMENTS);
-    // for (const auto& tau : *tauCont) if (CutsMETMaker::accept(tau)) metTaus.push_back(tau);
+    for (const auto& tau : *tauCont) if (CutsMETMaker::accept(tau)) metTaus.push_back(tau);
     RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefTau", xAOD::Type::Tau, newMet, metTaus.asDataVector(), metMap), "Failed rebuilding tau component.");
   } else {
     RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildMET("RefTau", xAOD::Type::Tau, newMet, tauCont, metMap), "Failed rebuilding tau component.");

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -600,12 +600,6 @@ EL::StatusCode MuonSelector :: histFinalize ()
 
 int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primaryVertex  ) {
 
-  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/InDetTrackingDC14
-
-  const xAOD::TrackParticle* tp  = muon->primaryTrackParticle();
-
-  float d0_significance = fabs( tp->d0() ) / sqrt(tp->definingParametersCovMatrix()(0,0) );
-  float z0sintheta      = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
 
   int type = static_cast<int>(muon->muonType());
 
@@ -632,6 +626,14 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
   // do not cut on impact parameter if muon is Standalone
   if ( type != xAOD::Muon::MuonType::MuonStandAlone ) {
+    
+    // Put tracking here, after pt cuts, to be safe with derivations.
+    // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/InDetTrackingDC14
+    const xAOD::TrackParticle* tp  = muon->primaryTrackParticle();
+
+    float d0_significance = fabs( tp->d0() ) / sqrt(tp->definingParametersCovMatrix()(0,0) );
+    float z0sintheta      = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
     // d0 cut
     if ( !( tp->d0() < m_d0_max ) ) {
     	if ( m_debug ) { Info("PassCuts()", "Muon failed d0 cut."); }

--- a/data/MET_MC15.config
+++ b/data/MET_MC15.config
@@ -1,0 +1,13 @@
+Debug             False
+MapName           METAssoc_AntiKt4EMTopo
+CoreName          MET_Core_AntiKt4EMTopo
+OutputContainer   RefFinalVBF
+InputJets         AntiKt4EMTopoJets_Signal
+InputElectrons    Electrons_Signal
+InputPhotons      Photons
+InputTaus         TauJets
+InputMuons        Muons_Signal
+ApplyPhotonCuts   True
+ApplyMuonCuts     True
+ApplyTauCuts      True
+

--- a/data/baseEvent.config
+++ b/data/baseEvent.config
@@ -5,4 +5,5 @@ VertexContainer           PrimaryVertices
 NTrackForPrimaryVertex    2
 TruthLevelOnly            False
 DerivationName		  HIGG3D1
+UseMetaData    False
 ## last option must be followed by a new line ##

--- a/util/test_multiAlgo.cxx
+++ b/util/test_multiAlgo.cxx
@@ -19,6 +19,7 @@
 #include "xAODAnaHelpers/ElectronSelector.h"
 #include "xAODAnaHelpers/Writer.h"
 #include "xAODAnaHelpers/OverlapRemover.h"
+#include "xAODAnaHelpers/METConstructor.h"
 #include "xAODAnaHelpers/TreeAlgo.h"
 
 #include "PATInterfaces/SystematicVariation.h"
@@ -140,6 +141,9 @@ int main( int argc, char* argv[] ) {
   OverlapRemover* overlapRemoval                = new OverlapRemover();
   overlapRemoval->setName("OverlapRemovalTool")->setConfig(localDataDir+"overlapRemoval.config");
 
+  METConstructor* met = new METConstructor();
+  met->setName("met")->setConfig(localDataDir+"MET_MC15.config");
+
   JetHistsAlgo* jk_AntiKt10LC                   = new JetHistsAlgo();
   jk_AntiKt10LC->setName("AntiKt10/")->setConfig(localDataDir+"test_jetPlotExample.config");
 
@@ -163,6 +167,7 @@ int main( int argc, char* argv[] ) {
   job.algsAdd( jetSelect_truth );
   job.algsAdd( jetHistsAlgo_truth );
   job.algsAdd( overlapRemoval );
+  job.algsAdd( met );
   job.algsAdd( jk_AntiKt10LC );
   job.algsAdd( out_tree );
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -1,0 +1,80 @@
+#ifndef xAODAnaHelpers_METConstructor_H
+#define xAODAnaHelpers_METConstructor_H
+
+#include <xAODAnaHelpers/Algorithm.h>
+
+// Infrastructure include(s):
+#include "xAODRootAccess/Init.h"
+#include "xAODRootAccess/TEvent.h"
+#include "xAODRootAccess/TStore.h"
+
+
+using std::string; 
+
+namespace met{
+  class METMaker;
+}
+
+
+class METConstructor : public xAH::Algorithm
+{
+  // put your configuration variables here as public variables.
+  // that way they can be set directly from CINT and python.
+public:
+
+  xAOD::TEvent *m_event;  //!
+  xAOD::TStore *m_store;  //!
+
+  bool m_debug;
+
+private:
+
+  // tools
+  met::METMaker* m_metmaker; //!
+
+  // configuration variables
+  TString m_referenceMETContainer;
+  TString m_mapName;
+  TString m_coreName;
+  TString m_outputContainer;
+  TString m_inputJets;
+  TString m_inputElectrons;
+  TString m_inputPhotons;
+  TString m_inputTaus;
+  TString m_inputMuons;
+
+  bool    m_doElectronCuts;
+  bool    m_doPhotonCuts;
+  bool    m_doTauCuts;
+  bool    m_doMuonCuts;
+
+
+  // variables that don't get filled at submission time should be
+  // protected from being send from the submission node to the worker
+  // node (done by the //!)
+public:
+  // Tree *myTree; //!
+  // TH1 *myHist; //!
+
+  // this is a standard constructor
+  METConstructor ();
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute();
+  virtual EL::StatusCode finalize();
+  virtual EL::StatusCode histFinalize();
+
+  // these are the functions not inherited from Algorithm
+  virtual EL::StatusCode configure ();
+  
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(METConstructor, 1);
+};
+
+#endif


### PR DESCRIPTION
This commit includes two distinct pieces: 

 1) METConstructor added to xAODAnaHelpers.  This code follows closely from [METMakerAlg.cxx](https://svnweb.cern.ch/trac/atlasoff/browser/Reconstruction/MET/METUtilities/trunk/src/METMakerAlg.cxx).  A test for it has been added in test_multiAlgo, with an example configuration in data/.  With Debug set to true, the stored MET values are printed and compared to the recalculated values and, for the most part, these agree well.  Further work is required to propagate the object systematics through this calculation.  The soft term uncertainty recommendations have not yet been released.

 2) I have changed the order of the muon and electron trackParticle access, so that it comes _after_ the pt and eta cuts.  This makes the cuts more compatible with derivations, where those collections may be slimmed, depending on the particles' pts and etas.  Since in those cases the track particles may not be available, this leads to a seg fault if the electrons or muons are not rejected before attempting access.  Hope this makes sense.

Thanks a lot for your consideration -- 

Jamie  