### PR TITLE
safer in case there is no primary vertex in the event

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -1020,7 +1020,10 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
   
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
-  float z0sintheta       = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
+  float z0sintheta = 1e8;
+  if (primaryVertex) z0sintheta = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
 
   // z0*sin(theta) cut
   //

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -879,7 +879,10 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
   
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
-  float z0sintheta	 = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
+  float z0sintheta = 1e8;
+  if (primaryVertex) z0sintheta = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
 
   // z0*sin(theta) cut
   //


### PR DESCRIPTION
In some cases, we don't require a primary vertex in the event.  In that case the z0sintheta cut creates a crash.  Add minimal protection for this.