### PR TITLE
Add jet index to individual jet histograms in JetHists.

### DIFF
--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -37,15 +37,35 @@ StatusCode JetHists::initialize() {
   // N leading jets
   if( m_infoSwitch->m_numLeadingJets > 0 ){
     std::stringstream jetNum;
+    std::stringstream jetTitle;
     for(int iJet=0; iJet < m_infoSwitch->m_numLeadingJets; ++iJet){
       jetNum << iJet;
-      m_NjetsPt.push_back(       book(m_name, ("jetPt_jet"+jetNum.str()),       "jet p_{T} [GeV]", 120, 0, 3000.) );
-      m_NjetsEta.push_back(      book(m_name, ("jetEta_jet"+jetNum.str()),      "jet #eta",         80, -4, 4) );
-      m_NjetsPhi.push_back(      book(m_name, ("jetPhi_jet"+jetNum.str()),      "jet Phi",120, -TMath::Pi(), TMath::Pi() ) );
-      m_NjetsM.push_back(        book(m_name, ("jetMass_jet"+jetNum.str()),     "jet Mass [GeV]",120, 0, 400) );
-      m_NjetsE.push_back(        book(m_name, ("jetEnergy_jet"+jetNum.str()),   "jet Energy [GeV]",120, 0, 4000.) );
-      m_NjetsRapidity.push_back( book(m_name, ("jetRapidity_jet"+jetNum.str()), "jet Rapidity",120, -10, 10) );
+
+      jetTitle << iJet+1;
+      switch(iJet)
+	{
+	case 0:
+	  jetTitle << "^{st}";
+	  break;
+	case 1:
+	  jetTitle << "^{nd}";
+	  break;
+	case 2:
+	  jetTitle << "^{rd}";
+	  break;
+	default:
+	  jetTitle << "^{th}";
+	  break;
+	}
+
+      m_NjetsPt.push_back(       book(m_name, ("jetPt_jet"+jetNum.str()),       jetTitle.str()+" jet p_{T} [GeV]" ,120,            0,       3000. ) );
+      m_NjetsEta.push_back(      book(m_name, ("jetEta_jet"+jetNum.str()),      jetTitle.str()+" jet #eta"        , 80,           -4,           4 ) );
+      m_NjetsPhi.push_back(      book(m_name, ("jetPhi_jet"+jetNum.str()),      jetTitle.str()+" jet Phi"         ,120, -TMath::Pi(), TMath::Pi() ) );
+      m_NjetsM.push_back(        book(m_name, ("jetMass_jet"+jetNum.str()),     jetTitle.str()+" jet Mass [GeV]"  ,120,            0,         400 ) );
+      m_NjetsE.push_back(        book(m_name, ("jetEnergy_jet"+jetNum.str()),   jetTitle.str()+" jet Energy [GeV]",120,            0,       4000. ) );
+      m_NjetsRapidity.push_back( book(m_name, ("jetRapidity_jet"+jetNum.str()), jetTitle.str()+" jet Rapidity"    ,120,          -10,          10 ) );
       jetNum.str("");
+      jetTitle.str("");
     }//for iJet
   }
 


### PR DESCRIPTION
When plotting the kinematics of individual jets (m_numLeadingJets option) in JetHists, the x-axis title is always "jet *property*". This is not very informative. The pull request updates the code to set the x-axis title for such histograms to "x^{th} jet *property*".