### PR TITLE
Use int value for int type variable in *.config, not a float!

### DIFF
--- a/data/jetSelect_signal.config
+++ b/data/jetSelect_signal.config
@@ -12,9 +12,9 @@ pTMaxJVF		50e3
 etaMaxJVF		2.4
 JVFCut			0.5
 #Recommend cut JVT < 0.64
-DoJVT			              True
-pTMaxJVT		            50e3
-etaMaxJVT		            2.4
-JVTCut			            0.64
+DoJVT			True
+pTMaxJVT		50e3
+etaMaxJVT		2.4
+JVTCut			0.64
 Debug			False
 ## last option must be followed by a new line ##

--- a/data/muonSelect_signal.config
+++ b/data/muonSelect_signal.config
@@ -34,7 +34,7 @@ MuonType Combined
 pTMin 10e3
 etaMax 2.5
 PassMin 0
-PassMax	1e8
+PassMax	1000
 # ----------------------------------------------------------------------------------- #
 #
 # muon quality as defined by xAOD::MuonQuality enum {Tight, Medium, Loose, VeryLoose} 


### PR DESCRIPTION
To avoid nasty bugs, make sure you use the correct values for different types in your *.config files

E.g., a thing like this:

```
passMax 1e8
```

will be interpreted as '1', not as '100000000' !!!

(@kratsg, I know what you are going to say! :smile: ) 