### PR TITLE
ROOT breaks std::cout (or rather overloads it in a strange way).

### DIFF
--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -59,11 +59,11 @@ namespace HelperClasses {
     const std::string m_configStr;
     std::set<std::string> m_configDetails;
     InfoSwitch(const std::string configStr) : m_configStr(configStr) {
-        std::stringstream ss(m_configStr);
-        std::istream_iterator<std::string> begin(ss);
-        std::istream_iterator<std::string> end;
-        m_configDetails = std::set<std::string>(begin, end);
-        //std::copy(m_configDetails.begin(), m_configDetails.end(), std::ostream_iterator<std::string>(std::cout, "\n"));
+        // parse and split by space
+        std::string token;
+        std::istringstream ss(m_configStr);
+        while ( std::getline(ss, token, ' ') )
+            m_configDetails.insert(token);
     };
     bool parse(const std::string flag) { return m_configDetails.find(flag) != m_configDetails.end(); };
   };


### PR DESCRIPTION
This totally works fine either way, however the original way just seems to break code that uses ROOT. I'm using a different way now with the sstream and getline which should work as we've used it before.

This resolves the issue that was discussed in #344 .

/cc @mmilesi @jdandoy @johnda102 and catdog