### PR TITLE
Event CutBookkeepers MetaData - This is it (?)

### DIFF
--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -63,7 +63,7 @@ class BasicEventSelection : public xAH::Algorithm
     bool m_useMetaData;
 
   private:
-    GoodRunsListSelectionTool*   m_grl;       //!
+    GoodRunsListSelectionTool*   m_grl;        //!
     CP::PileupReweightingTool*   m_pileuptool; //!
     int m_PU_default_channel; //!
     

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -1,14 +1,14 @@
-/********************************************************************************
+/********************************************************
  * HelpTreeBase:
  *
  * This class is meant to help the user write out a tree.
  * Some branches are included by default while others
  * need to be added by the user
  *
- * Gabriel Facini ( gabriel.facini@cern.ch ), Marco Milesi (marco.milesi@cern.ch)
+ * Gabriel Facini (gabriel.facini@cern.ch) 
+ * Marco Milesi (marco.milesi@cern.ch)
  *
- *
- ********************************************************************************/
+ ********************************************************/
 
 // Dear emacs, this is -*-c++-*-
 #ifndef xAODAnaHelpers_HelpTreeBase_H


### PR DESCRIPTION
Hi @gfacini , @kratsg , 

I dug into this email thread on PATHelp:

https://groups.cern.ch/group/hn-atlas-PATHelp/Lists/Archive/DispForm.aspx?ID=14739

and it seems like we needed to add a safety check where we retrieve the event bookkeepers for the initial number of events. 

Basically we need to make sure that we do not skip files where there are Incomplete CutBookkeepers (these files in principle *should* be skipped...), but ALL of them have  unknown input stream. 
This issue has been observed in some DAOD flavours, so it's good to make sure we handle it properly.

Please read through the email thread for the technicalities.

Another little thing I have added: now the metadata histogram is fillled with meaningful values also when processing **full** xAODs. In this case, the numbers are taken directly from the `CollectionTree` TTree (there is a TEvent::getEntries() method, but it cannot access the tree weight, so I got the info straight from the Tree)

This would close #15 

Marco


 