### PR TITLE
Fix 'passSel' flag for jets in JetSelector.cxx

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1408,9 +1408,13 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation ) {
     if ( m_jetInfoSwitch->m_flavTag) {
       const xAOD::BTagging * myBTag = jet_itr->btagging();
       if ( !m_DC14 ) {
-        m_jet_sv0.push_back(     myBTag -> SV0_significance3D()       );
-        m_jet_sv1.push_back(     myBTag -> SV1_loglikelihoodratio()   );
+      
+        static SG::AuxElement::ConstAccessor<double> SV0_significance3DAcc ("SV0_significance3D");
+        if ( SV0_significance3DAcc.isAvailable(*myBTag) ) { m_jet_sv0.push_back(  myBTag -> SV0_significance3D() ); }
+        
+	m_jet_sv1.push_back(     myBTag -> SV1_loglikelihoodratio()   );
         m_jet_ip3d.push_back(    myBTag -> IP3D_loglikelihoodratio()  );
+	
       }
       m_jet_sv1ip3d.push_back( myBTag -> SV1plusIP3D_discriminant() );
       m_jet_mv1.push_back(     myBTag -> MV1_discriminant()         );

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -94,13 +94,13 @@ JetSelector :: JetSelector () :
   m_mass_min                = 1e8;
   m_rapidity_max            = 1e8;
   m_rapidity_min            = 1e8;
-  m_truthLabel 	      = -1;
+  m_truthLabel 	            = -1;
 
-  m_doJVF 		      = false;
-  m_doBTagCut 		      = false;
-  m_pt_max_JVF 	      = 50e3;
-  m_eta_max_JVF 	      = 2.4;
-  m_JVFCut 		      = 0.5;
+  m_doJVF 		    = false;
+  m_doBTagCut 		    = false;
+  m_pt_max_JVF 	            = 50e3;
+  m_eta_max_JVF 	    = 2.4;
+  m_JVFCut 		    = 0.5;
 
   // Btag quality
   m_btag_veryloose          = false;
@@ -227,16 +227,16 @@ EL::StatusCode  JetSelector :: configure ()
   m_btag_loose_cut     = -0.3867;
   m_btag_medium_cut    =  0.0314;
   m_btag_tight_cut     =  0.5102;
-  if ( m_btag_veryloose ) { m_btagCut = m_btag_veryloose_cut; m_decor += "BTagVeryLoose";  }
-  if ( m_btag_loose     ) { m_btagCut = m_btag_loose_cut;     m_decor += "BTagLoose";      }
-  if ( m_btag_medium    ) { m_btagCut = m_btag_medium_cut;    m_decor += "BTagMedium";     }
-  if ( m_btag_tight     ) { m_btagCut = m_btag_tight_cut;     m_decor += "BTagTight";      }
+  if ( m_btag_veryloose ) { m_btagCut = m_btag_veryloose_cut; }
+  if ( m_btag_loose     ) { m_btagCut = m_btag_loose_cut;     }
+  if ( m_btag_medium    ) { m_btagCut = m_btag_medium_cut;    }
+  if ( m_btag_tight     ) { m_btagCut = m_btag_tight_cut;     }
 
   //} else if ( m_isLCjet ) {
-  //if ( m_btag_veryloose ) { m_btagCut = 0.1340; m_decor += "BTagVeryLoose";  }
-  //if ( m_btag_loose     ) { m_btagCut = 0.3511; m_decor += "BTagLoose";      }
-  //if ( m_btag_medium    ) { m_btagCut = 0.7892; m_decor += "BTagMedium";     }
-  //if ( m_btag_tight     ) { m_btagCut = 0.9827; m_decor += "BTagTight";      }
+  //if ( m_btag_veryloose ) { m_btagCut = 0.1340; }
+  //if ( m_btag_loose     ) { m_btagCut = 0.3511; }
+  //if ( m_btag_medium    ) { m_btagCut = 0.7892; }
+  //if ( m_btag_tight     ) { m_btagCut = 0.9827; }
   //}
 
 


### PR DESCRIPTION
-) In Root/HelpTreeBase.cxx, added a control on SV0_significance3D variable to check whether it's available before filling the tree.

-) In Root/JetSelector.cxx, make sure that the decoration for jets that pass the selection is 'passSel' ONLY (no appended strings).
   Jets that pass BTagging requirements will be decorated anyways later in the algorithm.
   This is needed to prevent crashes at the Overlap Removal stage.