### PR TITLE
Fix Jet Calibrator Systematics Handling 

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -393,7 +393,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
   m_muInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr );
-
+  std::cout << "Muon info switch detail string. "<< detailStr << std::endl;
   // always
   m_tree->Branch("nmuon",   &m_nmuon, "nmuon/I");
 
@@ -483,7 +483,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
   for ( auto muon_itr : *(muons) ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillMuons()", "Filling muon w/ pT = %2f", muon_itr->pt() / m_units ); }
-
+    if ( m_muInfoSwitch->m_kinematic ) std::cout << "kinematic or something" << std::endl;
     if ( m_muInfoSwitch->m_kinematic ) {
       m_muon_pt.push_back ( muon_itr->pt() / m_units  );
       m_muon_eta.push_back( muon_itr->eta() );
@@ -641,6 +641,9 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 void HelpTreeBase::ClearMuons() {
 
   m_nmuon = 0;
+
+  if ( m_muInfoSwitch ) std::cout << "Muon info switch defined." << std::endl;
+  else {std::cout << "Muon info switch ill-defined. Will exit" << std::endl; return;}
 
   if ( m_muInfoSwitch->m_kinematic ) {
     m_muon_pt.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -393,7 +393,6 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
   m_muInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr );
-  std::cout << "Muon info switch detail string. "<< detailStr << std::endl;
   // always
   m_tree->Branch("nmuon",   &m_nmuon, "nmuon/I");
 
@@ -483,7 +482,6 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
   for ( auto muon_itr : *(muons) ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillMuons()", "Filling muon w/ pT = %2f", muon_itr->pt() / m_units ); }
-    if ( m_muInfoSwitch->m_kinematic ) std::cout << "kinematic or something" << std::endl;
     if ( m_muInfoSwitch->m_kinematic ) {
       m_muon_pt.push_back ( muon_itr->pt() / m_units  );
       m_muon_eta.push_back( muon_itr->eta() );
@@ -641,9 +639,6 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 void HelpTreeBase::ClearMuons() {
 
   m_nmuon = 0;
-
-  if ( m_muInfoSwitch ) std::cout << "Muon info switch defined." << std::endl;
-  else {std::cout << "Muon info switch ill-defined. Will exit" << std::endl; return;}
 
   if ( m_muInfoSwitch->m_kinematic ) {
     m_muon_pt.clear();

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -151,10 +151,10 @@ bool HelperFunctions::isFilePrimaryxAOD(TFile* inputFile) {
     metaData->LoadTree(0);
     TObjArray* ar = metaData->GetListOfBranches();
     for (int i = 0; i < ar->GetEntries(); ++i) {
-  TBranch* b = (TBranch*) ar->At(i);
-  std::string name = std::string(b->GetName());
-  if (name == "StreamAOD")
-      return true;
+      TBranch* b = (TBranch*) ar->At(i);
+      std::string name = std::string(b->GetName());
+      if (name == "StreamAOD")
+        return true;
     }
 
     return false;

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -151,10 +151,10 @@ bool HelperFunctions::isFilePrimaryxAOD(TFile* inputFile) {
     metaData->LoadTree(0);
     TObjArray* ar = metaData->GetListOfBranches();
     for (int i = 0; i < ar->GetEntries(); ++i) {
-	TBranch* b = (TBranch*) ar->At(i);
-	std::string name = std::string(b->GetName());
-	if (name == "StreamAOD")
-	    return true;
+  TBranch* b = (TBranch*) ar->At(i);
+  std::string name = std::string(b->GetName());
+  if (name == "StreamAOD")
+      return true;
     }
 
     return false;
@@ -332,13 +332,13 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
       //
       if ( syst == CP::SystematicVariation (syst.basename(), CP::SystematicVariation::CONTINUOUS) ) {
         
-	outSystList.push_back(CP::SystematicSet());
+        outSystList.push_back(CP::SystematicSet());
         
-	if ( systVal == 0 ) {
+        if ( systVal == 0 ) {
           Error("HelperFunctions::getListofSystematics()","Setting continuous systematic to 0 is nominal! Please check!");
           RCU_THROW_MSG("Failure");
         }
-	
+  
         outSystList.back().insert(CP::SystematicVariation (syst.basename(), systVal));
       
       } else {
@@ -362,15 +362,15 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
       //
       if ( syst == CP::SystematicVariation (syst.basename(), CP::SystematicVariation::CONTINUOUS) ) {
         
-	if ( systVal == 0 ) {
-          Error("HelperFunctions::getListofSystematics()","Setting continuous systematic to 0 is nominal! Please check!");
-          RCU_THROW_MSG("Failure");
-        }
+      if ( systVal == 0 ) {
+        Error("HelperFunctions::getListofSystematics()","Setting continuous systematic to 0 is nominal! Please check!");
+        RCU_THROW_MSG("Failure");
+      }
         
-	outSystList.push_back(CP::SystematicSet());
-        outSystList.back().insert(CP::SystematicVariation (syst.basename(),  fabs(systVal)));
-        outSystList.push_back(CP::SystematicSet());
-        outSystList.back().insert(CP::SystematicVariation (syst.basename(), -1.0*fabs(systVal)));
+      outSystList.push_back(CP::SystematicSet());
+      outSystList.back().insert(CP::SystematicVariation (syst.basename(),  fabs(systVal)));
+      outSystList.push_back(CP::SystematicSet());
+      outSystList.back().insert(CP::SystematicVariation (syst.basename(), -1.0*fabs(systVal)));
       
       } else {
       // not a continuous systematic

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -94,6 +94,9 @@ JetCalibrator :: JetCalibrator () :
 
   //recalculate JVT using calibrated jets
   m_redoJVT                 = false;
+  
+  // Avoid the m_systName == "None" condition, which makes downstream algs malfunction
+  m_systName                = "All";
 
 }
 
@@ -141,6 +144,7 @@ EL::StatusCode  JetCalibrator :: configure ()
     m_cleanParent             = config->GetValue("CleanParent",             m_cleanParent);
 
     m_redoJVT                 = config->GetValue("RedoJVT",         m_redoJVT);
+    // m_systName                = config->GetValue("SystName",        m_systName.c_str());
 
     config->Print();
 
@@ -323,9 +327,14 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
+  m_systName = "All";
   // initialize and configure the jet uncertainity tool
   // only initialize if a config file has been given
   //------------------------------------------------
+  std::cout << "Everything good up to here." << std::endl; 
+  if( m_JESUncertConfig.empty() ) std::cout << "JES Uncertainty empty." << std::endl;
+  if( m_systName.empty() ) std::cout << "Systematics names empty." << std::endl;
+  else std::cout << "Systematic name is: " << m_systName << std::endl;
   if ( !m_JESUncertConfig.empty() && !m_systName.empty()  && m_systName != "None" ) {
     m_JESUncertConfig = gSystem->ExpandPathName( m_JESUncertConfig.c_str() );
     Info("initialize()","Initialize JES UNCERT with %s", m_JESUncertConfig.c_str());
@@ -341,6 +350,8 @@ EL::StatusCode JetCalibrator :: initialize ()
     Info("initialize()"," Initializing Jet Systematics :");
 
     //If just one systVal, then push it to the vector
+    std::cout<<"Size of m_systValVector: "<<m_systValVector.size()<<std::endl;
+    m_systVal = 1;
     if( m_systValVector.size() == 0) {
       if ( m_debug ){ Info("initialize()", "Pushing the following systVal to m_systValVector: %f", m_systVal ); }
       m_systValVector.push_back(m_systVal);

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -336,7 +336,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   //
   const CP::SystematicRegistry& systReg = CP::SystematicRegistry::getInstance();
   const CP::SystematicSet& recSyst = (systReg.recommendedSystematics());
-  Info("initialize()"," Initializing Muon Calibrator Systematics :");
+  Info("initialize()"," Initializing Jet Calibrator Systematics :");
   //
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!

--- a/data/jetCalib_AntiKt4TopoEMCalib.config
+++ b/data/jetCalib_AntiKt4TopoEMCalib.config
@@ -1,6 +1,6 @@
 InputContainer		AntiKt4EMTopoJets
 JetAlgorithm      	AntiKt4EMTopo
-OutputAlgo	  	AntiKt4EMTopoJets_Calib_Algo
+OutputAlgoSystNames	AntiKt4EMTopoJets_Calib_Algo
 OutputContainer   	AntiKt4EMTopoJets_Calib
 Sort            true
 # MC 8 TeV - for release 20 onwards
@@ -32,4 +32,7 @@ JERFullSys        	False
 JERApplyNominal   	False
 Debug             	False
 RedoJVT           	True
+# Parameters for configuring systematics. Leave blank unless running on systematics
+SystName
+SystVal
 ## last option must be followed by a new line ##

--- a/scripts/checkoutASGtags.py
+++ b/scripts/checkoutASGtags.py
@@ -37,8 +37,8 @@ dict_pkg = {
             '2.3.21': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency/tags/xAODBTaggingEfficiency-00-00-19",
                        "atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/CDIFiles/tags/CDIFiles-00-00-06"],
             '2.3.23': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/CDIFiles/tags/CDIFiles-00-00-06",
-                       "atlasoff/Reconstruction/Jet/JetUncertainties/tags/JetUncertainties-00-09-30"]
-                       
+                       "atlasoff/Reconstruction/Jet/JetUncertainties/tags/JetUncertainties-00-09-30"],
+            '2.3.24': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/CDIFiles/tags/CDIFiles-00-00-06"]
            }
 
 try:

--- a/scripts/checkoutASGtags.py
+++ b/scripts/checkoutASGtags.py
@@ -69,10 +69,12 @@ for pkg in packages_to_patch:
 
 #### Update Run II GRLs ####
 print "Updating GRL..."
-physicsGRL = "http://atlasdqm.web.cern.ch/atlasdqm/grlgen/All_Good/data15_13TeV.periodAllYear_DetStatus-v63-pro18-01_DQDefects-00-01-02_PHYS_StandardGRL_All_Good.xml"
+physicsGRL50ns = "http://atlasdqm.web.cern.ch/atlasdqm/grlgen/All_Good/data15_13TeV.periodAllYear_DetStatus-v63-pro18-01_DQDefects-00-01-02_PHYS_StandardGRL_All_Good.xml"
+physicsGRL25ns = "http://atlasdqm.web.cern.ch/atlasdqm/grlgen/All_Good/data15_13TeV.periodAllYear_DetStatus-v64-pro19_DQDefects-00-01-02_PHYS_StandardGRL_All_Good.xml"
 atlasReadyGRL = "http://atlasdqm.web.cern.ch/atlasdqm/grlgen/Atlas_Ready/data15_13TeV.periodAllYear_HEAD_DQDefects-00-01-02_PHYS_StandardGRL_Atlas_Ready.xml"
 try:
-  subprocess.call(["wget","-q",physicsGRL,"-O", "xAODAnaHelpers/data/"+physicsGRL.split('/')[-1]])
+  subprocess.call(["wget","-q",physicsGRL50ns,"-O", "xAODAnaHelpers/data/"+physicsGRL50ns.split('/')[-1]])
+  subprocess.call(["wget","-q",physicsGRL25ns,"-O", "xAODAnaHelpers/data/"+physicsGRL25ns.split('/')[-1]])
   subprocess.call(["wget","-q",atlasReadyGRL,"-O","xAODAnaHelpers/data/"+atlasReadyGRL.split('/')[-1]])
 except OSError as e:
   print "Error, wget is not available.  Will not download grl.  You can find the latest version at", physicsGRL

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -27,7 +27,7 @@ public:
   std::string m_outContainerName;
 
   std::string m_jetAlgo;
-  std::string m_outputAlgo;
+  std::string m_outputAlgoSystNames;
   std::string m_calibConfigData;
   std::string m_calibConfigFullSim;
   std::string m_calibConfigAFII;


### PR DESCRIPTION
Hi All,

Just a few changes to fix the jet calibration step.
* JetCalibrator
  * Call `HelperFunctions::getListofSystematics()` like the other calibrators do.
  * Run nominal if `m_systName` is empty. If configured to be `None` or a specific systematic, do not run nominal.
  * Improve guards against duplicating nominal case.
  * **N.B. `outputAlgo` configuration changed to `outputAlgoSystNames` for uniformity. May break prior analyses if config file is not changed accordingly.**
* Other Changes
  * Add 25ns GRL to the `checkoutASGtags.py` script.

This addresses issues #236 and #237; is relevant to discussion in PR #238.

Best,

Brian 