### PR TITLE
Removes an unnecessary constraint on the SystematicSets.

### DIFF
--- a/scripts/checkoutASGtags.py
+++ b/scripts/checkoutASGtags.py
@@ -54,7 +54,7 @@ dict_pkg = {
                        "atlasoff/Trigger/TrigConfiguration/TrigConfxAOD/tags/TrigConfxAOD-00-00-20",
                        "atlasoff/Trigger/TrigAnalysis/TrigEgammaMatchingTool/tags/TrigEgammaMatchingTool-00-00-11"
                       ],
-            '2.3.38': []
+            '2.3.38': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency/tags/xAODBTaggingEfficiency-00-00-26"]
            }
 
 try:


### PR DESCRIPTION
Variations not related to b-tagging are simply ignored, as they should.

See https://groups.cern.ch/group/atlas-sw-pat-releaserequests/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fatlas-sw-pat-releaserequests%2FLists%2FArchive%2FxAODBTaggingEfficiency%20update%207266&FolderCTID=0x01200200BF0F124D374B1440897E955B31960B6B for more information.

/cc @johnda102 to sign off