### PR TITLE
Don't require inputDQ2 when using condor

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
         raise OSError('Output directory {0:s} already exists. Either re-run with -f/--force, choose a different --submitDir, or rm -rf it yourself. Just deal with it, dang it.'.format(args.submit_dir))
 
     # they will need it to get it working
-    use_scanDQ2 = (args.use_scanDQ2)|(args.driver in ['prun', 'condor','lsf'])
+    use_scanDQ2 = (args.use_scanDQ2)|(args.driver in ['prun', 'lsf'])
     if use_scanDQ2:
       if os.getenv('XRDSYS') is None:
         raise EnvironmentError('xrootd client is not setup. Run localSetupFAX or equivalent.')


### PR DESCRIPTION
This closes #262. Can @kkrizka :+1: it?