### PR TITLE
Option to read Electron ID flags from Derivations

### DIFF
--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -62,6 +62,7 @@ public:
   
   /* electron PID */
   
+  bool           m_readIDFlagsFromDerivation;
   std::string    m_confDirPID;
   
   /* likelihood-based  */

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -39,13 +39,17 @@ class ElectronLHPIDManager
         
         /*  fill the multimap with WPs and corresponding tools */
 	std::pair < std::string, AsgElectronLikelihoodTool* > veryloose = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
-        m_allWPs.insert(veryloose);
+        m_allWPTools.insert(veryloose);
+	m_allWPs.insert("VeryLoose");
 	std::pair < std::string, AsgElectronLikelihoodTool* > loose = std::make_pair( std::string("Loose"), m_asgElectronLikelihoodTool_Loose );
-        m_allWPs.insert(loose);
+        m_allWPTools.insert(loose);
+	m_allWPs.insert("Loose");
 	std::pair < std::string, AsgElectronLikelihoodTool* > medium = std::make_pair( std::string("Medium"), m_asgElectronLikelihoodTool_Medium );
-        m_allWPs.insert(medium);
+        m_allWPTools.insert(medium);
+	m_allWPs.insert("Medium");
 	std::pair < std::string, AsgElectronLikelihoodTool* > tight = std::make_pair( std::string("Tight"), m_asgElectronLikelihoodTool_Tight );
-        m_allWPs.insert(tight);
+        m_allWPTools.insert(tight);
+	m_allWPs.insert("Tight");
      };
      
      ~ElectronLHPIDManager()
@@ -57,7 +61,7 @@ class ElectronLHPIDManager
      };
      
      
-     StatusCode setupTools( std::string selector_name, std::string confDir, std::string year ) {
+     StatusCode setupWPs( bool configTools, std::string selector_name = "", std::string confDir = "", std::string year = "" ) {
      
         HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
         unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
@@ -69,34 +73,50 @@ class ElectronLHPIDManager
 	/ to initialise ONLY the tools with WP tighter (or equal) the selected one.
 	/ The selected WP will be used to cut loose electrons in the selector, the tighter WPs to decorate! 
 	/
-	*/       
-	for ( auto it : (m_allWPs) ) {
+	*/ 
+	if ( configTools ) {      
+	  for ( auto it : (m_allWPTools) ) {
 
-	    /* instantiate tools (do it for all) */
-	    
-	    std::string tool_name = it.first + selector_name;
-	    it.second =  new AsgElectronLikelihoodTool( tool_name.c_str() );
-	    
-            HelperClasses::EnumParser<LikeEnum::Menu>  itWP_parser;
-            unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
-            
-            /* if this WP is looser than user's WP, skip to next */
-            if ( itWP_enum < selectedWP_enum ) { continue; }
-        
-            /* configure and initialise only tools with (WP >= selectedWP) */
-            it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */
-	    RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("primaryVertexContainer", "PrimaryVertices"), "Failed to set primaryVertexContainer property");
-	    std::string config_string = confDir + "ElectronLikelihood" + it.first + "OfflineConfig" + year + ".conf";
-	    
-	    Info("setupTools()", "Configuration file for LH tool: %s", config_string.c_str() ); 
-	    
-            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
-	    RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->initialize(), "Failed to initialize tool." );
-            
-	    /* copy map element into container of valid tools for later usage */
-	    m_validWPs.insert( it );
-	    
-        }
+	      /* instantiate tools (do it for all) */
+	      std::string tool_name = it.first + selector_name;
+	      it.second =  new AsgElectronLikelihoodTool( tool_name.c_str() );
+	      
+              HelperClasses::EnumParser<LikeEnum::Menu>  itWP_parser;
+              unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
+              
+              /* if this WP is looser than user's WP, skip to next */
+              if ( itWP_enum < selectedWP_enum ) { continue; }
+          
+              /* configure and initialise only tools with (WP >= selectedWP) */
+              it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */
+	      RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->setProperty("primaryVertexContainer", "PrimaryVertices"), "Failed to set primaryVertexContainer property");
+	      std::string config_string = confDir + "ElectronLikelihood" + it.first + "OfflineConfig" + year + ".conf";
+	      
+	      Info("setupWPs()", "Configuration file for LH tool: %s", config_string.c_str() ); 
+	      
+              RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
+	      RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->initialize(), "Failed to initialize tool." );
+	      
+	      /* copy map element into container of valid WPs for later usage */
+	      m_validWPTools.insert( it );
+	      
+          }
+	} else {
+	
+	  for ( auto it : (m_allWPs) ) {
+
+              HelperClasses::EnumParser<LikeEnum::Menu>  itWP_parser;
+              unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it) );
+              
+              /* if this WP is looser than user's WP, skip to next */
+              if ( itWP_enum < selectedWP_enum ) { continue; }
+   	      
+	      /* copy map element into container of valid WPs for later usage */
+	      m_validWPs.insert( it );
+	      
+          }
+	
+	}
 	
 	return StatusCode::SUCCESS;
      
@@ -105,7 +125,7 @@ class ElectronLHPIDManager
      /* set default values for decorations (do it for all WPs) */
      StatusCode setDecorations( const xAOD::Electron* electron ) {
        
-       for ( auto it : (m_allWPs) ) { 
+       for ( auto it : (m_allWPTools) ) { 
          const std::string defaultDecorWP =  "LH" + it.first;  
          electron->auxdecor<char>(defaultDecorWP) = -1;
        }
@@ -115,19 +135,23 @@ class ElectronLHPIDManager
      
      const std::string getSelectedWP ( ) { return m_selectedWP; }  
 	
-     /* returns a map containing all the tools  */
-     std::multimap< std::string, AsgElectronLikelihoodTool* > getTools() { return m_allWPs; };
-     
+     /* returns a map containing all the tools */
+     std::multimap< std::string, AsgElectronLikelihoodTool* > getAllWPTools()   { return m_allWPTools; };
      /* returns a map containing only the tools w/ (WP >= selected WP) */
-     std::multimap< std::string, AsgElectronLikelihoodTool* > getValidTools() { return m_validWPs; };
+     std::multimap< std::string, AsgElectronLikelihoodTool* > getValidWPTools() { return m_validWPTools; };
+     /* returns a string containing all the WPs */
+     const std::set<std::string>  getAllWPs()   { return m_allWPs; };
+     /* returns a string containing only the WPs >= selected WP */
+     const std::set<std::string>  getValidWPs() { return m_validWPs; };     
      
    private:   
      
      std::string m_selectedWP;
      bool        m_debug;
-     std::multimap<std::string, AsgElectronLikelihoodTool*> m_allWPs;
-     std::multimap<std::string, AsgElectronLikelihoodTool*> m_validWPs;
-     
+     std::multimap<std::string, AsgElectronLikelihoodTool*> m_allWPTools;
+     std::multimap<std::string, AsgElectronLikelihoodTool*> m_validWPTools;
+     std::set<std::string> m_allWPs;
+     std::set<std::string> m_validWPs;     
 
      AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLoose;  
      AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose;	 
@@ -150,11 +174,14 @@ class ElectronCutBasedPIDManager
 	
         /*  fill the multimap with WPs and corresponding tools. Use an ordered index to reflect the tightness order (0: loosest WP, ...) */
 	std::pair < std::string, AsgElectronIsEMSelector* > loose = std::make_pair( std::string("IsEMLoose"), m_asgElectronIsEMSelector_Loose );
-        m_allWPs.insert( loose );
+        m_allWPTools.insert( loose );
+	m_allWPs.insert("IsEMLoose");
 	std::pair < std::string, AsgElectronIsEMSelector* > medium = std::make_pair( std::string("IsEMMedium"), m_asgElectronIsEMSelector_Medium );
-        m_allWPs.insert( medium );
+        m_allWPTools.insert( medium );
+	m_allWPs.insert("IsEMMedium");
 	std::pair < std::string, AsgElectronIsEMSelector* > tight = std::make_pair( std::string("IsEMTight"), m_asgElectronIsEMSelector_Tight );
-        m_allWPs.insert( tight );
+        m_allWPTools.insert( tight );
+	m_allWPs.insert("IsEMTight");
      };
      
      ~ElectronCutBasedPIDManager()
@@ -164,8 +191,7 @@ class ElectronCutBasedPIDManager
      	if ( m_asgElectronIsEMSelector_Tight )     { m_asgElectronIsEMSelector_Tight = nullptr;  delete m_asgElectronIsEMSelector_Tight;  }
      };
      
-     
-     StatusCode setupTools( std::string selector_name, std::string confDir, std::string year ) {
+     StatusCode setupWPs( bool configTools, std::string selector_name = "", std::string confDir = "", std::string year = "" ) {
      
         HelperClasses::EnumParser<egammaPID::PID> selectedWP_parser;
         unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
@@ -180,49 +206,67 @@ class ElectronCutBasedPIDManager
 	/ egammaPID enums :http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Reconstruction/egamma/egammaEvent/egammaEvent/egammaPIDdefs.h
 	/
 	*/       
-	
-	for ( auto it : (m_allWPs) ) {
+	if ( configTools ) {      
+	  
+	  for ( auto it : (m_allWPTools) ) {
 
-	    /* instantiate tools (do it for all) */
-	    std::string tool_name = it.first + selector_name;
-	    it.second =  new AsgElectronIsEMSelector( tool_name.c_str() );
-           
-            HelperClasses::EnumParser<egammaPID::PID>  itWP_parser;
-            unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
-            
-            /* if this WP is looser than user's WP, skip to next */
-            if ( itWP_enum < selectedWP_enum ) { continue; }
+	      /* instantiate tools (do it for all) */
+	      std::string tool_name = it.first + selector_name;
+	      it.second =  new AsgElectronIsEMSelector( tool_name.c_str() );
+             
+              HelperClasses::EnumParser<egammaPID::PID>  itWP_parser;
+              unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it.first) );
+              
+              /* if this WP is looser than user's WP, skip to next */
+              if ( itWP_enum < selectedWP_enum ) { continue; }
 
-            /* configure and initialise only tools with (WP >= selectedWP) */
+              /* configure and initialise only tools with (WP >= selectedWP) */
 
-            it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */	    
-	    std::string config_string = confDir + "Electron" + it.first + "SelectorCutDefs" + year + ".conf";
-	    
-	    Info("setupTools()", "Configuration file for cut-based tool: %s", config_string.c_str() ); 
-	    
-            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
-    	    
-	    /* set the bitmask only for samples with 2012 config */
-    	    if ( year == "2012" )  {
-    	      unsigned int EMMask = 999;
-    	      if ( (it.first).find("IsEMLoose") != std::string::npos ) {
-    		EMMask = egammaPID::ElectronLoosePP;
-    	      } else if ( (it.first).find("IsEMMedium") != std::string::npos ) {
-    		EMMask = egammaPID::ElectronMediumPP;
-    	      } else if ( (it.first).find("IsEMTight") != std::string::npos ) {
-    		EMMask = egammaPID::ElectronTightPP;
-    	      } else {
-    		Error("setupTools()", "Unavailable electron cut-based PID bitmask for this operating point!");
-    		return EL::StatusCode::FAILURE;
+              it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */        
+	      std::string config_string = confDir + "Electron" + it.first + "SelectorCutDefs" + year + ".conf";
+	      
+	      Info("setupWPs()", "Configuration file for cut-based tool: %s", config_string.c_str() ); 
+	      
+              RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->setProperty("ConfigFile", config_string ), "Failed to set ConfigFile property");
+    	      
+	      /* set the bitmask only for samples with 2012 config */
+    	      if ( year == "2012" )  {
+    	  	unsigned int EMMask = 999;
+    	  	if ( (it.first).find("IsEMLoose") != std::string::npos ) {
+    	  	  EMMask = egammaPID::ElectronLoosePP;
+    	  	} else if ( (it.first).find("IsEMMedium") != std::string::npos ) {
+    	  	  EMMask = egammaPID::ElectronMediumPP;
+    	  	} else if ( (it.first).find("IsEMTight") != std::string::npos ) {
+    	  	  EMMask = egammaPID::ElectronTightPP;
+    	  	} else {
+    	  	  Error("setupWPs()", "Unavailable electron cut-based PID bitmask for this operating point!");
+    	  	  return EL::StatusCode::FAILURE;
+    	  	}
+    	  	RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->setProperty("isEMMask", EMMask ), "Failed to set isEMMask property");
     	      }
-    	      RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->setProperty("isEMMask", EMMask ), "Failed to set isEMMask property");
-    	    }
-            RETURN_CHECK( "ParticlePIDManager::setupTools()", it.second->initialize(), "Failed to initialize tool." );
-            
-	    /* copy map element into container of valid tools for later usage */
-	    m_validWPs.insert( it );
-	    
-        }
+              RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->initialize(), "Failed to initialize tool." );
+              
+	      /* copy map element into container of valid tools for later usage */
+	      m_validWPTools.insert( it );
+	      
+          } 
+	  
+	} else {
+	
+	  for ( auto it : (m_allWPs) ) {
+
+              HelperClasses::EnumParser<egammaPID::PID>  itWP_parser;
+              unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it) );
+              
+              /* if this WP is looser than user's WP, skip to next */
+              if ( itWP_enum < selectedWP_enum ) { continue; }
+   	      
+	      /* copy map element into container of valid WPs for later usage */
+	      m_validWPs.insert( it );
+	      
+          }
+
+	}
 	
 	return StatusCode::SUCCESS;
      
@@ -231,7 +275,7 @@ class ElectronCutBasedPIDManager
      /* set default values for decorations (do it for all WPs) */
      StatusCode setDecorations( const xAOD::Electron* electron ) {
        
-       for ( auto it : (m_allWPs) ) { 
+       for ( auto it : (m_allWPTools) ) { 
          std::string defaultDecorWP = it.first;  
 	 defaultDecorWP.erase(0,4);
          electron->auxdecor<char>(defaultDecorWP) = -1;
@@ -244,19 +288,24 @@ class ElectronCutBasedPIDManager
      const std::string getSelectedWP ( ) { return m_selectedWP; }  
      
      /* returns a map containing all the tools */
-     std::multimap< std::string, AsgElectronIsEMSelector* > getTools() { return m_allWPs; };
-    
+     std::multimap< std::string, AsgElectronIsEMSelector* > getAllWPTools() { return m_allWPTools; };
      /* returns a map containing only the tools w/ (WP >= selected WP) */
-     std::multimap< std::string, AsgElectronIsEMSelector* > getValidTools() { return m_validWPs; };
+     std::multimap< std::string, AsgElectronIsEMSelector* > getValidWPTools() { return m_validWPTools; };
+     /* returns a string containing all the WPs */
+     const std::set<std::string>  getAllWPs()   { return m_allWPs; };
+     /* returns a string containing only the WPs >= selected WP */
+     const std::set<std::string>  getValidWPs() { return m_validWPs; };     
      
    private:   
      
      std::string m_selectedWP;
      bool        m_debug;
      
-     std::multimap<std::string, AsgElectronIsEMSelector*> m_allWPs;
-     std::multimap<std::string, AsgElectronIsEMSelector*> m_validWPs;
-
+     std::multimap<std::string, AsgElectronIsEMSelector*> m_allWPTools;
+     std::multimap<std::string, AsgElectronIsEMSelector*> m_validWPTools;
+     std::set<std::string> m_allWPs;
+     std::set<std::string> m_validWPs;   
+     
      AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Loose;	 
      AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Medium;	 
      AsgElectronIsEMSelector*  m_asgElectronIsEMSelector_Tight;	 


### PR DESCRIPTION
This adds the possibility to read LH/cut-based Electron ID flags directly from DAODs (configurable - default is to use CP Tool to extract this info).

The `ParticlePIDManager.h` should be cleaned up a bit, but this is an addition that HTop requires pretty urgently so that can be done in the future.

@JamesSaxon, can you have a quick look at this and sign off? My tests worked fine.

