### PR TITLE
GRLExclusion List

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -644,6 +644,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
 
   // JVT pileup cut
   if ( m_doJVT ){
+    //std::cout << "pt/eta/JVT : " << jet->pt() << "/" << jet->eta() << "/" << jet->getAttribute< float >( "Jvt" ) << std::endl;
     if ( jet->pt() < m_pt_max_JVT ) {
       xAOD::JetFourMom_t jetConstitScaleP4 = jet->getAttribute< xAOD::JetFourMom_t >( "JetConstitScaleMomentum" );
       if ( fabs(jetConstitScaleP4.eta()) < m_eta_max_JVT ){

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -29,6 +29,7 @@ class BasicEventSelection : public xAH::Algorithm
     // GRL
     bool m_applyGRL;
     std::string m_GRLxml;
+    std::string m_GRLExcludeList;
     //PU Reweighting
     bool m_doPUreweighting;
     bool m_useMetaData;


### PR DESCRIPTION
Minor Change to GRL behaviour to allow specific RunNumbers to be excluded from the GRL check.  This allows the application of period specific GRLs (such as the current A1 GRL) which would normally fail any run's outside of the period.

@gfacini @johnda102 @kratsg 