### PR TITLE
Change on BJetEfficiencyCorrector and xAH_run

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -105,6 +105,7 @@ EL::StatusCode  BJetEfficiencyCorrector :: configure ()
     // Btag quality
     //
     m_operatingPt             = config->GetValue("OperatingPoint",  m_operatingPt.c_str());
+    m_operatingPtCDI          = config->GetValue("OperatingPointCDI", m_operatingPtCDI.c_str());
 
     m_decor                   = config->GetValue("DecorationName", m_decor.c_str());
 
@@ -154,7 +155,7 @@ EL::StatusCode  BJetEfficiencyCorrector :: configure ()
 
   // now take this name and convert it to the cut value for the CDI file
   // if using the fixed efficiency points
-  m_operatingPtCDI = m_operatingPt;
+  if(m_operatingPtCDI.empty()) m_operatingPtCDI = m_operatingPt;
   std::cout << "Using Standard OperatingPoint for CDI BTag Efficiency of " << m_operatingPtCDI << std::endl;
 
   // Outdated code for translating user friendly Btag WP to cut value

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -169,6 +169,7 @@ condor.add_argument('--optCondorWait', action='store_true' , required=False)
 
 # define arguments for lsf driver
 lsf.add_argument('--optLSFConf', metavar='', type=str, required=False, default='-q short')
+lsf.add_argument('--optLSFNFilesPerJob', metavar='', type=int, required=False, default=1)
 
 if __name__ == "__main__":
   SCRIPT_START_TIME = datetime.datetime.now()
@@ -354,6 +355,7 @@ if __name__ == "__main__":
 
     if args.driver == 'lsf':
       job.options().setBool(ROOT.EL.Job.optResetShell, False);
+      job.options().setDouble(ROOT.EL.Job.optFilesPerWorker, args.optLSFNFilesPerJob)
 
     if args.num_events > 0:
       xAH_logger.info("\tprocessing only %d events", args.num_events)

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -34,6 +34,7 @@ public:
   bool        m_coneFlavourLabel;
 
   std::string m_operatingPt;      // Operating point.
+  std::string m_operatingPtCDI;   // the one CDI will understand
   std::string m_decor;            // The decoration key written to passing objects
   std::string m_decorSF;          // The decoration key written to passing objects
 
@@ -46,8 +47,7 @@ private:
   BTaggingEfficiencyTool  *m_BJetEffSFTool; //!
 
   // configuration variables
-  std::string m_operatingPtCDI; // the one CDI will understand
-  bool m_getScaleFactors;
+  bool m_getScaleFactors;  //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 


### PR DESCRIPTION
1. BJetEfficiencyCorrector

Add support of using WP in CDI file different from the WP in BJetSelector. This would allow user to use a WP that does not have official calibration yet. For example, for antikt2 track-jet, one can cut on 77% WP but use 70% WP calibration as an approximation (before 77% WP calibration is available). By default, WP used in CDI file is the same as the WP used by BJetSelector.

2. xAH_run.py

Add option to specify number of files per worker for LSF driver
