### PR TITLE
Fix: algorithm registry

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -34,7 +34,7 @@ xAH::Algorithm::~Algorithm() {
     unregisterInstance();
 }
 
-StatusCode xAH::Algorithm::initialize(){
+StatusCode xAH::Algorithm::algInitialize(){
     registerInstance();
     return StatusCode::SUCCESS;
 }

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -13,6 +13,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(xAH::AlgorithmRegistry)
 
+std::map<std::string, int> xAH::Algorithm::m_instanceRegistry = {};
+
 int xAH::AlgorithmRegistry::countRegistered(std::string className){
 
   auto iter = m_registered_algos.find(className);

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -32,9 +32,8 @@ int xAH::AlgorithmRegistry::countRegistered(std::string className){
 // this is needed to distribute the algorithm to the workers
 ClassImp(xAH::Algorithm)
 
-xAH::Algorithm::Algorithm() :
+xAH::Algorithm::Algorithm(std::string className) :
   m_name(""),
-  m_classname(""),
   m_debug(false),
   m_verbose(false),
   m_systName(""),
@@ -44,8 +43,15 @@ xAH::Algorithm::Algorithm() :
   m_configName(""),
   m_event(nullptr),
   m_store(nullptr),
-  m_count_used(0)
-{}
+  m_className(className),
+  m_instanceRegistry()
+{
+    registerInstance();
+}
+
+xAH::Algorithm::~Algorithm() {
+    unregisterInstance();
+}
 
 xAH::Algorithm* xAH::Algorithm::setName(std::string name){
   m_name = name;
@@ -118,21 +124,21 @@ int xAH::Algorithm::isMC(){
   return (static_cast<uint32_t>(eventType(*ei)) & xAOD::EventInfo::IS_SIMULATION);
 }
 
-xAH::Algorithm* xAH::Algorithm::registerClass(xAH::AlgorithmRegistry &reg, std::string className){
-
-  Info("registerClass()","input class name: %s", className.c_str() );
-
-  m_classname = className;
-  
-  // the function will return 0 if the algo 
-  // isn't in the registry yet
-  m_count_used = reg.countRegistered(className);
-
-  // if not found already, set in the map in the registry the name of the algo
-  // and assign a value of 0 to the counter
-  if ( m_count_used == 0 ) { reg.m_registered_algos[className] = m_count_used; }
-
-  return this;
-
+void xAH::Algorithm::registerInstance(){
+    m_instanceRegistry[m_className]++;
 }
 
+int xAH::Algorithm::numInstances(){
+    if(m_instanceRegistry.find(m_className) == m_instanceRegistry.end()){
+        printf("numInstances: we seem to have recorded zero instances of %s. This should not happen.", m_className.c_str());
+        return 0;
+    }
+    return m_instanceRegistry.at(m_className);
+}
+
+void xAH::Algorithm::unregisterInstance(){
+    if(m_instanceRegistry.find(m_className) == m_instanceRegistry.end()){
+        printf("unregisterInstance: we seem to have recorded zero instances of %s. This should not happen.", m_className.c_str());
+    }
+    m_instanceRegistry[m_className]--;
+}

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -43,8 +43,7 @@ xAH::Algorithm::Algorithm(std::string className) :
   m_configName(""),
   m_event(nullptr),
   m_store(nullptr),
-  m_className(className),
-  m_instanceRegistry()
+  m_className(className)
 {
     registerInstance();
 }

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -10,26 +10,7 @@
 #include <xAODAnaHelpers/HelperFunctions.h>
 #include "xAODEventInfo/EventInfo.h"
 
-// this is needed to distribute the algorithm to the workers
-ClassImp(xAH::AlgorithmRegistry)
-
 std::map<std::string, int> xAH::Algorithm::m_instanceRegistry = {};
-
-int xAH::AlgorithmRegistry::countRegistered(std::string className){
-
-  auto iter = m_registered_algos.find(className);
-
-  if ( iter != m_registered_algos.end() ) {
-    Info("countRegistered()","input class name: %s is already in the registry! Increase counter by 1 and return it", className.c_str() );
-    m_registered_algos.at(className)++;
-    return m_registered_algos.at(className);
-  }
-
-  Info("countRegistered()","input class name: %s is not registered yet. Returning 0", className.c_str() );
-
-  return 0;
-
-}
 
 // this is needed to distribute the algorithm to the workers
 ClassImp(xAH::Algorithm)

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -28,11 +28,15 @@ xAH::Algorithm::Algorithm(std::string className) :
   m_store(nullptr),
   m_className(className)
 {
-    registerInstance();
 }
 
 xAH::Algorithm::~Algorithm() {
     unregisterInstance();
+}
+
+StatusCode xAH::Algorithm::initialize(){
+    registerInstance();
+    return StatusCode::SUCCESS;
 }
 
 xAH::Algorithm* xAH::Algorithm::setName(std::string name){

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -30,6 +30,10 @@ xAH::Algorithm::Algorithm(std::string className) :
 {
 }
 
+xAH::Algorithm::~Algorithm()
+{
+}
+
 StatusCode xAH::Algorithm::algInitialize(){
     registerInstance();
     return StatusCode::SUCCESS;

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -30,12 +30,13 @@ xAH::Algorithm::Algorithm(std::string className) :
 {
 }
 
-xAH::Algorithm::~Algorithm() {
-    unregisterInstance();
-}
-
 StatusCode xAH::Algorithm::algInitialize(){
     registerInstance();
+    return StatusCode::SUCCESS;
+}
+
+StatusCode xAH::Algorithm::algFinalize(){
+    unregisterInstance();
     return StatusCode::SUCCESS;
 }
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -34,8 +34,9 @@ ClassImp(BJetEfficiencyCorrector)
 
 
 BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
-  m_BJetSelectTool(nullptr),
-  m_BJetEffSFTool(nullptr)
+    Algorithm("BJetEfficiencyCorrector"),
+    m_BJetSelectTool(nullptr),
+    m_BJetEffSFTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -536,6 +536,8 @@ EL::StatusCode BJetEfficiencyCorrector :: finalize ()
 EL::StatusCode BJetEfficiencyCorrector :: histFinalize ()
 {
   Info("histFinalize()", "Calling histFinalize");
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -192,7 +192,7 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
 EL::StatusCode BJetEfficiencyCorrector :: histInitialize ()
 {
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -33,8 +33,8 @@ using HelperClasses::ToolName;
 ClassImp(BJetEfficiencyCorrector)
 
 
-BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
-    Algorithm("BJetEfficiencyCorrector"),
+BJetEfficiencyCorrector :: BJetEfficiencyCorrector (std::string className) :
+    Algorithm(className),
     m_BJetSelectTool(nullptr),
     m_BJetEffSFTool(nullptr)
 {

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -192,6 +192,7 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
 EL::StatusCode BJetEfficiencyCorrector :: histInitialize ()
 {
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -43,8 +43,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(BasicEventSelection)
 
-BasicEventSelection :: BasicEventSelection () :
-    Algorithm("BasicEventSelection"),
+BasicEventSelection :: BasicEventSelection (std::string className) :
+    Algorithm(className),
     m_PU_default_channel(0),
     m_grl(nullptr),
     m_pileuptool(nullptr),

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -249,7 +249,7 @@ EL::StatusCode BasicEventSelection :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   // Make sure configuration variables have been configured
   if ( !getConfig().empty() && ( this->configure() == EL::StatusCode::FAILURE ) ) {

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -921,6 +921,6 @@ EL::StatusCode BasicEventSelection :: histFinalize ()
   // outputs have been merged.  This is different from finalize() in
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -249,6 +249,7 @@ EL::StatusCode BasicEventSelection :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
 
   // Make sure configuration variables have been configured
   if ( !getConfig().empty() && ( this->configure() == EL::StatusCode::FAILURE ) ) {

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -44,23 +44,24 @@
 ClassImp(BasicEventSelection)
 
 BasicEventSelection :: BasicEventSelection () :
-  m_PU_default_channel(0),
-  m_grl(nullptr),
-  m_pileuptool(nullptr),
-  m_trigConfTool(nullptr),
-  m_trigDecTool(nullptr),
-  m_histEventCount(nullptr),
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_el_cutflowHist_1(nullptr),
-  m_el_cutflowHist_2(nullptr),
-  m_mu_cutflowHist_1(nullptr),
-  m_mu_cutflowHist_2(nullptr),
-  m_ph_cutflowHist_1(nullptr),
-  m_tau_cutflowHist_1(nullptr),
-  m_tau_cutflowHist_2(nullptr),
-  m_jet_cutflowHist_1(nullptr),
-  m_truth_cutflowHist_1(nullptr)
+    Algorithm("BasicEventSelection"),
+    m_PU_default_channel(0),
+    m_grl(nullptr),
+    m_pileuptool(nullptr),
+    m_trigConfTool(nullptr),
+    m_trigDecTool(nullptr),
+    m_histEventCount(nullptr),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_el_cutflowHist_1(nullptr),
+    m_el_cutflowHist_2(nullptr),
+    m_mu_cutflowHist_1(nullptr),
+    m_mu_cutflowHist_2(nullptr),
+    m_ph_cutflowHist_1(nullptr),
+    m_tau_cutflowHist_1(nullptr),
+    m_tau_cutflowHist_2(nullptr),
+    m_jet_cutflowHist_1(nullptr),
+    m_truth_cutflowHist_1(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -59,6 +59,8 @@ EL::StatusCode DebugTool :: setupJob (EL::Job& job)
 EL::StatusCode DebugTool :: histInitialize ()
 {
   Info("histInitialize()", "Calling histInitialize");
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -59,7 +59,7 @@ EL::StatusCode DebugTool :: setupJob (EL::Job& job)
 EL::StatusCode DebugTool :: histInitialize ()
 {
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -133,6 +133,7 @@ EL::StatusCode DebugTool :: finalize ()
 EL::StatusCode DebugTool :: histFinalize ()
 {
   Info("histFinalize()", "Calling histFinalize");
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -40,7 +40,8 @@ ClassImp(DebugTool)
 
 
 DebugTool :: DebugTool () :
-m_printStore(false)
+    Algorithm("DebugTool"),
+    m_printStore(false)
 {
   Info("DebugTool()", "Calling constructor");
 }
@@ -82,7 +83,7 @@ EL::StatusCode DebugTool :: changeInput (bool /*firstFile*/)
 EL::StatusCode DebugTool :: initialize ()
 {
   Info("initialize()", " ");
-  
+
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
@@ -102,8 +103,8 @@ EL::StatusCode DebugTool :: execute ()
   //
   // look what we have in TStore
   //
-  if ( m_printStore ) { 
-    m_store->print(); 
+  if ( m_printStore ) {
+    m_store->print();
   }
 
   return EL::StatusCode::SUCCESS;

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -39,8 +39,8 @@
 ClassImp(DebugTool)
 
 
-DebugTool :: DebugTool () :
-    Algorithm("DebugTool"),
+DebugTool :: DebugTool (std::string className) :
+    Algorithm(className),
     m_printStore(false)
 {
   Info("DebugTool()", "Calling constructor");

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -466,7 +466,7 @@ EL::StatusCode ElectronCalibrator :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -161,6 +161,7 @@ EL::StatusCode ElectronCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -50,8 +50,8 @@ ClassImp(ElectronCalibrator)
 
 ElectronCalibrator :: ElectronCalibrator (std::string className) :
     Algorithm(className),
-    m_IsolationCorrectionTool(nullptr),
-    m_EgammaCalibrationAndSmearingTool(nullptr)
+    m_EgammaCalibrationAndSmearingTool(nullptr),
+    m_IsolationCorrectionTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -161,7 +161,7 @@ EL::StatusCode ElectronCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -48,9 +48,9 @@ using HelperClasses::ToolName;
 ClassImp(ElectronCalibrator)
 
 
-ElectronCalibrator :: ElectronCalibrator () :
-    Algorithm("ElectronCalibrator"),
-    m_IsolationCorrectionTool(nullptr)
+ElectronCalibrator :: ElectronCalibrator (std::string className) :
+    Algorithm(className),
+    m_IsolationCorrectionTool(nullptr),
     m_EgammaCalibrationAndSmearingTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -6,7 +6,7 @@
  *
  * -) scale corrections for DATA
  * -) smearing corrections for MC
- * (data VS. MC check is done by the CP tool internally) 
+ * (data VS. MC check is done by the CP tool internally)
  *
  * M. Milesi (marco.milesi@cern.ch)
  *
@@ -49,8 +49,9 @@ ClassImp(ElectronCalibrator)
 
 
 ElectronCalibrator :: ElectronCalibrator () :
-  m_EgammaCalibrationAndSmearingTool(nullptr),
-  m_IsolationCorrectionTool(nullptr)
+    Algorithm("ElectronCalibrator"),
+    m_IsolationCorrectionTool(nullptr)
+    m_EgammaCalibrationAndSmearingTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -79,7 +80,7 @@ ElectronCalibrator :: ElectronCalibrator () :
 
   m_esModel                 = "";
   m_decorrelationModel      = "";
-  
+
   m_useDataDrivenLeakageCorr = false;
 
 }
@@ -217,12 +218,12 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   m_numObject     = 0;
 
   // initialize the CP::EgammaCalibrationAndSmearingTool
-  //  
+  //
   if ( asg::ToolStore::contains<CP::EgammaCalibrationAndSmearingTool>("EgammaCalibrationAndSmearingTool") ) {
     m_EgammaCalibrationAndSmearingTool = asg::ToolStore::get<CP::EgammaCalibrationAndSmearingTool>("EgammaCalibrationAndSmearingTool");
   } else {
     m_EgammaCalibrationAndSmearingTool = new CP::EgammaCalibrationAndSmearingTool("EgammaCalibrationAndSmearingTool");
-  }  
+  }
   m_EgammaCalibrationAndSmearingTool->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("ESModel", m_esModel),"Failed to set property ESModel");
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("decorrelationModel", m_decorrelationModel),"Failed to set property decorrelationModel");
@@ -230,26 +231,26 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   // For AFII samples
   //
   if ( m_isMC ) {
-    
+
     // Check simulation flavour for calibration config - cannot directly read metadata in xAOD otside of Athena!
     //
     // N.B.: With SampleHandler, you can define sample metadata in job steering macro!
-    // 
+    //
     //       They will be passed to the EL:;Worker automatically and can be retrieved anywhere in the EL::Algorithm
     //       I reasonably suppose everyone will use SH...
     //
-    //       IMPORTANT! the metadata name set in SH *must* be "AFII" (if not set, name will be *empty_string*) 
+    //       IMPORTANT! the metadata name set in SH *must* be "AFII" (if not set, name will be *empty_string*)
     //
-    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour"); 
-    
+    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
+
     if ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) {
       Info("initialize()", "Setting simulation flavour to AFII");
       RETURN_CHECK( "ElectronCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", true),"Failed to set property useAFII");
-      
-    } 
+
+    }
   }
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->initialize(), "Failed to properly initialize the EgammaCalibrationAndSmearingTool");
-    
+
   // Get a list of recommended systematics for this tool
   //
   const CP::SystematicSet recSyst = CP::SystematicSet();
@@ -264,28 +265,28 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   Info("initialize()","Will be using EgammaCalibrationAndSmearingTool systematic:");
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
-  
+
   // ***********************************************************
-  
+
   // initialize the CP::IsolationCorrectionTool
-  //  
+  //
   if ( asg::ToolStore::contains<CP::IsolationCorrectionTool>("IsolationCorrectionTool") ) {
     m_IsolationCorrectionTool = asg::ToolStore::get<CP::IsolationCorrectionTool>("IsolationCorrectionTool");
   } else {
     m_IsolationCorrectionTool = new CP::IsolationCorrectionTool("IsolationCorrectionTool");
-  }  
+  }
   m_IsolationCorrectionTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_IsolationCorrectionTool->setProperty("Apply_datadriven", m_useDataDrivenLeakageCorr ),"Failed to set property Apply_datadriven");
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_IsolationCorrectionTool->setProperty("IsMC", m_isMC ),"Failed to set property IsMC");
   RETURN_CHECK( "ElectronCalibrator::initialize()", m_IsolationCorrectionTool->initialize(), "Failed to properly initialize the IsolationCorrectionTool");
 
   // ***********************************************************
-  
+
   Info("initialize()", "ElectronCalibrator Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
@@ -374,11 +375,11 @@ EL::StatusCode ElectronCalibrator :: execute ()
 	  Warning("execute()", "Problem in CP::IsolationCorrectionTool::CorrectLeakage()");
 	}
       }
-      
+
       if ( m_debug ) { Info("execute()", "Calibrated pt with systematic: %s , pt = %.2f GeV", (syst_it).name().c_str(), (elSC_itr->pt() * 1e-3)); }
-      
+
       ++idx;
-      
+
     } // close calibration loop
 
     if ( !xAOD::setOriginalObjectLink(*inElectrons, *(calibElectronsSC.first)) ) {

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -503,7 +503,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -42,9 +42,10 @@ ClassImp(ElectronEfficiencyCorrector)
 
 
 ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
-  m_asgElEffCorrTool_elSF_PID(nullptr),
-  m_asgElEffCorrTool_elSF_Reco(nullptr),
-  m_asgElEffCorrTool_elSF_Trig(nullptr)
+    Algorithm("ElectronEfficiencyCorrector"),
+    m_asgElEffCorrTool_elSF_PID(nullptr),
+    m_asgElEffCorrTool_elSF_Reco(nullptr),
+    m_asgElEffCorrTool_elSF_Trig(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -216,44 +217,44 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   // initialize the AsgElectronEfficiencyCorrectionTool for PID efficiency SF
   //
 
-  // 
+  //
   // Parse the PID WP from m_corrFileNamePID (needs to be of the form "LH+WP")
   //
-  std::size_t init_pos = m_corrFileNamePID.find("offline") + 8;  
-  std::size_t end_pos  = m_corrFileNamePID.find("LH");  
+  std::size_t init_pos = m_corrFileNamePID.find("offline") + 8;
+  std::size_t end_pos  = m_corrFileNamePID.find("LH");
   m_PID_WP = "LH" + m_corrFileNamePID.substr( init_pos, (end_pos - init_pos) );
   if ( m_PID_WP.empty() ) {
     Error("initialize()", "m_PID_WP should not be empty! Exiting." );
-    return EL::StatusCode::FAILURE;  
+    return EL::StatusCode::FAILURE;
   }
   //
-  //  Add the chosen WP to the string labelling the vector<SF> decoration 
-  //   
-  m_outputSystNamesPID = m_outputSystNamesPID + "_" + m_PID_WP; 
+  //  Add the chosen WP to the string labelling the vector<SF> decoration
+  //
+  m_outputSystNamesPID = m_outputSystNamesPID + "_" + m_PID_WP;
 
   std::string pidEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_PID_" + m_PID_WP;
   m_asgElEffCorrTool_elSF_PID = new AsgElectronEfficiencyCorrectionTool(pidEffSF_tool_name);
 
   m_asgElEffCorrTool_elSF_PID->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-  
+
   std::vector<std::string> inputFilesPID{ m_corrFileNamePID } ; // initialise vector w/ all the files containing corrections
   RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->setProperty("CorrectionFileNameList",inputFilesPID),"Failed to set property CorrectionFileNameList");
-  
+
   int sim_flav(1); // default for FullSim
   if ( m_isMC ) {
-    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour"); 
+    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
     if ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) {
       Info("initialize()", "Setting simulation flavour to AFII");
       sim_flav = 3;
-    } 
+    }
   }
   RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
   RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool PID");
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-   //  
+   //
     CP::SystematicSet affectSystsPID = m_asgElEffCorrTool_elSF_PID->affectingSystematics();
     //
     // Convert into a simple list
@@ -266,11 +267,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   const CP::SystematicSet recSystsPID = m_asgElEffCorrTool_elSF_PID->recommendedSystematics();
   m_systListPID = HelperFunctions::getListofSystematics( recSystsPID, m_systNamePID, m_systValPID, m_debug );
-  
+
   Info("initialize()","Will be using AsgElectronEfficiencyCorrectionTool PID efficiency systematic:");
   for ( const auto& syst_it : m_systListPID ) {
     if ( m_systNamePID.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -286,7 +287,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
     m_asgElEffCorrTool_elSF_Reco = new AsgElectronEfficiencyCorrectionTool("ElectronEfficiencyCorrectionTool_effSF_Reco");
 
     m_asgElEffCorrTool_elSF_Reco->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-  
+
     std::vector<std::string> inputFilesReco{ m_corrFileNameReco } ; // initialise vector w/ all the files containing corrections
     RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("CorrectionFileNameList",inputFilesReco),"Failed to set property CorrectionFileNameList");
     RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("ForceDataType",1),"Failed to set property ForceDataType");
@@ -294,9 +295,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   }
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-    //  
+    //
     CP::SystematicSet affectSystsReco = m_asgElEffCorrTool_elSF_Reco->affectingSystematics();
     //
     // Convert into a simple list
@@ -313,7 +314,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   Info("initialize()","Will be using AsgElectronEfficiencyCorrectionTool reco efficiency systematic:");
   for ( const auto& syst_it : m_systListReco ) {
     if ( m_systNameReco.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -329,7 +330,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
     m_asgElEffCorrTool_elSF_Trig = new AsgElectronEfficiencyCorrectionTool("ElectronEfficiencyCorrectionTool_effSF_Trig");
 
     m_asgElEffCorrTool_elSF_Trig->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-  
+
     std::vector<std::string> inputFilesTrig{ m_corrFileNameTrig } ; // initialise vector w/ all the files containing corrections
     RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("CorrectionFileNameList",inputFilesTrig),"Failed to set property CorrectionFileNameList");
     RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("ForceDataType",1),"Failed to set property ForceDataType");
@@ -337,9 +338,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   }
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-   //  
+   //
     CP::SystematicSet affectSystsTrig = m_asgElEffCorrTool_elSF_Trig->affectingSystematics();
     //
     // Convert into a simple list
@@ -352,11 +353,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   const CP::SystematicSet recSystsTrig = m_asgElEffCorrTool_elSF_Trig->recommendedSystematics();
   m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, m_debug );
-  
+
   Info("initialize()","Will be using AsgElectronEfficiencyCorrectionTool Trig efficiency systematic:");
   for ( const auto& syst_it : m_systListTrig ) {
     if ( m_systNameTrig.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -378,7 +379,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
   // code will go.
 
   m_numEvent++;
-  
+
   if ( !m_isMC ) {
     if ( m_numEvent == 1 ) { Info("execute()", "Sample is Data! Do not apply any Electron Efficiency correction... "); }
     return EL::StatusCode::SUCCESS;
@@ -401,13 +402,13 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
   unsigned int countInputCont(0);
 
   if ( m_inputAlgoSystNames.empty() ) {
-      
+
       RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
-      
+
       // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
       //
       this->executeSF( inputElectrons, eventInfo, countInputCont );
-  
+
   } else {
   // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo.
   // This is the case of calibrators: one different SC for each calibration syst applied
@@ -420,7 +421,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
     	// loop over systematic sets available
 	//
     	for ( auto systName : *systNames ) {
-	
+
           RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
 
           if ( m_debug ){
@@ -440,8 +441,8 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
           ++countInputCont;
 
       } // close loop on systematic sets available from upstream algo
-  
-  } 
+
+  }
 
   // look what we have in TStore
   //
@@ -509,7 +510,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 {
 
   //
-  // In the following, every electron gets decorated with 2 vector<double>'s (for reco/PID efficiency SFs), 
+  // In the following, every electron gets decorated with 2 vector<double>'s (for reco/PID efficiency SFs),
   // and the event w/ 1 vector<double> (for trigger efficiency SFs)
   // Each vector contains the SFs, one SF for each syst (first component of each vector will be the nominal SF).
   //
@@ -524,34 +525,34 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
   // 1.
   // PID efficiency SFs - this is a per-ELECTRON weight
-  // 
+  //
   // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
   //
-  
+
   // Define also an *event* weight, which is the product of all the PID eff. SFs for each object in the event
   //
   std::string PID_SF_NAME_GLOBAL = m_outputSystNamesPID + "_GLOBAL";
   SG::AuxElement::Decorator< std::vector<float> > sfVecPID_GLOBAL ( PID_SF_NAME_GLOBAL );
 
   for ( const auto& syst_it : m_systListPID ) {
-    
+
     // Initialise product of SFs for *this* systematic
     //
-    float pidEffSF_GLOBAL(1.0); 
+    float pidEffSF_GLOBAL(1.0);
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElPIDEff_SF
     //
     std::string sfName  = "ElPIDEff_SF";
-  
+
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
     if(m_debug) Info("executeSF()", "Electron PID efficiency SF  name is: %s", sfName.c_str());
     sysVariationNamesPID->push_back(sfName);
-  
+
     // apply syst
     //
     if ( m_asgElEffCorrTool_elSF_PID->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
@@ -569,7 +570,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
        bool isBadElectron(false);
 
-       // 
+       //
        // obtain PID efficiency SF as a float (to be stored away separately)
        //
        //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* electron)
@@ -611,25 +612,25 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        sfVecPID( *el_itr ).push_back( pidEffSF );
 
        pidEffSF_GLOBAL *= pidEffSF;
-       
-       if ( m_debug ) { 
+
+       if ( m_debug ) {
          Info( "executeSF()", "===>>>");
-         Info( "executeSF()", " ");	
+         Info( "executeSF()", " ");
 	 Info( "executeSF()", "Electron %i, pt = %.2f GeV ", idx, (el_itr->pt() * 1e-3) );
 	 Info( "executeSF()", " ");
 	 Info( "executeSF()", "PID SF decoration: %s", m_outputSystNamesPID.c_str() );
-	 Info( "executeSF()", " ");	 
+	 Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "PID efficiency SF:");
          Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", pidEffSF );
          Info( "executeSF()", "--------------------------------------");
        }
-       
+
        ++idx;
-         
+
     } // close electron loop
-    
+
     // For *this* systematic, store the global SF weight for the event
     //
     if ( m_debug ) {
@@ -639,40 +640,40 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        Info( "executeSF()", "--------------------------------------");
     }
     sfVecPID_GLOBAL( *eventInfo ).push_back( pidEffSF_GLOBAL );
-    
+
   }  // close loop on PID efficiency systematics
 
 
   // 2.
   // Reco efficiency SFs - this is a per-ELECTRON weight
-  // 
+  //
   // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
-  //  
-  
+  //
+
   // Define also an *event* weight, which is the product of all the reco eff. SFs for each object in the event
   //
   std::string RECO_SF_NAME_GLOBAL = m_outputSystNamesReco + "_GLOBAL";
   SG::AuxElement::Decorator< std::vector<float> > sfVecReco_GLOBAL ( RECO_SF_NAME_GLOBAL );
 
   for ( const auto& syst_it : m_systListReco ) {
-    
+
     // Initialise product of SFs for *this* systematic
     //
-    float recoEffSF_GLOBAL(1.0); 
-    
+    float recoEffSF_GLOBAL(1.0);
+
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElRecoEff_SF
     //
     std::string sfName  = "ElRecoEff_SF";
-  
+
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
     if(m_debug) Info("executeSF()", "Electron Reco efficiency SF decoration name is: %s", sfName.c_str());
     sysVariationNamesReco->push_back(sfName);
-  
+
     // apply syst
     //
     if ( m_asgElEffCorrTool_elSF_Reco->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
@@ -690,7 +691,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
        bool isBadElectron(false);
 
-       // 
+       //
        // obtain Reco efficiency SF as a float (to be stored away separately)
        //
        //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* electron)
@@ -730,23 +731,23 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        // Add it to decoration vector
        //
        sfVecReco( *el_itr ).push_back( recoEffSF );
-       
+
        recoEffSF_GLOBAL *= recoEffSF;
-       
-       if ( m_debug ) { 
+
+       if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
 	 Info( "executeSF()", "Electron %i, pt = %.2f GeV ", idx, (el_itr->pt() * 1e-3) );
-	 Info( "executeSF()", " ");	
+	 Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Reco efficiency SF:");
          Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", recoEffSF );
          Info( "executeSF()", "--------------------------------------");
        }
-       
-       ++idx;  
-       
+
+       ++idx;
+
     } // close electron loop
 
     // For *this* systematic, store the global SF weight for the event
@@ -758,15 +759,15 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        Info( "executeSF()", "--------------------------------------");
     }
     sfVecReco_GLOBAL( *eventInfo ).push_back( recoEffSF_GLOBAL );
-    
+
   }  // close loop on Reco efficiency systematics
 
 
   // 3.
   // Trig efficiency SFs - this is a per-EVENT weight
-  //       
+  //
   SG::AuxElement::Decorator< std::vector<float> > sfVecTrig ( m_outputSystNamesTrig  );
- 
+
   // Loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
   //
@@ -776,14 +777,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
     //   template:  SYSNAME_ElTrigEff_SF
     //
     std::string sfName  = "ElTrigEff_SF";
-  
+
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
     if(m_debug) Info("executeSF()", "Electron Trig efficiency SF decoration name is: %s", sfName.c_str());
     sysVariationNamesTrig->push_back(sfName);
-  
+
     // apply syst
     //
     if ( m_asgElEffCorrTool_elSF_Trig->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
@@ -802,7 +803,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        // This is a per-EVENT weight!
        // Do not increase counter until we find a "good" electron
        //
-       if ( idx > 0 ) { break; }   
+       if ( idx > 0 ) { break; }
 
        if ( m_debug ) { Info( "executeSF()", "Applying Trig efficiency SF" ); }
 
@@ -835,25 +836,25 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 	 trigSF = 1.0;
        }
 
-       if ( m_debug ) { 
+       if ( m_debug ) {
          Info( "executeSF()", "===>>>");
-         Info( "executeSF()", " ");	
+         Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Trig efficiency SF:");
          Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", trigSF );
          Info( "executeSF()", "--------------------------------------");
        }
-       
+
        if ( !isBadElectron ) ++idx;
-  
+
     } // close electron loop
 
     //
     // Add trigger SF to event decoration vector
     //
     sfVecTrig( *eventInfo ).push_back( trigSF );
-    
+
   }  // close loop on Trig efficiency systematics
 
 
@@ -865,10 +866,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
   // e.g. the different SC containers w/ calibration systematics upstream.
   //
   // Use the counter defined in execute() to check this is done only once
-  // 
+  //
   // Also, make sure TStore does not contain the object yet (can happen if this module is instantiated more than once)
   //
-  if ( countSyst == 0 ) { 
+  if ( countSyst == 0 ) {
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesPID) )  { RETURN_CHECK( "ElectronEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesPID, m_outputSystNamesPID ), "Failed to record vector of systematic names PID"  ); }
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesReco) ) { RETURN_CHECK( "ElectronEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesReco, m_outputSystNamesReco), "Failed to record vector of systematic names Reco" ); }
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesTrig) ) { RETURN_CHECK( "ElectronEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig), "Failed to record vector of systematic names Trig" ); }

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -159,6 +159,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -159,7 +159,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -41,8 +41,8 @@ using HelperClasses::ToolName;
 ClassImp(ElectronEfficiencyCorrector)
 
 
-ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
-    Algorithm("ElectronEfficiencyCorrector"),
+ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string className) :
+    Algorithm(className),
     m_asgElEffCorrTool_elSF_PID(nullptr),
     m_asgElEffCorrTool_elSF_Reco(nullptr),
     m_asgElEffCorrTool_elSF_Trig(nullptr)

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -44,8 +44,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ElectronSelector)
 
-ElectronSelector :: ElectronSelector () :
-    Algorithm("ElectronSelector"),
+ElectronSelector :: ElectronSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_el_cutflowHist_1(nullptr),

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -264,7 +264,7 @@ EL::StatusCode ElectronSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -847,7 +847,7 @@ EL::StatusCode ElectronSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -45,15 +45,16 @@
 ClassImp(ElectronSelector)
 
 ElectronSelector :: ElectronSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_el_cutflowHist_1(nullptr),
-  m_el_cutflowHist_2(nullptr),
-  m_IsolationSelectionTool(nullptr),
-  m_el_LH_PIDManager(nullptr),
-  m_el_CutBased_PIDManager(nullptr),
-  m_trigDecTool(nullptr),
-  m_trigElMatchTool(nullptr)
+    Algorithm("ElectronSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_el_cutflowHist_1(nullptr),
+    m_el_cutflowHist_2(nullptr),
+    m_IsolationSelectionTool(nullptr),
+    m_el_LH_PIDManager(nullptr),
+    m_el_CutBased_PIDManager(nullptr),
+    m_trigDecTool(nullptr),
+    m_trigElMatchTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -111,7 +112,7 @@ ElectronSelector :: ElectronSelector () :
 
   m_readIDFlagsFromDerivation = false;
   m_confDirPID              = "mc15_20150224";
-  
+
   // likelihood-based PID
   m_doLHPIDcut              = false;
   m_LHOperatingPoint        = "Loose";
@@ -126,8 +127,8 @@ ElectronSelector :: ElectronSelector () :
   //
   m_MinIsoWPCut             = "";
   m_IsoWPList		    = "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
-  m_CaloIsoEff              = "0.1*x+90";  
-  m_TrackIsoEff             = "98";        
+  m_CaloIsoEff              = "0.1*x+90";
+  m_TrackIsoEff             = "98";
   m_CaloBasedIsoType        = "topoetcone20";
   m_TrackBasedIsoType       = "ptvarcone20";
 
@@ -184,7 +185,7 @@ EL::StatusCode  ElectronSelector :: configure ()
 
     m_MinIsoWPCut             = config->GetValue("MinIsoWPCut"       ,  m_MinIsoWPCut.c_str());
     m_IsoWPList		      = config->GetValue("IsolationWPList"   ,  m_IsoWPList.c_str());
-    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());  
+    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());
     m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  m_TrackIsoEff.c_str());
     m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  m_CaloBasedIsoType.c_str());
     m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  m_TrackBasedIsoType.c_str());
@@ -197,7 +198,7 @@ EL::StatusCode  ElectronSelector :: configure ()
 
     delete config; config = nullptr;
   }
- 
+
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
   if ( m_LHOperatingPoint != "VeryLoose" &&
@@ -219,13 +220,13 @@ EL::StatusCode  ElectronSelector :: configure ()
   //
   if ( m_IsoWPList.empty() ) {
     m_IsoWPList	= "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
-  } 
+  }
   std::string token;
   std::istringstream ss(m_IsoWPList);
   while ( std::getline(ss, token, ',') ) {
     m_IsoKeys.push_back(token);
   }
-  
+
   if ( m_inContainerName.empty() ) {
     Error("configure()", "InputContainer is empty!");
     return EL::StatusCode::FAILURE;
@@ -311,7 +312,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   // Let's see if the algorithm has been already used before:
   // if yes, will write object cutflow in a different histogram!
   //
-  // This is the case when the selector algorithm is used for 
+  // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
@@ -321,26 +322,26 @@ EL::StatusCode ElectronSelector :: initialize ()
   }
 
   if ( m_useCutFlow ) {
-    
+
     // retrieve the file in which the cutflow hists are stored
     //
     TFile *file     = wk()->getOutputFile ("cutflow");
-    
+
     // retrieve the event cutflows
     //
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
     m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-    
+
     // retrieve the object cutflow
     //
     m_el_cutflowHist_1 = (TH1D*)file->Get("cutflow_electrons_1");
-    
+
     m_el_cutflow_all             = m_el_cutflowHist_1->GetXaxis()->FindBin("all");
-    m_el_cutflow_author_cut      = m_el_cutflowHist_1->GetXaxis()->FindBin("author_cut");     
-    m_el_cutflow_OQ_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("OQ_cut");         
-    m_el_cutflow_ptmax_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");      
+    m_el_cutflow_author_cut      = m_el_cutflowHist_1->GetXaxis()->FindBin("author_cut");
+    m_el_cutflow_OQ_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("OQ_cut");
+    m_el_cutflow_ptmax_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_el_cutflow_ptmin_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
     m_el_cutflow_eta_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
     m_el_cutflow_PID_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("PID_cut");
@@ -348,14 +349,14 @@ EL::StatusCode ElectronSelector :: initialize ()
     m_el_cutflow_d0_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("d0_cut");
     m_el_cutflow_d0sig_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("d0sig_cut");
     m_el_cutflow_iso_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("iso_cut");
-    
+
     if ( m_isUsedBefore ) {
        m_el_cutflowHist_2 = (TH1D*)file->Get("cutflow_electrons_2");
-    
+
        m_el_cutflow_all 	    = m_el_cutflowHist_2->GetXaxis()->FindBin("all");
-       m_el_cutflow_author_cut      = m_el_cutflowHist_2->GetXaxis()->FindBin("author_cut");	 
-       m_el_cutflow_OQ_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("OQ_cut");	 
-       m_el_cutflow_ptmax_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");	 
+       m_el_cutflow_author_cut      = m_el_cutflowHist_2->GetXaxis()->FindBin("author_cut");
+       m_el_cutflow_OQ_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("OQ_cut");
+       m_el_cutflow_ptmax_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
        m_el_cutflow_ptmin_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
        m_el_cutflow_eta_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
        m_el_cutflow_PID_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("PID_cut");
@@ -364,7 +365,7 @@ EL::StatusCode ElectronSelector :: initialize ()
        m_el_cutflow_d0sig_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("d0sig_cut");
        m_el_cutflow_iso_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("iso_cut");
     }
-    
+
   }
 
   m_event = wk()->xaodEvent();
@@ -383,7 +384,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   m_weightNumEventPass  = 0;
   m_numObjectPass = 0;
 
-    
+
   // ****************************
   //
   // Initialise Electron ID tools
@@ -405,9 +406,9 @@ EL::StatusCode ElectronSelector :: initialize ()
     Info("initialize()", "Cutting on Electron Cut-Based PID! \n ********************" );
     Info("initialize()", "Selected cut-based WP: %s", (m_el_CutBased_PIDManager->getSelectedWP()).c_str() );
   } else {
-    Info("initialize()", "Will decorate each electron with all Electron Cut-Based PID WPs decison (pass/not pass)!" ); 
+    Info("initialize()", "Will decorate each electron with all Electron Cut-Based PID WPs decison (pass/not pass)!" );
   }
-  
+
   bool configTools_CutBased(false);
   if ( m_readIDFlagsFromDerivation ) {
     Info("initialize()", "Reading Electron cut-based ID from DAODs ..." );
@@ -417,7 +418,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     Info("initialize()", "Reading Electron cut-based ID from CP Tool ..." );
     RETURN_CHECK( "ElectronSelector::initialize()", m_el_CutBased_PIDManager->setupWPs( configTools_CutBased, this->m_name, confDir, m_CutBasedConfigYear ), "Failed to properly setup ElectronCutBasedPIDManager." );
   }
-   
+
   // if not using LH PID, make sure all the decorations will be set ... by choosing the loosest WP!
   //
   std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "VeryLoose";
@@ -427,7 +428,7 @@ EL::StatusCode ElectronSelector :: initialize ()
        Info("initialize()", "Cutting on Electron Likelihood PID! \n ********************" );
        Info("initialize()", "\t Selected LH WP: %s", (m_el_LH_PIDManager->getSelectedWP()).c_str() );
   } else {
-       Info("initialize()", "Will decorate each electron with all Electron Likelihood PID WPs decison (pass/not pass)!" ); 
+       Info("initialize()", "Will decorate each electron with all Electron Likelihood PID WPs decison (pass/not pass)!" );
   }
 
   bool configTools_LH(false);
@@ -460,22 +461,22 @@ EL::StatusCode ElectronSelector :: initialize ()
   // (start from 2nd element)
   //
   for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {
-     
+
      if ( m_debug ) { Info("initialize()", "Adding extra isolation WP %s to IsolationSelectionTool", (*WP_itr).c_str() ); }
-     
+
      if ( (*WP_itr).find("UserDefined") != std::string::npos ) {
-      
+
        HelperClasses::EnumParser<xAOD::Iso::IsolationType> isoParser;
-       
+
        std::vector< std::pair<xAOD::Iso::IsolationType, std::string> > myCuts;
        myCuts.push_back(std::make_pair<xAOD::Iso::IsolationType, std::string>(isoParser.parseEnum(m_TrackBasedIsoType), m_TrackIsoEff.c_str() ));
        myCuts.push_back(std::make_pair<xAOD::Iso::IsolationType, std::string>(isoParser.parseEnum(m_CaloBasedIsoType) , m_CaloIsoEff.c_str()  ));
-      
+
        CP::IsolationSelectionTool::IsoWPType iso_type(CP::IsolationSelectionTool::Efficiency);
        if ( (*WP_itr).find("Cut") != std::string::npos ) { iso_type = CP::IsolationSelectionTool::Cut; }
-      
+
        RETURN_CHECK( "ElectronSelector::initialize()", m_IsolationSelectionTool->addUserDefinedWP((*WP_itr).c_str(), xAOD::Type::Electron, myCuts, "", iso_type), "Failed to add user-defined isolation WP" );
-     
+
      } else {
         RETURN_CHECK( "ElectronSelector::initialize()", m_IsolationSelectionTool->addElectronWP( (*WP_itr).c_str() ), "Failed to add isolation WP" );
      }
@@ -502,7 +503,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     m_trigElMatchTool = new Trig::TrigEgammaMatchingTool( trigmatch_tool_name );
     RETURN_CHECK( "ElectronSelector::initialize()", m_trigElMatchTool->setProperty( "TriggerTool", trigDecHandle ), "Failed to configure TrigDecisionTool" );
     RETURN_CHECK( "ElectronSelector::initialize()", m_trigElMatchTool->initialize(), "Failed to properly initialize TrigMuonMatching." );
-    
+
   } else {
     Warning("initialize()", "\n***********************************************************\n Will not perform any electron trigger matching at this stage b/c : \n ");
     Warning("initialize()", "\t -) could not find the TrigDecisionTool in asg::ToolStore" );
@@ -512,7 +513,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   }
 
   // **********************************************************************************************
-  
+
   Info("initialize()", "ElectronSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
@@ -545,7 +546,7 @@ EL::StatusCode ElectronSelector :: execute ()
   // QUESTION: why this must be done in execute(), and does not work in initialize()?
   //
   if ( m_numEvent == 1 && m_trigDecTool ) {
-    
+
     // store the trigger chains that will be considered for matching
     //
     if ( m_ElTrigChains.find("ALL") != std::string::npos ) {
@@ -556,11 +557,11 @@ EL::StatusCode ElectronSelector :: execute ()
       //
       std::string trig;
       std::istringstream ss(m_ElTrigChains);
-      
+
       while ( std::getline(ss, trig, ',') ) {
     	m_ElTrigChainsList.push_back(trig);
       }
-    }	 
+    }
 
     Info("execute()", "Input electron trigger chains that will be considered for matching:\n");
     for ( auto const &chain : m_ElTrigChainsList ) { Info("execute()", "\t %s", chain.c_str()); }
@@ -752,19 +753,19 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
   //  2. there are no selected electrons in the event
   //
   if ( m_trigElMatchTool && selectedElectrons ) {
-    
+
     unsigned int nSelectedElectrons = selectedElectrons->size();
 
     if ( nSelectedElectrons > 0 ) {
-      
+
       if ( m_debug ) { Info("executeSelection()", "Now doing electron trigger matching..."); }
-     
+
       for ( auto const &chain : m_ElTrigChainsList ) {
-       
+
          if ( m_debug ) { Info("executeSelection()", "\t checking trigger chain %s", chain.c_str()); }
-       
+
          for ( auto const electron : *selectedElectrons ) {
-    	   
+
            //  For each electron, decorate w/ a map<string,char> with the 'isMatched' info associated
 	   //  to each trigger chain in the input list.
            //  If decoration map doesn't exist, create it (will be done only for the 1st iteration on the chain names)
@@ -773,12 +774,12 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
            if ( !isTrigMatchedMapElDecor.isAvailable( *electron ) ) {
 	     isTrigMatchedMapElDecor( *electron ) = std::map<std::string,char>();
            }
-	     
-	   int matched = ( m_trigElMatchTool->matchHLT( electron, chain ) ) ? 1 : 0;  
-	   
+
+	   int matched = ( m_trigElMatchTool->matchHLT( electron, chain ) ) ? 1 : 0;
+
            if ( m_debug ) { Info("executeSelection()", "\t\t is electron trigger matched? %i", matched); }
-	   	   
-	   ( isTrigMatchedMapElDecor( *electron ) )[chain] = static_cast<char>(matched);  
+
+	   ( isTrigMatchedMapElDecor( *electron ) )[chain] = static_cast<char>(matched);
          }
       }
 
@@ -786,7 +787,7 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
   }
 
   return true;
-  
+
 }
 
 EL::StatusCode ElectronSelector :: postExecute ()
@@ -820,7 +821,7 @@ EL::StatusCode ElectronSelector :: finalize ()
   if ( m_el_LH_PIDManager )       { m_el_LH_PIDManager = nullptr;       delete m_el_LH_PIDManager;  }
   if ( m_IsolationSelectionTool ) { m_IsolationSelectionTool = nullptr; delete m_IsolationSelectionTool; }
   if ( m_trigElMatchTool )        { m_trigElMatchTool = nullptr;        delete m_trigElMatchTool; }
-  
+
   if ( m_useCutFlow ) {
     Info("finalize()", "Filling cutflow");
     m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
@@ -854,7 +855,7 @@ EL::StatusCode ElectronSelector :: histFinalize ()
 int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Vertex *primaryVertex ) {
 
   float et    = electron->pt();
-  
+
   // all the eta cuts are done using the measurement of the cluster position with the 2nd layer cluster,
   // as for Egamma CP  recommendation
   //
@@ -867,7 +868,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_all, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // author cut
   //
   if ( m_doAuthorCut ) {
@@ -875,12 +876,12 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       if ( m_debug ) { Info("PassCuts()", "Electron failed author kinematic cut." ); }
       return 0;
     }
-  }  
-  m_el_cutflowHist_1->Fill( m_el_cutflow_author_cut, 1 );        
+  }
+  m_el_cutflowHist_1->Fill( m_el_cutflow_author_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_author_cut, 1 ); }
-  
+
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // Object Quality cut
   //
   if ( m_doOQCut ) {
@@ -889,11 +890,11 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       return 0;
     }
   }
-  m_el_cutflowHist_1->Fill( m_el_cutflow_OQ_cut, 1 );        
+  m_el_cutflowHist_1->Fill( m_el_cutflow_OQ_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_OQ_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // pT max cut
   //
   if ( m_pT_max != 1e8 ) {
@@ -902,11 +903,11 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       return 0;
     }
   }
-  m_el_cutflowHist_1->Fill( m_el_cutflow_ptmax_cut, 1 );        
+  m_el_cutflowHist_1->Fill( m_el_cutflow_ptmax_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_ptmax_cut, 1 ); }
-  
+
   // *********************************************************************************************************************************************************************
-  //   
+  //
   // pT min cut
   //
   if ( m_pT_min != 1e8 ) {
@@ -915,14 +916,14 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       return 0;
     }
   }
-  m_el_cutflowHist_1->Fill( m_el_cutflow_ptmin_cut, 1 );        
+  m_el_cutflowHist_1->Fill( m_el_cutflow_ptmin_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_ptmin_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // eta cuts
   //
-   
+
   // |eta| max cut
   //
   if ( m_eta_max != 1e8 ) {
@@ -943,25 +944,25 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_eta_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // electron PID cuts
   //
 
   //
   // likelihood PID
   //
-  
+
   // set default values for *this* electron decorations
   //
   m_el_LH_PIDManager->setDecorations( electron );
-  
+
   if ( m_readIDFlagsFromDerivation ) {
-    
+
     if ( m_doLHPIDcut &&  !electron->auxdata< int >( "DFCommonElectronsLH" + m_LHOperatingPoint ) ) {
    	if ( m_debug ) { Info("PassCuts()", "Electron failed likelihood PID cut w/ operating point %s", m_LHOperatingPoint.c_str() ); }
    	return 0;
     }
-    
+
     const std::set<std::string> myLHWPs = m_el_LH_PIDManager->getValidWPs();
     for ( auto it : (myLHWPs) ) {
       const std::string decorWP =  "LH" + it;
@@ -972,7 +973,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       electron->auxdecor<char>(decorWP) = static_cast<char>( electron->auxdata< int >( "DFCommonElectrons" + decorWP ) );
     }
   } else {
-  
+
     // retrieve only tools with WP >= selected WP, cut electrons if not satisfying selected WP, and decorate w/ tool decision all the others
     //
     typedef std::multimap< std::string, AsgElectronLikelihoodTool* > LHToolsMap;
@@ -993,7 +994,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       electron->auxdecor<char>(decorWP) = static_cast<char>( it.second->accept( *electron ) );
 
     }
-  
+
   }
 
   //
@@ -1005,12 +1006,12 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   m_el_CutBased_PIDManager->setDecorations( electron );
 
   if ( m_readIDFlagsFromDerivation ) {
-    
+
     if ( m_doCutBasedPIDcut &&  !electron->auxdata< int >( "DFCommonElectrons" + m_CutBasedOperatingPoint ) ) {
    	if ( m_debug ) { Info("PassCuts()", "Electron failed cut-based PID cut w/ operating point %s", m_CutBasedOperatingPoint.c_str() ); }
    	return 0;
     }
-    
+
     const std::set<std::string> myCutBasedWPs = m_el_CutBased_PIDManager->getValidWPs();
     for ( auto it : (myCutBasedWPs) ) {
       const std::string decorWP = it.erase(0,4);
@@ -1045,12 +1046,12 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
     }
 
   }
-  
+
   m_el_cutflowHist_1->Fill( m_el_cutflow_PID_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_PID_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // impact parameter cuts
   //
 
@@ -1062,10 +1063,10 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
     if ( m_debug ) Info( "PassCuts()", "Electron has no TrackParticle. Won't be selected.");
     return 0;
   }
-  
+
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
-  
+
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
 
   float z0sintheta = 1e8;
@@ -1082,14 +1083,14 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   }
   m_el_cutflowHist_1->Fill( m_el_cutflow_z0sintheta_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_z0sintheta_cut, 1 ); }
-  
+
   // d0 cut
   //
   if ( m_d0_max != 1e8 ) {
     if ( !( tp->d0() < m_d0_max ) ) {
       if ( m_debug ) { Info("PassCuts()", "Electron failed d0 cut."); }
       return 0;
-    }  
+    }
   }
   m_el_cutflowHist_1->Fill( m_el_cutflow_d0_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_d0_cut, 1 ); }
@@ -1110,32 +1111,32 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   d0SigDecor( *electron ) = static_cast<float>(d0_significance);
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // isolation cut
   //
-  
+
   // Get the "list" of input WPs with the accept() decision from the tool
   //
   Root::TAccept accept_list = m_IsolationSelectionTool->accept( *electron );
-  
+
   // Decorate w/ decision for all input WPs
   //
-  std::string base_decor("isIsolated");  
+  std::string base_decor("isIsolated");
   for ( auto WP_itr : m_IsoKeys ) {
-    
+
     std::string decorWP = base_decor + "_" + WP_itr;
-    
+
     if ( m_debug ) { Info("PassCuts()", "Decorate electron with %s - accept() ? %i", decorWP.c_str(), accept_list.getCutResult( WP_itr.c_str()) ); }
     electron->auxdecor<char>(decorWP) = static_cast<char>( accept_list.getCutResult( WP_itr.c_str() ) );
 
   }
-  
+
   // Apply the cut if needed
   //
   if ( !m_MinIsoWPCut.empty() && !accept_list.getCutResult( m_MinIsoWPCut.c_str() ) ) {
     if ( m_debug ) { Info("PassCuts()", "Electron failed isolation cut %s ",  m_MinIsoWPCut.c_str() ); }
     return 0;
-  }  
+  }
   m_el_cutflowHist_1->Fill( m_el_cutflow_iso_cut, 1 );
   if ( m_isUsedBefore ) { m_el_cutflowHist_2->Fill( m_el_cutflow_iso_cut, 1 ); }
 

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -316,9 +316,9 @@ EL::StatusCode ElectronSelector :: initialize ()
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
-  if ( this->countUsed() > 0 ) {
+  if ( this->numInstances() > 0 ) {
     m_isUsedBefore = true;
-    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );
+    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->numInstances() );
   }
 
   if ( m_useCutFlow ) {

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -264,7 +264,7 @@ EL::StatusCode ElectronSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -315,7 +315,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
-  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
+  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
   if ( this->countUsed() > 0 ) {
     m_isUsedBefore = true;
     Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -40,16 +40,17 @@
 #include "TEnv.h"
 #include "TSystem.h"
 
-using std::cout;  using std::endl;  
+using std::cout;  using std::endl;
 using std::vector;
 
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetRoIBuilder)
 
 HLTJetRoIBuilder :: HLTJetRoIBuilder () :
-  m_trigItem(""),
-  m_outContainerName(""),
-  m_trigDecTool(nullptr)
+    Algorithm("HLTJetRoIBuilder"),
+    m_trigItem(""),
+    m_outContainerName(""),
+    m_trigDecTool(nullptr)
 {
   Info("HLTJetRoIBuilder()", "Calling constructor");
 
@@ -122,7 +123,7 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
 
   ConstDataVector<xAOD::TrackParticleContainer>* selectedTracks = new ConstDataVector<xAOD::TrackParticleContainer>(SG::VIEW_ELEMENTS);
 
-  // 
+  //
   //  Make accessors/decorators
   //
   static SG::AuxElement::ConstAccessor< vector<ElementLink<DataVector<xAOD::IParticle> > > > jetLinkAcc("BTagBtagToJetAssociator");
@@ -133,10 +134,10 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
   auto bjetFeatureContainers = fc.containerFeature<xAOD::BTaggingContainer>();
 
   if(m_debug) cout << "ncontainers  " << bjetFeatureContainers.size() << endl;
-  
+
   for(auto  jcont : bjetFeatureContainers) {
     for (const xAOD::BTagging*  hlt_btag : *jcont.cptr()) {
-      
+
       bool isAvailableJet = jetLinkAcc.isAvailable(*hlt_btag);
 
       if(isAvailableJet){
@@ -172,8 +173,8 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
 	  //}else{
 	  //	if(m_debug) cout << " Trks Not Avalible." << endl;
 	  //}
-	  
-	  
+
+
 	  hltJets->push_back( newHLTBJet );
 	  if(m_debug) cout << "pushed back " << endl;
 	}
@@ -181,7 +182,7 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
       }else{
 	if(m_debug) cout << " Jet Not Avalible." << endl;
       }
-    }//BTagging 
+    }//BTagging
   }//bjetFeatures
 
   RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected dijets");

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -74,6 +74,7 @@ EL::StatusCode HLTJetRoIBuilder :: setupJob (EL::Job& job)
 
 EL::StatusCode HLTJetRoIBuilder :: histInitialize ()
 {
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -46,8 +46,8 @@ using std::vector;
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetRoIBuilder)
 
-HLTJetRoIBuilder :: HLTJetRoIBuilder () :
-    Algorithm("HLTJetRoIBuilder"),
+HLTJetRoIBuilder :: HLTJetRoIBuilder (std::string className) :
+    Algorithm(className),
     m_trigItem(""),
     m_outContainerName(""),
     m_trigDecTool(nullptr)

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -74,7 +74,7 @@ EL::StatusCode HLTJetRoIBuilder :: setupJob (EL::Job& job)
 
 EL::StatusCode HLTJetRoIBuilder :: histInitialize ()
 {
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -215,5 +215,6 @@ EL::StatusCode HLTJetRoIBuilder :: finalize ()
 EL::StatusCode HLTJetRoIBuilder :: histFinalize ()
 {
   Info("histFinalize()", "Calling histFinalize");
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -534,11 +534,11 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
 
   if( m_muInfoSwitch->m_energyLoss ) {
     m_tree->Branch("muon_EnergyLoss"                ,  &m_muon_EnergyLoss               );
-    m_tree->Branch("muon_EnergyLossSigma"           ,  &m_muon_EnergyLossSigma          );    
+    m_tree->Branch("muon_EnergyLossSigma"           ,  &m_muon_EnergyLossSigma          );
     m_tree->Branch("muon_energyLossType"            ,  &m_muon_energyLossType           );
     m_tree->Branch("muon_MeasEnergyLoss"            ,  &m_muon_MeasEnergyLoss           );
     m_tree->Branch("muon_MeasEnergyLossSigma"       ,  &m_muon_MeasEnergyLossSigma      );
-    m_tree->Branch("muon_ParamEnergyLoss"           ,  &m_muon_ParamEnergyLoss          );    
+    m_tree->Branch("muon_ParamEnergyLoss"           ,  &m_muon_ParamEnergyLoss          );
     m_tree->Branch("muon_ParamEnergyLossSigmaMinus" ,  &m_muon_ParamEnergyLossSigmaMinus);
     m_tree->Branch("muon_ParamEnergyLossSigmaPlus"  ,  &m_muon_ParamEnergyLossSigmaPlus );
   }
@@ -728,14 +728,14 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
     if(m_muInfoSwitch->m_energyLoss ) {
       static SG::AuxElement::Accessor< float >         accMuon_EnergyLoss                ("EnergyLoss");
-      static SG::AuxElement::Accessor< float >         accMuon_EnergyLossSigma           ("EnergyLossSigma");      
-      static SG::AuxElement::Accessor< unsigned char > accMuon_energyLossType            ("energyLossType");       
-      static SG::AuxElement::Accessor< float >         accMuon_MeasEnergyLoss            ("MeasEnergyLoss");          
-      static SG::AuxElement::Accessor< float >         accMuon_MeasEnergyLossSigma       ("MeasEnergyLossSigma");          
-      static SG::AuxElement::Accessor< float >         accMuon_ParamEnergyLoss           ("ParamEnergyLoss");      
+      static SG::AuxElement::Accessor< float >         accMuon_EnergyLossSigma           ("EnergyLossSigma");
+      static SG::AuxElement::Accessor< unsigned char > accMuon_energyLossType            ("energyLossType");
+      static SG::AuxElement::Accessor< float >         accMuon_MeasEnergyLoss            ("MeasEnergyLoss");
+      static SG::AuxElement::Accessor< float >         accMuon_MeasEnergyLossSigma       ("MeasEnergyLossSigma");
+      static SG::AuxElement::Accessor< float >         accMuon_ParamEnergyLoss           ("ParamEnergyLoss");
       static SG::AuxElement::Accessor< float >         accMuon_ParamEnergyLossSigmaMinus ("ParamEnergyLossSigmaMinus");
-      static SG::AuxElement::Accessor< float >         accMuon_ParamEnergyLossSigmaPlus  ("ParamEnergyLossSigmaPlus"); 
-      
+      static SG::AuxElement::Accessor< float >         accMuon_ParamEnergyLossSigmaPlus  ("ParamEnergyLossSigmaPlus");
+
       if(accMuon_EnergyLoss                .isAvailable( *muon_itr)) m_muon_EnergyLoss               .push_back(accMuon_EnergyLoss                (*muon_itr)  );
       if(accMuon_EnergyLossSigma           .isAvailable( *muon_itr)) m_muon_EnergyLossSigma          .push_back(accMuon_EnergyLossSigma           (*muon_itr)  );
       if(accMuon_energyLossType            .isAvailable( *muon_itr)) m_muon_energyLossType           .push_back(accMuon_energyLossType            (*muon_itr)  );
@@ -839,13 +839,13 @@ void HelpTreeBase::ClearMuons() {
 
   if ( m_muInfoSwitch->m_energyLoss ) {
     m_muon_EnergyLoss.clear();
-    m_muon_EnergyLossSigma.clear();		
-    m_muon_energyLossType.clear();		
-    m_muon_MeasEnergyLoss.clear();		
-    m_muon_MeasEnergyLossSigma.clear();	
-    m_muon_ParamEnergyLoss.clear();		
+    m_muon_EnergyLossSigma.clear();
+    m_muon_energyLossType.clear();
+    m_muon_MeasEnergyLoss.clear();
+    m_muon_MeasEnergyLossSigma.clear();
+    m_muon_ParamEnergyLoss.clear();
     m_muon_ParamEnergyLossSigmaMinus.clear();
-    m_muon_ParamEnergyLossSigmaPlus.clear(); 
+    m_muon_ParamEnergyLossSigmaPlus.clear();
 
   }
 
@@ -1351,22 +1351,22 @@ void HelpTreeBase::FillPhotons( const xAOD::PhotonContainer* photons ) {
       static SG::AuxElement::Accessor<char> isIsoCone40Acc         ("isIsolated_Cone40");
       static SG::AuxElement::Accessor<char> isIsoCone20Acc         ("isIsolated_Cone20");
 
-      if ( isIsoCone40CaloOnlyAcc.isAvailable( *ph_itr ) ) { 
-	m_ph_isIsolated_Cone40CaloOnly.push_back( isIsoCone40CaloOnlyAcc( *ph_itr ) ); 
-      } else { 
-	m_ph_isIsolated_Cone40CaloOnly.push_back( -1 ); 
+      if ( isIsoCone40CaloOnlyAcc.isAvailable( *ph_itr ) ) {
+	m_ph_isIsolated_Cone40CaloOnly.push_back( isIsoCone40CaloOnlyAcc( *ph_itr ) );
+      } else {
+	m_ph_isIsolated_Cone40CaloOnly.push_back( -1 );
       }
-      
-      if ( isIsoCone40Acc.isAvailable( *ph_itr ) ) { 
-	m_ph_isIsolated_Cone40.push_back( isIsoCone40Acc( *ph_itr ) ); 
-      } else { 
-	m_ph_isIsolated_Cone40.push_back( -1 ); 
+
+      if ( isIsoCone40Acc.isAvailable( *ph_itr ) ) {
+	m_ph_isIsolated_Cone40.push_back( isIsoCone40Acc( *ph_itr ) );
+      } else {
+	m_ph_isIsolated_Cone40.push_back( -1 );
       }
-      
-      if ( isIsoCone20Acc.isAvailable( *ph_itr ) ) { 
+
+      if ( isIsoCone20Acc.isAvailable( *ph_itr ) ) {
 	m_ph_isIsolated_Cone20.push_back( isIsoCone20Acc( *ph_itr ) );
-      } else { 
-	m_ph_isIsolated_Cone20.push_back( -1 ); 
+      } else {
+	m_ph_isIsolated_Cone20.push_back( -1 );
       }
 
       m_ph_etcone20    .push_back( ph_itr->isolation( xAOD::Iso::etcone20    ) / m_units  );
@@ -1401,7 +1401,7 @@ void HelpTreeBase::FillPhotons( const xAOD::PhotonContainer* photons ) {
         m_ph_IsTight.push_back( phTightAcc( *ph_itr ) );
 	if ( phTightAcc( *ph_itr ) == 1 ) { ++m_nph_IsTight; }
       } else { m_ph_IsTight.push_back( -1 ); }
-      
+
     }
 
     this->FillPhotonsUser(ph_itr);

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -691,6 +691,6 @@ EL::StatusCode JetCalibrator :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -200,7 +200,7 @@ EL::StatusCode JetCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -200,7 +200,7 @@ EL::StatusCode JetCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -40,10 +40,11 @@
 ClassImp(JetCalibrator)
 
 JetCalibrator :: JetCalibrator () :
-  m_runSysts(false),          // gets set later is syst applies to this tool
-  m_jetCalibration(nullptr),  // JetCalibrationTool
-  m_JESUncertTool(nullptr),   // JetUncertaintiesTool
-  m_jetCleaning(nullptr)      // JetCleaningTool
+    Algorithm("JetCalibrator"),
+    m_runSysts(false),          // gets set later is syst applies to this tool
+    m_jetCalibration(nullptr),  // JetCalibrationTool
+    m_JESUncertTool(nullptr),   // JetUncertaintiesTool
+    m_jetCleaning(nullptr)      // JetCleaningTool
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -277,10 +278,10 @@ EL::StatusCode JetCalibrator :: initialize ()
     //       They will be passed to the EL:;Worker automatically and can be retrieved anywhere in the EL::Algorithm
     //       I reasonably suppose everyone will use SH...
     //
-    //       IMPORTANT! the metadata name set in SH *must* be "AFII" (if not set, name will be *empty_string*) 
+    //       IMPORTANT! the metadata name set in SH *must* be "AFII" (if not set, name will be *empty_string*)
 
     //
-    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour"); 
+    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
     if ( m_setAFII ) {
       Info("initialize()", "Setting simulation flavour to AFII");
       m_isFullSim = false;
@@ -333,7 +334,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
-  // 
+  //
   // Get a list of recommended systematics for this tool
   //
   const CP::SystematicSet recSyst = CP::SystematicSet();

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -39,8 +39,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetCalibrator)
 
-JetCalibrator :: JetCalibrator () :
-    Algorithm("JetCalibrator"),
+JetCalibrator :: JetCalibrator (std::string className) :
+    Algorithm(className),
     m_runSysts(false),          // gets set later is syst applies to this tool
     m_jetCalibration(nullptr),  // JetCalibrationTool
     m_JESUncertTool(nullptr),   // JetUncertaintiesTool

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -238,12 +238,12 @@ StatusCode JetHists::initialize() {
     m_jf_mass           = book(m_name, "JetFitter_mass"          , "JetFitter_mass"          , 100,   0,     5 );
     m_jf_energyFraction = book(m_name, "JetFitter_energyFraction", "JetFitter_energyFraction", 100,  -0.1,   1.1 );
     m_jf_significance3d = book(m_name, "JetFitter_significance3d", "JetFitter_significance3d", 100,   0,    50 );
-    m_jf_deltaeta       = book(m_name, "JetFitter_deltaeta"      , "JetFitter_deltaeta"      , 100,  -0.2,   0.2);    
-    m_jf_deltaphi       = book(m_name, "JetFitter_deltaphi"      , "JetFitter_deltaphi"      , 100,  -0.2,   0.2);    
+    m_jf_deltaeta       = book(m_name, "JetFitter_deltaeta"      , "JetFitter_deltaeta"      , 100,  -0.2,   0.2);
+    m_jf_deltaphi       = book(m_name, "JetFitter_deltaphi"      , "JetFitter_deltaphi"      , 100,  -0.2,   0.2);
     m_jf_N2Tpar         = book(m_name, "JetFitter_N2Tpair"       , "JetFitter_N2Tpair"       ,  20,  -0.5,  19.5);
-    m_jf_pb             = book(m_name, "JetFitter_pb"            , "JetFitter_pb"            , 100,  -0.1,   1);    
-    m_jf_pc             = book(m_name, "JetFitter_pc"            , "JetFitter_pc"            , 100,  -0.1,   1);    
-    m_jf_pu             = book(m_name, "JetFitter_pu"            , "JetFitter_pu"            , 100,  -0.1,   1);    
+    m_jf_pb             = book(m_name, "JetFitter_pb"            , "JetFitter_pb"            , 100,  -0.1,   1);
+    m_jf_pc             = book(m_name, "JetFitter_pc"            , "JetFitter_pc"            , 100,  -0.1,   1);
+    m_jf_pu             = book(m_name, "JetFitter_pu"            , "JetFitter_pu"            , 100,  -0.1,   1);
 
   }
 
@@ -264,8 +264,8 @@ StatusCode JetHists::initialize() {
   }
 
   if( m_infoSwitch->m_ipDetails ) {
-    m_nIP2DTracks               = book(m_name, "nIP2DTracks"              , "nIP2DTracks"            ,  20,  -0.5, 19.5);  
-    m_IP2D_gradeOfTracks        = book(m_name, "IP2D_gradeOfTracks"       , "IP2D_gradeOfTracks"     ,  20,  -0.5, 19.5);  
+    m_nIP2DTracks               = book(m_name, "nIP2DTracks"              , "nIP2DTracks"            ,  20,  -0.5, 19.5);
+    m_IP2D_gradeOfTracks        = book(m_name, "IP2D_gradeOfTracks"       , "IP2D_gradeOfTracks"     ,  20,  -0.5, 19.5);
     m_IP2D_flagFromV0ofTracks   = book(m_name, "IP2D_flagFromV0ofTracks"  , "IP2D_flagFromV0ofTracks",   5,  -0.5,  4.5);
     m_IP2D_valD0wrtPVofTracks   = book(m_name, "IP2D_valD0wrtPVofTracks"  , "IP2D_valD0wrtPVofTracks", 100,  -2.0,  2.0);
     m_IP2D_sigD0wrtPVofTracks   = book(m_name, "IP2D_sigD0wrtPVofTracks"  , "IP2D_sigD0wrtPVofTracks", 100, -15.0, 15.0);
@@ -274,8 +274,8 @@ StatusCode JetHists::initialize() {
     m_IP2D_weightCofTracks      = book(m_name, "IP2D_weightCofTracks"     , "IP2D_weightCofTracks"   , 100,  -0.1, 1.5);
     m_IP2D_weightUofTracks      = book(m_name, "IP2D_weightUofTracks"     , "IP2D_weightUofTracks"   , 100,  -0.1, 1.5);
 
-    m_nIP3DTracks               = book(m_name, "nIP3DTracks"              , "nIP3DTracks"            ,  20,  -0.5, 19.5);  
-    m_IP3D_gradeOfTracks        = book(m_name, "IP3D_gradeOfTracks"       , "IP3D_gradeOfTracks"     ,  20,  -0.5, 19.5);  
+    m_nIP3DTracks               = book(m_name, "nIP3DTracks"              , "nIP3DTracks"            ,  20,  -0.5, 19.5);
+    m_IP3D_gradeOfTracks        = book(m_name, "IP3D_gradeOfTracks"       , "IP3D_gradeOfTracks"     ,  20,  -0.5, 19.5);
     m_IP3D_flagFromV0ofTracks   = book(m_name, "IP3D_flagFromV0ofTracks"  , "IP3D_flagFromV0ofTracks",   5,  -0.5,  4.5);
     m_IP3D_valD0wrtPVofTracks   = book(m_name, "IP3D_valD0wrtPVofTracks"  , "IP3D_valD0wrtPVofTracks", 100,  -2.0,  2.0);
     m_IP3D_sigD0wrtPVofTracks   = book(m_name, "IP3D_sigD0wrtPVofTracks"  , "IP3D_sigD0wrtPVofTracks", 100, -15.0, 15.0);
@@ -709,7 +709,7 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
     }else if(m_infoSwitch->m_flavTagHLT){
       btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
     }
-      
+
     double MV2c00 = -99;
     double MV2c10 = -99;
     double MV2c20 = -99;
@@ -730,7 +730,7 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       m_JetFitter       ->  Fill( btag_info->JetFitter_loglikelihoodratio() , eventWeight );
       m_JetFitterCombNN ->  Fill( btag_info->JetFitterCombNN_loglikelihoodratio() , eventWeight );
     }
-      
+
     if(m_infoSwitch->m_jetFitterDetails){
       static SG::AuxElement::ConstAccessor< int   > jf_nVTXAcc       ("JetFitter_nVTX");
       static SG::AuxElement::ConstAccessor< int   > jf_nSingleTracks ("JetFitter_nSingleTracks");
@@ -738,24 +738,24 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       static SG::AuxElement::ConstAccessor< float > jf_mass          ("JetFitter_mass");
       static SG::AuxElement::ConstAccessor< float > jf_energyFraction("JetFitter_energyFraction");
       static SG::AuxElement::ConstAccessor< float > jf_significance3d("JetFitter_significance3d");
-      static SG::AuxElement::ConstAccessor< float > jf_deltaeta      ("JetFitter_deltaeta");    
-      static SG::AuxElement::ConstAccessor< float > jf_deltaphi      ("JetFitter_deltaphi");    
+      static SG::AuxElement::ConstAccessor< float > jf_deltaeta      ("JetFitter_deltaeta");
+      static SG::AuxElement::ConstAccessor< float > jf_deltaphi      ("JetFitter_deltaphi");
       static SG::AuxElement::ConstAccessor< int   > jf_N2Tpar        ("JetFitter_N2Tpair");
-      static SG::AuxElement::ConstAccessor< double > jf_pb           ("JetFitter_pb");    
-      static SG::AuxElement::ConstAccessor< double > jf_pc           ("JetFitter_pc");    
-      static SG::AuxElement::ConstAccessor< double > jf_pu           ("JetFitter_pu");    
-    
+      static SG::AuxElement::ConstAccessor< double > jf_pb           ("JetFitter_pb");
+      static SG::AuxElement::ConstAccessor< double > jf_pc           ("JetFitter_pc");
+      static SG::AuxElement::ConstAccessor< double > jf_pu           ("JetFitter_pu");
+
       if(jf_nVTXAcc.isAvailable       (*btag_info)) m_jf_nVTX           ->Fill(jf_nVTXAcc       (*btag_info), eventWeight);
       if(jf_nSingleTracks.isAvailable (*btag_info)) m_jf_nSingleTracks  ->Fill(jf_nSingleTracks (*btag_info), eventWeight);
       if(jf_nTracksAtVtx.isAvailable  (*btag_info)) m_jf_nTracksAtVtx   ->Fill(jf_nTracksAtVtx  (*btag_info), eventWeight);
-      if(jf_mass.isAvailable          (*btag_info)) m_jf_mass           ->Fill(jf_mass          (*btag_info)/1000, eventWeight); 
-      if(jf_energyFraction.isAvailable(*btag_info)) m_jf_energyFraction ->Fill(jf_energyFraction(*btag_info), eventWeight); 
-      if(jf_significance3d.isAvailable(*btag_info)) m_jf_significance3d ->Fill(jf_significance3d(*btag_info), eventWeight); 
-      if(jf_deltaeta.isAvailable      (*btag_info)) m_jf_deltaeta       ->Fill(jf_deltaeta      (*btag_info), eventWeight); 
-      if(jf_deltaphi.isAvailable      (*btag_info)) m_jf_deltaphi       ->Fill(jf_deltaphi      (*btag_info), eventWeight); 
+      if(jf_mass.isAvailable          (*btag_info)) m_jf_mass           ->Fill(jf_mass          (*btag_info)/1000, eventWeight);
+      if(jf_energyFraction.isAvailable(*btag_info)) m_jf_energyFraction ->Fill(jf_energyFraction(*btag_info), eventWeight);
+      if(jf_significance3d.isAvailable(*btag_info)) m_jf_significance3d ->Fill(jf_significance3d(*btag_info), eventWeight);
+      if(jf_deltaeta.isAvailable      (*btag_info)) m_jf_deltaeta       ->Fill(jf_deltaeta      (*btag_info), eventWeight);
+      if(jf_deltaphi.isAvailable      (*btag_info)) m_jf_deltaphi       ->Fill(jf_deltaphi      (*btag_info), eventWeight);
       if(jf_N2Tpar.isAvailable        (*btag_info)) m_jf_N2Tpar         ->Fill(jf_N2Tpar        (*btag_info), eventWeight);
-      if(jf_pb.isAvailable            (*btag_info)) m_jf_pb             ->Fill(jf_pb            (*btag_info), eventWeight); 
-      if(jf_pu.isAvailable            (*btag_info)) m_jf_pu             ->Fill(jf_pu            (*btag_info), eventWeight); 
+      if(jf_pb.isAvailable            (*btag_info)) m_jf_pb             ->Fill(jf_pb            (*btag_info), eventWeight);
+      if(jf_pu.isAvailable            (*btag_info)) m_jf_pu             ->Fill(jf_pu            (*btag_info), eventWeight);
     }
 
 
@@ -766,14 +766,14 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       //
 
       /// @brief SV0 : Number of good tracks in vertex
-      static SG::AuxElement::ConstAccessor< int   >   sv0_NGTinSvxAcc     ("SV0_NGTinSvx");   
+      static SG::AuxElement::ConstAccessor< int   >   sv0_NGTinSvxAcc     ("SV0_NGTinSvx");
       // @brief SV0 : Number of 2-track pairs
-      static SG::AuxElement::ConstAccessor< int   >   sv0_N2TpairAcc      ("SV0_N2Tpair");   
+      static SG::AuxElement::ConstAccessor< int   >   sv0_N2TpairAcc      ("SV0_N2Tpair");
       /// @brief SV0 : vertex mass
-      static SG::AuxElement::ConstAccessor< float   > sv0_masssvxAcc      ("SV0_masssvx");   
+      static SG::AuxElement::ConstAccessor< float   > sv0_masssvxAcc      ("SV0_masssvx");
       /// @brief SV0 : energy fraction
       static SG::AuxElement::ConstAccessor< float   > sv0_efracsvxAcc     ("SV0_efracsvx");                                                                  	/// @brief SV0 : 3D vertex significance
-      static SG::AuxElement::ConstAccessor< float   > sv0_normdistAcc     ("SV0_normdist");                                                             
+      static SG::AuxElement::ConstAccessor< float   > sv0_normdistAcc     ("SV0_normdist");
 
       if(sv0_NGTinSvxAcc .isAvailable(*btag_info)) m_sv0_NGTinSvx -> Fill( sv0_NGTinSvxAcc (*btag_info), eventWeight);
       if(sv0_N2TpairAcc  .isAvailable(*btag_info)) m_sv0_N2Tpair  -> Fill( sv0_N2TpairAcc  (*btag_info), eventWeight);
@@ -786,14 +786,14 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       //
 
       /// @brief SV1 : Number of good tracks in vertex
-      static SG::AuxElement::ConstAccessor< int   >   sv1_NGTinSvxAcc     ("SV1_NGTinSvx");   
+      static SG::AuxElement::ConstAccessor< int   >   sv1_NGTinSvxAcc     ("SV1_NGTinSvx");
       // @brief SV1 : Number of 2-track pairs
-      static SG::AuxElement::ConstAccessor< int   >   sv1_N2TpairAcc      ("SV1_N2Tpair");   
+      static SG::AuxElement::ConstAccessor< int   >   sv1_N2TpairAcc      ("SV1_N2Tpair");
       /// @brief SV1 : vertex mass
-      static SG::AuxElement::ConstAccessor< float   > sv1_masssvxAcc      ("SV1_masssvx");   
+      static SG::AuxElement::ConstAccessor< float   > sv1_masssvxAcc      ("SV1_masssvx");
       /// @brief SV1 : energy fraction
       static SG::AuxElement::ConstAccessor< float   > sv1_efracsvxAcc     ("SV1_efracsvx");                                                                  	/// @brief SV1 : 3D vertex significance
-      static SG::AuxElement::ConstAccessor< float   > sv1_normdistAcc     ("SV1_normdist");                                                             
+      static SG::AuxElement::ConstAccessor< float   > sv1_normdistAcc     ("SV1_normdist");
 
       if(sv1_NGTinSvxAcc .isAvailable(*btag_info)) m_sv1_NGTinSvx -> Fill( sv1_NGTinSvxAcc (*btag_info), eventWeight);
       if(sv1_N2TpairAcc  .isAvailable(*btag_info)) m_sv1_N2Tpair  -> Fill( sv1_N2TpairAcc  (*btag_info), eventWeight);
@@ -811,23 +811,23 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       //
 
       /// @brief IP2D: track grade
-      static SG::AuxElement::ConstAccessor< vector<int>   >   IP2D_gradeOfTracksAcc     ("IP2D_gradeOfTracks");   
+      static SG::AuxElement::ConstAccessor< vector<int>   >   IP2D_gradeOfTracksAcc     ("IP2D_gradeOfTracks");
       /// @brief IP2D : tracks from V0
-      static SG::AuxElement::ConstAccessor< vector<bool>   >  IP2D_flagFromV0ofTracksAcc("IP2D_flagFromV0ofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<bool>   >  IP2D_flagFromV0ofTracksAcc("IP2D_flagFromV0ofTracks");
       /// @brief IP2D : d0 value with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_valD0wrtPVofTracksAcc("IP2D_valD0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_valD0wrtPVofTracksAcc("IP2D_valD0wrtPVofTracks");
       /// @brief IP2D : d0 significance with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_sigD0wrtPVofTracksAcc("IP2D_sigD0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_sigD0wrtPVofTracksAcc("IP2D_sigD0wrtPVofTracks");
       /// @brief IP2D : track contribution to B likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightBofTracksAcc   ("IP2D_weightBofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightBofTracksAcc   ("IP2D_weightBofTracks");
       /// @brief IP2D : track contribution to C likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightCofTracksAcc   ("IP2D_weightCofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightCofTracksAcc   ("IP2D_weightCofTracks");
       /// @brief IP2D : track contribution to U likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightUofTracksAcc   ("IP2D_weightUofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP2D_weightUofTracksAcc   ("IP2D_weightUofTracks");
 
       if(IP2D_gradeOfTracksAcc .isAvailable(*btag_info)){
 	unsigned int nIP2DTracks = IP2D_gradeOfTracksAcc(*btag_info).size();
-	m_nIP2DTracks -> Fill( nIP2DTracks, eventWeight);	  
+	m_nIP2DTracks -> Fill( nIP2DTracks, eventWeight);
 	for(int grade : IP2D_gradeOfTracksAcc(*btag_info))        m_IP2D_gradeOfTracks->Fill(grade, eventWeight);
       }
 
@@ -863,27 +863,27 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       //
 
       /// @brief IP3D: track grade
-      static SG::AuxElement::ConstAccessor< vector<int>   >   IP3D_gradeOfTracksAcc     ("IP3D_gradeOfTracks");   
+      static SG::AuxElement::ConstAccessor< vector<int>   >   IP3D_gradeOfTracksAcc     ("IP3D_gradeOfTracks");
       /// @brief IP3D : tracks from V0
-      static SG::AuxElement::ConstAccessor< vector<bool>   >  IP3D_flagFromV0ofTracksAcc("IP3D_flagFromV0ofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<bool>   >  IP3D_flagFromV0ofTracksAcc("IP3D_flagFromV0ofTracks");
       /// @brief IP3D : d0 value with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_valD0wrtPVofTracksAcc("IP3D_valD0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_valD0wrtPVofTracksAcc("IP3D_valD0wrtPVofTracks");
       /// @brief IP3D : d0 significance with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_sigD0wrtPVofTracksAcc("IP3D_sigD0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_sigD0wrtPVofTracksAcc("IP3D_sigD0wrtPVofTracks");
       /// @brief IP3D : z0 value with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_valZ0wrtPVofTracksAcc("IP3D_valZ0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_valZ0wrtPVofTracksAcc("IP3D_valZ0wrtPVofTracks");
       /// @brief IP3D : z0 significance with respect to primary vertex
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_sigZ0wrtPVofTracksAcc("IP3D_sigZ0wrtPVofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_sigZ0wrtPVofTracksAcc("IP3D_sigZ0wrtPVofTracks");
       /// @brief IP3D : track contribution to B likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightBofTracksAcc   ("IP3D_weightBofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightBofTracksAcc   ("IP3D_weightBofTracks");
       /// @brief IP3D : track contribution to C likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightCofTracksAcc   ("IP3D_weightCofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightCofTracksAcc   ("IP3D_weightCofTracks");
       /// @brief IP3D : track contribution to U likelihood
-      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightUofTracksAcc   ("IP3D_weightUofTracks");   
+      static SG::AuxElement::ConstAccessor< vector<float>   > IP3D_weightUofTracksAcc   ("IP3D_weightUofTracks");
 
       if(IP3D_gradeOfTracksAcc .isAvailable(*btag_info)){
 	unsigned int nIP3DTracks = IP3D_gradeOfTracksAcc(*btag_info).size();
-	m_nIP3DTracks -> Fill( nIP3DTracks, eventWeight);	  
+	m_nIP3DTracks -> Fill( nIP3DTracks, eventWeight);
 	for(int grade : IP3D_gradeOfTracksAcc(*btag_info))        m_IP3D_gradeOfTracks->Fill(grade, eventWeight);
       }
 
@@ -926,7 +926,7 @@ StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight, int /*pvL
       }
 
 
-      
+
     }
   }
 

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -43,7 +43,7 @@ EL::StatusCode JetHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -43,7 +43,7 @@ EL::StatusCode JetHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -177,4 +177,7 @@ EL::StatusCode JetHistsAlgo :: finalize () {
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode JetHistsAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode JetHistsAlgo :: histFinalize () {
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -18,8 +18,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetHistsAlgo)
 
-JetHistsAlgo :: JetHistsAlgo () :
-    Algorithm("JetHistsAlgo")
+JetHistsAlgo :: JetHistsAlgo (std::string className) :
+    Algorithm(className)
 {
   m_inContainerName         = "";
   // which plots will be turned on

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -18,7 +18,9 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetHistsAlgo)
 
-JetHistsAlgo :: JetHistsAlgo () {
+JetHistsAlgo :: JetHistsAlgo () :
+    Algorithm("JetHistsAlgo")
+{
   m_inContainerName         = "";
   // which plots will be turned on
   m_detailStr               = "";

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -303,7 +303,7 @@ EL::StatusCode JetSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -659,7 +659,7 @@ EL::StatusCode JetSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -47,10 +47,11 @@ ClassImp(JetSelector)
 
 
 JetSelector :: JetSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_jet_cutflowHist_1(nullptr),
-  m_BJetSelectTool(nullptr)
+    Algorithm("JetSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_jet_cutflowHist_1(nullptr),
+    m_BJetSelectTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -58,7 +59,7 @@ JetSelector :: JetSelector () :
   // called on both the submission and the worker node.  Most of your
   // initialization code will go into histInitialize() and
   // initialize().
-  
+
   Info("JetSelector()", "Calling constructor");
 
   // read debug flag from .config file
@@ -117,7 +118,7 @@ JetSelector :: JetSelector () :
   m_taggerName              = "MV2c20";
   m_operatingPt             = "FixedCutBEff_70";
   m_jetAuthor               = "AntiKt4EMTopoJets";
-  // for the b-tagging tool - these are the b-tagging groups minimums 
+  // for the b-tagging tool - these are the b-tagging groups minimums
   // users making tighter cuts can use the selector's parameters to keep
   // things consistent
   m_b_eta_max               = 2.5;
@@ -127,7 +128,7 @@ JetSelector :: JetSelector () :
   m_doHLTBTagCut            = false;
   m_HLTBTagTaggerName       = "MV2c20";
   m_HLTBTagCutValue         = -0.4434;
-  
+
   m_passAuxDecorKeys        = "";
   m_failAuxDecorKeys        = "";
 
@@ -344,32 +345,32 @@ EL::StatusCode JetSelector :: initialize ()
   // you create here won't be available in the output if you have no
   // input events.
   Info("initialize()", "Calling initialize");
-  
+
   if ( m_useCutFlow ) {
 
    // retrieve the file in which the cutflow hists are stored
     //
     TFile *file     = wk()->getOutputFile ("cutflow");
-    
+
     // retrieve the event cutflows
     //
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
     m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-    
+
     // retrieve the object cutflow
     //
     m_jet_cutflowHist_1 = (TH1D*)file->Get("cutflow_jets_1");
 
     m_jet_cutflow_all             = m_jet_cutflowHist_1->GetXaxis()->FindBin("all");
-    m_jet_cutflow_cleaning_cut    = m_jet_cutflowHist_1->GetXaxis()->FindBin("cleaning_cut");     
+    m_jet_cutflow_cleaning_cut    = m_jet_cutflowHist_1->GetXaxis()->FindBin("cleaning_cut");
     m_jet_cutflow_ptmax_cut       = m_jet_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
-    m_jet_cutflow_ptmin_cut       = m_jet_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");      
-    m_jet_cutflow_eta_cut         = m_jet_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); 
+    m_jet_cutflow_ptmin_cut       = m_jet_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
+    m_jet_cutflow_eta_cut         = m_jet_cutflowHist_1->GetXaxis()->FindBin("eta_cut");
     m_jet_cutflow_jvt_cut         = m_jet_cutflowHist_1->GetXaxis()->FindBin("JVT_cut");
     m_jet_cutflow_btag_cut        = m_jet_cutflowHist_1->GetXaxis()->FindBin("BTag_cut");
- 
+
   }
 
   if ( this->configure() == EL::StatusCode::FAILURE ) {
@@ -386,8 +387,8 @@ EL::StatusCode JetSelector :: initialize ()
   } else {
     m_BJetSelectTool = new BTaggingSelectionTool( sel_tool_name );
   }
-  m_BJetSelectTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO, ERROR  
-  
+  m_BJetSelectTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO, ERROR
+
   // if applying cut on nr. bjets, configure it
   //
   if ( m_doBTagCut ) {
@@ -406,7 +407,7 @@ EL::StatusCode JetSelector :: initialize ()
     RETURN_CHECK( "BJetSelection::initialize()", m_BJetSelectTool->initialize(), "Failed to properly initialize the BJetSelectionTool");
 
   }
-  
+
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
@@ -535,7 +536,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   static SG::AuxElement::Accessor< char > isCleanAcc("cleanJet");
 
   //
-  // This cannot be static as multiple instance of Jet Selector would 
+  // This cannot be static as multiple instance of Jet Selector would
   //   then share the same passSelDecor, including the m_decor name
   //
   SG::AuxElement::Decorator< char > passSelDecor( m_decor );
@@ -629,7 +630,7 @@ EL::StatusCode JetSelector :: finalize ()
   // gets called on worker nodes that processed input events.
 
   Info("finalize()", "%s", m_name.c_str());
-  
+
   if ( m_useCutFlow ) {
     Info("histFinalize()", "Filling cutflow");
     m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
@@ -680,12 +681,12 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   if ( m_pT_max != 1e8 ) {
     if ( jet->pt() > m_pT_max ) { return 0; }
   }
-  m_jet_cutflowHist_1->Fill( m_jet_cutflow_ptmax_cut, 1 );        
-  
+  m_jet_cutflowHist_1->Fill( m_jet_cutflow_ptmax_cut, 1 );
+
   if ( m_pT_min != 1e8 ) {
     if ( jet->pt() < m_pT_min ) { return 0; }
   }
-  m_jet_cutflowHist_1->Fill( m_jet_cutflow_ptmin_cut, 1 );        
+  m_jet_cutflowHist_1->Fill( m_jet_cutflow_ptmin_cut, 1 );
 
   // eta
   if ( m_eta_max != 1e8 ) {
@@ -694,7 +695,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   if ( m_eta_min != 1e8 ) {
     if ( fabs(jet->eta()) < m_eta_min ) { return 0; }
   }
-  m_jet_cutflowHist_1->Fill( m_jet_cutflow_eta_cut, 1 );        
+  m_jet_cutflowHist_1->Fill( m_jet_cutflow_eta_cut, 1 );
 
   // detEta
   if ( m_detEta_max != 1e8 ) {
@@ -757,17 +758,17 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
       }
     }
   } // m_doJVT
-  m_jet_cutflowHist_1->Fill( m_jet_cutflow_jvt_cut, 1 );        
+  m_jet_cutflowHist_1->Fill( m_jet_cutflow_jvt_cut, 1 );
 
   //
   //  BTagging
   //
   if ( m_doBTagCut ) {
     if ( m_debug ) { Info("PassCuts()", "Doing BTagging"); }
-    if ( m_BJetSelectTool->accept( jet ) ) { 
-      m_jet_cutflowHist_1->Fill( m_jet_cutflow_btag_cut, 1 );        
+    if ( m_BJetSelectTool->accept( jet ) ) {
+      m_jet_cutflowHist_1->Fill( m_jet_cutflow_btag_cut, 1 );
     } else {
-      return 0; 
+      return 0;
     }
   }
 
@@ -777,7 +778,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   //
   if ( m_doHLTBTagCut ) {
     const xAOD::BTagging *btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
-    
+
     double tagValue = -99;
     if(m_HLTBTagTaggerName=="MV2c20"){
       btag_info->MVx_discriminant("MV2c20", tagValue);

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -303,6 +303,7 @@ EL::StatusCode JetSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -46,8 +46,8 @@
 ClassImp(JetSelector)
 
 
-JetSelector :: JetSelector () :
-    Algorithm("JetSelector"),
+JetSelector :: JetSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_jet_cutflowHist_1(nullptr),

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -48,7 +48,6 @@
 #pragma link off all functions;
 #pragma link C++ nestedclass;
 
-#pragma link C++ class xAH::AlgorithmRegistry+;
 #pragma link C++ class xAH::Algorithm+;
 
 #pragma link C++ class BasicEventSelection+;

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -167,6 +167,7 @@ EL::StatusCode METConstructor :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -52,20 +52,23 @@ using std::cout; using std::cerr; using std::endl;
 ClassImp(METConstructor)
 
 
-METConstructor :: METConstructor () : m_metmaker(0) {
+METConstructor :: METConstructor () :
+    Algorithm("METConstructor"),
+    m_metmaker(0)
+{
 
   m_debug           = false;
-  
+
   m_referenceMETContainer = "MET_Reference_AntiKt4LCTopo";
   m_mapName               = "METAssoc_AntiKt4LCTopo";
   m_coreName              = "MET_Core_AntiKt4LCTopo";
   m_outputContainer       = "NewRefFinal";
 
-  m_inputJets       = ""; 
-  m_inputElectrons  = ""; 
-  m_inputPhotons    = ""; 
-  m_inputTaus       = ""; 
-  m_inputMuons      = ""; 
+  m_inputJets       = "";
+  m_inputElectrons  = "";
+  m_inputPhotons    = "";
+  m_inputTaus       = "";
+  m_inputMuons      = "";
 
   m_doElectronCuts  = false;
   m_doPhotonCuts    = false;
@@ -125,7 +128,7 @@ EL::StatusCode  METConstructor :: configure ()
 
   m_useCaloJetTerm  = config->GetValue("UseCaloJetTerm",    m_useCaloJetTerm);
   m_useTrackJetTerm = config->GetValue("UseTrackJetTerm",   m_useTrackJetTerm);
-  
+
   if( m_mapName.Length() == 0 ) {
     Error("configure()", "MapName is empty!");
     return EL::StatusCode::FAILURE;
@@ -344,7 +347,7 @@ EL::StatusCode METConstructor :: execute ()
   const xAOD::MissingETContainer* coreMet(0);
   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_verbose), "Failed retrieving jet cont.");
   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_verbose), "Failed retrieving MET Core.");
-  
+
   if ( m_useCaloJetTerm ) {
     RETURN_CHECK("METConstructor::execute()", m_metmaker->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut), "Failed to build cluster-based jet/MET.");
   } else if ( m_useTrackJetTerm ) {

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -52,8 +52,8 @@ using std::cout; using std::cerr; using std::endl;
 ClassImp(METConstructor)
 
 
-METConstructor :: METConstructor () :
-    Algorithm("METConstructor"),
+METConstructor :: METConstructor (std::string className) :
+    Algorithm(className),
     m_metmaker(0)
 {
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -438,6 +438,6 @@ EL::StatusCode METConstructor :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -167,7 +167,7 @@ EL::StatusCode METConstructor :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MetHists.cxx
+++ b/Root/MetHists.cxx
@@ -32,7 +32,7 @@ StatusCode MetHists::initialize() {
   m_metFinalClusPy    = book(m_name,  "metFinalClusPy",    "metFinalClusPy",    100,  -200,    200);
   m_metFinalClusSumEt = book(m_name,  "metFinalClusSumEt", "metFinalClusSumEt", 100,     0,   2000);
   m_metFinalClusPhi   = book(m_name,  "metFinalClusPhi",   "metFinalClusPhi",   100,    -3.2,    3.2);
-  
+
   m_metFinalTrk       = book(m_name, "metFinalTrk",       "metFinalTrk",       100,     0,    200);
   m_metFinalTrkPx     = book(m_name, "metFinalTrkPx",     "metFinalTrkPx",     100,  -200,    200);
   m_metFinalTrkPy     = book(m_name, "metFinalTrkPy",     "metFinalTrkPy",     100,  -200,    200);
@@ -43,13 +43,13 @@ StatusCode MetHists::initialize() {
 }
 
 StatusCode MetHists::execute( const xAOD::MissingETContainer* met, float eventWeight ) {
-  
+
   if(m_debug) std::cout << "in execute " <<std::endl;
 
   //
   // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
   //
-  const xAOD::MissingET* final_clus = *met->find("FinalClus"); 
+  const xAOD::MissingET* final_clus = *met->find("FinalClus");
   m_metFinalClus      -> Fill( final_clus->met()   / 1e3, eventWeight);
   m_metFinalClusPx    -> Fill( final_clus->mpx()   / 1e3, eventWeight);
   m_metFinalClusPy    -> Fill( final_clus->mpy()   / 1e3, eventWeight);
@@ -59,7 +59,7 @@ StatusCode MetHists::execute( const xAOD::MissingETContainer* met, float eventWe
   //
   // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
   //
-  const xAOD::MissingET* final_trk = *met->find("FinalTrk"); 
+  const xAOD::MissingET* final_trk = *met->find("FinalTrk");
   m_metFinalTrk       -> Fill( final_trk->met()   / 1e3,  eventWeight);
   m_metFinalTrkPx     -> Fill( final_trk->mpx()   / 1e3,  eventWeight);
   m_metFinalTrkPy     -> Fill( final_trk->mpy()   / 1e3,  eventWeight);

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -38,6 +38,7 @@ EL::StatusCode MetHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   // needed here and not in initalize since this is called first
   Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -16,7 +16,8 @@
 ClassImp(MetHistsAlgo)
 
 MetHistsAlgo :: MetHistsAlgo () :
-  m_plots(nullptr)
+    Algorithm("MetHistsAlgo"),
+    m_plots(nullptr)
 {
   m_inContainerName         = "";
   m_detailStr               = "";

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -38,7 +38,7 @@ EL::StatusCode MetHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   // needed here and not in initalize since this is called first
   Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -15,8 +15,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MetHistsAlgo)
 
-MetHistsAlgo :: MetHistsAlgo () :
-    Algorithm("MetHistsAlgo"),
+MetHistsAlgo :: MetHistsAlgo (std::string className) :
+    Algorithm(className),
     m_plots(nullptr)
 {
   m_inContainerName         = "";

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -102,5 +102,7 @@ EL::StatusCode MetHistsAlgo :: histFinalize ()
 {
   // clean up memory
   if(m_plots) delete m_plots;
+
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -41,8 +41,8 @@ using HelperClasses::ToolName;
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonCalibrator)
 
-MuonCalibrator :: MuonCalibrator () :
-    Algorithm("MuonCalibrator"),
+MuonCalibrator :: MuonCalibrator (std::string className) :
+    Algorithm(className),
     m_muonCalibrationAndSmearingTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -145,7 +145,7 @@ EL::StatusCode MuonCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -42,7 +42,8 @@ using HelperClasses::ToolName;
 ClassImp(MuonCalibrator)
 
 MuonCalibrator :: MuonCalibrator () :
-  m_muonCalibrationAndSmearingTool(nullptr)
+    Algorithm("MuonCalibrator"),
+    m_muonCalibrationAndSmearingTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -54,12 +55,12 @@ MuonCalibrator :: MuonCalibrator () :
   Info("MuonCalibrator()", "Calling constructor");
 
   m_debug                   = false;
-  
+
   // input container to be read from TEvent or TStore
   //
   m_inContainerName         = "";
   m_outContainerName        = "";
-  
+
   m_release                 = "PreRecs";
 
   m_sort                    = true;
@@ -190,7 +191,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
     Error("initialize()", "Failed to properly configure. Exiting." );
     return EL::StatusCode::FAILURE;
   }
-  
+
   // Check if is MC
   //
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -200,13 +201,13 @@ EL::StatusCode MuonCalibrator :: initialize ()
   m_numEvent      = 0;
   m_numObject     = 0;
 
-  // Initialize the CP::MuonCalibrationAndSmearingTool 
+  // Initialize the CP::MuonCalibrationAndSmearingTool
   //
   if ( asg::ToolStore::contains<CP::MuonCalibrationAndSmearingTool>("MuonCalibrationAndSmearingTool") ) {
     m_muonCalibrationAndSmearingTool = asg::ToolStore::get<CP::MuonCalibrationAndSmearingTool>("MuonCalibrationAndSmearingTool");
   } else {
     m_muonCalibrationAndSmearingTool = new CP::MuonCalibrationAndSmearingTool("MuonCalibrationAndSmearingTool");
-  }  
+  }
   m_muonCalibrationAndSmearingTool->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
   RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTool->setProperty("Release", m_release),"Failed to set property Release");
   RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTool->initialize(), "Failed to properly initialize the MuonCalibrationAndSmearingTool.");
@@ -227,7 +228,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   Info("initialize()","Will be using MuonCalibrationAndSmearingTool systematic:");
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -308,11 +309,11 @@ EL::StatusCode MuonCalibrator :: execute ()
 	    Warning("execute()", "MuonCalibrationAndSmearingTool returned Error CorrectionCode");		  // If OutOfValidityRange is returned no modification is made and the original muon values are taken.
 	  }
 	}
-      
+
 	if ( m_debug ) { Info("execute()", "  corrected muon pt = %.2f GeV", (muSC_itr->pt() * 1e-3)); }
 
 	++idx;
-      
+
       } // close calibration loop
     }
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -145,6 +145,7 @@ EL::StatusCode MuonCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -410,6 +410,6 @@ EL::StatusCode MuonCalibrator :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -42,10 +42,11 @@ ClassImp(MuonEfficiencyCorrector)
 
 
 MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
-  m_asgMuonEffCorrTool_muSF_Reco(nullptr),
-  m_asgMuonEffCorrTool_muSF_Iso(nullptr),
-  m_asgMuonEffCorrTool_muSF_Trig(nullptr),
-  m_pileuptool(nullptr)
+    Algorithm("MuonEfficiencyCorrector"),
+    m_asgMuonEffCorrTool_muSF_Reco(nullptr),
+    m_asgMuonEffCorrTool_muSF_Iso(nullptr),
+    m_asgMuonEffCorrTool_muSF_Trig(nullptr),
+    m_pileuptool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -64,7 +65,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
 
   // Reco efficiency SF
   //
-  m_WorkingPointReco           = "Loose"; 
+  m_WorkingPointReco           = "Loose";
 
   // Iso efficiency SF
   //
@@ -82,13 +83,13 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
   //
   m_inputAlgoSystNames         = "";
   m_systValReco 	       = 0.0;
-  m_systValIso 	               = 0.0;  
-  m_systValTrig 	       = 0.0;  
+  m_systValIso 	               = 0.0;
+  m_systValTrig 	       = 0.0;
   m_systNameReco	       = "";
   m_systNameIso	               = "";
   m_systNameTrig	       = "";
   m_outputSystNamesReco        = "MuonEfficiencyCorrector_RecoSyst";
-  m_outputSystNamesIso         = "MuonEfficiencyCorrector_IsoSyst";  
+  m_outputSystNamesIso         = "MuonEfficiencyCorrector_IsoSyst";
   m_outputSystNamesTrig        = "MuonEfficiencyCorrector_TrigSyst";
 
 }
@@ -133,7 +134,7 @@ EL::StatusCode  MuonEfficiencyCorrector :: configure ()
     m_systValIso 		 = config->GetValue("SystValIso" , m_systValIso);
     m_systValTrig 		 = config->GetValue("SystValTrig" , m_systValTrig);
     m_systNameReco	         = config->GetValue("SystNameReco" , m_systNameReco.c_str());
-    m_systNameIso	         = config->GetValue("SystNameIso" , m_systNameIso.c_str());    
+    m_systNameIso	         = config->GetValue("SystNameIso" , m_systNameIso.c_str());
     m_systNameTrig		 = config->GetValue("SystNameTrig" , m_systNameTrig.c_str());
     m_outputSystNamesReco        = config->GetValue("OutputSystNamesReco", m_outputSystNamesReco.c_str());
     m_outputSystNamesIso         = config->GetValue("OutputSystNamesIso",  m_outputSystNamesIso.c_str());
@@ -239,7 +240,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // 1.
   // initialize the CP::MuonEfficiencyScaleFactors Tool for reco efficiency SF
   //
-  
+
   if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>("MuonEfficiencyScaleFactors_effSF_Reco") ) {
     m_asgMuonEffCorrTool_muSF_Reco = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>("MuonEfficiencyScaleFactors_effSF_Reco");
   } else {
@@ -250,9 +251,9 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   }
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-    //  
+    //
     CP::SystematicSet affectSystsReco = m_asgMuonEffCorrTool_muSF_Reco->affectingSystematics();
     //
     // Convert into a simple list
@@ -269,7 +270,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   Info("initialize()","Will be using MuonEfficiencyScaleFactors tool reco efficiency systematic:");
   for ( const auto& syst_it : m_systListReco ) {
     if ( m_systNameReco.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -283,21 +284,21 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // Add an "Iso" suffix to the WP (required for tool configuration)
   //
   std::string tool_WP = m_WorkingPointIso + "Iso";
-    
+
   std::string isoEffSF_tool_name = "MuonEfficiencyScaleFactors_effSF_Iso_" + m_WorkingPointIso;
   m_asgMuonEffCorrTool_muSF_Iso = new CP::MuonEfficiencyScaleFactors(isoEffSF_tool_name);
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->setProperty("WorkingPoint", tool_WP ), "Failed to set Working Point property of MuonEfficiencyScaleFactors for iso efficiency SF");
   RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for iso efficiency SF");
 
   //
-  //  Add the chosen WP to the string labelling the vector<SF> decoration 
-  //   
+  //  Add the chosen WP to the string labelling the vector<SF> decoration
+  //
   m_outputSystNamesIso = m_outputSystNamesIso + "_" + m_WorkingPointIso;
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-   //  
+   //
     CP::SystematicSet affectSystsIso = m_asgMuonEffCorrTool_muSF_Iso->affectingSystematics();
     //
     // Convert into a simple list
@@ -310,11 +311,11 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //
   const CP::SystematicSet recSystsIso = m_asgMuonEffCorrTool_muSF_Iso->recommendedSystematics();
   m_systListIso = HelperFunctions::getListofSystematics( recSystsIso, m_systNameIso, m_systValIso, m_debug );
-  
+
   Info("initialize()","Will be using MuonEfficiencyScaleFactors tool iso efficiency systematic:");
   for ( const auto& syst_it : m_systListIso ) {
     if ( m_systNameIso.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -332,34 +333,34 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     int runNumber(m_runNumber);
     if ( asg::ToolStore::contains<CP::PileupReweightingTool>("Pileup") ) {
       m_pileuptool = asg::ToolStore::get<CP::PileupReweightingTool>("Pileup");
-    }	
+    }
     //
     // If PileupReweightingTool exists, and a specific runNumber hasn't been set by the user yet,
     // use the random runNumber weighted by integrated luminosity got from CP::PileupReweightingTool::getRandomRunNumber()
     // Source: // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/ExtendedPileupReweighting#Generating_PRW_config_files
-    // 
+    //
     if ( m_runNumber == 900000 && m_pileuptool ) {
-      runNumber = m_pileuptool->getRandomRunNumber( *eventInfo, false ); 
+      runNumber = m_pileuptool->getRandomRunNumber( *eventInfo, false );
       Info("initialize()","CP::MuonTriggerScaleFactors - setting runNumber %i read from CP::PileupReweightingTool::getRandomRunNumber()", runNumber);
     } else {
       Warning("initialize()","CP::MuonTriggerScaleFactors - setting runNumber %i read from user's configuration - NOT RECOMMENDED", runNumber );
-    } 
+    }
     if( m_asgMuonEffCorrTool_muSF_Trig->setRunNumber( runNumber ) == CP::CorrectionCode::Error ) {
       Warning("initialize()","Cannot set RunNumber for MuonTriggerScaleFactors tool");
     }
     //
     // Add an "Iso" prefix to the WP (required for tool configuration)
     //
-    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;  
+    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("Isolation", iso_trig_WP ),"Failed to set Isolation property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("MuonQuality", m_WorkingPointRecoTrig ),"Failed to set MuonQuality property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->initialize(), "Failed to properly initialize MuonTriggerScaleFactors");
   }
 
   if ( m_debug ) {
-  
+
     // Get a list of affecting systematics
-   //  
+   //
     CP::SystematicSet affectSystsTrig = m_asgMuonEffCorrTool_muSF_Trig->affectingSystematics();
     //
     // Convert into a simple list
@@ -372,11 +373,11 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //
   const CP::SystematicSet recSystsTrig = m_asgMuonEffCorrTool_muSF_Trig->recommendedSystematics();
   m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, m_debug );
-  
+
   Info("initialize()","Will be using MuonEfficiencyScaleFactors tool trigger efficiency systematic:");
   for ( const auto& syst_it : m_systListTrig ) {
     if ( m_systNameTrig.empty() ) {
-      Info("initialize()","\t Running w/ nominal configuration only!"); 
+      Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
@@ -396,9 +397,9 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   // events, e.g. read input variables, apply cuts, and fill
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
-  
+
   m_numEvent++;
-  
+
   if ( !m_isMC ) {
     if ( m_numEvent == 1 ) { Info("execute()", "Sample is Data! Do not apply any Muon Efficiency correction... "); }
     return EL::StatusCode::SUCCESS;
@@ -504,7 +505,7 @@ EL::StatusCode MuonEfficiencyCorrector :: finalize ()
   if ( m_asgMuonEffCorrTool_muSF_Reco )  { m_asgMuonEffCorrTool_muSF_Reco = nullptr; delete m_asgMuonEffCorrTool_muSF_Reco; }
   if ( m_asgMuonEffCorrTool_muSF_Iso )   { m_asgMuonEffCorrTool_muSF_Iso = nullptr;  delete m_asgMuonEffCorrTool_muSF_Iso;  }
   if ( m_asgMuonEffCorrTool_muSF_Trig )  { m_asgMuonEffCorrTool_muSF_Trig = nullptr; delete m_asgMuonEffCorrTool_muSF_Trig; }
-  if ( m_pileuptool )                    { m_pileuptool = nullptr;                   delete m_pileuptool; }  
+  if ( m_pileuptool )                    { m_pileuptool = nullptr;                   delete m_pileuptool; }
 
   return EL::StatusCode::SUCCESS;
 }
@@ -532,7 +533,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 {
 
   //
-  // In the following, every muon gets decorated with 2 vector<double>'s (for reco/iso efficiency SFs), 
+  // In the following, every muon gets decorated with 2 vector<double>'s (for reco/iso efficiency SFs),
   // and the event w/ 1 vector<double> (for trigger efficiency SFs)
   // Each vector contains the SFs, one SF for each syst (first component of each vector will be the nominal SF).
   //
@@ -547,22 +548,22 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 
   // 1.
   // Reco efficiency SFs - this is a per-MUON weight
-  // 
+  //
   // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
   //
-  
+
   // Define also an *event* weight, which is the product of all the reco eff. SFs for each object in the event
   //
   std::string RECO_SF_NAME_GLOBAL = m_outputSystNamesReco + "_GLOBAL";
   SG::AuxElement::Decorator< std::vector<float> > sfVecReco_GLOBAL ( RECO_SF_NAME_GLOBAL );
-  
+
   for ( const auto& syst_it : m_systListReco ) {
-    
+
     // Initialise product of SFs for *this* systematic
     //
-    float recoEffSF_GLOBAL(1.0); 
-    
+    float recoEffSF_GLOBAL(1.0);
+
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_MuRecoEff_SF
     //
@@ -589,7 +590,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 
        if ( m_debug ) { Info( "executeSF()", "Applying reco efficiency SF" ); }
 
-       // a) 
+       // a)
        // decorate directly the muon with reco efficiency (useful at all?), and the corresponding SF
        //
        if ( m_asgMuonEffCorrTool_muSF_Reco->applyRecoEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
@@ -597,7 +598,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        }
        if ( m_asgMuonEffCorrTool_muSF_Reco->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
          Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor");
-       }       
+       }
 
        // b)
        // obtain reco efficiency SF as a float (to be stored away separately)
@@ -618,14 +619,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        // Add it to decoration vector
        //
        sfVecReco( *mu_itr ).push_back( recoEffSF );
-       
+
        recoEffSF_GLOBAL *= recoEffSF;
-       
-       if ( m_debug ) { 
+
+       if ( m_debug ) {
          Info( "executeSF()", "===>>>");
-         Info( "executeSF()", " ");	 
+         Info( "executeSF()", " ");
 	 Info( "executeSF()", "Muon %i, pt = %.2f GeV ", idx, (mu_itr->pt() * 1e-3) );
-	 Info( "executeSF()", " ");	
+	 Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Reco efficiency:");
@@ -635,11 +636,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
          Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", recoEffSF );
          Info( "executeSF()", "--------------------------------------");
        }
-       
+
        ++idx;
 
     } // close muon loop
-    
+
     // For *this* systematic, store the global SF weight for the event
     //
     if ( m_debug ) {
@@ -658,18 +659,18 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
   // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
   //
-  
+
   // Define also an *event* weight, which is the product of all the iso eff. SFs for each object in the event
   //
   std::string ISO_SF_NAME_GLOBAL = m_outputSystNamesIso + "_GLOBAL";
   SG::AuxElement::Decorator< std::vector<float> > sfVecIso_GLOBAL ( ISO_SF_NAME_GLOBAL );
-  
+
   for ( const auto& syst_it : m_systListIso ) {
-   
+
     // Initialise product of SFs for *this* systematic
     //
     float isoEffSF_GLOBAL(1.0);
-     
+
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_MuIsoEff_SF_WP
     //
@@ -690,13 +691,13 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
     if ( m_debug ) { Info("executeSF()", "Successfully applied systematic: %s", syst_it.name().c_str()); }
 
     // and now apply Iso efficiency SF!
-    //  
+    //
     unsigned int idx(0);
     for ( auto mu_itr : *(inputMuons) ) {
-       
+
        if ( m_debug ) { Info( "executeSF()", "Applying iso efficiency SF" ); }
 
-       // a) 
+       // a)
        // decorate directly the muon with iso efficiency (useful at all?), and the corresponding SF
        //
        if ( m_asgMuonEffCorrTool_muSF_Iso->applyRecoEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
@@ -704,7 +705,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        }
        if ( m_asgMuonEffCorrTool_muSF_Iso->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
          Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor");
-       }       
+       }
 
        // b)
        // obtain iso efficiency SF as a float (to be stored away separately)
@@ -725,16 +726,16 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        // Add it to decoration vector
        //
        sfVecIso( *mu_itr ).push_back(IsoEffSF);
-      
+
        isoEffSF_GLOBAL *= IsoEffSF;
-      
-       if ( m_debug ) { 
+
+       if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
 	 Info( "executeSF()", "Muon %i, pt = %.2f GeV ", idx, (mu_itr->pt() * 1e-3) );
 	 Info( "executeSF()", " ");
 	 Info( "executeSF()", "Isolation SF decoration: %s", m_outputSystNamesIso.c_str() );
-	 Info( "executeSF()", " ");	
+	 Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Iso efficiency:");
@@ -744,11 +745,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
          Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", IsoEffSF );
          Info( "executeSF()", "--------------------------------------");
        }
-       
-       ++idx;    
-       
+
+       ++idx;
+
     } // close muon loop
-   
+
     // For *this* systematic, store the global SF weight for the event
     //
     if ( m_debug ) {
@@ -758,7 +759,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        Info( "executeSF()", "--------------------------------------");
     }
     sfVecIso_GLOBAL( *eventInfo ).push_back( isoEffSF_GLOBAL );
-  
+
   }  // close loop on isolation efficiency SF systematics
 
   // 3.
@@ -804,9 +805,9 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 	  Warning( "executeSF()", "Problem in getTriggerScaleFactor - single muon trigger(s)");
 	  triggerEffSF = 1.0;
 	}
-        if ( m_debug ) { 
+        if ( m_debug ) {
           Info( "executeSF()", "===>>>");
-          Info( "executeSF()", " ");	   
+          Info( "executeSF()", " ");
           Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
           Info( "executeSF()", " ");
           Info( "executeSF()", "Trigger efficiency SF:");
@@ -821,9 +822,9 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 	    Warning( "executeSF()", "Problem in getTriggerScaleFactor - dimuon trigger(s)");
 	    triggerEffSF = 1.0;
           }
-          if ( m_debug ) { 
+          if ( m_debug ) {
             Info( "executeSF()", "===>>>");
-            Info( "executeSF()", " ");       
+            Info( "executeSF()", " ");
             Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
             Info( "executeSF()", " ");
             Info( "executeSF()", "Trigger efficiency SF:");

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -182,6 +182,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -182,7 +182,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -526,7 +526,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -41,8 +41,8 @@ using HelperClasses::ToolName;
 ClassImp(MuonEfficiencyCorrector)
 
 
-MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
-    Algorithm("MuonEfficiencyCorrector"),
+MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
+    Algorithm(className),
     m_asgMuonEffCorrTool_muSF_Reco(nullptr),
     m_asgMuonEffCorrTool_muSF_Iso(nullptr),
     m_asgMuonEffCorrTool_muSF_Trig(nullptr),

--- a/Root/MuonHists.cxx
+++ b/Root/MuonHists.cxx
@@ -69,7 +69,7 @@ StatusCode MuonHists::initialize() {
     m_topoetcone30 = book(m_name, "topoetcone30", "topoetcone30", 100, 0, 10);
     m_topoetcone40 = book(m_name, "topoetcone40", "topoetcone40", 100, 0, 10);
 
-  }    
+  }
 
 
   // quality
@@ -159,7 +159,7 @@ StatusCode MuonHists::execute( const xAOD::Muon* muon, float eventWeight) {
     static SG::AuxElement::Accessor<char> isLooseQAcc ("isLooseQ");
     static SG::AuxElement::Accessor<char> isMediumQAcc ("isMediumQ");
     static SG::AuxElement::Accessor<char> isTightQAcc ("isTightQ");
-    
+
     if( isVeryLooseQAcc.isAvailable( *muon ) ) { m_isVeryLoose->Fill( static_cast<int>(isVeryLooseQAcc( *muon )),  eventWeight ); } else { m_isVeryLoose->Fill( -1 ,  eventWeight ); }
     if( isLooseQAcc.isAvailable( *muon ) )     { m_isLoose    ->Fill( static_cast<int>(isLooseQAcc    ( *muon )),  eventWeight ); }         else { m_isLoose->Fill( -1 ,  eventWeight ); }
     if( isMediumQAcc.isAvailable( *muon ) )    { m_isMedium   ->Fill( static_cast<int>(isMediumQAcc   ( *muon )),  eventWeight ); }       else { m_isMedium->Fill( -1 ,  eventWeight ); }

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -42,7 +42,7 @@ EL::StatusCode MuonHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -17,7 +17,9 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonHistsAlgo)
 
-MuonHistsAlgo :: MuonHistsAlgo () {
+MuonHistsAlgo :: MuonHistsAlgo () :
+    Algorithm("MuonHistsAlgo")
+{
   m_inContainerName         = "";
   // which plots will be turned on
   m_detailStr               = "";

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -171,4 +171,7 @@ EL::StatusCode MuonHistsAlgo :: finalize () {
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode MuonHistsAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode MuonHistsAlgo :: histFinalize () {
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -17,8 +17,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonHistsAlgo)
 
-MuonHistsAlgo :: MuonHistsAlgo () :
-    Algorithm("MuonHistsAlgo")
+MuonHistsAlgo :: MuonHistsAlgo (std::string className) :
+    Algorithm(className)
 {
   m_inContainerName         = "";
   // which plots will be turned on

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -42,7 +42,7 @@ EL::StatusCode MuonHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -308,9 +308,9 @@ EL::StatusCode MuonSelector :: initialize ()
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
-  if ( this->countUsed() > 0 ) {
+  if ( this->numInstances() > 0 ) {
     m_isUsedBefore = true;
-    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );
+    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->numInstances() );
   }
 
   if ( m_useCutFlow ) {

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -853,7 +853,7 @@ EL::StatusCode MuonSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -257,7 +257,7 @@ EL::StatusCode MuonSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -257,6 +257,7 @@ EL::StatusCode MuonSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -45,14 +45,15 @@ ClassImp(MuonSelector)
 
 
 MuonSelector :: MuonSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_mu_cutflowHist_1(nullptr),
-  m_mu_cutflowHist_2(nullptr),
-  m_IsolationSelectionTool(nullptr),
-  m_muonSelectionTool(nullptr),
-  m_trigDecTool(nullptr),
-  m_trigMuonMatchTool(nullptr)
+    Algorithm("MuonSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_mu_cutflowHist_1(nullptr),
+    m_mu_cutflowHist_2(nullptr),
+    m_IsolationSelectionTool(nullptr),
+    m_muonSelectionTool(nullptr),
+    m_trigDecTool(nullptr),
+    m_trigMuonMatchTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -110,8 +111,8 @@ MuonSelector :: MuonSelector () :
   //
   m_MinIsoWPCut             = "";
   m_IsoWPList		    = "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
-  m_CaloIsoEff              = "0.1*x+90";  
-  m_TrackIsoEff             = "98";        
+  m_CaloIsoEff              = "0.1*x+90";
+  m_TrackIsoEff             = "98";
   m_CaloBasedIsoType        = "topoetcone20";
   m_TrackBasedIsoType       = "ptvarcone30";
 
@@ -161,7 +162,7 @@ EL::StatusCode  MuonSelector :: configure ()
 
     m_MinIsoWPCut             = config->GetValue("MinIsoWPCut"       ,  m_MinIsoWPCut.c_str());
     m_IsoWPList		      = config->GetValue("IsolationWPList"   ,  m_IsoWPList.c_str());
-    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());  
+    m_CaloIsoEff              = config->GetValue("CaloIsoEfficiecny" ,  m_CaloIsoEff.c_str());
     m_TrackIsoEff             = config->GetValue("TrackIsoEfficiency",  m_TrackIsoEff.c_str());
     m_CaloBasedIsoType        = config->GetValue("CaloBasedIsoType"  ,  m_CaloBasedIsoType.c_str());
     m_TrackBasedIsoType       = config->GetValue("TrackBasedIsoType" ,  m_TrackBasedIsoType.c_str());
@@ -212,7 +213,7 @@ EL::StatusCode  MuonSelector :: configure ()
   //
   if ( m_IsoWPList.empty() ) {
     m_IsoWPList	= "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
-  } 
+  }
   std::string token;
   std::istringstream ss(m_IsoWPList);
   while ( std::getline(ss, token, ',') ) {
@@ -303,7 +304,7 @@ EL::StatusCode MuonSelector :: initialize ()
   // Let's see if the algorithm has been already used before:
   // if yes, will write object cutflow in a different histogram!
   //
-  // This is the case when the selector algorithm is used for 
+  // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
@@ -313,25 +314,25 @@ EL::StatusCode MuonSelector :: initialize ()
   }
 
   if ( m_useCutFlow ) {
-    
+
     // retrieve the file in which the cutflow hists are stored
     //
     TFile *file     = wk()->getOutputFile ("cutflow");
-    
+
     // retrieve the event cutflows
     //
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
     m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-    
+
     // retrieve the object cutflow
     //
     m_mu_cutflowHist_1  = (TH1D*)file->Get("cutflow_muons_1");
 
     m_mu_cutflow_all                  = m_mu_cutflowHist_1->GetXaxis()->FindBin("all");
-    m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_1->GetXaxis()->FindBin("eta_and_quality_cut");     
-    m_mu_cutflow_ptmax_cut            = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");      
+    m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_1->GetXaxis()->FindBin("eta_and_quality_cut");
+    m_mu_cutflow_ptmax_cut            = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_mu_cutflow_ptmin_cut            = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
     m_mu_cutflow_type_cut             = m_mu_cutflowHist_1->GetXaxis()->FindBin("type_cut");
     m_mu_cutflow_z0sintheta_cut       = m_mu_cutflowHist_1->GetXaxis()->FindBin("z0sintheta_cut");
@@ -343,8 +344,8 @@ EL::StatusCode MuonSelector :: initialize ()
        m_mu_cutflowHist_2 = (TH1D*)file->Get("cutflow_muons_2");
 
        m_mu_cutflow_all 		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("all");
-       m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_2->GetXaxis()->FindBin("eta_and_quality_cut");     
-       m_mu_cutflow_ptmax_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");      
+       m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_2->GetXaxis()->FindBin("eta_and_quality_cut");
+       m_mu_cutflow_ptmax_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
        m_mu_cutflow_ptmin_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
        m_mu_cutflow_type_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("type_cut");
        m_mu_cutflow_z0sintheta_cut	 = m_mu_cutflowHist_2->GetXaxis()->FindBin("z0sintheta_cut");
@@ -352,7 +353,7 @@ EL::StatusCode MuonSelector :: initialize ()
        m_mu_cutflow_d0sig_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("d0sig_cut");
        m_mu_cutflow_iso_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("iso_cut");
     }
-    
+
   }
 
   m_event = wk()->xaodEvent();
@@ -370,7 +371,7 @@ EL::StatusCode MuonSelector :: initialize ()
   m_numEventPass  = 0;
   m_weightNumEventPass  = 0;
   m_numObjectPass = 0;
-  
+
   // ********************************
   //
   // Initialise CP::MuonSelectionTool
@@ -390,7 +391,7 @@ EL::StatusCode MuonSelector :: initialize ()
   RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MaxEta",    static_cast<double>(m_eta_max)), "Failed to set MaxEta property");
   RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->setProperty("MuQuality", m_muonQuality), "Failed to set MuQuality property" );
   RETURN_CHECK("MuonSelector::initialize()", m_muonSelectionTool->initialize(), "Failed to properly initialize the Muon Selection Tool");
- 
+
   // *************************************
   //
   // Initialise CP::IsolationSelectionTool
@@ -400,7 +401,7 @@ EL::StatusCode MuonSelector :: initialize ()
   std::string iso_tool_name = std::string("IsolationSelectionTool_") + m_name;
   m_IsolationSelectionTool = new CP::IsolationSelectionTool( iso_tool_name );
   m_IsolationSelectionTool->msg().setLevel( MSG::ERROR); // ERROR, VERBOSE, DEBUG, INFO
-  
+
   // Do this only for the first WP in the list
   //
   if ( m_debug ) { Info("initialize()", "Adding isolation WP %s to IsolationSelectionTool", (m_IsoKeys.at(0)).c_str() ); }
@@ -411,24 +412,24 @@ EL::StatusCode MuonSelector :: initialize ()
   // (start from 2nd element)
   //
   for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {
-     
+
      if ( m_debug ) { Info("initialize()", "Adding extra isolation WP %s to IsolationSelectionTool", (*WP_itr).c_str() ); }
-     
+
      if ( (*WP_itr).find("UserDefined") != std::string::npos ) {
-      
+
        HelperClasses::EnumParser<xAOD::Iso::IsolationType> isoParser;
-       
+
        std::vector< std::pair<xAOD::Iso::IsolationType, std::string> > myCuts;
        myCuts.push_back(std::make_pair<xAOD::Iso::IsolationType, std::string>(isoParser.parseEnum(m_TrackBasedIsoType), m_TrackIsoEff.c_str() ));
        myCuts.push_back(std::make_pair<xAOD::Iso::IsolationType, std::string>(isoParser.parseEnum(m_CaloBasedIsoType) , m_CaloIsoEff.c_str()  ));
-      
+
        CP::IsolationSelectionTool::IsoWPType iso_type(CP::IsolationSelectionTool::Efficiency);
        if ( (*WP_itr).find("Cut") != std::string::npos ) { iso_type = CP::IsolationSelectionTool::Cut; }
-      
+
        RETURN_CHECK( "ElectronSelector::initialize()", m_IsolationSelectionTool->addUserDefinedWP((*WP_itr).c_str(), xAOD::Type::Muon, myCuts, "", iso_type), "Failed to add user-defined isolation WP" );
-     
+
      } else {
-     
+
         RETURN_CHECK( "ElectronSelector::initialize()", m_IsolationSelectionTool->addMuonWP( (*WP_itr).c_str() ), "Failed to add isolation WP" );
 
      }
@@ -439,7 +440,7 @@ EL::StatusCode MuonSelector :: initialize ()
   // Initialise Trig::TrigMuonMatching tool
   //
   // **************************************
-  
+
   // NB: need to retrieve the TrigDecisionTool from asg::ToolStore to configure the tool!
   //     do not initialise if there are no input trigger chains
   //
@@ -495,7 +496,7 @@ EL::StatusCode MuonSelector :: execute ()
   // QUESTION: why this must be done in execute(), and does not work in initialize()?
   //
   if ( m_numEvent == 1 && m_trigDecTool ) {
-    
+
     // store the trigger chains that will be considered for matching
     //
     if ( m_singleMuTrigChains.find("ALL") != std::string::npos ) {
@@ -506,29 +507,29 @@ EL::StatusCode MuonSelector :: execute ()
       //
       std::string singlemu_trig;
       std::istringstream ss_singlemu_trig(m_singleMuTrigChains);
-      
+
       while ( std::getline(ss_singlemu_trig, singlemu_trig, ',') ) {
     	m_singleMuTrigChainsList.push_back(singlemu_trig);
       }
-      
+
       std::string dimu_trig;
       std::istringstream ss_dimu_trig(m_diMuTrigChains);
-      
+
       while ( std::getline(ss_dimu_trig, dimu_trig, ',') ) {
     	m_diMuTrigChainsList.push_back(dimu_trig);
       }
-    }	 
+    }
 
     Info("execute()", "Input single muon trigger chains that will be considered for matching:\n");
     for ( auto const &chain : m_singleMuTrigChainsList ) { Info("execute()", "\t %s", chain.c_str()); }
     Info("execute()", "\n");
-    
+
     Info("execute()", "Input di-muon trigger chains that will be considered for matching:\n");
     for ( auto const &chain : m_diMuTrigChainsList ) { Info("execute()", "\t %s", chain.c_str()); }
-    Info("execute()", "\n");    
-    
+    Info("execute()", "\n");
+
   }
-  
+
   // did any collection pass the cuts?
   //
   bool eventPass(false);
@@ -718,21 +719,21 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
   //
 
   if ( m_trigMuonMatchTool && selectedMuons ) {
-  
+
     unsigned int nSelectedMuons = selectedMuons->size();
 
     static SG::AuxElement::Decorator< std::map<std::string,char> > isTrigMatchedMapMuDecor( "isTrigMatchedMapMu" );
 
     if ( nSelectedMuons > 0 ) {
-      
+
       if ( m_debug ) { Info("executeSelection()", "Single Muon Trigger Matching "); }
 
       for ( auto const &chain : m_singleMuTrigChainsList ) {
-       
+
         if ( m_debug ) { Info("executeSelection()", "\t checking trigger chain %s", chain.c_str()); }
-       
+
         for ( auto const muon : *selectedMuons ) {
-          
+
           //  For each muon, decorate w/ a map<string,char> with the 'isMatched' info associated
           //  to each trigger chain in the input list.
           //  If decoration map doesn't exist for this muon yet, create it (will be done only for the 1st iteration on the chain names)
@@ -740,23 +741,23 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
           if ( !isTrigMatchedMapMuDecor.isAvailable( *muon ) ) {
             isTrigMatchedMapMuDecor( *muon ) = std::map<std::string,char>();
           }
-            
-          int matched = ( m_trigMuonMatchTool->match( muon, chain, m_minDeltaR ) ) ? 1 : 0;  
-          
+
+          int matched = ( m_trigMuonMatchTool->match( muon, chain, m_minDeltaR ) ) ? 1 : 0;
+
           if ( m_debug ) { Info("executeSelection()", "\t\t is muon trigger matched? %i", matched); }
-                  
-          ( isTrigMatchedMapMuDecor( *muon ) )[chain] = static_cast<char>(matched);  
+
+          ( isTrigMatchedMapMuDecor( *muon ) )[chain] = static_cast<char>(matched);
         }
       }
-    
-    }    
-    
+
+    }
+
     if ( nSelectedMuons > 1 ) {
-      
+
       if ( m_debug ) { Info("executeSelection()", "DiMuon Trigger Matching "); }
-      
+
       for ( auto const &chain : m_diMuTrigChainsList ) {
-        
+
 	if ( m_debug ) { Info("executeSelection()", "\t checking trigger chain %s", chain.c_str()); }
 
         // take the first two muons in the selected container
@@ -786,7 +787,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
        } else {
          if ( m_debug ) { Info("executeSelection()", "\t\t chain %s not supported", chain.c_str()); }
        }
-      
+
       }
     }
   }
@@ -856,16 +857,16 @@ EL::StatusCode MuonSelector :: histFinalize ()
 }
 
 int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primaryVertex  ) {
- 
+
   // fill cutflow bin 'all' before any cut
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_all, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_all, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // MuonSelectorTool cut: quality & |eta| acceptance cut
   //
-  
+
   // quality decorators
   static SG::AuxElement::Decorator< char > isVeryLooseQDecor("isVeryLooseQ");
   static SG::AuxElement::Decorator< char > isLooseQDecor("isLooseQ");
@@ -887,9 +888,9 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_eta_and_quaility_cut, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_eta_and_quaility_cut, 1 ); }
-	   
+
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // pT max cut
   //
   if ( m_pT_max != 1e8 ) {
@@ -900,11 +901,11 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_ptmax_cut, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_ptmax_cut, 1 ); }
-  
+
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // pT min cut
-  //  
+  //
   if ( m_pT_min != 1e8 ) {
     if ( muon->pt() < m_pT_min ) {
       if ( m_debug ) { Info("PassCuts()", "Muon failed pT min cut."); }
@@ -915,7 +916,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_ptmin_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // muon type cut
   //
   HelperClasses::EnumParser<xAOD::Muon::MuonType> muTypeParser;
@@ -929,10 +930,10 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_type_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // impact parameter cuts
-  //  
-  
+  //
+
   // Put tracking cuts here, after pt cuts, to be safe with derivations.
 
   // The following returns a pointer (which should not usually be NULL, but might be if the muon has been stripped of information) to the
@@ -947,11 +948,11 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   if ( !tp ) {
     if ( m_debug ) Info( "PassCuts()", "Muon has no TrackParticle. Won't be selected.");
     return 0;
-  }    
+  }
 
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
-  
+
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
 
   float z0sintheta = 1e8;
@@ -966,7 +967,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_z0sintheta_cut, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_z0sintheta_cut, 1 ); }
-  
+
   // d0 cut
   //
   if ( !( tp->d0() < m_d0_max ) ) {
@@ -975,7 +976,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_d0_cut, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_d0_cut, 1 ); }
-  
+
   // d0sig cut
   //
   if ( !( d0_significance < m_d0sig_max ) ) {
@@ -988,34 +989,34 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   // decorate muon w/ d0sig info
   static SG::AuxElement::Decorator< float > d0SigDecor("d0sig");
   d0SigDecor( *muon ) = static_cast<float>(d0_significance);
-  
+
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // isolation cut
   //
-  
+
   // Get the "list" of input WPs with the accept() decision from the tool
   //
   Root::TAccept accept_list = m_IsolationSelectionTool->accept( *muon );
-  
+
   // Decorate w/ decision for all input WPs
   //
-  std::string base_decor("isIsolated");  
+  std::string base_decor("isIsolated");
   for ( auto WP_itr : m_IsoKeys ) {
-    
+
     std::string decorWP = base_decor + "_" + WP_itr;
-    
+
     if ( m_debug ) { Info("PassCuts()", "Decorate muon with %s - accept() ? %i", decorWP.c_str(), accept_list.getCutResult( WP_itr.c_str()) ); }
     muon->auxdecor<char>(decorWP) = static_cast<char>( accept_list.getCutResult( WP_itr.c_str() ) );
 
   }
-  
+
   // Apply the cut if needed
   //
   if ( !m_MinIsoWPCut.empty() && !accept_list.getCutResult( m_MinIsoWPCut.c_str() ) ) {
     if ( m_debug ) { Info("PassCuts()", "Muon failed isolation cut %s ",  m_MinIsoWPCut.c_str() ); }
     return 0;
-  }  
+  }
   m_mu_cutflowHist_1->Fill( m_mu_cutflow_iso_cut, 1 );
   if ( m_isUsedBefore ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_iso_cut, 1 ); }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -307,7 +307,7 @@ EL::StatusCode MuonSelector :: initialize ()
   // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
-  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
+  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
   if ( this->countUsed() > 0 ) {
     m_isUsedBefore = true;
     Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -44,8 +44,8 @@
 ClassImp(MuonSelector)
 
 
-MuonSelector :: MuonSelector () :
-    Algorithm("MuonSelector"),
+MuonSelector :: MuonSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_mu_cutflowHist_1(nullptr),

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -256,6 +256,7 @@ EL::StatusCode OverlapRemover :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -47,8 +47,8 @@ using HelperClasses::ToolName;
 ClassImp(OverlapRemover)
 
 
-OverlapRemover :: OverlapRemover () :
-    Algorithm("OverlapRemover"),
+OverlapRemover :: OverlapRemover (std::string className) :
+    Algorithm(className),
     m_useElectrons(false),
     m_useMuons(false),
     m_usePhotons(false),

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -1,6 +1,6 @@
 /*************************************************
  *
- * Interface to ASG overlap removal tool 
+ * Interface to ASG overlap removal tool
  ( applying recommendations from Harmonisation TF ).
  *
  * M. Milesi (marco.milesi@cern.ch)
@@ -48,18 +48,19 @@ ClassImp(OverlapRemover)
 
 
 OverlapRemover :: OverlapRemover () :
-  m_useElectrons(false),
-  m_useMuons(false),
-  m_usePhotons(false),
-  m_useTaus(false),
-  m_dummyElectronContainer(nullptr),
-  m_dummyMuonContainer(nullptr),
-  m_overlapRemovalTool(nullptr),
-  m_el_cutflowHist_1(nullptr),
-  m_mu_cutflowHist_1(nullptr),
-  m_jet_cutflowHist_1(nullptr),
-  m_ph_cutflowHist_1(nullptr),
-  m_tau_cutflowHist_1(nullptr)
+    Algorithm("OverlapRemover"),
+    m_useElectrons(false),
+    m_useMuons(false),
+    m_usePhotons(false),
+    m_useTaus(false),
+    m_dummyElectronContainer(nullptr),
+    m_dummyMuonContainer(nullptr),
+    m_overlapRemovalTool(nullptr),
+    m_el_cutflowHist_1(nullptr),
+    m_mu_cutflowHist_1(nullptr),
+    m_jet_cutflowHist_1(nullptr),
+    m_ph_cutflowHist_1(nullptr),
+    m_tau_cutflowHist_1(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -80,8 +81,8 @@ OverlapRemover :: OverlapRemover () :
   m_inContainerName_Muons       = "";
   m_inputAlgoMuons              = "";  // name of vector<string> of syst retrieved from TStore
   m_outputAlgoMuons             = "MuonCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
-                                                               // NB: This is practically useless for the OR, since OR does not skim events 
-                                                               // (unlike the Selectors)! 
+                                                               // NB: This is practically useless for the OR, since OR does not skim events
+                                                               // (unlike the Selectors)!
                                                                // --> output syst set will be equal to input syst set, no matter what.
                                                                // KEEP THIS ATTRIBUTE ONLY FOR BW COMPATIBILITY
 
@@ -89,17 +90,17 @@ OverlapRemover :: OverlapRemover () :
   m_inContainerName_Electrons   = "";
   m_inputAlgoElectrons          = "";  // name of vector<string> of syst retrieved from TStore
   m_outputAlgoElectrons         = "ElectronCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
-                                                                   // NB: This is practically useless for the OR, since OR does not skim events 
-                                                                   // (unlike the Selectors)! 
+                                                                   // NB: This is practically useless for the OR, since OR does not skim events
+                                                                   // (unlike the Selectors)!
                                                                    // --> output syst set will be equal to input syst set, no matter what.
                                                                    // KEEP THIS ATTRIBUTE ONLY FOR BW COMPATIBILITY
- 
+
   /* Jets */
   m_inContainerName_Jets        = "";
   m_inputAlgoJets               = "";  // name of vector<string> of syst retrieved from TStore
   m_outputAlgoJets              = "JetCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
-                                                              // NB: This is practically useless for the OR, since OR does not skim events 
-                                                              // (unlike the Selectors)! 
+                                                              // NB: This is practically useless for the OR, since OR does not skim events
+                                                              // (unlike the Selectors)!
                                                               // --> output syst set will be equal to input syst set, no matter what.
                                                               // KEEP THIS ATTRIBUTE ONLY FOR BW COMPATIBILITY
 
@@ -112,8 +113,8 @@ OverlapRemover :: OverlapRemover () :
   m_inContainerName_Taus        = "";
   m_inputAlgoTaus               = "";  // name of vector<string> of syst retrieved from TStore
   m_outputAlgoTaus              = "TauCollection_OR_Algo";    // name of vector<string> of syst pushed in TStore
-                                                              // NB: This is practically useless for the OR, since OR does not skim events 
-                                                              // (unlike the Selectors)! 
+                                                              // NB: This is practically useless for the OR, since OR does not skim events
+                                                              // (unlike the Selectors)!
                                                               // --> output syst set will be equal to input syst set, no matter what.
                                                               // KEEP THIS ATTRIBUTE ONLY FOR BW COMPATIBILITY
 
@@ -205,14 +206,14 @@ EL::StatusCode  OverlapRemover :: configure ()
   }
 
   // be more flexible w/ electrons, muons, photons and taus :)
-  if ( !m_inContainerName_Electrons.empty() ) { 
-    m_useElectrons = true; 
+  if ( !m_inContainerName_Electrons.empty() ) {
+    m_useElectrons = true;
   } else{
     m_dummyElectronContainer = new xAOD::ElectronContainer();
   }
 
-  if ( !m_inContainerName_Muons.empty() )     { 
-    m_useMuons     = true; 
+  if ( !m_inContainerName_Muons.empty() )     {
+    m_useMuons     = true;
   } else {
     m_dummyMuonContainer = new xAOD::MuonContainer();
   }
@@ -295,7 +296,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   if ( setCutFlowHist() == EL::StatusCode::FAILURE ) {
     Error("initialize()", "Failed to setup cutflow histograms. Exiting." );
     return EL::StatusCode::FAILURE;
-  }  
+  }
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -311,7 +312,7 @@ EL::StatusCode OverlapRemover :: initialize ()
     Error("initialize()", "Failed to properly set event/object counters. Exiting." );
     return EL::StatusCode::FAILURE;
   }
-  
+
   // initialize ASG overlap removal tool
   //
   m_overlapRemovalTool = new OverlapRemovalTool( "OverlapRemovalTool" );
@@ -321,7 +322,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   //
   const std::string selected_label = ( m_useSelected ) ? "passSel" : "";  // set with decoration flag you use for selected objects if want to consider only selected objects in OR, otherwise it will perform OR on all objects
   RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->setProperty("InputLabel",  selected_label), "");
-  RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->setProperty("OverlapLabel", "overlaps"), "Failed to set property OverlapLabel"); // tool will decorate objects with 'overlaps' boolean if they overlap 
+  RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->setProperty("OverlapLabel", "overlaps"), "Failed to set property OverlapLabel"); // tool will decorate objects with 'overlaps' boolean if they overlap
   RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->initialize(), "Failed to properly initialize the OverlapRemovalTool.");
 
   Info("initialize()", "OverlapRemover Interface succesfully initialized!" );
@@ -351,15 +352,15 @@ EL::StatusCode OverlapRemover :: execute ()
   // --------------------------------------------------------------------------------------------
   //
   // always run the nominal case
- 
+
   executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus, NOMINAL);
-    
+
   // look what do we have in TStore
   if ( m_verbose ) { m_store->print(); }
 
   // -----------------------------------------------------------------------------------------------
   //
-  // if at least one of the m_inputAlgo* is not empty, and there's at least one non-empty syst name, 
+  // if at least one of the m_inputAlgo* is not empty, and there's at least one non-empty syst name,
   // then perform OR for every non-empty systematic set
 
   // ****************** //
@@ -380,7 +381,7 @@ EL::StatusCode OverlapRemover :: execute ()
       executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  ELSYST, systNames_el);
     }
 
-  } 
+  }
 
   // **************** //
   //      Muons       //
@@ -420,7 +421,7 @@ EL::StatusCode OverlapRemover :: execute ()
       executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  JETSYST, systNames_jet);
     }
 
-  } 
+  }
 
   // **************** //
   //     Photons      //
@@ -438,7 +439,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  PHSYST, systNames_photon);
 
-  } 
+  }
 
   // **************** //
   //       Taus       //
@@ -456,7 +457,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus, TAUSYST, systNames_tau);
 
-  }  
+  }
 
   // look what do we have in TStore
   if ( m_verbose ) { m_store->print(); }
@@ -533,7 +534,7 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const char* type, const xAOD
       Error("fillObjectCutflow()", "Overlap decoration missing for object of type %s ", type );
       return EL::StatusCode::FAILURE;
     }
-    if ( !overlapAcc( *obj_itr ) ) { 
+    if ( !overlapAcc( *obj_itr ) ) {
       switch(obj_itr->type())
 	{
 	case xAOD::Type::Electron:
@@ -550,17 +551,17 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const char* type, const xAOD
 	  break;
 	case xAOD::Type::Tau:
 	  m_tau_cutflowHist_1->Fill( m_tau_cutflow_OR_cut, 1 );
-	  break;	  
+	  break;
 	default:
 	  Error("OverlapRemover::fillObjectCutflow()","Unsupported object");
 	  return EL::StatusCode::FAILURE;
 	  break;
 	}
     }
-    
+
     if ( m_debug ) {
       if ( selectAcc.isAvailable( *obj_itr) ){
-        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f selected %i overlaps %i ", type, (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), selectAcc( *obj_itr ), overlapAcc( *obj_itr ) ); 
+        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f selected %i overlaps %i ", type, (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), selectAcc( *obj_itr ), overlapAcc( *obj_itr ) );
       } else {
         Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f overlaps %i ", type, (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), overlapAcc( *obj_itr) );
       }
@@ -569,9 +570,9 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const char* type, const xAOD
         const xAOD::IParticle* overlapObj = *objLinkAcc( *obj_itr );
         std::stringstream ss_or; ss_or << overlapObj->type();
         Info("fillObjectCutflow()", "	Overlap: type %s pt %6.2f", (ss_or.str()).c_str(), overlapObj->pt()/1e3);
-      }    
+      }
     }
- 
+
   }
 
   return EL::StatusCode::SUCCESS;
@@ -632,7 +633,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Jets.c_str()); }
       }
 
-      if ( m_usePhotons ) {      
+      if ( m_usePhotons ) {
          if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
          } else {
@@ -641,21 +642,21 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
          }
       }
 
-      if ( m_useTaus ) {      
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {   
+      if ( m_useTaus ) {
+         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
          } else {
            nomContainerNotFound = true;
 	   if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Taus.c_str()); }
 	 }
       }
-      
+
       if ( nomContainerNotFound ) {return EL::StatusCode::SUCCESS;}
 
-      if ( m_debug ) { 
+      if ( m_debug ) {
 	if ( m_useElectrons ) { Info("execute()",  "inElectrons : %lu", inElectrons->size()); }
 	if ( m_useMuons )     { Info("execute()",  "inMuons : %lu", inMuons->size()); }
-	Info("execute()",  "inJets : %lu", inJets->size() );  
+	Info("execute()",  "inJets : %lu", inJets->size() );
 	if ( m_usePhotons )   { Info("execute()",  "inPhotons : %lu", inPhotons->size());  }
 	if ( m_useTaus    )   { Info("execute()",  "inTaus : %lu",    inTaus->size());  }
       }
@@ -697,14 +698,14 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
       if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
 
-      if ( m_debug ) { 
-	if ( m_useElectrons) { Info("execute()",  "selectedElectrons : %lu", selectedElectrons->size()); } 
-	if ( m_useMuons )    { Info("execute()",  "selectedMuons : %lu",     selectedMuons->size()); } 
-	Info("execute()",  "selectedJets : %lu", selectedJets->size()); 
-	if ( m_usePhotons )  { Info("execute()",  "selectedPhotons : %lu", selectedPhotons->size()); } 
+      if ( m_debug ) {
+	if ( m_useElectrons) { Info("execute()",  "selectedElectrons : %lu", selectedElectrons->size()); }
+	if ( m_useMuons )    { Info("execute()",  "selectedMuons : %lu",     selectedMuons->size()); }
+	Info("execute()",  "selectedJets : %lu", selectedJets->size());
+	if ( m_usePhotons )  { Info("execute()",  "selectedPhotons : %lu", selectedPhotons->size()); }
         if ( m_useTaus )     { Info("execute()",  "selectedTaus : %lu", selectedTaus->size() ); }
       }
-      
+
       // add ConstDataVector to TStore
       //
       if ( m_createSelectedContainers ) {
@@ -729,33 +730,33 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the electron syst loop ...
       //
-      if ( m_useMuons ) { 
+      if ( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
         } else {
-          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str()); 
+          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
       	  return EL::StatusCode::FAILURE;
         }
       }
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
         RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
       } else {
-        Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str()); 
+        Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
 	return EL::StatusCode::FAILURE;
       }
-      if ( m_usePhotons ) {      
+      if ( m_usePhotons ) {
          if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str()); 
+           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
 	   return EL::StatusCode::FAILURE;
          }
       }
-      if ( m_useTaus ) {      
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {   
+      if ( m_useTaus ) {
+         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str()); 
+           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
 	   return EL::StatusCode::FAILURE;
 	 }
       }
@@ -770,10 +771,10 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(el_syst_cont_name) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, m_event, m_store, m_verbose) ,"");
         } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find syst container %s in xAOD::TStore. Aborting", el_syst_cont_name.c_str()); 
+           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find syst container %s in xAOD::TStore. Aborting", el_syst_cont_name.c_str());
 	   return EL::StatusCode::FAILURE;
 	}
-	
+
 	if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
         // do the actual OR
@@ -836,29 +837,29 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
         } else {
-          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str()); 
+          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
       	  return EL::StatusCode::FAILURE;
         }
       }
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
         RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
       } else {
-        Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str()); 
+        Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
 	return EL::StatusCode::FAILURE;
       }
-      if ( m_usePhotons ) {      
+      if ( m_usePhotons ) {
          if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str()); 
+           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
 	   return EL::StatusCode::FAILURE;
          }
       }
-      if ( m_useTaus ) {      
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {   
+      if ( m_useTaus ) {
+         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str()); 
+           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
 	   return EL::StatusCode::FAILURE;
 	 }
       }
@@ -873,7 +874,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(mu_syst_cont_name) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, m_event, m_store, m_verbose) ,"");
         } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find syst container %s in xAOD::TStore. Aborting",mu_syst_cont_name.c_str()); 
+           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find syst container %s in xAOD::TStore. Aborting",mu_syst_cont_name.c_str());
 	   return EL::StatusCode::FAILURE;
 	}
 
@@ -937,35 +938,35 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the jet syst loop ...
       //
-      if ( m_useElectrons ) { 
+      if ( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
         } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str()); 
+          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
       	  return EL::StatusCode::FAILURE;
         }
       }
-      if ( m_useMuons ) { 
+      if ( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
         } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str()); 
+          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
       	  return EL::StatusCode::FAILURE;
         }
       }
-      if ( m_usePhotons ) {      
+      if ( m_usePhotons ) {
          if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str()); 
+           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
 	   return EL::StatusCode::FAILURE;
          }
       }
-      if ( m_useTaus ) {      
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {   
+      if ( m_useTaus ) {
+         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
 	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
          } else {
-           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str()); 
+           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
 	   return EL::StatusCode::FAILURE;
 	 }
       }
@@ -980,7 +981,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
          if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(jet_syst_cont_name) ) {
            RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, m_event, m_store, m_verbose) ,"");
          } else {
-            Error("executeOR()", "Attempt at running w/ jet systematics. Could not find syst container %s in xAOD::TStore. Aborting",jet_syst_cont_name.c_str()); 
+            Error("executeOR()", "Attempt at running w/ jet systematics. Could not find syst container %s in xAOD::TStore. Aborting",jet_syst_cont_name.c_str());
 	    return EL::StatusCode::FAILURE;
 	 }
 
@@ -998,7 +999,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 	 fillObjectCutflow("jet", inJets, "passSel", ORdecor);
 	 if( m_usePhotons )    fillObjectCutflow("photon", inPhotons, "passSel", ORdecor);
 	 if( m_useTaus )       fillObjectCutflow("tau", inTaus, "passSel", ORdecor);
-	 
+
 	 // make a copy of input container(s) with selected objects
 	 //
 	 if ( m_createSelectedContainers ) {
@@ -1054,7 +1055,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 	// Create an empty container
 	inElectrons = m_dummyElectronContainer;
       }
-      
+
       if ( m_useMuons ) {
 	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
       } else {
@@ -1074,12 +1075,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
          if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(photon_syst_cont_name) ) {
            RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, m_event, m_store, m_verbose) ,"");
          } else {
-            Error("executeOR()", "Attempt at running w/ photon systematics. Could not find syst container %s in xAOD::TStore. Aborting",photon_syst_cont_name.c_str()); 
+            Error("executeOR()", "Attempt at running w/ photon systematics. Could not find syst container %s in xAOD::TStore. Aborting",photon_syst_cont_name.c_str());
 	    return EL::StatusCode::FAILURE;
 	 }
 
-         if ( m_debug ) { 
-	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  
+         if ( m_debug ) {
+	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
 	 }
 
          // do the actual OR
@@ -1150,7 +1151,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 	// Create an empty container
 	inElectrons = m_dummyElectronContainer;
       }
-      
+
       if ( m_useMuons ) {
 	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
       } else {
@@ -1173,12 +1174,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
          if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(tau_syst_cont_name) ) {
            RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, m_event, m_store, m_verbose) ,"");
          } else {
-            Error("executeOR()", "Attempt at running w/ tau systematics. Could not find syst container %s in xAOD::TStore. Aborting", tau_syst_cont_name.c_str()); 
+            Error("executeOR()", "Attempt at running w/ tau systematics. Could not find syst container %s in xAOD::TStore. Aborting", tau_syst_cont_name.c_str());
 	    return EL::StatusCode::FAILURE;
 	 }
 
-         if ( m_debug ) { 
-	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  
+         if ( m_debug ) {
+	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
 	 }
 
          // do the actual OR
@@ -1221,7 +1222,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container"); }
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
           if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedPhotons,   m_outContainerName_Photons + systName ), "Failed to store const data container"); }
-          RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); 
+          RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container");
         }
       } // close loop on systematic sets available from upstream algo (Taus)
 
@@ -1241,13 +1242,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
 EL::StatusCode OverlapRemover :: setCutFlowHist( )
 {
- 
+
  if ( m_useCutFlow ) {
-   
+
    // retrieve the file in which the cutflow hists are stored
    //
    TFile *file     = wk()->getOutputFile ("cutflow");
-       
+
    // retrieve the object cutflow
    //
    m_el_cutflowHist_1	 = (TH1D*)file->Get("cutflow_electrons_1");
@@ -1268,7 +1269,7 @@ EL::StatusCode OverlapRemover :: setCutFlowHist( )
 EL::StatusCode OverlapRemover :: setCounters( )
 {
   m_numEvent      = 0;
-  m_numObject     = 0;  
-  
+  m_numObject     = 0;
+
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -256,7 +256,7 @@ EL::StatusCode OverlapRemover :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -516,7 +516,7 @@ EL::StatusCode OverlapRemover :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -570,7 +570,7 @@ EL::StatusCode PhotonCalibrator :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -180,7 +180,7 @@ EL::StatusCode PhotonCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -60,8 +60,8 @@ using HelperClasses::ToolName;
 ClassImp(PhotonCalibrator)
 
 
-PhotonCalibrator :: PhotonCalibrator () :
-    Algorithm("PhotonCalibrator"),
+PhotonCalibrator :: PhotonCalibrator (std::string className) :
+    Algorithm(className),
     m_EgammaCalibrationAndSmearingTool(nullptr),
     m_photonFudgeMCTool(nullptr),
     m_photonTightIsEMSelector(nullptr),

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -180,6 +180,7 @@ EL::StatusCode PhotonCalibrator :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -6,7 +6,7 @@
  *
  * -) scale corrections for DATA
  * -) smearing corrections for MC
- * (data VS. MC check is done by the CP tool internally) 
+ * (data VS. MC check is done by the CP tool internally)
  *
  * M. Milesi (marco.milesi@cern.ch)
  *
@@ -61,7 +61,15 @@ ClassImp(PhotonCalibrator)
 
 
 PhotonCalibrator :: PhotonCalibrator () :
-m_EgammaCalibrationAndSmearingTool(nullptr), m_photonFudgeMCTool(nullptr), m_photonTightIsEMSelector(nullptr), m_photonMediumIsEMSelector(nullptr), m_photonLooseIsEMSelector(nullptr), m_photonTightEffTool(nullptr), m_photonMediumEffTool(nullptr), m_photonLooseEffTool(nullptr)
+    Algorithm("PhotonCalibrator"),
+    m_EgammaCalibrationAndSmearingTool(nullptr),
+    m_photonFudgeMCTool(nullptr),
+    m_photonTightIsEMSelector(nullptr),
+    m_photonMediumIsEMSelector(nullptr),
+    m_photonLooseIsEMSelector(nullptr),
+    m_photonTightEffTool(nullptr),
+    m_photonMediumEffTool(nullptr),
+    m_photonLooseEffTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -81,7 +89,7 @@ m_EgammaCalibrationAndSmearingTool(nullptr), m_photonFudgeMCTool(nullptr), m_pho
 
   m_sort                    = true;
   m_isMC                    = false;
-  
+
   m_toolInitializationAtTheFirstEventDone = false;
 
   // Systematics stuff
@@ -122,11 +130,11 @@ EL::StatusCode  PhotonCalibrator :: configure ()
 
     m_esModel		      = config->GetValue("ESModel" , m_esModel.c_str() );
     m_decorrelationModel      = config->GetValue("DecorrelationModel" , m_decorrelationModel.c_str() );
-    
+
     m_useAFII                 = config->GetValue("AFII" , false );
 
     config->Print();
-    
+
     Info("configure()", "PhotonCalibrator Interface succesfully configured! ");
 
     delete config; config = nullptr;
@@ -213,26 +221,26 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   m_store = wk()->xaodStore();
 
   Info("initialize()", "Number of events in file: %lld ", m_event->getEntries() );
-  
+
   if ( this->configure() == EL::StatusCode::FAILURE ) {
     Error("initialize()", "Failed to properly configure. Exiting." );
     return EL::StatusCode::FAILURE;
   }
-  
+
   MSG::Level msgLevel = (m_debug) ? MSG::VERBOSE : MSG::INFO;
-  
+
   m_numEvent      = 0;
   m_numObject     = 0;
-  
+
   // initialize the CP::EgammaCalibrationAndSmearingTool
-  //  
+  //
   const std::string CalibToolName = m_name + "_EgammaCalibrationAndSmearingTool_Photons";
   if ( asg::ToolStore::contains<CP::EgammaCalibrationAndSmearingTool>(CalibToolName.c_str()) ) {
     m_EgammaCalibrationAndSmearingTool = asg::ToolStore::get<CP::EgammaCalibrationAndSmearingTool>(CalibToolName.c_str());
   } else {
     m_EgammaCalibrationAndSmearingTool = new CP::EgammaCalibrationAndSmearingTool(CalibToolName.c_str());
-  }  
-  
+  }
+
   RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("ESModel", m_esModel),"Failed to set property ESModel");
   RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("decorrelationModel", m_decorrelationModel),"Failed to set property decorrelationModel");
   if (m_useAFII) {
@@ -240,79 +248,79 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   }
   RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->initialize(), "Failed to properly initialize the EgammaCalibrationAndSmearingTool");
   m_EgammaCalibrationAndSmearingTool->msg().setLevel( msgLevel );
-  
+
   // Get a list of recommended systematics for this tool
   //
   //const CP::SystematicRegistry& systReg = CP::SystematicRegistry::getInstance();
   const CP::SystematicSet& recSyst = m_EgammaCalibrationAndSmearingTool->recommendedSystematics();;
   Info("initialize()"," Initializing Photon Calibrator Systematics :");
-  
+
   m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
-  
+
   Info("initialize()","Will be using EgammaCalibrationAndSmearingTool systematic:");
   for ( const auto& syst_it : m_systList ) {
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
-    
+
   //isEM selector tools
   //------------------
   //create the selectors
   // Tight
   const std::string TightSelectorName = m_name + "_PhotonTightIsEMSelector";
-  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(TightSelectorName.c_str()) ) {  
+  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(TightSelectorName.c_str()) ) {
     m_photonTightIsEMSelector = asg::ToolStore::get<AsgPhotonIsEMSelector>(TightSelectorName.c_str());
   } else {
     m_photonTightIsEMSelector = new AsgPhotonIsEMSelector ( TightSelectorName.c_str() );
   }
   m_photonTightIsEMSelector->msg().setLevel( msgLevel );
-  
+
   // Medium
   const std::string MediumSelectorName = m_name + "_PhotonMediumIsEMSelector";
-  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(MediumSelectorName.c_str()) ) {  
+  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(MediumSelectorName.c_str()) ) {
     m_photonMediumIsEMSelector = asg::ToolStore::get<AsgPhotonIsEMSelector>(MediumSelectorName.c_str());
   } else {
     m_photonMediumIsEMSelector = new AsgPhotonIsEMSelector ( MediumSelectorName.c_str() );
   }
   m_photonMediumIsEMSelector->msg().setLevel( msgLevel );
-  
+
   // Loose
   const std::string LooseSelectorName = m_name + "_PhotonLooseIsEMSelector";
-  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(LooseSelectorName.c_str()) ) {  
+  if ( asg::ToolStore::contains<AsgPhotonIsEMSelector>(LooseSelectorName.c_str()) ) {
     m_photonLooseIsEMSelector = asg::ToolStore::get<AsgPhotonIsEMSelector>(LooseSelectorName.c_str());
   } else {
     m_photonLooseIsEMSelector = new AsgPhotonIsEMSelector ( LooseSelectorName.c_str() );
   }
   m_photonLooseIsEMSelector->msg().setLevel( msgLevel );
-  
+
   //set the type of selection
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightIsEMSelector->setProperty("isEMMask", egammaPID::PhotonTight), "failed in initialization");
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumIsEMSelector->setProperty("isEMMask", egammaPID::PhotonMedium), "failed in initialization");
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseIsEMSelector->setProperty("isEMMask", egammaPID::PhotonLoose), "failed in initialization");
-  
+
   //set the configuration file
   // todo : monitor the config files!
-  RETURN_CHECK("PhotonHandler::initializeTools()", 
+  RETURN_CHECK("PhotonHandler::initializeTools()",
 	       m_photonTightIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMTightSelectorCutDefs.conf"),
-	       "failed in setting property");  
+	       "failed in setting property");
   RETURN_CHECK("PhotonHandler::initializeTools()",
 	       m_photonMediumIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMMediumSelectorCutDefs.conf"),
 	       "failed in setting property");
   RETURN_CHECK("PhotonHandler::initializeTools()",
 	       m_photonLooseIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMLooseSelectorCutDefs.conf"),
 	       "failed in setting property");
-  
-  
+
+
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightIsEMSelector->initialize(), "failed in initialization for Tight");
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumIsEMSelector->initialize(), "failed in initialization for Medium");
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseIsEMSelector->initialize(), "failed in initialization for Loose");
-  
+
   // ***********************************************************
-  
+
   //
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
-  
+
   // fudge MC tool
   //--------------
   const std::string FudgeMCToolName = m_name + "PhotonFudgeMCTool";
@@ -324,9 +332,9 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   m_photonFudgeMCTool->msg().setLevel( msgLevel );
   RETURN_CHECK("PhotonHandler::initializeTools()", m_photonFudgeMCTool->initialize(),
 	       "failed in initialization of fudge MC tool");
-  
+
   Info("initialize()", "PhotonCalibrator Interface succesfully initialized!" );
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -341,7 +349,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
   if ( m_debug ) { Info("execute()", "Applying Photon Calibration ... "); }
 
   m_numEvent++;
-  
+
   // get the collection from TEvent or TStore
   //
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -352,27 +360,27 @@ EL::StatusCode PhotonCalibrator :: execute ()
   if ( ! m_toolInitializationAtTheFirstEventDone ) {
     EL_RETURN_CHECK ("PhotonCalibrator::execute() ", toolInitializationAtTheFirstEvent (eventInfo));
   }
-  
-  
+
+
 
   const xAOD::PhotonContainer* inPhotons(nullptr);
   RETURN_CHECK("PhotonCalibrator::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName, m_event, m_store, m_verbose) ,
 	       Form("Failed in retrieving %s in %s", m_inContainerName.c_str(), m_name.c_str() ));
-  
+
   if ( m_debug ) { Info("execute()", "Retrieve has been completed with container name = %s", m_inContainerName.c_str()); }
-  
+
   // loop over available systematics - remember syst == EMPTY_STRING --> baseline
   // prepare a vector of the names of CDV containers
   // must be a pointer to be recorded in TStore
   //
   std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-  
+
   for ( const auto& syst_it : m_systList ) {
-    if ( m_debug ) { Info("execute()", "Systematic Loop for m_systList=%s", syst_it.name().c_str() ); } 
+    if ( m_debug ) { Info("execute()", "Systematic Loop for m_systList=%s", syst_it.name().c_str() ); }
     // discard photon systematics
     //
     //if ( (syst_it.name()).find("PH_", 0) != std::string::npos ) { continue; }
-    
+
     std::string outSCContainerName(m_outSCContainerName);
     std::string outSCAuxContainerName(m_outSCAuxContainerName);
     std::string outContainerName(m_outContainerName);
@@ -387,12 +395,12 @@ EL::StatusCode PhotonCalibrator :: execute ()
     // apply syst
     //
     if (m_debug) { Info("execute()", "syst_it.name()=%s", syst_it.name().c_str()); }
-    
+
     if ( m_EgammaCalibrationAndSmearingTool->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
       Error("execute()", "Failed to configure EgammaCalibrationAndSmearingTool for systematic %s", syst_it.name().c_str());
       return EL::StatusCode::FAILURE;
     }
-    
+
     if ( m_debug ) { Info("execute()", "Systematics applied"); }
     // create shallow copy for calibration - one per syst
     //
@@ -401,8 +409,8 @@ EL::StatusCode PhotonCalibrator :: execute ()
     // create ConstDataVector to be eventually stored in TStore
     //
     ConstDataVector<xAOD::PhotonContainer>* calibPhotonsCDV = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-    calibPhotonsCDV->reserve( calibPhotonsSC.first->size() );    
-    
+    calibPhotonsCDV->reserve( calibPhotonsSC.first->size() );
+
     // now calibrate!
     // four momentum calibration
     unsigned int idx(0);
@@ -414,30 +422,30 @@ EL::StatusCode PhotonCalibrator :: execute ()
       if ( m_debug ) {
         Info( "execute", "Checking photon %i, raw pt = %.2f GeV ", idx, (phSC_itr->pt() * 1e-3) );
       }
-      
+
       if ( phSC_itr->pt() > 7e3 && !(phSC_itr->caloCluster()) ){
 	Warning( "execute", "photon %i, raw pt = %.2f GeV, does not have caloCluster()! ", idx, (phSC_itr->pt() * 1e-3) );
       }
-      
+
       // apply calibration (w/ syst)
       //
       if ( (phSC_itr->author() & xAOD::EgammaParameters::AuthorPhoton) || (phSC_itr->author() & xAOD::EgammaParameters::AuthorAmbiguous) ) {
 	if ( m_EgammaCalibrationAndSmearingTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
 	  Warning("execute()", "Problem in CP::EgammaCalibrationAndSmearingTool::applyCorrection()");
-	}	
-	
-	//if ( m_IsolationCorrectionTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) { /// indeed wrong 
+	}
+
+	//if ( m_IsolationCorrectionTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) { /// indeed wrong
 	if ( m_IsolationCorrectionTool->CorrectLeakage( *phSC_itr ) != CP::CorrectionCode::Ok ) {
 	  Warning("execute()", "Problem in CP::IsolationCorrection::applyCorrection()");
 	}
       }
-      
+
       if ( m_debug ) { Info("execute()", "Calibrated pt with systematic: %s , pt = %.2f GeV", (syst_it).name().c_str(), (phSC_itr->pt() * 1e-3)); }
-      
+
       EL_RETURN_CHECK ( "PhotonCalibrator::execute()", decorate(phSC_itr));
-      
+
       ++idx;
-      
+
     } // close calibration loop
 
     if ( !xAOD::setOriginalObjectLink(*inPhotons, *(calibPhotonsSC.first)) ) {
@@ -501,11 +509,11 @@ EL::StatusCode PhotonCalibrator :: finalize ()
 
   Info("finalize()", "Deleting tool instances...");
 
-  if ( m_EgammaCalibrationAndSmearingTool ) { 
+  if ( m_EgammaCalibrationAndSmearingTool ) {
     delete m_EgammaCalibrationAndSmearingTool;
-    m_EgammaCalibrationAndSmearingTool = nullptr; 
+    m_EgammaCalibrationAndSmearingTool = nullptr;
   }
-  if ( m_photonFudgeMCTool ) { 
+  if ( m_photonFudgeMCTool ) {
     delete m_photonFudgeMCTool;
     m_photonFudgeMCTool = nullptr;
   }
@@ -513,35 +521,35 @@ EL::StatusCode PhotonCalibrator :: finalize ()
   if ( m_photonTightIsEMSelector ) {
     delete m_photonTightIsEMSelector;
     m_photonTightIsEMSelector = nullptr;
-  } 
-  
+  }
+
   if (m_photonMediumIsEMSelector) {
     delete m_photonMediumIsEMSelector;
     m_photonMediumIsEMSelector = nullptr;
   }
-  
+
   if (m_photonLooseIsEMSelector) {
     delete m_photonLooseIsEMSelector;
     m_photonLooseIsEMSelector = nullptr;
   }
-  
+
   if (m_photonTightEffTool) {
     delete m_photonTightEffTool;
     m_photonTightEffTool = nullptr;
   }
-  
+
   if (m_photonMediumEffTool) {
     delete m_photonMediumEffTool;
     m_photonMediumEffTool = nullptr;
   }
-  
+
   if (m_photonLooseEffTool) {
     delete m_photonLooseEffTool;
     m_photonLooseEffTool = nullptr;
   }
-  
+
   Info("finalize()", "Finalization done.");
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -559,14 +567,14 @@ EL::StatusCode PhotonCalibrator :: histFinalize ()
   // outputs have been merged.  This is different from finalize() in
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
-  
+
   Info("histFinalize()", "Calling histFinalize");
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
 EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
-{  
+{
   // (1) apply fudge factors
   if((!m_useAFII) && m_isMC){
     if(m_photonFudgeMCTool->applyCorrection(*photon) == CP::CorrectionCode::Error){
@@ -574,7 +582,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
       return EL::StatusCode::FAILURE;
     }
   }
-  
+
   // (2) evaluate the ID quality
   const bool isTight  = m_photonTightIsEMSelector->accept(photon);
   const bool isMedium = m_photonMediumIsEMSelector->accept(photon);
@@ -583,7 +591,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
   photon->auxdecor< bool >( "PhotonID_Medium"   ) = isMedium;
   photon->auxdecor< bool >( "PhotonID_Loose"    ) = isLoose;
   if (m_debug) {Info("decorate()", "isTight=%s isMedium=%s isLoose=%s", isTight ? "Y" : "N", isMedium ? "Y" : "N", isLoose ? "Y" : "N" ); }
-  
+
   // (3) set efficiency correction
   if (m_isMC) {
     const xAOD::CaloCluster* cluster = photon->caloCluster();
@@ -595,13 +603,13 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
 	cluster_et = cluster->e() / cosh(cluster_eta);
       }
     }
-  
-    bool inCrack = abs(cluster_eta)>1.37 && abs(cluster_eta)<1.52; 
-  
+
+    bool inCrack = abs(cluster_eta)>1.37 && abs(cluster_eta)<1.52;
+
     // photon SF
     double photonTightEffSF(1.), photonMediumEffSF(1.), photonLooseEffSF(1.);
     double photonTightEffSFError(0.), photonMediumEffSFError(0.), photonLooseEffSFError(0.);
-  
+
     // configuration files not yet available for 13 TeV :(
     //sf only available after basic kinematic selection
     if(cluster_et > 20000. && fabs(cluster_eta) < 2.37 && !inCrack){
@@ -609,7 +617,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
       if(m_photonTightEffTool->getEfficiencyScaleFactor(*photon, photonTightEffSF) == CP::CorrectionCode::Error){
 	Error("PhotonHandler::decorate()", "getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
 	return EL::StatusCode::FAILURE;
-      }    
+      }
       if(m_photonMediumEffTool->getEfficiencyScaleFactor(*photon, photonMediumEffSF) == CP::CorrectionCode::Error){
 	Error("PhotonHandler::decorate()", "getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
 	return EL::StatusCode::FAILURE;
@@ -622,7 +630,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
       if(m_photonTightEffTool->getEfficiencyScaleFactorError(*photon, photonTightEffSFError) == CP::CorrectionCode::Error){
 	Error("PhotonHandler::decorate()", "getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
 	return EL::StatusCode::FAILURE;
-      }    
+      }
       if(m_photonMediumEffTool->getEfficiencyScaleFactorError(*photon, photonMediumEffSFError) == CP::CorrectionCode::Error){
 	Error("PhotonHandler::decorate()", "getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
 	return EL::StatusCode::FAILURE;
@@ -632,7 +640,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
 	return EL::StatusCode::FAILURE;
       }
     }
-  
+
     photon->auxdecor< float >( "PhotonID_Tight_EffSF"  ) = photonTightEffSF;
     photon->auxdecor< float >( "PhotonID_Medium_EffSF" ) = photonMediumEffSF;
     photon->auxdecor< float >( "PhotonID_Loose_EffSF"  ) = photonLooseEffSF;
@@ -640,47 +648,47 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
     photon->auxdecor< float >( "PhotonID_Tight_EffSF_Error"  ) = photonTightEffSFError;
     photon->auxdecor< float >( "PhotonID_Medium_EffSF_Error" ) = photonMediumEffSFError;
     photon->auxdecor< float >( "PhotonID_Loose_EffSF_Error"  ) = photonLooseEffSFError;
-  
-    if (m_debug) {Info("decorate()", "Tight=%f (%f) Medium=%f (%f) Loose=%f (%f)", 
-		       photonTightEffSF, photonTightEffSFError, 
+
+    if (m_debug) {Info("decorate()", "Tight=%f (%f) Medium=%f (%f) Loose=%f (%f)",
+		       photonTightEffSF, photonTightEffSFError,
 		       photonMediumEffSF, photonMediumEffSFError,
 		       photonLooseEffSF, photonLooseEffSFError); }
   }
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
 EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xAOD::EventInfo* eventInfo )
 {
   MSG::Level msgLevel = (m_debug) ? MSG::VERBOSE : MSG::INFO;
-  
+
   // Efficiency correction
   if (m_isMC) {
-    // in order to use EventInfo 
+    // in order to use EventInfo
     // some tools are initialized after the first events are stored from file
     if (m_toolInitializationAtTheFirstEventDone) {
       Error("toolInitializationAtTheFirstEvent ()", "please call this function only when m_toolInitializationAtTheFirstEventDone = false");
-      return EL::StatusCode::FAILURE; 
-    } 
-  
+      return EL::StatusCode::FAILURE;
+    }
+
     int dataType = PATCore::ParticleDataType::Data;
     if (eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION )) {
-      if (m_useAFII) { 
+      if (m_useAFII) {
 	dataType = PATCore::ParticleDataType::Fast;
       } else {
-	dataType = PATCore::ParticleDataType::Full; 
+	dataType = PATCore::ParticleDataType::Full;
       }
-    } 
-  
-    if (m_debug) { Info("toolInitializationAtTheFirstEvent()", "isSimulation=%s isAFII=%s selected dataType=%d", 
+    }
+
+    if (m_debug) { Info("toolInitializationAtTheFirstEvent()", "isSimulation=%s isAFII=%s selected dataType=%d",
 			( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) ? "Y" : "N"), (m_useAFII ? "Y" : "N" ), dataType ); }
-  
+
     // photon efficiency correction tool
     //----------------------------------
     //create the tools
     // Tight
     const std::string TightCorrectorName = m_name + "_PhotonTightEfficiencyCorrectionTool";
-    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(TightCorrectorName.c_str()) ) {  
+    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(TightCorrectorName.c_str()) ) {
       m_photonTightEffTool = asg::ToolStore::get<AsgPhotonEfficiencyCorrectionTool>(TightCorrectorName.c_str());
     } else {
       m_photonTightEffTool = new AsgPhotonEfficiencyCorrectionTool(TightCorrectorName.c_str());
@@ -689,7 +697,7 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
 
     // Medium
     const std::string MediumCorrectorName = m_name + "_PhotonMediumEfficiencyCorrectionTool";
-    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(MediumCorrectorName.c_str()) ) {  
+    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(MediumCorrectorName.c_str()) ) {
       m_photonMediumEffTool = asg::ToolStore::get<AsgPhotonEfficiencyCorrectionTool>(MediumCorrectorName.c_str());
     } else {
       m_photonMediumEffTool = new AsgPhotonEfficiencyCorrectionTool(MediumCorrectorName.c_str());
@@ -698,13 +706,13 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
 
     // Loose
     const std::string LooseCorrectorName = m_name + "_PhotonLooseEfficiencyCorrectionTool";
-    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(LooseCorrectorName.c_str()) ) {  
+    if ( asg::ToolStore::contains<AsgPhotonEfficiencyCorrectionTool>(LooseCorrectorName.c_str()) ) {
       m_photonLooseEffTool = asg::ToolStore::get<AsgPhotonEfficiencyCorrectionTool>(LooseCorrectorName.c_str());
     } else {
       m_photonLooseEffTool = new AsgPhotonEfficiencyCorrectionTool(LooseCorrectorName.c_str());
     }
     m_photonLooseEffTool->msg().setLevel( msgLevel );
-    
+
     // todo : Set input files ** not yet available for 13 TeV ** Date : 13 May
     // recommended files here: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommended_input_files
     std::string file_unc = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.unc.v01.root");
@@ -713,14 +721,14 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
       file_unc = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.unc.v01.root");
       file_con = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.con.v01.root");
     }
-  
+
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
-  
+
     // set data type
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("ForceDataType", dataType), "failed in setting property");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("ForceDataType", dataType), "failed in setting property");
@@ -730,17 +738,17 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->initialize(), "failed in initialization");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->initialize(), "failed in initialization");
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool->initialize(), "failed in initialization");
-  
+
   }
-  
+
   //IsolationCorrectionTool
   const std::string IsoCorrToolName = m_name + "_IsolationCorrectiongTool_Photons";
   if ( asg::ToolStore::contains<CP::IsolationCorrectionTool>(IsoCorrToolName.c_str()) ) {
     m_IsolationCorrectionTool = asg::ToolStore::get<CP::IsolationCorrectionTool>(IsoCorrToolName.c_str());
   } else {
     m_IsolationCorrectionTool = new CP::IsolationCorrectionTool(IsoCorrToolName.c_str());
-  }  
-  
+  }
+
   if (m_isMC) {
     RETURN_CHECK( "PhotonCalibrator::initializeTool()", m_IsolationCorrectionTool->setProperty("IsMC", true), "Failed in IsolationCorrectionTool setProperty");
   } else {
@@ -748,8 +756,8 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
   }
   RETURN_CHECK( "PhotonCalibrator::initializeTool()", m_IsolationCorrectionTool->initialize(), "Failed in IsolationCorrectionTool initialization");
   m_IsolationCorrectionTool->msg().setLevel( msgLevel );
-  
+
   m_toolInitializationAtTheFirstEventDone = true;
-  
-  return EL::StatusCode::SUCCESS; 
+
+  return EL::StatusCode::SUCCESS;
 }

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -200,7 +200,7 @@ EL::StatusCode PhotonSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -40,12 +40,13 @@
 ClassImp(PhotonSelector)
 
 PhotonSelector :: PhotonSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_ph_cutflowHist_1(nullptr),
-  m_IsolationSelectionTool(nullptr),
-  m_trigDecTool(nullptr),
-  m_match_Tool(nullptr)
+    Algorithm("PhotonSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_ph_cutflowHist_1(nullptr),
+    m_IsolationSelectionTool(nullptr),
+    m_trigDecTool(nullptr),
+    m_match_Tool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -54,14 +55,14 @@ PhotonSelector :: PhotonSelector () :
   // initialization code will go into histInitialize() and
   // initialize().
   Info("PhotonSelector()", "Calling constructor");
-  
+
   m_debug                   = false;
   m_useCutFlow              = true;
-  
+
   // input container to be read from TEvent or TStore
   //
   m_inContainerName         = "";
-  
+
   // Systematics stuff
   //
   m_inputAlgoSystNames      = "";
@@ -77,7 +78,7 @@ PhotonSelector :: PhotonSelector () :
   m_createSelectedContainer = true;
   // if requested, a new container is made using the SG::VIEW_ELEMENTS option
   m_outContainerName        = "";
-  
+
   // if only want to look at a subset of object
   //
   m_nToProcess              = -1;
@@ -95,7 +96,7 @@ PhotonSelector :: PhotonSelector () :
 
   // PID
   m_photonIdCut             = "None";
-  
+
   // isolation stuff
   //
   m_MinIsoWPCut             = "";
@@ -112,19 +113,19 @@ PhotonSelector::~PhotonSelector() {}
 EL::StatusCode  PhotonSelector :: configure ()
 {
   if ( !getConfig().empty() ) {
-    
+
     Info("configure()", "Configuing PhotonSelector Interface. User configuration read from : %s ", getConfig().c_str());
-    
+
     TEnv* config = new TEnv(getConfig(true).c_str());
-    
+
     m_debug                   = config->GetValue("Debug" ,      m_debug);
     m_useCutFlow              = config->GetValue("UseCutFlow",  m_useCutFlow);
-    
+
     m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
-    
+
     m_inputAlgoSystNames      = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
     m_outputAlgoSystNames     = config->GetValue("OutputAlgoSystNames", m_outputAlgoSystNames.c_str());
-    
+
     m_decorateSelectedObjects = config->GetValue("DecorateSelectedObjects", m_decorateSelectedObjects);
     m_createSelectedContainer = config->GetValue("CreateSelectedContainer", m_createSelectedContainer);
     m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
@@ -148,11 +149,11 @@ EL::StatusCode  PhotonSelector :: configure ()
     m_PhTrigChains            = config->GetValue("PhTrigChains"      , m_PhTrigChains.c_str() );
 
     config->Print();
-    
+
     Info("configure()", "PhotonSelector Interface succesfully configured! ");
     delete config; config = nullptr;
   }
-  
+
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
   // Parse input isolation WP list, split by comma, and put into a vector for later use
@@ -163,12 +164,12 @@ EL::StatusCode  PhotonSelector :: configure ()
   while ( std::getline(ss, token, ',') ) {
     m_IsoKeys.push_back(token);
   }
-  
+
   if ( m_inContainerName.empty() ) {
     Error("configure()", "InputContainer is empty!");
     return EL::StatusCode::FAILURE;
   }
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -182,12 +183,12 @@ EL::StatusCode PhotonSelector :: setupJob (EL::Job& job)
   // sole advantage of putting it here is that it gets automatically
   // activated/deactivated when you add/remove the algorithm from your
   // job, which may or may not be of value to you.
-  
+
   Info("setupJob()", "Calling setupJob");
-  
+
   job.useXAOD ();
   xAOD::Init( "PhotonSelector" ).ignore(); // call before opening first file
-  
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -197,7 +198,7 @@ EL::StatusCode PhotonSelector :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  
+
   Info("histInitialize()", "Calling histInitialize");
 
 
@@ -241,11 +242,11 @@ EL::StatusCode PhotonSelector :: initialize ()
   // Let's see if the algorithm has been already used before:
   // if yes, will write object cutflow in a different histogram!
   //
-  // This is the case when the selector algorithm is used for 
+  // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
-  
+
   if ( m_useCutFlow ) {
 
     // retrieve the file in which the cutflow hists are stored
@@ -267,14 +268,14 @@ EL::StatusCode PhotonSelector :: initialize ()
     m_ph_cutflow_author_cut      = m_ph_cutflowHist_1->GetXaxis()->FindBin("author_cut");
     m_ph_cutflow_OQ_cut          = m_ph_cutflowHist_1->GetXaxis()->FindBin("OQ_cut");
     m_ph_cutflow_PID_cut         = m_ph_cutflowHist_1->GetXaxis()->FindBin("PID_cut");
-    m_ph_cutflow_ptmax_cut       = m_ph_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");      
+    m_ph_cutflow_ptmax_cut       = m_ph_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_ph_cutflow_ptmin_cut       = m_ph_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
     m_ph_cutflow_eta_cut         = m_ph_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
     m_ph_cutflow_iso_cut         = m_ph_cutflowHist_1->GetXaxis()->FindBin("iso_cut");
 
 
   }
-  
+
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
@@ -305,10 +306,10 @@ EL::StatusCode PhotonSelector :: initialize ()
   if ( m_debug ) { Info("initialize()", "Adding isolation WP %s to IsolationSelectionTool", (m_IsoKeys.at(0)).c_str() ); }
   RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->setProperty("PhotonWP", (m_IsoKeys.at(0)).c_str()), "Failed to configure base WP" );
   RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->initialize(), "Failed to properly initialize IsolationSelectionTool." );
-  
-  for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {  
+
+  for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {
     if ( m_debug ) { Info("initialize()", "Adding extra isolation WP %s to IsolationSelectionTool", (*WP_itr).c_str() ); }
-    RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->addPhotonWP( (*WP_itr).c_str() ), "Failed to add isolation WP" );    
+    RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->addPhotonWP( (*WP_itr).c_str() ), "Failed to add isolation WP" );
   }
 
   // ***************************************
@@ -342,11 +343,11 @@ EL::StatusCode PhotonSelector :: initialize ()
       m_match_Tool = new Trig::TrigEgammaMatchingTool(MatchingToolName.c_str());
       RETURN_CHECK( "PhotonSelector::initialize()", m_match_Tool->setProperty( "TriggerTool", trigDecHandle ), "Failed to configure TrigDecisionTool" );
       RETURN_CHECK( "PhotonSelector::initialize()", m_match_Tool->initialize(), "Failed to properly initialize TrigMuonMatching." );
-    } 
+    }
   }
 
   // **********************************************************************************************
-  
+
   Info("initialize()", "PhotonSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
@@ -379,7 +380,7 @@ EL::StatusCode PhotonSelector :: execute ()
   m_numEvent++;
 
   bool eventPass(false);
-  bool countPass(true); // for cutflow: count for the 1st collection in the syst container - could be better as should only count for the nominal  
+  bool countPass(true); // for cutflow: count for the 1st collection in the syst container - could be better as should only count for the nominal
   const xAOD::PhotonContainer* inPhotons(nullptr);
 
   // if input comes from xAOD, or just running one collection,
@@ -393,7 +394,7 @@ EL::StatusCode PhotonSelector :: execute ()
 
     // create output container (if requested)
     ConstDataVector<xAOD::PhotonContainer>* selectedPhotons(nullptr);
-    if ( m_createSelectedContainer ) { selectedPhotons = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS); }  
+    if ( m_createSelectedContainer ) { selectedPhotons = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS); }
 
     // find the selected photons, and return if event passes object selection
     //
@@ -487,14 +488,14 @@ EL::StatusCode PhotonSelector :: execute ()
   return EL::StatusCode::SUCCESS;
 }
 
-bool PhotonSelector :: executeSelection ( const xAOD::PhotonContainer* inPhotons, 
+bool PhotonSelector :: executeSelection ( const xAOD::PhotonContainer* inPhotons,
 					  float mcEvtWeight, bool countPass,
 					  ConstDataVector<xAOD::PhotonContainer>* selectedPhotons )
 {
   int nPass(0); int nObj(0);
   static SG::AuxElement::Decorator< char > passSelDecor( "passSel" );
-  
-  for ( auto ph_itr : *inPhotons ) { // duplicated of basic loop  
+
+  for ( auto ph_itr : *inPhotons ) { // duplicated of basic loop
 
     // if only looking at a subset of photons make sure all are decorated
     //
@@ -553,19 +554,19 @@ bool PhotonSelector :: executeSelection ( const xAOD::PhotonContainer* inPhotons
   //  2. there are no selected photons in the event
   //
   if ( m_match_Tool && selectedPhotons ) {
-    
+
     unsigned int nSelectedPhotons = selectedPhotons->size();
 
     if ( nSelectedPhotons > 0 ) {
-      
+
       if ( m_debug ) { Info("executeSelection()", "Now doing photon trigger matching..."); }
-     
+
       for ( auto const &chain : m_PhTrigChainsList ) {
 
 	if ( m_debug ) { Info("executeSelection()", "\t checking trigger chain %s", chain.c_str()); }
 
 	for ( auto const photon : *selectedPhotons ) {
-	  
+
 	  SG::AuxElement::Decorator< std::map<std::string,bool> > isTrigMatchedMapPhDecor( "isTrigMatchedMapPh" );
 	  if ( !isTrigMatchedMapPhDecor.isAvailable( *photon ) ) {
 	    isTrigMatchedMapPhDecor( *photon ) = std::map<std::string,bool>();
@@ -574,13 +575,13 @@ bool PhotonSelector :: executeSelection ( const xAOD::PhotonContainer* inPhotons
 	  bool matched = false;
 
 	  static const bool DO_TEMPORAL_MATCHING = true;
-	  
-	  if (!DO_TEMPORAL_MATCHING)  { // the current matching tool does not work for the photon 
-	    matched = ( m_match_Tool->matchHLT( photon, chain ) );  
-	   
+
+	  if (!DO_TEMPORAL_MATCHING)  { // the current matching tool does not work for the photon
+	    matched = ( m_match_Tool->matchHLT( photon, chain ) );
+
 	    if ( m_debug ) { Info("executeSelection()", "\t\t is photon trigger matched? %s for %s", (matched ? "Y" : "N"), chain.c_str()); }
 	  } else {
-	   
+
 	    if(m_event->contains<xAOD::PhotonContainer>("HLT_xAOD__PhotonContainer_egamma_Photons")){ // check if trigger photon info exist
 	      // get trigger list from config file
 	      Trig::FeatureContainer fc = m_trigDecTool->features(chain);
@@ -612,14 +613,14 @@ bool PhotonSelector :: executeSelection ( const xAOD::PhotonContainer* inPhotons
       }
     }
   }
-  
+
   return true;
 }
 
-bool PhotonSelector :: passCuts( const xAOD::Photon* photon ) 
+bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
 {
   float et    = photon->pt();
-  
+
   // all the eta cuts are done using the measurement of the cluster position with the 2nd layer cluster,
   // as for Egamma CP  recommendation
   //
@@ -637,9 +638,9 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   }
 
   m_ph_cutflowHist_1->Fill( m_ph_cutflow_all, 1 );
-  
+
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // author cut
   //
   if( m_doAuthorCut ) {
@@ -651,7 +652,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   m_ph_cutflowHist_1->Fill( m_ph_cutflow_author_cut, 1 );
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // Object Quality cut
   //
   if ( m_doOQCut ) {
@@ -660,13 +661,13 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
       return 0;
     }
   }
-  m_ph_cutflowHist_1->Fill( m_ph_cutflow_OQ_cut, 1 );      
+  m_ph_cutflowHist_1->Fill( m_ph_cutflow_OQ_cut, 1 );
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // ID cut
-  //  
-  if ( m_photonIdCut != "None" ) {        
+  //
+  if ( m_photonIdCut != "None" ) {
     // it crashes in case the "PhotonID_X" is not stored on purpose
     if ( ! photon->auxdecor< bool >( photonIDKeyName ) ) {
       if ( m_debug ) { Info("PassCuts()", "Photon failed ID cut." ); }
@@ -676,7 +677,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   m_ph_cutflowHist_1->Fill( m_ph_cutflow_PID_cut, 1 );
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // pT max cut
   //
   if ( m_pT_max != 1e8 ) {
@@ -685,10 +686,10 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
       return false;
     }
   }
-  m_ph_cutflowHist_1->Fill( m_ph_cutflow_ptmax_cut, 1 );        
-  
+  m_ph_cutflowHist_1->Fill( m_ph_cutflow_ptmax_cut, 1 );
+
   // *********************************************************************************************************************************************************************
-  //   
+  //
   // pT min cut
   //
   if ( m_pT_min != 1e8 ) {
@@ -697,13 +698,13 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
       return false;
     }
   }
-  m_ph_cutflowHist_1->Fill( m_ph_cutflow_ptmin_cut, 1 );        
+  m_ph_cutflowHist_1->Fill( m_ph_cutflow_ptmin_cut, 1 );
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // eta cuts
   //
-   
+
   // |eta| max cut
   //
   if ( m_eta_max != 1e8 ) {
@@ -723,7 +724,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   m_ph_cutflowHist_1->Fill( m_ph_cutflow_eta_cut, 1 );
 
   // *********************************************************************************************************************************************************************
-  // 
+  //
   // isolation cut
   //
 
@@ -734,7 +735,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
 
   // Decorate w/ decision for all input WPs
   //
-  const std::string base_decor("isIsolated");  
+  const std::string base_decor("isIsolated");
   for ( auto WP_itr : m_IsoKeys ) {
 
     std::string decorWP = base_decor + "_" + WP_itr;
@@ -742,7 +743,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
     if ( m_debug ) { Info("PassCuts()", "Decorate photon with %s - accept() ? %i", decorWP.c_str(), accept_list.getCutResult( WP_itr.c_str()) ); }
     photon->auxdecor<char>(decorWP) = static_cast<char>( accept_list.getCutResult( WP_itr.c_str() ) );
 
-  }  
+  }
 
   // Apply the cut if needed
   //
@@ -780,7 +781,7 @@ EL::StatusCode PhotonSelector :: finalize ()
   // submission node after all your histogram outputs have been
   // merged.  This is different from histFinalize() in that it only
   // gets called on worker nodes that processed input events.
-  
+
   Info("finalize()", "Deleting tool instances...");
 
   if ( m_useCutFlow ) {
@@ -788,23 +789,23 @@ EL::StatusCode PhotonSelector :: finalize ()
     m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
     m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
   }
-  
+
   if (m_debug) { Info("finalize()", "Cutflow filled"); }
-  
+
   if (m_IsolationSelectionTool) {
     delete m_IsolationSelectionTool;
     m_IsolationSelectionTool = nullptr;
   }
-  
+
   if (m_debug) { Info("finalize()", "Isolation Tool deleted"); }
-  
+
   if (m_match_Tool) {
     delete m_match_Tool;
     m_match_Tool = nullptr;
   }
-  
+
   if (m_debug) { Info("finalize()", "Matching Tool deleted"); }
-  
+
   Info("finalize()", "Finalization done.");
   return EL::StatusCode::SUCCESS;
 }
@@ -823,10 +824,10 @@ EL::StatusCode PhotonSelector :: histFinalize ()
   // outputs have been merged.  This is different from finalize() in
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
-  
+
   Info("histFinalize()", "Calling histFinalize");
-  
-  
+
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -826,7 +826,7 @@ EL::StatusCode PhotonSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -39,8 +39,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(PhotonSelector)
 
-PhotonSelector :: PhotonSelector () :
-    Algorithm("PhotonSelector"),
+PhotonSelector :: PhotonSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_ph_cutflowHist_1(nullptr),

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -245,7 +245,7 @@ EL::StatusCode PhotonSelector :: initialize ()
   // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
-  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
+  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
 
   if ( m_useCutFlow ) {
 

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -200,7 +200,7 @@ EL::StatusCode PhotonSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -177,7 +177,7 @@ EL::StatusCode TauSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -565,7 +565,7 @@ EL::StatusCode TauSelector :: histFinalize ()
   // they processed input events.
 
   Info("histFinalize()", "Calling histFinalize");
-
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -227,7 +227,7 @@ EL::StatusCode TauSelector :: initialize ()
   // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
-  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
+  Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
   if ( this->countUsed() > 0 ) {
     m_isUsedBefore = true;
     Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -40,12 +40,13 @@ ClassImp(TauSelector)
 
 
 TauSelector :: TauSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_tau_cutflowHist_1(nullptr),
-  m_tau_cutflowHist_2(nullptr),
-  m_TauSelTool(nullptr),
-  m_TOELLHDecorator(nullptr)
+    Algorithm("TauSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_tau_cutflowHist_1(nullptr),
+    m_tau_cutflowHist_2(nullptr),
+    m_TauSelTool(nullptr),
+    m_TOELLHDecorator(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -127,9 +128,9 @@ EL::StatusCode  TauSelector :: configure ()
 
     m_ConfigPath              = config->GetValue("ConfigPath", m_ConfigPath.c_str());
     m_EleOLRFilePath          = config->GetValue("EleOLRFilePath", m_EleOLRFilePath.c_str());
-   
+
     m_minPtDAOD               = config->GetValue("MinPtDAOD", m_minPtDAOD);
- 
+
     config->Print();
 
     Info("configure()", "TauSelector Interface succesfully configured! ");
@@ -223,7 +224,7 @@ EL::StatusCode TauSelector :: initialize ()
   // Let's see if the algorithm has been already used before:
   // if yes, will write object cutflow in a different histogram!
   //
-  // This is the case when the selector algorithm is used for 
+  // This is the case when the selector algorithm is used for
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_classname).c_str() );
@@ -233,32 +234,32 @@ EL::StatusCode TauSelector :: initialize ()
   }
 
   if ( m_useCutFlow ) {
-    
+
     // retrieve the file in which the cutflow hists are stored
     //
     TFile *file     = wk()->getOutputFile ("cutflow");
-    
+
     // retrieve the event cutflows
     //
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
     m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-    
+
     // retrieve the object cutflow
     //
     m_tau_cutflowHist_1  = (TH1D*)file->Get("cutflow_taus_1");
 
     m_tau_cutflow_all                  = m_tau_cutflowHist_1->GetXaxis()->FindBin("all");
-    m_tau_cutflow_selected             = m_tau_cutflowHist_1->GetXaxis()->FindBin("selected");     
-    
+    m_tau_cutflow_selected             = m_tau_cutflowHist_1->GetXaxis()->FindBin("selected");
+
     if ( m_isUsedBefore ) {
       m_tau_cutflowHist_2 = (TH1D*)file->Get("cutflow_taus_2");
-     
+
       m_tau_cutflow_all                  = m_tau_cutflowHist_2->GetXaxis()->FindBin("all");
-      m_tau_cutflow_selected             = m_tau_cutflowHist_2->GetXaxis()->FindBin("selected");     
+      m_tau_cutflow_selected             = m_tau_cutflowHist_2->GetXaxis()->FindBin("selected");
     }
-    
+
   }
 
   m_event = wk()->xaodEvent();
@@ -276,19 +277,19 @@ EL::StatusCode TauSelector :: initialize ()
   m_numEventPass  = 0;
   m_weightNumEventPass  = 0;
   m_numObjectPass = 0;
-  
+
   // ********************************
   //
   // Initialise TauSelectionTool
   //
   // ********************************
-  
+
   std::string sel_tool_name = std::string("TauSelectionTool_") + m_name;
   m_TauSelTool = new TauAnalysisTools::TauSelectionTool( sel_tool_name );
   m_TauSelTool->msg().setLevel( MSG::INFO ); // VERBOSE, INFO, DEBUG
-  
+
   RETURN_CHECK("TauSelector::initialize()", m_TauSelTool->setProperty("ConfigPath",m_ConfigPath.c_str()), "Failed to set ConfigPath property");
-  if ( !m_EleOLRFilePath.empty() ) { 
+  if ( !m_EleOLRFilePath.empty() ) {
     RETURN_CHECK("TauSelector::initialize()", m_TauSelTool->setProperty("EleOLRFilePath",m_EleOLRFilePath.c_str()), "Failed to set EleOLRFilePath property");
   }
   RETURN_CHECK("TauSelector::initialize()", m_TauSelTool->initialize(), "Failed to properly initialize TauSelectionTool");
@@ -297,7 +298,7 @@ EL::StatusCode TauSelector :: initialize ()
   m_TOELLHDecorator = new TauAnalysisTools::TauOverlappingElectronLLHDecorator( eleOLR_tool_name );
   m_TOELLHDecorator->msg().setLevel( MSG::INFO); // VERBOSE, INFO, DEBUG
   RETURN_CHECK("TauSelector::initialize()", m_TOELLHDecorator->initialize(), "Failed to properly initialize TauOverlappingElectronLLHDecorator");
-  
+
   Info("initialize()", "TauSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
@@ -569,13 +570,13 @@ EL::StatusCode TauSelector :: histFinalize ()
 }
 
 int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
- 
+
   // fill cutflow bin 'all' before any cut
   m_tau_cutflowHist_1->Fill( m_tau_cutflow_all, 1 );
   if ( m_isUsedBefore ) { m_tau_cutflowHist_2->Fill( m_tau_cutflow_all, 1 ); }
 
   // **********************************************************************************************************
-  // 
+  //
   // TauSelectorTool cut
   //
 
@@ -583,9 +584,9 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
     if ( m_debug ) { Info("PassCuts()", "Tau failed minimal pT requirement for usage with derivations"); }
     return 0;
   }
-  
+
   m_TOELLHDecorator->decorate( *tau );
- 
+
   if ( ! m_TauSelTool->accept( *tau ) ) {
     if ( m_debug ) { Info("PassCuts()", "Tau failed requirements of TauSelectionTool"); }
     return 0;

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -39,8 +39,8 @@
 ClassImp(TauSelector)
 
 
-TauSelector :: TauSelector () :
-    Algorithm("TauSelector"),
+TauSelector :: TauSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_tau_cutflowHist_1(nullptr),

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -228,9 +228,9 @@ EL::StatusCode TauSelector :: initialize ()
   // preselecting objects, and then again for the final selection
   //
   Info("initialize()", "Algorithm name: '%s' - of type '%s' ", (this->m_name).c_str(), (this->m_className).c_str() );
-  if ( this->countUsed() > 0 ) {
+  if ( this->numInstances() > 0 ) {
     m_isUsedBefore = true;
-    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->countUsed() );
+    Info("initialize()", "\t An algorithm of the same type has been already used %i times", this->numInstances() );
   }
 
   if ( m_useCutFlow ) {

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -177,7 +177,7 @@ EL::StatusCode TauSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -17,7 +17,8 @@
 ClassImp(TrackHistsAlgo)
 
 TrackHistsAlgo :: TrackHistsAlgo () :
-  m_plots(nullptr)
+    Algorithm("TrackHistsAlgo"),
+    m_plots(nullptr)
 {
   m_inContainerName         = "";
   m_detailStr               = "";

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -40,7 +40,7 @@ EL::StatusCode TrackHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   // needed here and not in initalize since this is called first
   Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -130,5 +130,6 @@ EL::StatusCode TrackHistsAlgo :: histFinalize ()
 {
   // clean up memory
   if(m_plots) delete m_plots;
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -40,6 +40,7 @@ EL::StatusCode TrackHistsAlgo :: histInitialize ()
 {
 
   Info("histInitialize()", "%s", m_name.c_str() );
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   // needed here and not in initalize since this is called first
   Info("histInitialize()", "Attempting to configure using: %s", getConfig().c_str());
   if ( this->configure() == EL::StatusCode::FAILURE ) {

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -16,8 +16,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TrackHistsAlgo)
 
-TrackHistsAlgo :: TrackHistsAlgo () :
-    Algorithm("TrackHistsAlgo"),
+TrackHistsAlgo :: TrackHistsAlgo (std::string className) :
+    Algorithm(className),
     m_plots(nullptr)
 {
   m_inContainerName         = "";

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -24,8 +24,9 @@ ClassImp(TrackSelector)
 
 
 TrackSelector :: TrackSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr)
+    Algorithm("TrackSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -178,7 +178,7 @@ EL::StatusCode TrackSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -23,8 +23,8 @@
 ClassImp(TrackSelector)
 
 
-TrackSelector :: TrackSelector () :
-    Algorithm("TrackSelector"),
+TrackSelector :: TrackSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr)
 {

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -381,6 +381,7 @@ EL::StatusCode TrackSelector :: histFinalize ()
   // outputs have been merged.  This is different from finalize() in
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -178,7 +178,7 @@ EL::StatusCode TrackSelector :: histInitialize ()
   // connected.
 
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -21,7 +21,8 @@
 ClassImp(TreeAlgo)
 
 TreeAlgo :: TreeAlgo () :
-  m_helpTree(nullptr)
+    Algorithm("TreeAlgo"),
+    m_helpTree(nullptr)
 {
   this->SetName("TreeAlgo"); // needed if you want to retrieve this algo with wk()->getAlg(ALG_NAME) downstream
 
@@ -44,7 +45,7 @@ TreeAlgo :: TreeAlgo () :
   m_jetContainerName        = "";
   m_fatJetContainerName     = "";
   m_tauContainerName        = "";
-  m_METContainerName        = "";  
+  m_METContainerName        = "";
 
   // DC14 switch for little things that need to happen to run
   // for those samples with the corresponding packages
@@ -113,7 +114,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
   if ( !m_jetContainerName.empty() )    {   m_helpTree->AddJets       (m_jetDetailStr);     }
   if ( !m_fatJetContainerName.empty() ) {   m_helpTree->AddFatJets    (m_fatJetDetailStr);  }
   if ( !m_tauContainerName.empty() )    {   m_helpTree->AddTaus       (m_tauDetailStr);     }
-  if ( !m_METContainerName.empty() )    {   m_helpTree->AddMET        (m_METDetailStr);     }  
+  if ( !m_METContainerName.empty() )    {   m_helpTree->AddMET        (m_METDetailStr);     }
 
   Info("treeInitialize()", "Successfully initialized output tree");
 
@@ -145,7 +146,7 @@ EL::StatusCode TreeAlgo :: configure ()
     m_jetContainerName        = config->GetValue("JetContainerName",        m_jetContainerName.c_str());
     m_fatJetContainerName     = config->GetValue("FatJetContainerName",     m_fatJetContainerName.c_str());
     m_tauContainerName        = config->GetValue("TauContainerName",        m_tauContainerName.c_str());
-    m_METContainerName        = config->GetValue("METContainerName",        m_METContainerName.c_str());    
+    m_METContainerName        = config->GetValue("METContainerName",        m_METContainerName.c_str());
 
     // DC14 switch for little things that need to happen to run
     // for those samples with the corresponding packages

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -20,8 +20,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TreeAlgo)
 
-TreeAlgo :: TreeAlgo () :
-    Algorithm("TreeAlgo"),
+TreeAlgo :: TreeAlgo (std::string className) :
+    Algorithm(className),
     m_helpTree(nullptr)
 {
   this->SetName("TreeAlgo"); // needed if you want to retrieve this algo with wk()->getAlg(ALG_NAME) downstream

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -44,9 +44,10 @@
 ClassImp(TruthSelector)
 
 TruthSelector :: TruthSelector () :
-  m_cutflowHist(nullptr),
-  m_cutflowHistW(nullptr),
-  m_truth_cutflowHist_1(nullptr)
+    Algorithm("TruthSelector"),
+    m_cutflowHist(nullptr),
+    m_cutflowHistW(nullptr),
+    m_truth_cutflowHist_1(nullptr)
 {
   Info("TruthSelector()", "Calling constructor");
 
@@ -131,7 +132,7 @@ EL::StatusCode  TruthSelector :: configure ()
   }
 
   m_decor   = "passSel";
-  
+
   if ( m_decorateSelectedObjects ) {
     Info("configure()"," Decorate Jets with %s", m_decor.c_str());
   }
@@ -179,29 +180,29 @@ EL::StatusCode TruthSelector :: changeInput (bool /*firstFile*/)
 EL::StatusCode TruthSelector :: initialize ()
 {
   Info("initialize()", "Calling initialize");
-  
+
   if ( m_useCutFlow ) {
 
    // retrieve the file in which the cutflow hists are stored
     //
     TFile *file     = wk()->getOutputFile ("cutflow");
-    
+
     // retrieve the event cutflows
     //
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());
     m_cutflowHistW->GetXaxis()->FindBin(m_name.c_str());
-    
+
     // retrieve the object cutflow
     //
     m_truth_cutflowHist_1 = (TH1D*)file->Get("cutflow_truths_1");
 
     m_truth_cutflow_all             = m_truth_cutflowHist_1->GetXaxis()->FindBin("all");
     m_truth_cutflow_ptmax_cut       = m_truth_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
-    m_truth_cutflow_ptmin_cut       = m_truth_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");      
-    m_truth_cutflow_eta_cut         = m_truth_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); 
- 
+    m_truth_cutflow_ptmin_cut       = m_truth_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
+    m_truth_cutflow_eta_cut         = m_truth_cutflowHist_1->GetXaxis()->FindBin("eta_cut");
+
   }
 
   if ( this->configure() == EL::StatusCode::FAILURE ) {
@@ -209,7 +210,7 @@ EL::StatusCode TruthSelector :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-  
+
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
@@ -255,12 +256,12 @@ EL::StatusCode TruthSelector :: execute ()
 
   // if input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
-  
+
   // this will be the collection processed - no matter what!!
   RETURN_CHECK("TruthSelector::execute()", HelperFunctions::retrieve(inTruthParts, m_inContainerName, m_event, m_store, m_verbose) ,"");
 
   pass = executeSelection( inTruthParts, mcEvtWeight, count, m_outContainerName);
-    
+
   // look what we have in TStore
   if ( m_verbose ) { m_store->print(); }
 
@@ -353,7 +354,7 @@ EL::StatusCode TruthSelector :: postExecute ()
 EL::StatusCode TruthSelector :: finalize ()
 {
   Info("finalize()", "%s", m_name.c_str());
-  
+
   if ( m_useCutFlow ) {
     Info("histFinalize()", "Filling cutflow");
     m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
@@ -380,12 +381,12 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
   if ( m_pT_max != 1e8 ) {
     if ( truthPart->pt() > m_pT_max ) { return 0; }
   }
-  m_truth_cutflowHist_1->Fill( m_truth_cutflow_ptmax_cut, 1 );        
-  
+  m_truth_cutflowHist_1->Fill( m_truth_cutflow_ptmax_cut, 1 );
+
   if ( m_pT_min != 1e8 ) {
     if ( truthPart->pt() < m_pT_min ) { return 0; }
   }
-  m_truth_cutflowHist_1->Fill( m_truth_cutflow_ptmin_cut, 1 );        
+  m_truth_cutflowHist_1->Fill( m_truth_cutflow_ptmin_cut, 1 );
 
   // eta
   if ( m_eta_max != 1e8 ) {
@@ -394,7 +395,7 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
   if ( m_eta_min != 1e8 ) {
     if ( fabs(truthPart->eta()) < m_eta_min ) { return 0; }
   }
-  m_truth_cutflowHist_1->Fill( m_truth_cutflow_eta_cut, 1 );        
+  m_truth_cutflowHist_1->Fill( m_truth_cutflow_eta_cut, 1 );
 
   // mass
   if ( m_mass_max != 1e8 ) {

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -369,6 +369,7 @@ EL::StatusCode TruthSelector :: finalize ()
 EL::StatusCode TruthSelector :: histFinalize ()
 {
   Info("histFinalize()", "Calling histFinalize");
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -43,8 +43,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TruthSelector)
 
-TruthSelector :: TruthSelector () :
-    Algorithm("TruthSelector"),
+TruthSelector :: TruthSelector (std::string className) :
+    Algorithm(className),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_truth_cutflowHist_1(nullptr)

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -155,7 +155,7 @@ EL::StatusCode TruthSelector :: setupJob (EL::Job& job)
 EL::StatusCode TruthSelector :: histInitialize ()
 {
   Info("histInitialize()", "Calling histInitialize");
-
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -155,7 +155,7 @@ EL::StatusCode TruthSelector :: setupJob (EL::Job& job)
 EL::StatusCode TruthSelector :: histInitialize ()
 {
   Info("histInitialize()", "Calling histInitialize");
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -20,8 +20,8 @@ ClassImp(Writer)
 
 
 
-Writer :: Writer () :
-    Algorithm("Writer")
+Writer :: Writer (std::string className) :
+    Algorithm(className)
 {
   m_outputLabel               = "";
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -254,5 +254,6 @@ EL::StatusCode Writer :: histFinalize ()
   // outputs have been merged.  This is different from finalize() in
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -88,6 +88,7 @@ EL::StatusCode Writer :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
+  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -88,7 +88,7 @@ EL::StatusCode Writer :: histInitialize ()
   // beginning on each worker node, e.g. create histograms and output
   // trees.  This method gets called before any input files are
   // connected.
-  RETURN_CHECK("xAH::Algorithm::initialize()", xAH::Algorithm::initialize(), "");
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -20,7 +20,9 @@ ClassImp(Writer)
 
 
 
-Writer :: Writer () {
+Writer :: Writer () :
+    Algorithm("Writer")
+{
   m_outputLabel               = "";
 
   m_jetContainerNamesStr      = "";

--- a/docs/Utilities.rst
+++ b/docs/Utilities.rst
@@ -9,4 +9,4 @@ Utilities
    HelperFunctions
    ParticlePIDManager
    ReturnCheck
-
+   xAHAlgorithm

--- a/docs/xAHAlgorithm.rst
+++ b/docs/xAHAlgorithm.rst
@@ -1,0 +1,8 @@
+xAH::Algorithm
+==============
+
+.. doxygenclass:: xAH::Algorithm
+   :members:
+   :undoc-members:
+   :protected-members:
+   :private-members:

--- a/util/test_multiAlgo.cxx
+++ b/util/test_multiAlgo.cxx
@@ -27,11 +27,11 @@
 #include <sstream>
 
 // usage:
-// test_multiAlgo [optional] outdir maxevts dataPath/ datasetname filename 
-// NB: 
+// test_multiAlgo [optional] outdir maxevts dataPath/ datasetname filename
+// NB:
 //    -) 'outdir' , 'maxevts' and 'dataPath/' must be all specified
 //       --> use '-1' for maxevts if you want to run them all
-//     
+//
 
 
 int main( int argc, char* argv[] ) {
@@ -96,10 +96,6 @@ int main( int argc, char* argv[] ) {
 
   std::string localDataDir = "$ROOTCOREBIN/data/xAODAnaHelpers/";
 
-  // this class will hold the class name of the algorithms used below, and the number
-  // of times an algo is used
-  xAH::AlgorithmRegistry registry;
-
   BasicEventSelection* baseEventSel             = new BasicEventSelection();
   baseEventSel->setName("baseEventSel")->setConfig(localDataDir+"baseEvent.config");
 
@@ -110,58 +106,58 @@ int main( int argc, char* argv[] ) {
 //  JetCalibrator* jetCalib                       = new JetCalibrator(        "jetCalib_AntiKt4TopoEM",   localDataDir+"jetCalib_AntiKt4TopoEMCalib.config", "JET_GroupedNP_1", -1);
 
   JetCalibrator* jetCalib                       = new JetCalibrator();
-  jetCalib->setName("jetCalib_AntiKt4TopoEM")->setConfig(localDataDir+"jetCalib_AntiKt4TopoEMCalib.config")->registerClass(registry, "JetCalibrator");
+  jetCalib->setName("jetCalib_AntiKt4TopoEM")->setConfig(localDataDir+"jetCalib_AntiKt4TopoEMCalib.config");
 
   MuonCalibrator* muonCalib                     = new MuonCalibrator();
-  muonCalib->setName("muonCalib")->setConfig(localDataDir+"muonCalib.config")->registerClass(registry, "MuonCalibrator");
+  muonCalib->setName("muonCalib")->setConfig(localDataDir+"muonCalib.config");
 
   ElectronCalibrator* electronCalib             = new ElectronCalibrator();
-  electronCalib->setName("electronCalib")->setConfig(localDataDir+"electronCalib.config")->registerClass(registry, "ElectronCalibrator");/*->setSysts("All");*/
+  electronCalib->setName("electronCalib")->setConfig(localDataDir+"electronCalib.config");
 
   MuonEfficiencyCorrector*      muonEffCorr     = new MuonEfficiencyCorrector();
-  muonEffCorr->setName("muonEfficiencyCorrector")->setConfig(localDataDir+"muonEffCorr.config")->registerClass(registry, "MuonEfficiencyCorrector");
+  muonEffCorr->setName("muonEfficiencyCorrector")->setConfig(localDataDir+"muonEffCorr.config");
 
   ElectronEfficiencyCorrector*  electronEffCorr = new ElectronEfficiencyCorrector();
-  electronEffCorr->setName("electronEfficiencyCorrector")->setConfig(localDataDir+"electronEffCorr.config")->registerClass(registry, "ElectronEfficiencyCorrector");/*->setSysts("All");*/
+  electronEffCorr->setName("electronEfficiencyCorrector")->setConfig(localDataDir+"electronEffCorr.config");
 
   MuonSelector* muonSelect_signal               = new MuonSelector();
-  muonSelect_signal->setName("muonSelect_signal")->setConfig(localDataDir+"muonSelect_signal.config")->registerClass(registry, "MuonSelector");
+  muonSelect_signal->setName("muonSelect_signal")->setConfig(localDataDir+"muonSelect_signal.config");
 
   ElectronSelector* electronSelect_signal       = new ElectronSelector();
-  electronSelect_signal->setName("electronSelect_signal")->setConfig(localDataDir+"electronSelect_signal.config")->registerClass(registry, "ElectronSelector");
+  electronSelect_signal->setName("electronSelect_signal")->setConfig(localDataDir+"electronSelect_signal.config");
 
   JetSelector* jetSelect_signal                 = new JetSelector();
-  jetSelect_signal->setName("jetSelect_signal")->setConfig(localDataDir+"jetSelect_signal.config")->registerClass(registry, "JetSelector");
+  jetSelect_signal->setName("jetSelect_signal")->setConfig(localDataDir+"jetSelect_signal.config");
 
   JetSelector* bjetSelect_signal                = new JetSelector();
-  bjetSelect_signal->setName("bjetSelect_signal")->setConfig(localDataDir+"bjetSelect_signal.config")->registerClass(registry, "JetSelector");
+  bjetSelect_signal->setName("bjetSelect_signal")->setConfig(localDataDir+"bjetSelect_signal.config");
 
   BJetEfficiencyCorrector* bjetEffCorr_btag     = new BJetEfficiencyCorrector();
-  bjetEffCorr_btag->setName("bjetEffCor_btag")->setConfig(localDataDir+"bjetEffCorr.config")->registerClass(registry, "BJetEfficiencyCorrector");
+  bjetEffCorr_btag->setName("bjetEffCor_btag")->setConfig(localDataDir+"bjetEffCorr.config");
 
   JetHistsAlgo* jetHistsAlgo_signal             = new JetHistsAlgo();
-  jetHistsAlgo_signal->setName("jetHistsAlgo_signal")->setConfig(localDataDir+"jetHistsAlgo_signal.config")->registerClass(registry, "JetHistsAlgo");
+  jetHistsAlgo_signal->setName("jetHistsAlgo_signal")->setConfig(localDataDir+"jetHistsAlgo_signal.config");
 
   JetHistsAlgo* jetHistsAlgo_btag               = new JetHistsAlgo();
-  jetHistsAlgo_btag->setName("jetHistsAlgo_btag")->setConfig(localDataDir+"jetHistsAlgo_btagged.config")->registerClass(registry, "JetHistsAlgo");
+  jetHistsAlgo_btag->setName("jetHistsAlgo_btag")->setConfig(localDataDir+"jetHistsAlgo_btagged.config");
 
   JetSelector* jetSelect_truth                  = new JetSelector();
-  jetSelect_truth->setName("jetSelect_truth")->setConfig(localDataDir+"jetSelect_truth.config")->registerClass(registry, "JetSelector");
+  jetSelect_truth->setName("jetSelect_truth")->setConfig(localDataDir+"jetSelect_truth.config");
 
   JetHistsAlgo* jetHistsAlgo_truth              = new JetHistsAlgo();
-  jetHistsAlgo_truth->setName("jetHistsAlgo_truth")->setConfig(localDataDir+"jetHistsAlgo_truth.config")->registerClass(registry, "JetHistsAlgo");
+  jetHistsAlgo_truth->setName("jetHistsAlgo_truth")->setConfig(localDataDir+"jetHistsAlgo_truth.config");
 
   OverlapRemover* overlapRemoval                = new OverlapRemover();
-  overlapRemoval->setName("OverlapRemovalTool")->setConfig(localDataDir+"overlapRemoval.config")->registerClass(registry, "OverlapRemover");
+  overlapRemoval->setName("OverlapRemovalTool")->setConfig(localDataDir+"overlapRemoval.config");
 
   METConstructor* met = new METConstructor();
-  met->setName("met")->setConfig(localDataDir+"MET_MC15.config")->registerClass(registry, "METConstructor");
+  met->setName("met")->setConfig(localDataDir+"MET_MC15.config");
 
   JetHistsAlgo* jk_AntiKt10LC                   = new JetHistsAlgo();
-  jk_AntiKt10LC->setName("AntiKt10/")->setConfig(localDataDir+"test_jetPlotExample.config")->registerClass(registry, "JetHistsAlgo");
+  jk_AntiKt10LC->setName("AntiKt10/")->setConfig(localDataDir+"test_jetPlotExample.config");
 
   TreeAlgo* out_tree                            = new TreeAlgo();
-  out_tree->setName("physics")->setConfig(localDataDir+"tree.config")->registerClass(registry, "TreeAlgo");
+  out_tree->setName("physics")->setConfig(localDataDir+"tree.config");
 
   // Attach algorithms
   job.algsAdd( baseEventSel );

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -131,7 +131,7 @@ namespace xAH {
                 bookkeeps the number of times :cpp:member:`xAH::Algorithm::m_className` has been used in a variable shared among all classes/instances that inherit from me
             @endrst
          */
-	static std::map<std::string, int> m_instanceRegistry;
+	static std::map<std::string, int> m_instanceRegistry = {};
   };
 
 }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -12,6 +12,9 @@
 
 #include <string>
 
+// for StatusCode::isSuccess
+#include "AsgTools/StatusCode.h"
+
 namespace xAH {
 
     /**
@@ -59,6 +62,11 @@ namespace xAH {
         /// @cond
         ClassDef(Algorithm, 1);
         /// @endcond
+
+        /**
+            @brief Run any initializations commmon to all xAH Algorithms (such as registerInstance). Call this inside :code:`histInitialize` for best results.
+         */
+        StatusCode initialize();
 
         /**
             @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -131,7 +131,7 @@ namespace xAH {
                 bookkeeps the number of times :cpp:member:`xAH::Algorithm::m_className` has been used in a variable shared among all classes/instances that inherit from me
             @endrst
          */
-	static std::map<std::string, int> m_instanceRegistry = {};
+	static std::map<std::string, int> m_instanceRegistry;
   };
 
 }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -14,22 +14,83 @@
 
 namespace xAH {
 
+    /**
+        @rst
+
+            This is used by all algorithms within |xAH|.
+
+            .. note:: The expectation is that the user does not directly use this class but rather inherits from it.
+
+            The main goal of this algorithm class is to standardize how everyone defines an algorithm that plugs into |xAH|. A series of common utilities are provided such as :cpp:member:`~xAH::Algorithm::m_className` which defines the class name so we can manage a registry :cpp:member:`~xAH::Algorithm::m_instanceRegistry` to keep |xAH| as flexible as possible to our users.
+
+            We expect the user to create a new algorithm, such as a selector for jets::
+
+                class JetSelector : public xAH::Algorithm
+                {
+                    // ...
+                };
+
+            The above example is taken from our implementation in :cpp:class:`JetSelector`. Just remember that when you write your initializer, you will be expected to do something like::
+
+                // this is needed to distribute the algorithm to the workers
+                ClassImp(JetSelector)
+
+
+                JetSelector :: JetSelector () :
+                    Algorithm("JetSelector"),
+                    ...
+                {
+                    // ...
+                }
+
+            which this class will automatically register all instances of for you. Each instance can have a different name :cpp:member:`~xAH::Algorithm::m_name` but will have the same :cpp:member:`~xAH::Algorithm::m_className` so we can track how many references have been made. This is useful for selectors to deal with cutflows, but can be useful for other algorithms that need to know how many times they've been instantiated in a single job.
+
+        @endrst
+
+     */
   class Algorithm : public EL::Algorithm {
       public:
+        /**
+            @brief Initialization
+            @param className    This is the name of the class that inherits from :cpp:class:`~xAH::Algorithm`
+         */
         Algorithm(std::string className);
         ~Algorithm();
         /// @cond
         ClassDef(Algorithm, 1);
         /// @endcond
 
+        /**
+            @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)
+            @param name         The name of the instance
+         */
         Algorithm* setName(std::string name);
+        /**
+            @brief Let the algorithm know you wish to configure using a ROOT::TEnv() file
+            @param configName   The path to the config file you wish to use. Can expand the path for you automatically.
+         */
         Algorithm* setConfig(std::string configName);
+        /**
+            @brief Retrieve the path to the config file
+            @param expand       Whether to retrieve the raw string set or the expanded path version
+         */
         std::string getConfig(bool expand=false);
 
-        // 00 = no verbosity
-        // 01 = debug only
-        // 10 = verbose only
-        // 11 = debug and verbose
+        /**
+            @rst
+                Set the level of verbosity in algorithms.
+
+                ===== ====== ===== =======
+                Value Binary Debug Verbose
+                ===== ====== ===== =======
+                0     00
+                1     01     x
+                2     10           x
+                3     11     x     x
+                ===== ====== ===== =======
+
+            @endrst
+         */
         Algorithm* setLevel(int level);
 
         Algorithm* setSyst(std::string systName);

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -14,26 +14,6 @@
 
 namespace xAH {
 
-  class AlgorithmRegistry {
-
-      public:
-        AlgorithmRegistry(){};
-	virtual ~AlgorithmRegistry() {};
-        /// @cond
-        ClassDef(AlgorithmRegistry, 1);
-        /// @endcond
-
-        // this maps bookkeeps the names of the algorithms
-        // which are used, and how many times they have
-        // been used before as well
-        std::map<std::string, int> m_registered_algos;
-
-        // returns how many times an algo has been
-        // already used
-        int countRegistered(std::string className);
-
-  };
-
   class Algorithm : public EL::Algorithm {
       public:
         Algorithm(std::string className);

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -95,18 +95,21 @@ namespace xAH {
 
         /**
             @brief Enable and set the systematic with default value 0
-            @param systName     The systematic to set the value for
+            @param systName     The name of the systematic
          */
         Algorithm* setSyst(std::string systName);
         /**
             @brief Enable and set the systematic with the value
-            @param systName     The systematic to set the value for
+            @param systName     The name of the systematic
             @param systVal      The value to set the systematic to
+            @rst
+                .. note:: This will set the systematic to the value :math:`\pm x`.
+            @endrst
          */
         Algorithm* setSyst(std::string systName, float systVal);
         /**
             @brief Enable and set the systemtatic with the vector of values
-            @param systName             The systematic to set the value for
+            @param systName             The name of the systematic
             @param systValVector        The values to set the systematic to
          */
         Algorithm* setSyst(std::string systName, std::vector<float> systValVector);
@@ -114,8 +117,9 @@ namespace xAH {
         /** All algorithms initialized should have a unique name, to differentiate them at the TObject level */
         std::string m_name;
 
-        /** Booleans for enabling verbosity */
+        /** Enable debug output */
         bool m_debug,
+        /** Enable verbose output */
              m_verbose;
 
         /** If running systematics, the name of the systematic */
@@ -160,18 +164,10 @@ namespace xAH {
         // will try to determine if data or if MC
         // returns: -1=unknown (could not determine), 0=data, 1=mc
         /**
-            @rst
-                Try to determine if we are running over data or MC.
-
-                ============ =======
-                Return Value Meaning
-                ============ =======
-                -1           Unknown
-                0            Data
-                1            MC
-                ============ =======
-
-            @endrst
+            @brief Try to determine if we are running over data or MC.
+            @retval -1  Unknown
+            @retval 0   Data
+            @retval 1   MC
          */
         int isMC();
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -164,10 +164,18 @@ namespace xAH {
         // will try to determine if data or if MC
         // returns: -1=unknown (could not determine), 0=data, 1=mc
         /**
-            @brief Try to determine if we are running over data or MC.
-            @retval -1  Unknown
-            @retval 0   Data
-            @retval 1   MC
+            @rst
+                Try to determine if we are running over data or MC.
+
+                ============ =======
+                Return Value Meaning
+                ============ =======
+                -1           Unknown
+                0            Data
+                1            MC
+                ============ =======
+
+            @endrst
          */
         int isMC();
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -19,7 +19,9 @@ namespace xAH {
       public:
         AlgorithmRegistry(){};
 	virtual ~AlgorithmRegistry() {};
+        /// @cond
         ClassDef(AlgorithmRegistry, 1);
+        /// @endcond
 
         // this maps bookkeeps the names of the algorithms
         // which are used, and how many times they have
@@ -34,8 +36,11 @@ namespace xAH {
 
   class Algorithm : public EL::Algorithm {
       public:
-        Algorithm();
+        Algorithm(std::string className);
+        ~Algorithm();
+        /// @cond
         ClassDef(Algorithm, 1);
+        /// @endcond
 
         Algorithm* setName(std::string name);
         Algorithm* setConfig(std::string configName);
@@ -53,10 +58,7 @@ namespace xAH {
 
         // each algorithm should have a unique name for init, to differentiate them
         std::string m_name;
-	
-        // each algorithm have a 'class' name (e.g., 'ElectronSelector', 'JetCalibrator' ...) to identify the type
-	std::string m_classname;
-       
+
         // enable verbosity, debugging or not
         bool m_debug,
              m_verbose;
@@ -94,14 +96,47 @@ namespace xAH {
         // returns: -1=unknown (could not determine), 0=data, 1=mc
         int isMC();
 
-	// returns how many times an algo of *this* type
-	// has already been used
-	int countUsed() { return m_count_used; };
+        /**
+            @rst
+                Register the given instance under the moniker :cpp:member:`xAH::Algorithm::m_className`
+                This will increase the reference count by 1.
+            @endrst
+         */
+        void registerInstance();
+        /**
+            @rst
+                Return number of instances registered under the moniker :cpp:member:`xAH::Algorithm::m_className`
+
+                This will return the reference count.
+
+                .. warning:: If for some reason the instance wasn't registered, we spit out a warning.
+            @endrst
+         */
+        int numInstances();
+        /**
+            @rst
+                Unregister the given instance under the moniker :cpp:member:`xAH::Algorithm::m_className`
+
+                This will decrease the reference count by 1.
+
+                .. warning:: If for some reason the instance wasn't registered, we spit out a warning.
+            @endrst
+         */
+        void unregisterInstance();
 
       private:
-        // bookkeeps the number of times an algo of *this* type has been used
-	int m_count_used;
-
+        /**
+            @rst
+                the moniker by which all instances are tracked in :cpp:member:`xAH::Algorithm::m_instanceRegistry`
+            @endrst
+         */
+        std::string m_className;
+        /**
+            @rst
+                bookkeeps the number of times :cpp:member:`xAH::Algorithm::m_className` has been used in a variable shared among all classes/instances that inherit from me
+            @endrst
+         */
+	static std::map<std::string, int> m_instanceRegistry;
   };
 
 }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -79,12 +79,6 @@ namespace xAH {
         // 1: this is mc
         int m_isMC;
 
-	// register the name of the algorithms
-	// in a record.
-	// This can be used as a 'database' for other algos
-	// to check if a class of the same type already exists
-	Algorithm* registerClass(AlgorithmRegistry &reg, std::string className);
-
       protected:
         // name of a config file to load in, optional
         std::string m_configName;
@@ -95,6 +89,13 @@ namespace xAH {
         // will try to determine if data or if MC
         // returns: -1=unknown (could not determine), 0=data, 1=mc
         int isMC();
+
+        /**
+            @rst
+                the moniker by which all instances are tracked in :cpp:member:`xAH::Algorithm::m_instanceRegistry`
+            @endrst
+         */
+        std::string m_className;
 
         /**
             @rst
@@ -125,12 +126,6 @@ namespace xAH {
         void unregisterInstance();
 
       private:
-        /**
-            @rst
-                the moniker by which all instances are tracked in :cpp:member:`xAH::Algorithm::m_instanceRegistry`
-            @endrst
-         */
-        std::string m_className;
         /**
             @rst
                 bookkeeps the number of times :cpp:member:`xAH::Algorithm::m_className` has been used in a variable shared among all classes/instances that inherit from me

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -93,42 +93,86 @@ namespace xAH {
          */
         Algorithm* setLevel(int level);
 
+        /**
+            @brief Enable and set the systematic with default value 0
+            @param systName     The systematic to set the value for
+         */
         Algorithm* setSyst(std::string systName);
+        /**
+            @brief Enable and set the systematic with the value
+            @param systName     The systematic to set the value for
+            @param systVal      The value to set the systematic to
+         */
         Algorithm* setSyst(std::string systName, float systVal);
+        /**
+            @brief Enable and set the systemtatic with the vector of values
+            @param systName             The systematic to set the value for
+            @param systValVector        The values to set the systematic to
+         */
         Algorithm* setSyst(std::string systName, std::vector<float> systValVector);
 
-        // each algorithm should have a unique name for init, to differentiate them
+        /** All algorithms initialized should have a unique name, to differentiate them at the TObject level */
         std::string m_name;
 
-        // enable verbosity, debugging or not
+        /** Booleans for enabling verbosity */
         bool m_debug,
              m_verbose;
 
-        // if running systs - the name of the systematic
+        /** If running systematics, the name of the systematic */
         std::string m_systName;
-        // if running systs - the value ( +/- 1 )
+        /** If running systematics, the value to set the systematic to
+            @rst
+                .. note:: This will set the systematic to the value :math:`\pm x`.
+            @endrst
+         */
         float m_systVal;
-        // for running multiple syst points
+        /** If running systematics, you can run multiple points and store them in here */
         std::vector<float> m_systValVector;
 
-        // custom EventInfo container name
+        /** If the xAOD has a different EventInfo container name, set it here */
         std::string m_eventInfoContainerName;
 
-        // override at algorithm level
-        // default: -1, use eventInfo object to determine if data or mc
-        // 0: this is data
-        // 1: this is mc
+        /**
+            @rst
+                This is an override at the algorithm level to force analyzing MC or not.
+
+                ===== ========================================================
+                Value Meaning
+                ===== ========================================================
+                -1    Default, use eventInfo object to determine if data or mc
+                0     Treat the input as data
+                1     Treat the input as MC
+                ===== ========================================================
+
+            @endrst
+         */
         int m_isMC;
 
       protected:
-        // name of a config file to load in, optional
+        /** The name of the TEnv config file to load in, optional */
         std::string m_configName;
 
+        /** The TEvent object */
         xAOD::TEvent* m_event; //!
+        /** The TStore object */
         xAOD::TStore* m_store; //!
 
         // will try to determine if data or if MC
         // returns: -1=unknown (could not determine), 0=data, 1=mc
+        /**
+            @rst
+                Try to determine if we are running over data or MC.
+
+                ============ =======
+                Return Value Meaning
+                ============ =======
+                -1           Unknown
+                0            Data
+                1            MC
+                ============ =======
+
+            @endrst
+         */
         int isMC();
 
         /**

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -69,6 +69,11 @@ namespace xAH {
         StatusCode algInitialize();
 
         /**
+            @brief Run any finalizations common to all xAH Algorithms (such as unregisterInstance). Call this inside :code:`histFinalize` for best results.
+         */
+        StatusCode algFinalize();
+
+        /**
             @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)
             @param name         The name of the instance
          */

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -66,7 +66,7 @@ namespace xAH {
         /**
             @brief Run any initializations commmon to all xAH Algorithms (such as registerInstance). Call this inside :code:`histInitialize` for best results.
          */
-        StatusCode initialize();
+        StatusCode algInitialize();
 
         /**
             @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -54,7 +54,7 @@ namespace xAH {
             @brief Initialization
             @param className    This is the name of the class that inherits from :cpp:class:`~xAH::Algorithm`
          */
-        Algorithm(std::string className);
+        Algorithm(std::string className = "Algorithm");
         ~Algorithm();
         /// @cond
         ClassDef(Algorithm, 1);

--- a/xAODAnaHelpers/AnalysisBase.h
+++ b/xAODAnaHelpers/AnalysisBase.h
@@ -16,8 +16,8 @@
 #include "TEnv.h"
 #include "TSystem.h"
 
-int setupJob(int argc, char* argv[],  EL::Job& job, 
-	     std::string& configName, std::string& submitDir, std::string& systName, 
+int setupJob(int argc, char* argv[],  EL::Job& job,
+	     std::string& configName, std::string& submitDir, std::string& systName,
 	     float& systVal, bool& f_grid, bool& f_production, std::string& outputName,   std::vector< std::string >& outputContainerNames){
 
 
@@ -256,7 +256,7 @@ int setupJob(int argc, char* argv[],  EL::Job& job,
   }else{
     std::cout << "No Match " << outputName << std::endl;
   }
-    
+
 
   // Set the name of the input TTree. It's always "CollectionTree" for xAOD files.
   sh.setMetaString( "nc_tree", "CollectionTree" );

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -57,7 +57,7 @@ private:
 public:
 
   // this is a standard constructor
-  BJetEfficiencyCorrector ();
+  BJetEfficiencyCorrector (std::string className = "BJetEfficiencyCorrector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -106,8 +106,8 @@ class BasicEventSelection : public xAH::Algorithm
     TH1D* m_mu_cutflowHist_1;    //!
     TH1D* m_mu_cutflowHist_2;    //!
     TH1D* m_ph_cutflowHist_1;    //!
-    TH1D* m_tau_cutflowHist_1;   //!    
-    TH1D* m_tau_cutflowHist_2;   //!    
+    TH1D* m_tau_cutflowHist_1;   //!
+    TH1D* m_tau_cutflowHist_2;   //!
     TH1D* m_jet_cutflowHist_1;   //!
     TH1D* m_truth_cutflowHist_1; //!
 
@@ -120,7 +120,7 @@ class BasicEventSelection : public xAH::Algorithm
     //
 
     // this is a standard constructor
-    BasicEventSelection ();
+    BasicEventSelection (std::string className = "BasicEventSelection");
 
     // these are the functions inherited from Algorithm
     virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/DebugTool.h
+++ b/xAODAnaHelpers/DebugTool.h
@@ -18,7 +18,7 @@ public:
 public:
 
   // this is a standard constructor
-  DebugTool ();
+  DebugTool (std::string className = "DebugTool");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -67,7 +67,7 @@ public:
 
 
   // this is a standard constructor
-  ElectronCalibrator ();
+  ElectronCalibrator (std::string className = "ElectronCalibrator");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -70,7 +70,7 @@ public:
 
 
   // this is a standard constructor
-  ElectronEfficiencyCorrector ();
+  ElectronEfficiencyCorrector (std::string className = "ElectronEfficiencyCorrector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -144,7 +144,7 @@ public:
 
   /* this is a standard constructor */
 
-  ElectronSelector ();
+  ElectronSelector (std::string className = "ElectronSelector");
 
   ~ElectronSelector();
 

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -39,7 +39,7 @@ private:
 public:
 
   // this is a standard constructor
-  HLTJetRoIBuilder ();
+  HLTJetRoIBuilder (std::string className = "HLTJetRoIBuilder");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -627,13 +627,13 @@ protected:
   std::vector<float> m_muon_trkPixdEdX;            // not available in DC14
 
   std::vector<float>         m_muon_EnergyLoss;
-  std::vector<float>         m_muon_EnergyLossSigma;		
-  std::vector<unsigned char> m_muon_energyLossType;		
-  std::vector<float>         m_muon_MeasEnergyLoss;		
-  std::vector<float>         m_muon_MeasEnergyLossSigma;	
-  std::vector<float>         m_muon_ParamEnergyLoss;		
+  std::vector<float>         m_muon_EnergyLossSigma;
+  std::vector<unsigned char> m_muon_energyLossType;
+  std::vector<float>         m_muon_MeasEnergyLoss;
+  std::vector<float>         m_muon_MeasEnergyLossSigma;
+  std::vector<float>         m_muon_ParamEnergyLoss;
   std::vector<float>         m_muon_ParamEnergyLossSigmaMinus;
-  std::vector<float>         m_muon_ParamEnergyLossSigmaPlus; 
+  std::vector<float>         m_muon_ParamEnergyLossSigmaPlus;
 
   //
   // electrons
@@ -675,9 +675,9 @@ protected:
   std::vector<float> m_el_topoetcone40;
 
   // PID
-  int m_nel_LHVeryLoose; 
+  int m_nel_LHVeryLoose;
   std::vector<int>   m_el_LHVeryLoose;
-  int m_nel_LHLoose; 
+  int m_nel_LHLoose;
   std::vector<int>   m_el_LHLoose;
   int m_nel_LHMedium;
   std::vector<int>   m_el_LHMedium;
@@ -747,11 +747,11 @@ protected:
   std::vector<float> m_ph_topoetcone40;
 
   // PID
-  int m_nph_IsLoose; 
+  int m_nph_IsLoose;
   std::vector<int>   m_ph_IsLoose;
-  int m_nph_IsMedium; 
+  int m_nph_IsMedium;
   std::vector<int>   m_ph_IsMedium;
-  int m_nph_IsTight; 
+  int m_nph_IsTight;
   std::vector<int>   m_ph_IsTight;
 
   //

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -362,7 +362,7 @@ namespace HelperFunctions {
       for ( auto sys : *sys_list ) {
 	if ( !sys.empty() ) { return true; }
       }
-    } 
+    }
     return false;
   }
 

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -101,7 +101,7 @@ public:
 
 
   // this is a standard constructor
-  JetCalibrator ();
+  JetCalibrator (std::string className = "JetCalibrator");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -147,8 +147,8 @@ class JetHists : public HistogramManager
     TH1F* m_jf_mass           ; //!
     TH1F* m_jf_energyFraction ; //!
     TH1F* m_jf_significance3d ; //!
-    TH1F* m_jf_deltaeta       ; //!  
-    TH1F* m_jf_deltaphi       ; //!  
+    TH1F* m_jf_deltaeta       ; //!
+    TH1F* m_jf_deltaphi       ; //!
     TH1F* m_jf_N2Tpar         ; //!
     TH1F* m_jf_pb             ; //!
     TH1F* m_jf_pc             ; //!
@@ -166,8 +166,8 @@ class JetHists : public HistogramManager
     TH1F* m_sv1_efracsvx ; //!
     TH1F* m_sv1_normdist ; //!
 
-    TH1F* m_nIP2DTracks              ; //!  
-    TH1F* m_IP2D_gradeOfTracks       ; //!  
+    TH1F* m_nIP2DTracks              ; //!
+    TH1F* m_IP2D_gradeOfTracks       ; //!
     TH1F* m_IP2D_flagFromV0ofTracks  ; //!
     TH1F* m_IP2D_valD0wrtPVofTracks  ; //!
     TH1F* m_IP2D_sigD0wrtPVofTracks  ; //!
@@ -176,8 +176,8 @@ class JetHists : public HistogramManager
     TH1F* m_IP2D_weightCofTracks     ; //!
     TH1F* m_IP2D_weightUofTracks     ; //!
 
-    TH1F* m_nIP3DTracks              ; //!  
-    TH1F* m_IP3D_gradeOfTracks       ; //!  
+    TH1F* m_nIP3DTracks              ; //!
+    TH1F* m_IP3D_gradeOfTracks       ; //!
     TH1F* m_IP3D_flagFromV0ofTracks  ; //!
     TH1F* m_IP3D_valD0wrtPVofTracks  ; //!
     TH1F* m_IP3D_sigD0wrtPVofTracks  ; //!

--- a/xAODAnaHelpers/JetHistsAlgo.h
+++ b/xAODAnaHelpers/JetHistsAlgo.h
@@ -29,7 +29,7 @@ public:
 
 
   // this is a standard constructor
-  JetHistsAlgo ();
+  JetHistsAlgo (std::string className = "JetHistsAlgo");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -114,7 +114,7 @@ public:
 
 
   // this is a standard constructor
-  JetSelector ();
+  JetSelector (std::string className = "JetSelector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -10,7 +10,7 @@
 
 
 
-using std::string; 
+using std::string;
 
 namespace met { class METMaker; }
 namespace TauAnalysisTools { class TauSelectionTool; }
@@ -44,7 +44,7 @@ public:
   bool    m_doMuonEloss;
   bool    m_doIsolMuonEloss;
   bool    m_doJVTCut;
-  
+
   bool    m_useCaloJetTerm;
   bool    m_useTrackJetTerm;
 
@@ -62,7 +62,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  METConstructor ();
+  METConstructor (std::string className = "METConstructor");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);
@@ -77,7 +77,7 @@ public:
 
   // these are the functions not inherited from Algorithm
   virtual EL::StatusCode configure ();
-  
+
   // this is needed to distribute the algorithm to the workers
   ClassDef(METConstructor, 1);
 };

--- a/xAODAnaHelpers/MetHists.h
+++ b/xAODAnaHelpers/MetHists.h
@@ -26,7 +26,7 @@ class MetHists : public HistogramManager
     HelperClasses::METInfoSwitch* m_infoSwitch;
 
   private:
-    
+
     TH1F*   m_metFinalClus      ; //!
     TH1F*   m_metFinalClusPx    ; //!
     TH1F*   m_metFinalClusPy    ; //!
@@ -38,7 +38,7 @@ class MetHists : public HistogramManager
     TH1F*   m_metFinalTrkPy     ; //!
     TH1F*   m_metFinalTrkSumEt  ; //!
     TH1F*   m_metFinalTrkPhi    ; //!
-    
+
 };
 
 #endif

--- a/xAODAnaHelpers/MetHistsAlgo.h
+++ b/xAODAnaHelpers/MetHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MetHistsAlgo ();
+  MetHistsAlgo (std::string className = "MetHistsAlgo");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -52,7 +52,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonCalibrator ();
+  MuonCalibrator (std::string className = "MuonCalibrator");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -85,7 +85,7 @@ public:
 
 
   // this is a standard constructor
-  MuonEfficiencyCorrector ();
+  MuonEfficiencyCorrector (std::string className = "MuonEfficiencyCorrector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonHists.h
+++ b/xAODAnaHelpers/MuonHists.h
@@ -26,7 +26,7 @@ class MuonHists : public HistogramManager
     HelperClasses::MuonInfoSwitch* m_infoSwitch;
 
   private:
-    
+
     //basic
     TH1F* m_Pt;                  //!
     TH1F* m_Eta;                 //!
@@ -53,7 +53,7 @@ class MuonHists : public HistogramManager
     TH1F* m_isIsolated_FixedCutTightTrackOnly	   ; //!
     TH1F* m_isIsolated_UserDefinedFixEfficiency	   ; //!
     TH1F* m_isIsolated_UserDefinedCut		   ; //!
-    
+
     TH1F* m_ptcone20				   ; //!
     TH1F* m_ptcone30				   ; //!
     TH1F* m_ptcone40				   ; //!
@@ -69,7 +69,7 @@ class MuonHists : public HistogramManager
     TH1F* m_isLoose				   ; //!
     TH1F* m_isMedium				   ; //!
     TH1F* m_isTight                                ; //!
-    
+
 };
 
 #endif

--- a/xAODAnaHelpers/MuonHistsAlgo.h
+++ b/xAODAnaHelpers/MuonHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonHistsAlgo ();
+  MuonHistsAlgo (std::string className = "MuonHistsAlgo");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -122,7 +122,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonSelector ();
+  MuonSelector (std::string className = "MuonSelector");
 
   ~MuonSelector();
 

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -107,7 +107,7 @@ private:
   TH1D* m_jet_cutflowHist_1;   //!
   TH1D* m_ph_cutflowHist_1;    //!
   TH1D* m_tau_cutflowHist_1;   //!
-  
+
   int m_el_cutflow_OR_cut;     //!
   int m_mu_cutflow_OR_cut;     //!
   int m_jet_cutflow_OR_cut;    //!
@@ -123,7 +123,7 @@ public:
 
 
   // this is a standard constructor
-  OverlapRemover ();
+  OverlapRemover (std::string className = "OverlapRemover");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -82,7 +82,7 @@ public:
 
 
   // this is a standard constructor
-  PhotonCalibrator ();
+  PhotonCalibrator (std::string className = "PhotonCalibrator");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/PhotonSelector.h
+++ b/xAODAnaHelpers/PhotonSelector.h
@@ -98,7 +98,7 @@ public:
 
   /* this is a standard constructor */
 
-  PhotonSelector ();
+  PhotonSelector (std::string className = "PhotonSelector");
 
   ~PhotonSelector();
 

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -38,7 +38,7 @@ public:
   int            m_pass_max;  	             /* maximum number of objects passing cuts */
   std::string    m_ConfigPath;               /* path to config file for the TauSelectionTool */
   std::string    m_EleOLRFilePath;           /* path to input file for overlap-based electron veto */
-  float          m_minPtDAOD;                /* a minimal pT threshold b/c some derivations may apply 
+  float          m_minPtDAOD;                /* a minimal pT threshold b/c some derivations may apply
                                                 a thinning on tau tracks' features needed by the TauSelectionTool,
 						which would cause a crash at runtime */
 
@@ -63,7 +63,7 @@ private:
   // object cutflow
   TH1D* m_tau_cutflowHist_1;                //!
   TH1D* m_tau_cutflowHist_2;                //!
-  
+
   int   m_tau_cutflow_all;		    //!
   int   m_tau_cutflow_selected;             //!
 
@@ -80,7 +80,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TauSelector ();
+  TauSelector (std::string className = "TauSelector");
 
   ~TauSelector();
 

--- a/xAODAnaHelpers/TrackHistsAlgo.h
+++ b/xAODAnaHelpers/TrackHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TrackHistsAlgo ();
+  TrackHistsAlgo (std::string className = "TrackHistsAlgo");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -67,7 +67,7 @@ public:
 
 
   // this is a standard constructor
-  TrackSelector ();
+  TrackSelector (std::string className = "TrackSelector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -43,7 +43,7 @@ private:
 public:
 
   // this is a standard constructor
-  TreeAlgo ();                                           //!
+  TreeAlgo (std::string className = "TreeAlgo");                                           //!
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);           //!

--- a/xAODAnaHelpers/TruthSelector.h
+++ b/xAODAnaHelpers/TruthSelector.h
@@ -68,7 +68,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TruthSelector ();
+  TruthSelector (std::string className = "TruthSelector");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/Writer.h
+++ b/xAODAnaHelpers/Writer.h
@@ -32,7 +32,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  Writer ();
+  Writer (std::string className = "Writer");
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);


### PR DESCRIPTION
This will close #366 . @johnda102 will need to confirm that it works.

This is a potential interface breaking change. Please note the following:

- `countUsed()` is deprecated in favor of `numInstances()` which reflects the meaning behind it
- `xAH::AlgorithmRegistry` is gone. The `Root/LinkDef.h` file has been correspondingly updated.
- `xAH::Algorithm` manages the entire thing in a static `std::map`
- All algorithms that inherit from `xAH::Algorithm` need to do something like
  ```
  JetSelector :: JetSelector () :
      Algorithm("JetSelector"),
          ...
        {
            // ...
        }
  ```

  which will tell `xAH::Algorithm` to automatically register by calling `xAH::Algorithm::registerInstance()` for us. The instance is unregistered from the map (it's reference-count decreases by one for the given class name) through `xAH::Algorithm::~Algorithm`
- `m_classname` is now renamed `m_className`

# The *ENTIRE* class has been documented.