### PR TITLE
Fixed bug, causing vector out of range error

### DIFF
--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -650,7 +650,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // add vector<string container_names_syst> to TStore
       //
-      RETURN_CHECK( "execute()", m_store->record( vecOutContainerNames_el, m_outputAlgoMuons ), "Failed to record vector of output container names.");
+      RETURN_CHECK( "execute()", m_store->record( vecOutContainerNames_el, m_outputAlgoElectrons ), "Failed to record vector of output container names.");
       break;
     }
     case (2) : // muon syst


### PR DESCRIPTION
Change l.653 from:
```RETURN_CHECK( "execute()", m_store->record( vecOutContainerNames_el, m_outputAlgoMuons ), "Failed to record vector of output container names.");```
to:
``` RETURN_CHECK( "execute()", m_store->record( vecOutContainerNames_el, m_outputAlgoElectrons ), "Failed to record vector of output container names.");```
In order to prevent causing errors like:
```
Info in <OverlapRemover::execute()>: Applying Overlap Removal... 
Info in <OverlapRemover::execute()>: inElectrons : 2, inMuons : 1, inJets : 4
Info in <OverlapRemover::printObj()>:   electron pt  38.58 eta -0.75 phi  1.61 selected 1 overlaps 0 
Info in <OverlapRemover::printObj()>:   electron pt  40.72 eta  0.21 phi -1.46 selected 1 overlaps 0 
Info in <OverlapRemover::printObj()>:   muon pt  21.64 eta -1.24 phi -1.21 selected 1 overlaps 0 
Info in <OverlapRemover::printObj()>:   jet pt  76.97 eta -1.28 phi -1.20 selected 1 overlaps 1 
Info in <OverlapRemover::printObj()>:   jet pt  70.66 eta  1.49 phi  1.89 selected 1 overlaps 0 
Info in <OverlapRemover::printObj()>:   jet pt  56.09 eta -0.75 phi  1.61 selected 1 overlaps 1 
Info in <OverlapRemover::printObj()>:   jet pt  52.96 eta  0.21 phi -1.47 selected 1 overlaps 1 
Info in <OverlapRemover::execute()>: selectedElectrons : 2, selectedMuons : 1, selectedJets : 1
Info in <OverlapRemover::execute()>: output vector already contains the following ELECTRON systematics:
Info in <OverlapRemover::execute()>: 	  
Info in <OverlapRemover::execute()>: output vector already contains MUON systematics:
Info in <OverlapRemover::execute()>: 	  
Error in <xAOD::TStore::record>: /build1/atnight/localbuilds/nightlies/AnalysisBase-2.3.X/AnalysisBase/rel_nightly/xAODRootAccess/Root/TStore.cxx:241 Trying to overwrite object with key "SignalMuons_OR_Algo"
Error in <execute()>: /afs/cern.ch/user/b/btuan/work/xAODAnaHelpers/Root/OverlapRemover.cxx:736 Failed to execute: m_store->record( vecOutContainerNames_mu, m_outputAlgoMuons )
	Failed to record vector of output container names.

Info in <OverlapRemover::execute()>: output vector already contains the following JET systematics:
Info in <OverlapRemover::execute()>:
```