### PR TITLE
updates to METConstructor for Alex and Marco

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -51,7 +51,31 @@ using std::cout; using std::cerr; using std::endl;
 ClassImp(METConstructor)
 
 
-METConstructor :: METConstructor () : m_metmaker(0) {}
+METConstructor :: METConstructor () : m_metmaker(0) {
+
+  m_debug           = false;
+  m_referenceMETContainer = "MET_Reference_AntiKt4LCTopo";
+
+  m_mapName         = "METAssoc_AntiKt4LCTopo";
+  m_coreName        = "MET_Core_AntiKt4LCTopo";
+  m_outputContainer = "NewRefFinal";
+
+  m_inputJets       = ""; 
+  m_inputElectrons  = ""; 
+  m_inputPhotons    = ""; 
+  m_inputTaus       = ""; 
+  m_inputMuons      = ""; 
+
+  m_doElectronCuts  = false;
+  m_doPhotonCuts    = false;
+  m_doTauCuts       = false;
+  m_doMuonCuts      = false;
+
+  m_doMuonEloss     = false;
+  m_doIsolMuonEloss = false;
+  m_doJVFCut        = false;
+
+}
 
 EL::StatusCode  METConstructor :: configure ()
 {
@@ -71,23 +95,27 @@ EL::StatusCode  METConstructor :: configure ()
   TEnv* config = new TEnv(getConfig(true).c_str());
 
   // read debug flag from .config file
-  m_debug           = config->GetValue("Debug" , false );
-  m_referenceMETContainer = config->GetValue("Reference",       "MET_Reference_AntiKt4LCTopo");
+  m_debug           = config->GetValue("Debug" , m_debug);
+  m_referenceMETContainer = config->GetValue("Reference", m_referenceMETContainer);
 
-  m_mapName         = config->GetValue("MapName",         "METAssoc_AntiKt4LCTopo");
-  m_coreName        = config->GetValue("CoreName",        "MET_Core_AntiKt4LCTopo");
-  m_outputContainer = config->GetValue("OutputContainer", "NewRefFinal");
+  m_mapName         = config->GetValue("MapName",           m_mapName);
+  m_coreName        = config->GetValue("CoreName",          m_coreName);
+  m_outputContainer = config->GetValue("OutputContainer",   m_outputContainer);
 
-  m_inputJets       = config->GetValue("InputJets",       "");
-  m_inputElectrons  = config->GetValue("InputElectrons",  "");
-  m_inputPhotons    = config->GetValue("InputPhotons",    "");
-  m_inputTaus       = config->GetValue("InputTaus",       "");
-  m_inputMuons      = config->GetValue("InputMuons",      "");
+  m_inputJets       = config->GetValue("InputJets",         m_inputJets);
+  m_inputElectrons  = config->GetValue("InputElectrons",    m_inputElectrons);
+  m_inputPhotons    = config->GetValue("InputPhotons",      m_inputPhotons);
+  m_inputTaus       = config->GetValue("InputTaus",         m_inputTaus);
+  m_inputMuons      = config->GetValue("InputMuons",        m_inputMuons);
 
-  m_doElectronCuts  = config->GetValue("ApplyElectronCuts", false);
-  m_doPhotonCuts    = config->GetValue("ApplyPhotonCuts",   false);
-  m_doTauCuts       = config->GetValue("ApplyTauCuts",      false);
-  m_doMuonCuts      = config->GetValue("ApplyMuonCuts",     false);
+  m_doElectronCuts  = config->GetValue("ApplyElectronCuts", m_doElectronCuts);
+  m_doPhotonCuts    = config->GetValue("ApplyPhotonCuts",   m_doPhotonCuts);
+  m_doTauCuts       = config->GetValue("ApplyTauCuts",      m_doTauCuts);
+  m_doMuonCuts      = config->GetValue("ApplyMuonCuts",     m_doMuonCuts);
+
+  m_doMuonEloss     = config->GetValue("DoMuonEloss",       m_doMuonEloss);
+  m_doIsolMuonEloss = config->GetValue("DoIsolMuonEloss",   m_doIsolMuonEloss);
+  m_doJVFCut        = config->GetValue("DoJVFCut",          m_doJVFCut);
 
   if( m_mapName.Length() == 0 ) {
     Error("configure()", "MapName is empty!");
@@ -179,6 +207,9 @@ EL::StatusCode METConstructor :: initialize ()
     Error("initialize()", "Failed to properly initialize. Exiting." );
     return EL::StatusCode::FAILURE;
   }
+
+  RETURN_CHECK( "METConstructor::initialize()", m_metmaker->setProperty( "DoMuonEloss", m_doMuonEloss), "");
+  RETURN_CHECK( "METConstructor::initialize()", m_metmaker->setProperty( "DoIsolMuonEloss", m_doIsolMuonEloss), "");
 
   Info("initialize()", "METConstructor Interface %s succesfully initialized!", m_name.c_str());
 
@@ -277,7 +308,7 @@ EL::StatusCode METConstructor :: execute ()
   const xAOD::MissingETContainer* coreMet(0);
   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_verbose), "Failed retrieving jet cont.");
   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_verbose), "Failed retrieving MET Core.");
-  RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, false), "Failed to build jet/MET.");
+  RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVFCut), "Failed to build jet/MET.");
 
 
   RETURN_CHECK("METConstructor::execute()", m_metmaker->buildMETSum("FinalClus", newMet, MissingETBase::Source::LCTopo), "Failed to build FinalClus MET.");

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -26,8 +26,6 @@ public:
   xAOD::TStore *m_store;  //!
 
   // configuration variables
-  bool m_debug;
-
   TString m_referenceMETContainer;
   TString m_mapName;
   TString m_coreName;
@@ -43,12 +41,14 @@ public:
   bool    m_doTauCuts;
   bool    m_doMuonCuts;
 
+  bool    m_doMuonEloss;
+  bool    m_doIsolMuonEloss;
+  bool    m_doJVFCut;
 
 private:
 
   // tools
   met::METMaker* m_metmaker; //!
-
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
Hi Marco, all -- 

Per private mail, I've checked a few things in the METConstructor.

  - The JVT treatment seems to be correct: it is false by default, but I have made it configurable (DoJVFCut).  The name of the decoration, "Jvt," matches what is done elsewhere in xAH.
  - I've added the possibility to specify the MuonEloss options (DoMuonEloss, DoIsolMuonEloss), though there seems to be a bug in METMaker when MuonEloss is true and IsolMuonEloss is false.  Rui and I are in touch with TJ et al.
  - In the [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/METUtilities#METMaker_For_MC15_Data15), it says that it "may be wiser" to only run one type of soft term, but the [example](https://svnweb.cern.ch/trac/atlasoff/browser/Reconstruction/MET/METUtilities/trunk/util/example_METMaker_advanced.cxx#L205) does both and this seems more straightforward to me.
  - Default options have been set so that the configuration only *updates* based on the variables, as is done for the other modules.

Marta (in the email) has said she is working on the systematics (fixing was a grid crash), so we can follow up with her in that thread.

Let me know if you have any other questions or if this gives you any trouble -- 

Jamie

