### PR TITLE
Allow multiple systematics WP

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -16,15 +16,15 @@ ClassImp(xAH::AlgorithmRegistry)
 int xAH::AlgorithmRegistry::countRegistered(std::string className){
 
   auto iter = m_registered_algos.find(className);
-  
-  if ( iter != m_registered_algos.end() ) {  
+
+  if ( iter != m_registered_algos.end() ) {
     Info("countRegistered()","input class name: %s is already in the registry! Increase counter by 1 and return it", className.c_str() );
     m_registered_algos.at(className)++;
     return m_registered_algos.at(className);
   }
-    
+
   Info("countRegistered()","input class name: %s is not registered yet. Returning 0", className.c_str() );
-  
+
   return 0;
 
 }
@@ -90,6 +90,12 @@ xAH::Algorithm* xAH::Algorithm::setSyst(std::string systName, float systVal){
   return this;
 }
 
+xAH::Algorithm* xAH::Algorithm::setSyst(std::string systName, std::vector<float> systValVector){
+  m_systName = systName;
+  m_systValVector = systValVector;
+  return this;
+}
+
 int xAH::Algorithm::isMC(){
   // first override if need to
   if(m_isMC == 0 || m_isMC == 1) return m_isMC;
@@ -115,14 +121,14 @@ xAH::Algorithm* xAH::Algorithm::registerClass(xAH::AlgorithmRegistry &reg, std::
 
   Info("registerClass()","input class name: %s", className.c_str() );
 
-  // the function will return 0 if the algo 
+  // the function will return 0 if the algo
   // isn't in the registry yet
-  m_count_used = reg.countRegistered(className); 
-  
+  m_count_used = reg.countRegistered(className);
+
   // if not found already, set in the map in the registry the name of the algo
   // and assign a value of 0 to the counter
   if ( m_count_used == 0 ) { reg.m_registered_algos[className] = m_count_used; }
-  
+
   return this;
 
 }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -332,12 +332,20 @@ EL::StatusCode JetCalibrator :: initialize ()
     const CP::SystematicSet recSysts = m_JESUncertTool->recommendedSystematics();
 
     Info("initialize()"," Initializing Jet Systematics :");
-    std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal );
 
-    //for ( const auto& syst_it : JESSysList ){
-    for(int i=0; i < JESSysList.size(); ++i){
-      m_systList.push_back(  JESSysList.at(i) );
-      m_systType.push_back(1);
+    //If just one systVal, then push it to the vector
+    if( m_systValVector.size() == 0)
+      m_systValVector.push_back(m_systVal);
+
+    for(unsigned int iSyst=0; iSyst < m_systValVector.size(); ++iSyst){
+      m_systVal = m_systValVector.at(iSyst);
+      std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal );
+
+      //for ( const auto& syst_it : JESSysList ){
+      for(unsigned int i=0; i < JESSysList.size(); ++i){
+        m_systList.push_back(  JESSysList.at(i) );
+        m_systType.push_back(1);
+      }
     }
 
     // Setup the tool for the 1st systematic on the list
@@ -393,9 +401,8 @@ EL::StatusCode JetCalibrator :: initialize ()
     const CP::SystematicSet recSysts = m_JERSmearTool->recommendedSystematics();
     Info("initialize()", " Initializing JER Systematics :");
 
-    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal );
-    //for ( const auto& syst_it : JERSysList ){
-    for(int i=0; i < JERSysList.size(); ++i){
+    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, 1 ); //Only 1 sys allowed
+    for(unsigned int i=0; i < JERSysList.size(); ++i){
       m_systList.push_back(  JERSysList.at(i) );
       m_systType.push_back(2);
     }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -19,19 +19,19 @@ namespace xAH {
       public:
         AlgorithmRegistry(){};
 	virtual ~AlgorithmRegistry() {};
-        ClassDef(AlgorithmRegistry, 1);      
-     
+        ClassDef(AlgorithmRegistry, 1);
+
         // this maps bookkeeps the names of the algorithms
-        // which are used, and how many times they have 
+        // which are used, and how many times they have
         // been used before as well
         std::map<std::string, int> m_registered_algos;
 
-        // returns how many times an algo has been 
+        // returns how many times an algo has been
         // already used
         int countRegistered(std::string className);
 
   };
-  
+
   class Algorithm : public EL::Algorithm {
       public:
         Algorithm();
@@ -49,10 +49,11 @@ namespace xAH {
 
         Algorithm* setSyst(std::string systName);
         Algorithm* setSyst(std::string systName, float systVal);
+        Algorithm* setSyst(std::string systName, std::vector<float> systValVector);
 
         // each algorithm should have a unique name for init, to differentiate them
         std::string m_name;
-       
+
         // enable verbosity, debugging or not
         bool m_debug,
              m_verbose;
@@ -61,6 +62,8 @@ namespace xAH {
         std::string m_systName;
         // if running systs - the value ( +/- 1 )
         float m_systVal;
+        // for running multiple syst points
+        std::vector<float> m_systValVector;
 
         // custom EventInfo container name
         std::string m_eventInfoContainerName;
@@ -70,10 +73,10 @@ namespace xAH {
         // 0: this is data
         // 1: this is mc
         int m_isMC;
-	
-	// register the name of the algorithms 
+
+	// register the name of the algorithms
 	// in a record.
-	// This can be used as a 'database' for other algos 
+	// This can be used as a 'database' for other algos
 	// to check if a class of the same type already exists
 	Algorithm* registerClass(AlgorithmRegistry &reg, std::string className);
 
@@ -87,16 +90,16 @@ namespace xAH {
         // will try to determine if data or if MC
         // returns: -1=unknown (could not determine), 0=data, 1=mc
         int isMC();
-	
-	// returns how many times an algo of *this* type 
+
+	// returns how many times an algo of *this* type
 	// has already been used
 	int countUsed() { return m_count_used; };
-      
+
       private:
         // bookkeeps the number of times an algo of *this* type has been used
-	int m_count_used;	
+	int m_count_used;
 
   };
- 
+
 }
 #endif


### PR DESCRIPTION
Allows several working points (sigmas) to be run over, rather than just one, for systematic variations.  This introduces a vector of floats, m_systValVector, similar to m_systVal.  m_systVal still remains and can be used, so there is complete backwards compatibility.  This vector of systematic values is used in JetCalibrator when running JES systematics.