### PR TITLE
Apparently, you use setDouble() for optGridNFiles

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
   prun.add_argument('--optGridMemory',           metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridMergeOutput',      metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridNFiles',           metavar='', type=float, required=False, default=None)
-  prun.add_argument('--optGridNFilesPerJob',     metavar='', type=int, required=False, default=None)
+  prun.add_argument('--optGridNFilesPerJob',     metavar='', type=float, required=False, default=None)
   prun.add_argument('--optGridNGBPerJob',        metavar='', type=int, required=False, default=2)
   prun.add_argument('--optGridNJobs',            metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridNoSubmit',         metavar='', type=int, required=False, default=None)

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
   prun.add_argument('--optGridMaxFileSize',      metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridMemory',           metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridMergeOutput',      metavar='', type=int, required=False, default=None)
-  prun.add_argument('--optGridNFiles',           metavar='', type=int, required=False, default=None)
+  prun.add_argument('--optGridNFiles',           metavar='', type=float, required=False, default=None)
   prun.add_argument('--optGridNFilesPerJob',     metavar='', type=int, required=False, default=None)
   prun.add_argument('--optGridNGBPerJob',        metavar='', type=int, required=False, default=2)
   prun.add_argument('--optGridNJobs',            metavar='', type=int, required=False, default=None)


### PR DESCRIPTION
@JamesSaxon and @Rui found this strange bug. Apparently NFiles requires setDouble().