### PR TITLE
TruthSelector now uses cutflow_truths_1 for object cutflow.

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -53,7 +53,8 @@ BasicEventSelection :: BasicEventSelection () :
   m_el_cutflowHist_2(nullptr),
   m_mu_cutflowHist_1(nullptr),
   m_mu_cutflowHist_2(nullptr),
-  m_jet_cutflowHist_1(nullptr)
+  m_jet_cutflowHist_1(nullptr),
+  m_truth_cutflowHist_1(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -454,16 +455,18 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
   // initialise object cutflows, which will be picked by the object selector algos downstream and filled.
   //
-  m_el_cutflowHist_1  = new TH1D("cutflow_electrons_1", "cutflow_electrons_1", 1, 1, 2);
+  m_el_cutflowHist_1     = new TH1D("cutflow_electrons_1", "cutflow_electrons_1", 1, 1, 2);
   m_el_cutflowHist_1->SetBit(TH1::kCanRebin);
-  m_el_cutflowHist_2  = new TH1D("cutflow_electrons_2", "cutflow_electrons_2", 1, 1, 2);
+  m_el_cutflowHist_2     = new TH1D("cutflow_electrons_2", "cutflow_electrons_2", 1, 1, 2);
   m_el_cutflowHist_2->SetBit(TH1::kCanRebin);
-  m_mu_cutflowHist_1  = new TH1D("cutflow_muons_1", "cutflow_muons_1", 1, 1, 2);
+  m_mu_cutflowHist_1     = new TH1D("cutflow_muons_1", "cutflow_muons_1", 1, 1, 2);
   m_mu_cutflowHist_1->SetBit(TH1::kCanRebin);
-  m_mu_cutflowHist_2  = new TH1D("cutflow_muons_2", "cutflow_muons_2", 1, 1, 2);
+  m_mu_cutflowHist_2     = new TH1D("cutflow_muons_2", "cutflow_muons_2", 1, 1, 2);
   m_mu_cutflowHist_2->SetBit(TH1::kCanRebin);
-  m_jet_cutflowHist_1  = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
+  m_jet_cutflowHist_1    = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
   m_jet_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
+  m_truth_cutflowHist_1->SetBit(TH1::kCanRebin);
 
   // start labelling the bins for the event cutflow
   //

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -661,7 +661,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
       if ( !isCleanAcc( *jet ) ) { return 0; }
     }
   }
-  m_jet_cutflowHist_1->Fill( m_jet_cutflow_cleaning_cut, 1 );        
+  m_jet_cutflowHist_1->Fill( m_jet_cutflow_cleaning_cut, 1 );
 
   // pT
   if ( m_pT_max != 1e8 ) {

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -195,7 +195,7 @@ EL::StatusCode TruthSelector :: initialize ()
     
     // retrieve the object cutflow
     //
-    m_truth_cutflowHist_1 = (TH1D*)file->Get("cutflow_jets_1");
+    m_truth_cutflowHist_1 = (TH1D*)file->Get("cutflow_truths_1");
 
     m_truth_cutflow_all             = m_truth_cutflowHist_1->GetXaxis()->FindBin("all");
     m_truth_cutflow_ptmax_cut       = m_truth_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -94,11 +94,12 @@ class BasicEventSelection : public xAH::Algorithm
     int m_cutflow_trigger;  //!
     
     // object cutflow
-    TH1D* m_el_cutflowHist_1;  //!
-    TH1D* m_el_cutflowHist_2;  //!
-    TH1D* m_mu_cutflowHist_1;  //!
-    TH1D* m_mu_cutflowHist_2;  //!
-    TH1D* m_jet_cutflowHist_1; //!    
+    TH1D* m_el_cutflowHist_1;    //!
+    TH1D* m_el_cutflowHist_2;    //!
+    TH1D* m_mu_cutflowHist_1;    //!
+    TH1D* m_mu_cutflowHist_2;    //!
+    TH1D* m_jet_cutflowHist_1;   //!
+    TH1D* m_truth_cutflowHist_1; //!
 
     // variables that don't get filled at submission time should be
     // protected from being send from the submission node to the worker


### PR DESCRIPTION
The TruthSelector was using the cutflow_jets_1 histogram, which is also used by JetSelector. I changed it to use cutflow_truths_1, since it is a cutflow of a different collection.

There is still a problem with two separate TruthSelector algorithms using the same cutflow histogram, but I'll make another bug report for it.