### PR TITLE
Make JetCleaning optional

### DIFF
--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -50,6 +50,8 @@ public:
   bool m_JERFullSys;
   bool m_JERApplyNominal;
 
+  /// enable to apply jet cleaning
+  bool m_doCleaning;
   std::string m_jetCleanCutLevel;
   bool m_saveAllCleanDecisions;
   bool m_jetCleanUgly;


### PR DESCRIPTION
Fat Jets should not be cleaned -- however there's no way to turn this off. This adds an `m_doCleaning` option to JetCalibrator.

This closes #411 .