### PR TITLE
Pull request for multiple jet collections including trigger jets.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,42 @@
+# Files I don't want to commit #
+################################
+BasicEventSelection.*
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
 *.pyc
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Files I don't want to commit #
-################################
-BasicEventSelection.*
-
 # Compiled source #
 ###################
 *.com

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -603,19 +603,31 @@ EL::StatusCode BasicEventSelection :: initialize ()
   //
 
   if( !m_triggerSelection.empty() || m_applyTriggerCut || m_storeTrigDecisions || m_storePassL1 || m_storePassHLT || m_storeTrigKeys ) {
+      
+    //if it's there, it must be already configured
+    if ( asg::ToolStore::contains<Trig::TrigDecisionTool>( "TrigDecisionTool" ) && asg::ToolStore::contains<TrigConf::xAODConfigTool>("xAODConfigTool")) {
+        
+      m_trigDecTool = asg::ToolStore::get<Trig::TrigDecisionTool>("TrigDecisionTool");
+      m_trigConfTool = asg::ToolStore::get<TrigConf::xAODConfigTool>("xAODConfigTool");
 
-    m_trigConfTool = new TrigConf::xAODConfigTool( "xAODConfigTool" );
-    RETURN_CHECK("BasicEventSelection::initialize()", m_trigConfTool->initialize(), "Failed to properly initialize TrigConf::xAODConfigTool");
-    ToolHandle< TrigConf::ITrigConfigTool > configHandle( m_trigConfTool );
+    }
+    
+    else {
 
-    m_trigDecTool = new Trig::TrigDecisionTool( "TrigDecisionTool" );
-    RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "ConfigTool", configHandle ), "");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "TrigDecisionKey", "xTrigDecision" ), "");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "OutputLevel", MSG::ERROR), "");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->initialize(), "Failed to properly initialize Trig::TrigDecisionTool");
-    Info("initialize()", "Successfully configured Trig::TrigDecisionTool!");
+      m_trigConfTool = new TrigConf::xAODConfigTool( "xAODConfigTool" );
+      RETURN_CHECK("BasicEventSelection::initialize()", m_trigConfTool->initialize(), "Failed to properly initialize TrigConf::xAODConfigTool");
+      ToolHandle< TrigConf::ITrigConfigTool > configHandle( m_trigConfTool );
 
-  }
+      m_trigDecTool = new Trig::TrigDecisionTool( "TrigDecisionTool" );
+      RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "ConfigTool", configHandle ), "");
+      RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "TrigDecisionKey", "xTrigDecision" ), "");
+      RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "OutputLevel", MSG::ERROR), "");
+      RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->initialize(), "Failed to properly initialize Trig::TrigDecisionTool");
+      Info("initialize()", "Successfully configured Trig::TrigDecisionTool!");
+        
+    }
+      
+  }//end trigger configuration
 
   // As a check, let's see the number of events in our file (long long int)
   //

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -913,10 +913,10 @@ EL::StatusCode BasicEventSelection :: finalize ()
 
   m_RunNr_VS_EvtNr.clear();
 
-  if ( m_grl )          {  m_grl = nullptr;	     delete m_grl; }
-  if ( m_pileuptool )   {  m_pileuptool = nullptr;   delete m_pileuptool; }
-  if ( m_trigDecTool )  {  m_trigDecTool = nullptr;  delete m_trigDecTool; }
-  if ( m_trigConfTool ) {  m_trigConfTool = nullptr; delete m_trigConfTool; }
+    if ( m_grl )        { delete m_grl; m_grl = nullptr; }
+  if ( m_pileuptool )   { delete m_pileuptool;  m_pileuptool = nullptr; }
+  if ( m_trigDecTool )  { delete m_trigDecTool;  m_trigDecTool = nullptr; }
+  if ( m_trigConfTool ) { delete m_trigConfTool;  m_trigConfTool = nullptr; }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -1,0 +1,223 @@
+/******************************************
+ *
+ * This class gets HLT jets from the TDT and can be expanded to get other features
+ *
+ * Merlin Davies (merlin.davies@cern.ch)
+ * Caterina Doglioni (caterina.doglioni@cern.ch)
+ * John Alison (john.alison@cern.ch)
+ *
+ *
+ ******************************************/
+
+// c++ include(s):
+#include <iostream>
+#include <vector>
+
+// EL include(s):
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+
+// EDM include(s):
+//CD: do we need all this stuff?
+#include "xAODEventInfo/EventInfo.h"
+#include "xAODJet/JetContainer.h"
+#include "xAODJet/JetAuxContainer.h"
+#include "xAODJet/Jet.h"
+#include "xAODBase/IParticleHelpers.h"
+#include "xAODBase/IParticleContainer.h"
+#include "xAODBase/IParticle.h"
+#include "AthContainers/ConstDataVector.h"
+#include "AthContainers/DataVector.h"
+#include "xAODCore/ShallowCopy.h"
+
+// package include(s):
+#include "xAODAnaHelpers/HelperFunctions.h"
+#include "xAODAnaHelpers/HLTJetGetter.h"
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+
+#include "TrigConfxAOD/xAODConfigTool.h"
+#include "TrigDecisionTool/TrigDecisionTool.h"
+
+// ROOT include(s):
+#include "TEnv.h"
+#include "TSystem.h"
+
+using std::cout;  using std::endl;
+using std::vector;
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(HLTJetGetter)
+
+HLTJetGetter :: HLTJetGetter (std::string className) :
+    Algorithm(className),
+    m_trigItem(""),
+    m_outContainerName(""),
+    m_trigDecTool(nullptr)
+{
+  Info("HLTJetGetter()", "Calling constructor");
+
+  // read debug flag from .config file
+  m_debug                   = false;
+
+  m_sort                    = true;
+
+}
+
+
+EL::StatusCode HLTJetGetter :: setupJob (EL::Job& job)
+{
+  Info("setupJob()", "Calling setupJob");
+  job.useXAOD ();
+  xAOD::Init( "HLTJetGetter" ).ignore(); // call before opening first file
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: histInitialize ()
+{
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: fileExecute ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: changeInput (bool /*firstFile*/)
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: initialize ()
+{
+
+  Info("initialize()", "Initializing HLTJetGetter Interface... ");
+
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+
+  //
+  // Grab the TrigDecTool from the ToolStore
+  //
+  m_trigDecTool = dynamic_cast<Trig::TrigDecisionTool*>(asg::ToolStore::get("TrigDecisionTool"));
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode HLTJetGetter :: execute ()
+{
+  if ( m_debug ) { Info("execute()", "Getting HLT jets... "); }
+
+  //
+  // Create the new container and its auxiliary store.
+  //
+  xAOD::JetContainer*     hltJets    = new xAOD::JetContainer();
+  xAOD::JetAuxContainer*  hltJetsAux = new xAOD::JetAuxContainer();
+  hltJets->setStore( hltJetsAux ); //< Connect the two
+
+  ConstDataVector<xAOD::TrackParticleContainer>* selectedTracks = new ConstDataVector<xAOD::TrackParticleContainer>(SG::VIEW_ELEMENTS);
+
+  //
+  //  Make accessors/decorators
+  //
+  static SG::AuxElement::ConstAccessor< vector<ElementLink<DataVector<xAOD::IParticle> > > > jetLinkAcc("BTagBtagToJetAssociator");
+  static SG::AuxElement::ConstAccessor< vector<ElementLink<xAOD::TrackParticleContainer> > > trkLinkAcc("BTagTrackToJetAssociator");
+  static SG::AuxElement::Decorator< const xAOD::BTagging* > hltBTagDecor( "HLTBTag" );
+
+  Trig::FeatureContainer fc = m_trigDecTool->features(m_trigItem);
+  auto bjetFeatureContainers = fc.containerFeature<xAOD::BTaggingContainer>();
+
+  if(m_debug) cout << "ncontainers  " << bjetFeatureContainers.size() << endl;
+
+  for(auto  jcont : bjetFeatureContainers) {
+    for (const xAOD::BTagging*  hlt_btag : *jcont.cptr()) {
+
+      bool isAvailableJet = jetLinkAcc.isAvailable(*hlt_btag);
+
+      if(isAvailableJet){
+	vector<ElementLink<DataVector<xAOD::IParticle> > > jetLinkObj = jetLinkAcc(*hlt_btag);
+	if(m_debug) cout << "Filling " << jetLinkObj.size() << " jets ... " <<endl;
+
+	if(jetLinkObj.size()){
+	  const xAOD::Jet* hltBJet = dynamic_cast<const xAOD::Jet*>(*(jetLinkObj.at(0)));
+	  if(m_debug) cout << "Adding hltBJet " << hltBJet << " " << hlt_btag << endl;
+
+	  xAOD::Jet* newHLTBJet = new xAOD::Jet();
+	  newHLTBJet->makePrivateStore( hltBJet );
+
+	  //
+	  // Add Link to BTagging Info
+	  //
+	  newHLTBJet->auxdecor< const xAOD::BTagging* >("HLTBTag") = hlt_btag;
+	  if(m_debug) cout << "Added link " << endl;
+
+	  //
+	  // Add Tracks to BJet
+	  //
+	  //bool isAvailableTrks = trkLinkAcc.isAvailable(*hlt_btag);
+	  //if(isAvailableTrks){
+	  //	vector<ElementLink<xAOD::TrackParticleContainer> > trkLinkObj = trkLinkAcc(*hlt_btag);
+	  //	//h_nTrks->Fill(trkLinkObj.size());
+	  //	if(m_debug) cout << "Filling " << trkLinkObj.size() << " tracks...";
+	  //
+	  //	for(auto& trkPtr: trkLinkObj){
+	  //	  const xAOD::TrackParticle* thisHLTTrk = *(trkPtr);
+	  //	  selectedTracks->push_back( thisHLTTrk );
+	  //	}
+	  //}else{
+	  //	if(m_debug) cout << " Trks Not Avalible." << endl;
+	  //}
+
+
+	  hltJets->push_back( newHLTBJet );
+	  if(m_debug) cout << "pushed back " << endl;
+	}
+	if(m_debug) cout << " ...done." << endl;
+      }else{
+	if(m_debug) cout << " Jet Not Avalible." << endl;
+      }
+    }//BTagging
+  }//bjetFeatures
+
+  RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected dijets");
+  RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJetsAux, m_outContainerName+"Aux."), "Failed to record selected dijetsAux.");
+
+  if ( m_debug ) { m_store->print(); }
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: postExecute ()
+{
+  if ( m_debug ) { Info("postExecute()", "Calling postExecute"); }
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: finalize ()
+{
+  Info("finalize()", "Deleting tool instances...");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode HLTJetGetter :: histFinalize ()
+{
+  Info("histFinalize()", "Calling histFinalize");
+  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
+  return EL::StatusCode::SUCCESS;
+}

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -209,8 +209,8 @@ EL::StatusCode HLTJetGetter :: finalize ()
     Info("finalize()", "Deleting tool instances...");
     
     //question: are we doing this twice?
-    if ( m_trigDecTool )  {  m_trigDecTool = nullptr;  delete m_trigDecTool; }
-    if ( m_trigConfTool ) {  m_trigConfTool = nullptr; delete m_trigConfTool; }
+    if ( m_trigDecTool )  {  delete m_trigDecTool; m_trigDecTool = nullptr;  }
+    if ( m_trigConfTool ) {  delete m_trigConfTool; m_trigConfTool = nullptr; }
     
     return EL::StatusCode::SUCCESS;
 }

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -19,9 +19,6 @@
 #include <EventLoop/Worker.h>
 
 // EDM include(s):
-<<<<<<< 23ea71dd850f66585ee1f7d2749bed218228fe87
-=======
-//CD: do we need all this stuff?
 #include "xAODEventInfo/EventInfo.h"
 #include "xAODJet/JetContainer.h"
 #include "xAODJet/JetAuxContainer.h"
@@ -46,49 +43,48 @@ using std::vector;
 ClassImp(HLTJetGetter)
 
 HLTJetGetter :: HLTJetGetter (std::string className) :
-    Algorithm(className),
-    m_triggerList(".*"),
-    m_inContainerName(""),
-    m_outContainerName(""),
-    m_trigDecTool(nullptr)
+Algorithm(className),
+m_triggerList(".*"),
+m_inContainerName(""),
+m_outContainerName(""),
+m_trigDecTool(nullptr)
 {
-  Info("HLTJetGetter()", "Calling constructor");
-
-  // read debug flag from .config file
-  m_debug                   = false;
-  //m_sort                    = true;
-
+    Info("HLTJetGetter()", "Calling constructor");
+    
+    // read debug flag from .config file
+    m_debug                   = false;
+    
 }
 
 
 EL::StatusCode HLTJetGetter :: setupJob (EL::Job& job)
 {
-  Info("setupJob()", "Calling setupJob");
-  job.useXAOD ();
-  xAOD::Init( "HLTJetGetter" ).ignore(); // call before opening first file
-  return EL::StatusCode::SUCCESS;
+    Info("setupJob()", "Calling setupJob");
+    job.useXAOD ();
+    xAOD::Init( "HLTJetGetter" ).ignore(); // call before opening first file
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: histInitialize ()
 {
-  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
-  return EL::StatusCode::SUCCESS;
+    RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: fileExecute ()
 {
-  return EL::StatusCode::SUCCESS;
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: changeInput (bool /*firstFile*/)
 {
-  return EL::StatusCode::SUCCESS;
+    return EL::StatusCode::SUCCESS;
 }
 
 EL::StatusCode  HLTJetGetter :: configure ()
@@ -101,13 +97,13 @@ EL::StatusCode  HLTJetGetter :: configure ()
         
         // read debug flag from .config file
         m_debug                   = config->GetValue("Debug" , m_debug);
-        // input container to be read from TDT (will be stripped - TODO: put here stripped name already?)
+        // input container to be read from TDT
         m_inContainerName         = config->GetValue("InputContainer",  m_inContainerName.c_str());
         // output container is passed on with this output container name
         m_outContainerName        = config->GetValue("OutputContainer", m_outContainerName.c_str());
         // list of triggers whose features have to be pulled from TDT: ".*" for all
         m_triggerList             = config->GetValue("TriggerList", m_triggerList.c_str());
-
+        
         config->Print();
         
         delete config; config = nullptr;
@@ -120,7 +116,7 @@ EL::StatusCode  HLTJetGetter :: configure ()
     }
     
     if ( !getConfig().empty() )
-        Info("configure()", "JetCalibrator Interface succesfully configured! ");
+    Info("configure()", "JetCalibrator Interface succesfully configured! ");
     
     return EL::StatusCode::SUCCESS;
 }
@@ -128,88 +124,101 @@ EL::StatusCode  HLTJetGetter :: configure ()
 
 EL::StatusCode HLTJetGetter :: initialize ()
 {
-
-  Info("initialize()", "Initializing HLTJetGetter Interface... ");
-
-  m_event = wk()->xaodEvent();
-  m_store = wk()->xaodStore();
-
-  //
-  // Grab the TrigDecTool from the ToolStore
-  //
-
-  if ( asg::ToolStore::contains<Trig::TrigDecisionTool>( "TrigDecisionTool" ) ) {
-    m_trigDecTool = asg::ToolStore::get<Trig::TrigDecisionTool>("TrigDecisionTool");
-  } else {
-    Error("Initialize()", "the Trigger Decision Tool is not initialized.. [%s]", m_name.c_str());
-    return EL::StatusCode::FAILURE;
-  }
     
-  // Configure
-  if ( this->configure() == EL::StatusCode::FAILURE ) {
-    Error("initialize()", "Failed to properly configure. Exiting." );
-    return EL::StatusCode::FAILURE;
-  }
-
-  return EL::StatusCode::SUCCESS;
+    Info("initialize()", "Initializing HLTJetGetter Interface... ");
+    
+    m_event = wk()->xaodEvent();
+    m_store = wk()->xaodStore();
+    
+    //
+    // Grab the TrigDecTool from the ToolStore
+    //
+    
+    if ( asg::ToolStore::contains<Trig::TrigDecisionTool>( "TrigDecisionTool" ) ) {
+        m_trigDecTool = asg::ToolStore::get<Trig::TrigDecisionTool>("TrigDecisionTool");
+    } else {
+        Info ("Initialize()", "the Trigger Decision Tool is not yet initialized...[%s]. Doing so now.", m_name.c_str());
+        
+        m_trigConfTool = new TrigConf::xAODConfigTool( "xAODConfigTool" );
+        RETURN_CHECK("BasicEventSelection::initialize()", m_trigConfTool->initialize(), "Failed to properly initialize TrigConf::xAODConfigTool");
+        ToolHandle< TrigConf::ITrigConfigTool > configHandle( m_trigConfTool );
+        
+        m_trigDecTool = new Trig::TrigDecisionTool( "TrigDecisionTool" );
+        RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "ConfigTool", configHandle ), "");
+        RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "TrigDecisionKey", "xTrigDecision" ), "");
+        RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->setProperty( "OutputLevel", MSG::ERROR), "");
+        RETURN_CHECK("BasicEventSelection::initialize()", m_trigDecTool->initialize(), "Failed to properly initialize Trig::TrigDecisionTool");
+        Info("initialize()", "Successfully configured Trig::TrigDecisionTool!");
+    }
+    
+    // Configure
+    if ( this->configure() == EL::StatusCode::FAILURE ) {
+        Error("initialize()", "Failed to properly configure. Exiting." );
+        return EL::StatusCode::FAILURE;
+    }
+    
+    return EL::StatusCode::SUCCESS;
 }
 
 
 EL::StatusCode HLTJetGetter :: execute ()
 {
-  if ( m_debug ) { Info("execute()", "Getting HLT jets... "); }
-
-  //
-  // Create the new container and its auxiliary store.
-  //
-  xAOD::JetContainer*     hltJets    = new xAOD::JetContainer();
-  xAOD::JetAuxContainer*  hltJetsAux = new xAOD::JetAuxContainer();
-  hltJets->setStore( hltJetsAux ); //< Connect the two
-
-  //Retrieving jets via trigger decision tool:
-  const Trig::ChainGroup * chainGroup = m_trigDecTool->getChainGroup(m_triggerList.c_str()); //Trigger list:
-  auto chainFeatures = chainGroup->features(); //Gets features associated to chain defined above
-  std::string stripped_name = m_inContainerName;
-  stripped_name.erase(0, 23); //Stripping 'HLT_xAOD__JetContainer_' from input container name
-  auto JetFeatureContainers = chainFeatures.containerFeature<xAOD::JetContainer>(stripped_name.c_str());
-
-  for( auto fContainer : JetFeatureContainers ) {
-    for( auto trigJet : *fContainer.cptr() ) {
-      xAOD::Jet *Jet = new xAOD::Jet();
-      *Jet = *trigJet;
-      hltJets->push_back( Jet );
-    }//end trigJet loop
-  }//end feature container loop
-  
-  RETURN_CHECK("HLTJetGetter::execute()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected hltJets");
-  RETURN_CHECK("HLTJetGetter::execute()", m_store->record( hltJetsAux, m_outContainerName+"Aux."), "Failed to record selected hltJetsAux.");
-
-  if ( m_debug ) { m_store->print(); }
-
-  return EL::StatusCode::SUCCESS;
+    if ( m_debug ) { Info("execute()", "Getting HLT jets... "); }
+    
+    //
+    // Create the new container and its auxiliary store.
+    //
+    xAOD::JetContainer*     hltJets    = new xAOD::JetContainer();
+    xAOD::JetAuxContainer*  hltJetsAux = new xAOD::JetAuxContainer();
+    hltJets->setStore( hltJetsAux ); //< Connect the two
+    
+    //Retrieving jets via trigger decision tool:
+    const Trig::ChainGroup * chainGroup = m_trigDecTool->getChainGroup(m_triggerList.c_str()); //Trigger list:
+    auto chainFeatures = chainGroup->features(); //Gets features associated to chain defined above
+    auto JetFeatureContainers = chainFeatures.containerFeature<xAOD::JetContainer>(m_inContainerName.c_str());
+    
+    RETURN_CHECK("HLTJetGetter::execute()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected hltJets");
+    RETURN_CHECK("HLTJetGetter::execute()", m_store->record( hltJetsAux, m_outContainerName+"Aux."), "Failed to record selected hltJetsAux.");
+    
+    for( auto fContainer : JetFeatureContainers ) {
+        for( auto trigJet : *fContainer.cptr() ) {
+            xAOD::Jet *Jet = new xAOD::Jet();
+            *Jet = *trigJet;
+            hltJets->push_back( Jet );
+        }//end trigJet loop
+    }//end feature container loop
+    
+    if ( m_verbose ) { m_store->print(); }
+    
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: postExecute ()
 {
-  if ( m_debug ) { Info("postExecute()", "Calling postExecute"); }
-  return EL::StatusCode::SUCCESS;
+    if ( m_debug ) { Info("postExecute()", "Calling postExecute"); }
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: finalize ()
 {
-  Info("finalize()", "Deleting tool instances...");
-  return EL::StatusCode::SUCCESS;
+    Info("finalize()", "Deleting tool instances...");
+    
+    //question: are we doing this twice?
+    if ( m_trigDecTool )  {  m_trigDecTool = nullptr;  delete m_trigDecTool; }
+    if ( m_trigConfTool ) {  m_trigConfTool = nullptr; delete m_trigConfTool; }
+    
+    return EL::StatusCode::SUCCESS;
 }
 
 
 
 EL::StatusCode HLTJetGetter :: histFinalize ()
 {
-  Info("histFinalize()", "Calling histFinalize");
-  RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
-  return EL::StatusCode::SUCCESS;
+    Info("histFinalize()", "Calling histFinalize");
+    RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
+    return EL::StatusCode::SUCCESS;
 }

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -28,7 +28,6 @@
 #include "xAODAnaHelpers/HelperFunctions.h"
 #include "xAODAnaHelpers/HLTJetGetter.h"
 #include <xAODAnaHelpers/tools/ReturnCheck.h>
-
 #include "TrigConfxAOD/xAODConfigTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 
@@ -36,24 +35,22 @@
 #include "TEnv.h"
 #include "TSystem.h"
 
-using std::cout;  using std::endl;
-using std::vector;
-
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetGetter)
 
 HLTJetGetter :: HLTJetGetter (std::string className) :
 Algorithm(className),
-m_triggerList(".*"),
-m_inContainerName(""),
-m_outContainerName(""),
 m_trigDecTool(nullptr)
 {
     Info("HLTJetGetter()", "Calling constructor");
-    
-    // read debug flag from .config file
-    m_debug                   = false;
-    
+
+    // regex list of triggers
+    m_triggerList = ".*";
+    // input container to be read from TEvent or TStore
+    m_inContainerName = "";
+    // shallow copies are made with this output container name
+    m_outContainerName = "";
+
 }
 
 

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -19,6 +19,9 @@
 #include <EventLoop/Worker.h>
 
 // EDM include(s):
+<<<<<<< 23ea71dd850f66585ee1f7d2749bed218228fe87
+=======
+//CD: do we need all this stuff?
 #include "xAODEventInfo/EventInfo.h"
 #include "xAODJet/JetContainer.h"
 #include "xAODJet/JetAuxContainer.h"
@@ -53,7 +56,6 @@ HLTJetGetter :: HLTJetGetter (std::string className) :
 
   // read debug flag from .config file
   m_debug                   = false;
-    
   //m_sort                    = true;
 
 }
@@ -122,7 +124,6 @@ EL::StatusCode  HLTJetGetter :: configure ()
     
     return EL::StatusCode::SUCCESS;
 }
-
 
 
 EL::StatusCode HLTJetGetter :: initialize ()

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -124,6 +124,7 @@ EL::StatusCode  HLTJetGetter :: configure ()
 
 EL::StatusCode HLTJetGetter :: initialize ()
 {
+
     
     Info("initialize()", "Initializing HLTJetGetter Interface... ");
     

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -19,17 +19,10 @@
 #include <EventLoop/Worker.h>
 
 // EDM include(s):
-//CD: do we need all this stuff?
 #include "xAODEventInfo/EventInfo.h"
 #include "xAODJet/JetContainer.h"
 #include "xAODJet/JetAuxContainer.h"
 #include "xAODJet/Jet.h"
-#include "xAODBase/IParticleHelpers.h"
-#include "xAODBase/IParticleContainer.h"
-#include "xAODBase/IParticle.h"
-#include "AthContainers/ConstDataVector.h"
-#include "AthContainers/DataVector.h"
-#include "xAODCore/ShallowCopy.h"
 
 // package include(s):
 #include "xAODAnaHelpers/HelperFunctions.h"
@@ -51,7 +44,6 @@ ClassImp(HLTJetGetter)
 
 HLTJetGetter :: HLTJetGetter (std::string className) :
     Algorithm(className),
-    //m_trigItem(""),
     m_triggerList(".*"),
     m_inContainerName(""),
     m_outContainerName(""),
@@ -125,10 +117,6 @@ EL::StatusCode  HLTJetGetter :: configure ()
         return EL::StatusCode::FAILURE;
     }
     
-    //Needed for later?
-    //m_outSCContainerName      = m_outContainerName + "ShallowCopy";
-    //m_outSCAuxContainerName   = m_outSCContainerName + "Aux."; // the period is very important!
-    
     if ( !getConfig().empty() )
         Info("configure()", "JetCalibrator Interface succesfully configured! ");
     
@@ -148,7 +136,6 @@ EL::StatusCode HLTJetGetter :: initialize ()
   //
   // Grab the TrigDecTool from the ToolStore
   //
-  //m_trigDecTool = dynamic_cast<Trig::TrigDecisionTool*>(asg::ToolStore::get("TrigDecisionTool"));
 
   if ( asg::ToolStore::contains<Trig::TrigDecisionTool>( "TrigDecisionTool" ) ) {
     m_trigDecTool = asg::ToolStore::get<Trig::TrigDecisionTool>("TrigDecisionTool");
@@ -178,19 +165,12 @@ EL::StatusCode HLTJetGetter :: execute ()
   xAOD::JetAuxContainer*  hltJetsAux = new xAOD::JetAuxContainer();
   hltJets->setStore( hltJetsAux ); //< Connect the two
 
-    std::cout << "1" << std::endl;
-    //std::cout << m_trigDecTool->Get << std::endl;
-    std::cout << "1" << std::endl;
   //Retrieving jets via trigger decision tool:
   const Trig::ChainGroup * chainGroup = m_trigDecTool->getChainGroup(m_triggerList.c_str()); //Trigger list:
-    std::cout << "2" << std::endl;
   auto chainFeatures = chainGroup->features(); //Gets features associated to chain defined above
-    std::cout << "3" << std::endl;
   std::string stripped_name = m_inContainerName;
   stripped_name.erase(0, 23); //Stripping 'HLT_xAOD__JetContainer_' from input container name
-    std::cout << "4" << std::endl;
   auto JetFeatureContainers = chainFeatures.containerFeature<xAOD::JetContainer>(stripped_name.c_str());
-    std::cout << "5" << std::endl;
 
   for( auto fContainer : JetFeatureContainers ) {
     for( auto trigJet : *fContainer.cptr() ) {

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -189,7 +189,7 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
   RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected dijets");
   RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJetsAux, m_outContainerName+"Aux."), "Failed to record selected dijetsAux.");
 
-  if ( m_debug ) { m_store->print(); }
+  if ( m_verbose ) { m_store->print(); }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -427,6 +427,7 @@ void HelpTreeBase::ClearTrigger() {
  ********************/
 
 /* TODO: jet trigger */
+//CD: is this useful at all?
 void HelpTreeBase::AddJetTrigger( const std::string detailStr )
 {
   if ( m_debug )  Info("AddJetTrigger()", "Adding jet trigger variables: %s", detailStr.c_str());

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1484,8 +1484,10 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 
   if(m_debug) Info("AddJets()", "Adding jet %s with variables: %s", jetName.c_str(), detailStr.c_str());
 
-  m_jetInfoSwitch = new HelperClasses::JetInfoSwitch( detailStr );
-
+  //m_jetInfoSwitch = new HelperClasses::JetInfoSwitch( detailStr );
+  
+  m_thisJetInfoSwitch[jetName] = new HelperClasses::JetInfoSwitch( detailStr );
+    
   m_jets[jetName] = new jetInfo();
 
   jetInfo* thisJet = m_jets[jetName];
@@ -1493,18 +1495,18 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
   // always
   m_tree->Branch(("n"+jetName+"s").c_str(),    &thisJet->N,("n"+jetName+"s/I").c_str());
 
-  if ( m_jetInfoSwitch->m_kinematic ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_kinematic ) {
     m_tree->Branch((jetName+"_E"  ).c_str(),  &thisJet->m_jet_E);
     m_tree->Branch((jetName+"_pt" ).c_str(),  &thisJet->m_jet_pt);
     m_tree->Branch((jetName+"_phi").c_str(),  &thisJet->m_jet_phi);
     m_tree->Branch((jetName+"_eta").c_str(),  &thisJet->m_jet_eta);
   }
 
-  if ( m_jetInfoSwitch->m_rapidity ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_rapidity ) {
     m_tree->Branch((jetName+"_rapidity").c_str(), &thisJet->m_jet_rapidity);
   }
 
-  if( m_jetInfoSwitch->m_clean ) {
+  if( m_thisJetInfoSwitch[jetName]->m_clean ) {
     m_tree->Branch((jetName+"_Timing").c_str(),                        &thisJet->m_jet_time               );
     m_tree->Branch((jetName+"_LArQuality").c_str(),                    &thisJet->m_jet_LArQuality         );
     m_tree->Branch((jetName+"_HECQuality").c_str(),                    &thisJet->m_jet_hecq               );
@@ -1526,7 +1528,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_clean_passTightBadUgly").c_str(),        &thisJet->m_jet_clean_passTightBadUgly         );
   }
 
-  if ( m_jetInfoSwitch->m_energy ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_energy ) {
     m_tree->Branch((jetName+"_HECFrac").c_str(), 	            &thisJet->m_jet_HECf	    );
     m_tree->Branch((jetName+"_EMFrac").c_str(),  	            &thisJet->m_jet_EMf	    );
     m_tree->Branch((jetName+"_CentroidR").c_str(),	            &thisJet->m_jet_centroidR      );
@@ -1537,7 +1539,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_Width").c_str(),                     &thisJet->m_jet_width          );
   }
 
-  if ( m_jetInfoSwitch->m_scales ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_scales ) {
     m_tree->Branch((jetName+"_emScalePt").c_str(),              &thisJet->m_jet_emPt            );
     m_tree->Branch((jetName+"_constScalePt").c_str(),           &thisJet->m_jet_constPt         );
     m_tree->Branch((jetName+"_pileupScalePt").c_str(),          &thisJet->m_jet_pileupPt        );
@@ -1547,11 +1549,11 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_insituScalePt").c_str(),          &thisJet->m_jet_insituPt        );
   }
 
-  if ( m_jetInfoSwitch->m_layer ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_layer ) {
     m_tree->Branch((jetName+"_EnergyPerSampling").c_str(),     &thisJet->m_jet_ePerSamp   );
   }
 
-  if ( m_jetInfoSwitch->m_trackAll ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_trackAll ) {
     m_tree->Branch((jetName+"_NumTrkPt1000").c_str(),	    &thisJet->m_jet_NTrkPt1000   );
     m_tree->Branch((jetName+"_SumPtTrkPt1000").c_str(),    &thisJet->m_jet_SumPtPt1000  );
     m_tree->Branch((jetName+"_TrackWidthPt1000").c_str(),  &thisJet->m_jet_TrkWPt1000   );
@@ -1561,7 +1563,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_JVF").c_str(),		    &thisJet->m_jet_jvf	        );
   }
 
-  if ( m_jetInfoSwitch->m_trackPV ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_trackPV ) {
     m_tree->Branch((jetName+"_NumTrkPt1000PV").c_str(),      &thisJet->m_jet_NTrkPt1000PV   );
     m_tree->Branch((jetName+"_SumPtTrkPt1000PV").c_str(),    &thisJet->m_jet_SumPtPt1000PV  );
     m_tree->Branch((jetName+"_TrackWidthPt1000PV").c_str(),  &thisJet->m_jet_TrkWPt1000PV   );
@@ -1575,11 +1577,11 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     //m_tree->Branch((jetName+"_GhostTrackAssociationFraction").c_str(), &thisJet->m_jet_ghostTrackAssFrac);
   }
 
-  if ( m_jetInfoSwitch->m_allTrack ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     // if want to apply the selection of the PV then need to setup track selection tool
     // this applies the JVF/JVT selection cuts
     // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JvtManualRecalculation
-    if( m_jetInfoSwitch->m_allTrackPVSel ) {
+    if( m_thisJetInfoSwitch[jetName]->m_allTrackPVSel ) {
       m_trkSelTool = new InDet::InDetTrackSelectionTool( "JetTrackSelection", "Loose" );
       m_trkSelTool->initialize();
       // to do this need to have AddJets return a status code
@@ -1594,7 +1596,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_GhostTrack_e").c_str(),     &thisJet->m_jet_GhostTrack_e    );
     m_tree->Branch((jetName+"_GhostTrack_d0").c_str(),    &thisJet->m_jet_GhostTrack_d0   );
     m_tree->Branch((jetName+"_GhostTrack_z0").c_str(),    &thisJet->m_jet_GhostTrack_z0   );
-    if ( m_jetInfoSwitch->m_allTrackDetail ) {
+    if ( m_thisJetInfoSwitch[jetName]->m_allTrackDetail ) {
       m_tree->Branch((jetName+"_GhostTrack_nPixelHits").c_str(),                           &thisJet->m_jet_GhostTrack_nPixHits);
       m_tree->Branch((jetName+"_GhostTrack_nSCTHits").c_str(),                             &thisJet->m_jet_GhostTrack_nSCTHits);
       m_tree->Branch((jetName+"_GhostTrack_nTRTHits").c_str(),                             &thisJet->m_jet_GhostTrack_nTRTHits);
@@ -1609,11 +1611,11 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     }
   }
 
-  if ( m_jetInfoSwitch->m_constituent ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_constituent ) {
     m_tree->Branch((jetName+"_numConstituents").c_str() ,   &thisJet->m_jet_numConstituents);
   }
 
-  if ( m_jetInfoSwitch->m_constituentAll ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_constituentAll ) {
     m_tree->Branch((jetName+"_constituentWeights").c_str(), &thisJet->m_jet_constitWeights);
     m_tree->Branch((jetName+"_constituent_pt").c_str(),    &thisJet->m_jet_constit_pt    );
     m_tree->Branch((jetName+"_constituent_eta").c_str(),    &thisJet->m_jet_constit_eta   );
@@ -1621,7 +1623,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_constituent_e").c_str(),    &thisJet->m_jet_constit_e     );
   }
 
-  if( m_jetInfoSwitch->m_flavTag ) {
+  if( m_thisJetInfoSwitch[jetName]->m_flavTag ) {
     if ( !m_DC14 ) {
       m_tree->Branch((jetName+"_SV0").c_str(),           &thisJet->m_jet_sv0);
       m_tree->Branch((jetName+"_SV1").c_str(),           &thisJet->m_jet_sv1);
@@ -1634,9 +1636,9 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_HadronConeExclTruthLabelID").c_str(), &thisJet->m_jet_hadConeExclTruthLabel);
   }
 
-  if( !m_jetInfoSwitch->m_sfFTagFix.empty() ) {
-    for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFix.size(); i++ ) {
-      switch( m_jetInfoSwitch->m_sfFTagFix.at(i) ) {
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFix.empty() ) {
+    for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFix.size(); i++ ) {
+      switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFix.at(i) ) {
         case 30 :
 	  m_tree->Branch(("n"+jetName+"s_mv2c20_Fix30").c_str(),   &thisJet->m_njet_mv2c20_Fix30,("n"+jetName+"s_mv2c20_Fix30/I").c_str());
           m_tree->Branch((jetName+"_MV2c20_isFix30").c_str(),   &thisJet->m_jet_mv2c20_isFix30);
@@ -1702,15 +1704,15 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 	  }
           break;
         default:
-          std::cout << "BTag Fixed operating point of " << m_jetInfoSwitch->m_sfFTagFix.at(i)
+          std::cout << "BTag Fixed operating point of " << m_thisJetInfoSwitch[jetName]->m_sfFTagFix.at(i)
             << " is unknown to xAH" << std::endl;
       }
     }
   } // sfFTagFix
 
-  if( !m_jetInfoSwitch->m_sfFTagFlt.empty() ) {
-    for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFlt.size(); i++ ) {
-      switch( m_jetInfoSwitch->m_sfFTagFlt.at(i) ) {
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.empty() ) {
+    for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.size(); i++ ) {
+      switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.at(i) ) {
         case 30 :
 	  m_tree->Branch(("n"+jetName+"s_mv2c20_Flt30").c_str(),   &thisJet->m_njet_mv2c20_Flt30,("n"+jetName+"s_mv2c20_Flt30/I").c_str());
           m_tree->Branch((jetName+"_MV2c20_isFlt30").c_str(),   &thisJet->m_jet_mv2c20_isFlt30);
@@ -1768,13 +1770,13 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 	  }
           break;
         default:
-          std::cout << "BTag Flat operating point of " << m_jetInfoSwitch->m_sfFTagFlt.at(i)
+          std::cout << "BTag Flat operating point of " << m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.at(i)
             << " is unknown to xAH" << std::endl;
       }
     }
   } // sfFTagFlt
 
-  if( m_jetInfoSwitch->m_area ) {
+  if( m_thisJetInfoSwitch[jetName]->m_area ) {
     m_tree->Branch((jetName+"_GhostArea").c_str(),     &thisJet->m_jet_ghostArea);
     m_tree->Branch((jetName+"_ActiveArea").c_str(),    &thisJet->m_jet_activeArea);
     m_tree->Branch((jetName+"_VoronoiArea").c_str(),   &thisJet->m_jet_voronoiArea);
@@ -1784,7 +1786,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_ActiveArea4vec_m").c_str(),   &thisJet->m_jet_activeArea_m);
   }
 
-  if ( m_jetInfoSwitch->m_truth && m_isMC ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truth && m_isMC ) {
     m_tree->Branch((jetName+"_ConeTruthLabelID").c_str(),   &thisJet->m_jet_truthConeLabelID );
     m_tree->Branch((jetName+"_TruthCount").c_str(),         &thisJet->m_jet_truthCount     );
 //    m_tree->Branch((jetName+"_TruthPt").c_str(),            &thisJet->m_jet_truthPt        );
@@ -1799,7 +1801,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_truth_eta").c_str(), &thisJet->m_jet_truth_eta);
   }
 
-  if ( m_jetInfoSwitch->m_truthDetails ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truthDetails ) {
     m_tree->Branch((jetName+"_GhostBHadronsFinalCount").c_str(),   &thisJet->m_jet_truthCount_BhadFinal );
     m_tree->Branch((jetName+"_GhostBHadronsInitialCount").c_str(), &thisJet->m_jet_truthCount_BhadInit  );
     m_tree->Branch((jetName+"_GhostBQuarksFinalCount").c_str(),    &thisJet->m_jet_truthCount_BQFinal   );
@@ -1822,7 +1824,9 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
     m_tree->Branch((jetName+"_truth_partonDR").c_str(), &thisJet->m_jet_truth_partonDR);
   }
 
+
   this->AddJetsUser(detailStr, jetName);
+    
 }
 
 
@@ -1832,7 +1836,8 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
 
   const xAOD::VertexContainer* vertices(nullptr);
   const xAOD::Vertex *pv = 0;
-  if( m_jetInfoSwitch->m_trackPV || m_jetInfoSwitch->m_allTrack ) {
+    
+  if( m_thisJetInfoSwitch[jetName]->m_trackPV || m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     HelperFunctions::retrieve( vertices, "PrimaryVertices", m_event, 0 );
     pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
     pv = vertices->at( pvLocation );
@@ -1848,9 +1853,9 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
     HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, false);
 
 
-    if( !m_jetInfoSwitch->m_sfFTagFix.empty() ) {
-      for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFix.size(); i++ ) {
-    	switch( m_jetInfoSwitch->m_sfFTagFix.at(i) ) {
+    if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFix.empty() ) {
+      for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFix.size(); i++ ) {
+    	switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFix.at(i) ) {
     	  case 30 :
             static SG::AuxElement::ConstAccessor< std::vector<float> > sfFix30_GLOBAL("BTag_SF_FixedCutBEff_30_GLOBAL");
             if ( sfFix30_GLOBAL.isAvailable( *eventInfo ) ) { thisJet->m_weight_jet_mv2c20_sfFix30 = sfFix30_GLOBAL( *eventInfo ); } else { thisJet->m_weight_jet_mv2c20_sfFix30.push_back(-999.0); }
@@ -1887,9 +1892,9 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
       }
     } // sfFTagFix
 
-    if( !m_jetInfoSwitch->m_sfFTagFlt.empty() ) {
-      for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFlt.size(); i++ ) {
-    	switch( m_jetInfoSwitch->m_sfFTagFlt.at(i) ) {
+    if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.empty() ) {
+      for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.size(); i++ ) {
+    	switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.at(i) ) {
     	  case 30 :
             static SG::AuxElement::ConstAccessor< std::vector<float> > sfFlt30_GLOBAL("BTag_SF_FlatBEff_30_GLOBAL");
             if ( sfFlt30_GLOBAL.isAvailable( *eventInfo ) ) { thisJet->m_weight_jet_mv2c20_sfFlt30 = sfFlt30_GLOBAL( *eventInfo ); } else { thisJet->m_weight_jet_mv2c20_sfFlt30.push_back(-999.0); }
@@ -1936,7 +1941,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     
   jetInfo* thisJet = m_jets[jetName];
 
-  if( m_jetInfoSwitch->m_kinematic ){
+  if( m_thisJetInfoSwitch[jetName]->m_kinematic ){
     thisJet->m_jet_pt.push_back ( jet_itr->pt() / m_units );
     thisJet->m_jet_eta.push_back( jet_itr->eta() );
     thisJet->m_jet_phi.push_back( jet_itr->phi() );
@@ -1944,11 +1949,11 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
   }
 
 
-  if( m_jetInfoSwitch->m_rapidity ){
+  if( m_thisJetInfoSwitch[jetName]->m_rapidity ){
     thisJet->m_jet_rapidity.push_back( jet_itr->rapidity() );
   }
 
-  if (m_jetInfoSwitch->m_clean) {
+  if (m_thisJetInfoSwitch[jetName]->m_clean) {
 
     static SG::AuxElement::ConstAccessor<float> jetTime ("Timing");
     safeFill<float, float>(jet_itr, jetTime, thisJet->m_jet_time, -999);
@@ -2009,7 +2014,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 
   } // clean
 
-  if ( m_jetInfoSwitch->m_energy ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_energy ) {
 
     static SG::AuxElement::ConstAccessor<float> HECf ("HECFrac");
     safeFill<float, float>(jet_itr, HECf, thisJet->m_jet_HECf, -999);
@@ -2039,7 +2044,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 
 
     // each step of the calibration sequence
-  if ( m_jetInfoSwitch->m_scales ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_scales ) {
     xAOD::JetFourMom_t fourVec;
     bool status(false);
     // EM Scale
@@ -2072,7 +2077,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     else { thisJet->m_jet_insituPt.push_back( -999 ); }
   }
 
-  if ( m_jetInfoSwitch->m_layer ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_layer ) {
     static SG::AuxElement::ConstAccessor< std::vector<float> > ePerSamp ("EnergyPerSampling");
     if ( ePerSamp.isAvailable( *jet_itr ) ) {
       thisJet->m_jet_ePerSamp.push_back( ePerSamp( *jet_itr ) );
@@ -2089,8 +2094,8 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
   }
 
-  if ( m_jetInfoSwitch->m_trackAll || m_jetInfoSwitch->m_trackPV ) {
-
+    
+  if ( m_thisJetInfoSwitch[jetName]->m_trackAll || m_thisJetInfoSwitch[jetName]->m_trackPV ) {
 
     // several moments calculated from all verticies
     // one accessor for each and just use appropiately in the following
@@ -2102,7 +2107,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     static SG::AuxElement::ConstAccessor< std::vector<float> > trkWidth500 ("TrackWidthPt500");
     static SG::AuxElement::ConstAccessor< std::vector<float> > jvf("JVF");
 
-    if ( m_jetInfoSwitch->m_trackAll ) {
+    if ( m_thisJetInfoSwitch[jetName]->m_trackAll ) {
 
       std::vector<int> junkInt(1,-999);
       std::vector<float> junkFlt(1,-999);
@@ -2144,8 +2149,8 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
       } else { thisJet->m_jet_jvf.push_back( junkFlt ); }
 
     } // trackAll
-
-    if ( m_jetInfoSwitch->m_trackPV && pvLocation >= 0 ) {
+      
+    if ( m_thisJetInfoSwitch[jetName]->m_trackPV && pvLocation >= 0 ) {
 
       if ( nTrk1000.isAvailable( *jet_itr ) ) {
 	thisJet->m_jet_NTrkPt1000PV.push_back( nTrk1000( *jet_itr )[pvLocation] );
@@ -2199,7 +2204,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 
   }
 
-  if ( m_jetInfoSwitch->m_allTrack ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     static SG::AuxElement::ConstAccessor< int > ghostTrackCount("GhostTrackCount");
     if ( ghostTrackCount.isAvailable( *jet_itr ) ) {
       thisJet->m_jet_GhostTrackCount.push_back( ghostTrackCount( *jet_itr ) );
@@ -2234,7 +2239,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 	if( !link_itr.isValid() ) { continue; }
 	const xAOD::TrackParticle* track = dynamic_cast<const xAOD::TrackParticle*>( *link_itr );
 	// if asking for tracks passing PV selection ( i.e. JVF JVT tracks )
-	if( m_jetInfoSwitch->m_allTrackPVSel ) {
+	if( m_thisJetInfoSwitch[jetName]->m_allTrackPVSel ) {
 	  // PV selection from
 	  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JvtManualRecalculation
 	  if( track->pt() < 500 )                { continue; } // pT cut
@@ -2251,7 +2256,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 	e.  push_back( track->e()  / m_units );
 	d0. push_back( track->d0() );
 	z0. push_back( track->z0() + track->vz() - pv->z() ); // store z0 wrt PV...most useful
-	if( m_jetInfoSwitch->m_allTrackDetail ) {
+	if( m_thisJetInfoSwitch[jetName]->m_allTrackDetail ) {
 	  uint8_t getInt(0);
 	  // n pix, sct, trt
 	  track->summaryValue( getInt, xAOD::numberOfPixelHits );
@@ -2289,7 +2294,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     thisJet->m_jet_GhostTrack_e.  push_back( e   );
     thisJet->m_jet_GhostTrack_d0. push_back( d0  );
     thisJet->m_jet_GhostTrack_z0. push_back( z0  );
-    if( m_jetInfoSwitch->m_allTrackDetail ) {
+    if( m_thisJetInfoSwitch[jetName]->m_allTrackDetail ) {
       thisJet->m_jet_GhostTrack_nPixHits.push_back( nPixHits );
       thisJet->m_jet_GhostTrack_nSCTHits.push_back( nSCTHits );
       thisJet->m_jet_GhostTrack_nTRTHits.push_back( nTRTHits );
@@ -2304,11 +2309,11 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
   } // allTrack switch
 
-  if( m_jetInfoSwitch->m_constituent ) {
+  if( m_thisJetInfoSwitch[jetName]->m_constituent ) {
     thisJet->m_jet_numConstituents.push_back( jet_itr->numConstituents() );
   }
 
-  if( m_jetInfoSwitch->m_constituentAll ) {
+  if( m_thisJetInfoSwitch[jetName]->m_constituentAll ) {
     thisJet->m_jet_constitWeights.push_back( jet_itr->getAttribute< std::vector<float> >( "constituentWeights" ) );
     std::vector<float> pt;
     std::vector<float> eta;
@@ -2335,7 +2340,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     thisJet->m_jet_constit_e.  push_back( e   );
   }
 
-  if ( m_jetInfoSwitch->m_flavTag) {
+  if ( m_thisJetInfoSwitch[jetName]->m_flavTag) {
     const xAOD::BTagging * myBTag = jet_itr->btagging();
     if ( !m_DC14 ) {
 
@@ -2362,9 +2367,9 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 
   }
 
-  if( !m_jetInfoSwitch->m_sfFTagFix.empty() ) {
-    for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFix.size(); i++ ) {
-      switch( m_jetInfoSwitch->m_sfFTagFix.at(i) ) {
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFix.empty() ) {
+    for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFix.size(); i++ ) {
+      switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFix.at(i) ) {
       case 30 : this->Fill_Fix30( jet_itr, thisJet );
 	break;
       case 50 : this->Fill_Fix50( jet_itr, thisJet );
@@ -2385,9 +2390,9 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
   } // sfFTagFix
 
-  if( !m_jetInfoSwitch->m_sfFTagFlt.empty() ) {
-    for( unsigned int i=0; i<m_jetInfoSwitch->m_sfFTagFlt.size(); i++ ) {
-      switch( m_jetInfoSwitch->m_sfFTagFlt.at(i) ) {
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.empty() ) {
+    for( unsigned int i=0; i<m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.size(); i++ ) {
+      switch( m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.at(i) ) {
       case 30 : this->Fill_Flt30( jet_itr, thisJet );
 	break;
       case 40 : this->Fill_Flt40( jet_itr, thisJet );
@@ -2406,7 +2411,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
   } // sfFTagFlt
 
-  if ( m_jetInfoSwitch->m_area ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_area ) {
 
     static SG::AuxElement::ConstAccessor<float> ghostArea("JetGhostArea");
     safeFill<float, float>(jet_itr, ghostArea, thisJet->m_jet_ghostArea, -999);
@@ -2430,7 +2435,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     safeFill<float, float>(jet_itr, activeArea_m, thisJet->m_jet_activeArea_m, -999);
   }
 
-  if ( m_jetInfoSwitch->m_truth && m_isMC ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truth && m_isMC ) {
 
     static SG::AuxElement::ConstAccessor<int> ConeTruthLabelID ("ConeTruthLabelID");
     safeFill<int, int>(jet_itr, ConeTruthLabelID, thisJet->m_jet_truthConeLabelID, -999);
@@ -2474,7 +2479,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
 
   }
 
-  if ( m_jetInfoSwitch->m_truthDetails ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truthDetails ) {
 
     //
     // B-Hadron Details
@@ -2563,7 +2568,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   jetInfo* thisJet = m_jets[jetName];
 
   thisJet->N = 0;
-  if( m_jetInfoSwitch->m_kinematic ){
+  if( m_thisJetInfoSwitch[jetName]->m_kinematic ){
     thisJet->m_jet_pt.clear();
     thisJet->m_jet_eta.clear();
     thisJet->m_jet_phi.clear();
@@ -2572,12 +2577,12 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
 
 
   // rapidity
-  if( m_jetInfoSwitch->m_rapidity ) {
+  if( m_thisJetInfoSwitch[jetName]->m_rapidity ) {
     thisJet->m_jet_rapidity.clear();
   }
 
   // clean
-  if( m_jetInfoSwitch->m_clean ) {
+  if( m_thisJetInfoSwitch[jetName]->m_clean ) {
     thisJet->m_jet_time.clear();
     thisJet->m_jet_LArQuality.clear();
     thisJet->m_jet_hecq.clear();
@@ -2600,7 +2605,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // energy
-  if ( m_jetInfoSwitch->m_energy ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_energy ) {
     thisJet->m_jet_HECf.clear();
     thisJet->m_jet_EMf.clear();
     thisJet->m_jet_centroidR.clear();
@@ -2612,7 +2617,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // each step of the calibration sequence
-  if ( m_jetInfoSwitch->m_scales ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_scales ) {
     thisJet->m_jet_emPt.clear();
     thisJet->m_jet_constPt.clear();
     thisJet->m_jet_pileupPt.clear();
@@ -2623,12 +2628,12 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // layer
-  if ( m_jetInfoSwitch->m_layer ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_layer ) {
     thisJet->m_jet_ePerSamp.clear();
   }
 
   // trackAll
-  if ( m_jetInfoSwitch->m_trackAll ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_trackAll ) {
     thisJet->m_jet_NTrkPt1000.clear();
     thisJet->m_jet_SumPtPt1000.clear();
     thisJet->m_jet_TrkWPt1000.clear();
@@ -2640,7 +2645,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // trackPV
-  if ( m_jetInfoSwitch->m_trackPV ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_trackPV ) {
     thisJet->m_jet_NTrkPt1000PV.clear();
     thisJet->m_jet_SumPtPt1000PV.clear();
     thisJet->m_jet_TrkWPt1000PV.clear();
@@ -2650,7 +2655,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     thisJet->m_jet_jvfPV.clear();
   }
 
-  if ( m_jetInfoSwitch->m_trackAll || m_jetInfoSwitch->m_trackPV ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_trackAll || m_thisJetInfoSwitch[jetName]->m_trackPV ) {
     thisJet->m_jet_Jvt.clear();
     thisJet->m_jet_JvtJvfcorr.clear();
     thisJet->m_jet_JvtRpt.clear();
@@ -2658,7 +2663,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
 
-  if ( m_jetInfoSwitch->m_allTrack ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     thisJet->m_jet_GhostTrackCount.clear();
     thisJet->m_jet_GhostTrackPt.clear();
     thisJet->m_jet_GhostTrack_pt.clear();
@@ -2668,7 +2673,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     thisJet->m_jet_GhostTrack_e.clear();
     thisJet->m_jet_GhostTrack_d0.clear();
     thisJet->m_jet_GhostTrack_z0.clear();
-    if ( m_jetInfoSwitch->m_allTrackDetail ) {
+    if ( m_thisJetInfoSwitch[jetName]->m_allTrackDetail ) {
       thisJet->m_jet_GhostTrack_nPixHits.clear();
       thisJet->m_jet_GhostTrack_nSCTHits.clear();
       thisJet->m_jet_GhostTrack_nTRTHits.clear();
@@ -2683,11 +2688,11 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     }
   }
 
-  if( m_jetInfoSwitch->m_constituent ) {
+  if( m_thisJetInfoSwitch[jetName]->m_constituent ) {
     thisJet->m_jet_numConstituents.clear();
   }
 
-  if( m_jetInfoSwitch->m_constituentAll ) {
+  if( m_thisJetInfoSwitch[jetName]->m_constituentAll ) {
     thisJet->m_jet_constitWeights.clear();
     thisJet->m_jet_constit_pt.clear();
     thisJet->m_jet_constit_eta.clear();
@@ -2696,7 +2701,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // flavor tag
-  if ( m_jetInfoSwitch->m_flavTag ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_flavTag ) {
     thisJet->m_jet_sv0.clear();
     thisJet->m_jet_sv1.clear();
     thisJet->m_jet_ip3d.clear();
@@ -2707,7 +2712,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     thisJet->m_jet_hadConeExclTruthLabel.clear();
   }
 
-  if( !m_jetInfoSwitch->m_sfFTagFix.empty() ) { // just clear them all....
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFix.empty() ) { // just clear them all....
 
     thisJet->m_njet_mv2c20_Fix30 = 0;
     thisJet->m_jet_mv2c20_isFix30.clear();
@@ -2750,7 +2755,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     thisJet->m_jet_mv2c20_sfFix90.clear();
   }
 
-  if( !m_jetInfoSwitch->m_sfFTagFlt.empty() ) { // just clear them all....
+  if( !m_thisJetInfoSwitch[jetName]->m_sfFTagFlt.empty() ) { // just clear them all....
 
     thisJet->m_njet_mv2c20_Flt30 = 0;
     thisJet->m_jet_mv2c20_isFlt30.clear();
@@ -2788,7 +2793,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
     thisJet->m_jet_mv2c20_sfFlt85.clear();
   }
 
-  if ( m_jetInfoSwitch->m_area ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_area ) {
     thisJet->m_jet_ghostArea.clear();
     thisJet->m_jet_activeArea.clear();
     thisJet->m_jet_voronoiArea.clear();
@@ -2799,7 +2804,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // truth
-  if ( m_jetInfoSwitch->m_truth && m_isMC ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truth && m_isMC ) {
     thisJet->m_jet_truthConeLabelID.clear();
     thisJet->m_jet_truthCount.clear();
     thisJet->m_jet_truthPt.clear();
@@ -2815,7 +2820,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
   }
 
   // truth_detail
-  if ( m_jetInfoSwitch->m_truthDetails ) {
+  if ( m_thisJetInfoSwitch[jetName]->m_truthDetails ) {
     thisJet->m_jet_truthCount_BhadFinal.clear();
     thisJet->m_jet_truthCount_BhadInit.clear();
     thisJet->m_jet_truthCount_BQFinal.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -89,13 +89,9 @@ HelpTreeBase::~HelpTreeBase() {
     delete m_metInfoSwitch;
     
     //jet
-    
-    std::map<std::string, HelperClasses::JetInfoSwitch*>::iterator jetInfoSwitchMap_itr = m_thisJetInfoSwitch.begin();
-    std::map<std::string, HelperClasses::JetInfoSwitch*>::iterator jetInfoSwitchMap_end = m_thisJetInfoSwitch.end();
-    for( ; jetInfoSwitchMap_itr != jetInfoSwitchMap_end; ++jetInfoSwitchMap_itr) {
-        delete jetInfoSwitchMap_itr->second;
-    }
-    
+
+    for(auto jetInfoSwitch: m_thisJetInfoSwitch)
+        delete jetInfoSwitch.second;    
     
 }
 

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -94,6 +94,14 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("bcid",               &m_bcid,           "bcid/I");
   }
 
+  if ( m_eventInfoSwitch->m_eventCleaning ) {
+    
+    m_tree->Branch("TileError",          &m_TileError,      "TileError/O");
+    m_tree->Branch("SCTError",           &m_SCTError,      "SCTError/O");
+    m_tree->Branch("LArError",           &m_LArError,      "LArError/O");
+
+  }
+    
   if ( m_eventInfoSwitch->m_pileup ) {
     m_tree->Branch("weight_pileup",      &m_weight_pileup,  "weight_pileup/F");
     m_tree->Branch("NPV",                &m_npv,            "NPV/I");
@@ -170,6 +178,19 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     m_mcEventWeight         = eventInfo->mcEventWeight();
   } else {
     m_bcid                  = eventInfo->bcid();
+  }
+    
+  if ( m_eventInfoSwitch->m_eventCleaning ) {
+      
+    if ( eventInfo->errorState(xAOD::EventInfo::LAr)==xAOD::EventInfo::Error ) m_LArError = true;
+    else m_LArError = false;
+    
+    if ( eventInfo->errorState(xAOD::EventInfo::Tile)==xAOD::EventInfo::Error ) m_TileError = true;
+    else m_TileError = false;
+    
+    if ( eventInfo->errorState(xAOD::EventInfo::SCT)==xAOD::EventInfo::Error ) m_SCTError = true;
+    else m_SCTError = false;
+
   }
 
   if ( m_eventInfoSwitch->m_pileup ) {
@@ -1912,7 +1933,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
 
 
 void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName ) {
-
+    
   jetInfo* thisJet = m_jets[jetName];
 
   if( m_jetInfoSwitch->m_kinematic ){
@@ -2529,10 +2550,11 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
 
   }
-
+    
   this->FillJetsUser(jet_itr, jetName);
-
   thisJet->N++;
+    
+  
   return;
 }
 
@@ -2957,6 +2979,10 @@ void HelpTreeBase::ClearFatJets() {
 void HelpTreeBase::ClearEvent() {
   m_runNumber = m_eventNumber = m_mcEventNumber = m_mcChannelNumber = m_bcid = m_lumiBlock;
   m_coreFlags = 0;
+  //eventCleaning
+  m_LArError = false;
+  m_TileError = false;
+  m_SCTError = false;
   m_mcEventWeight = 1.;
   m_weight_pileup = 1.;
   // pileup

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1883,7 +1883,6 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
     pv = vertices->at( pvLocation );
   }
 
-
   jetInfo* thisJet = m_jets[jetName];
 
   // Global event BTag SF weight (--> the product of each object's weight)
@@ -1967,7 +1966,6 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
       }
     } // sfFTagFlt
   }
-
 
   for( auto jet_itr : *jets ) {
     this->FillJet(jet_itr, pv, pvLocation, jetName);

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -416,7 +416,7 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
   // save a vector of strings holding passing decisions
   if ( m_trigInfoSwitch->m_passTriggers ) {
 
-    if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_passTriggers"); }
+    if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_passTriggers"); }
     static SG::AuxElement::ConstAccessor< std::vector< std::string > > passTrigs("passTriggers");
     if( passTrigs.isAvailable( *eventInfo ) ) { m_passTriggers = passTrigs( *eventInfo ); }
 

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -31,7 +31,6 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   m_muInfoSwitch(nullptr),
   m_elInfoSwitch(nullptr),
   m_phInfoSwitch(nullptr),
-  m_jetInfoSwitch(nullptr),
   m_truthInfoSwitch(nullptr),
   m_fatJetInfoSwitch(nullptr),
   m_tauInfoSwitch(nullptr),
@@ -57,6 +56,49 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
 }
+
+HelpTreeBase::~HelpTreeBase() {
+    
+    //delete all the info switches that have been built earlier on
+    
+    //event
+    delete m_eventInfoSwitch;
+    
+    //trig
+    delete m_trigInfoSwitch;
+    
+    //mu
+    delete m_muInfoSwitch;
+    
+    //el
+    delete m_elInfoSwitch;
+    
+    //ph
+    delete m_phInfoSwitch;
+    
+    //truth
+    delete m_truthInfoSwitch;
+    
+    //fatjet
+    delete m_fatJetInfoSwitch;
+    
+    //tau
+    delete m_tauInfoSwitch;
+    
+    //met
+    delete m_metInfoSwitch;
+    
+    //jet
+    
+    std::map<std::string, HelperClasses::JetInfoSwitch*>::iterator jetInfoSwitchMap_itr = m_thisJetInfoSwitch.begin();
+    std::map<std::string, HelperClasses::JetInfoSwitch*>::iterator jetInfoSwitchMap_end = m_thisJetInfoSwitch.end();
+    for( ; jetInfoSwitchMap_itr != jetInfoSwitchMap_end; ++jetInfoSwitchMap_itr) {
+        delete jetInfoSwitchMap_itr->second;
+    }
+    
+    
+}
+
 
 HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent* event, xAOD::TStore* store, const float units, bool debug, bool DC14):
   HelpTreeBase(event, tree, file, units, debug, DC14, store)
@@ -1483,8 +1525,6 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 {
 
   if(m_debug) Info("AddJets()", "Adding jet %s with variables: %s", jetName.c_str(), detailStr.c_str());
-
-  //m_jetInfoSwitch = new HelperClasses::JetInfoSwitch( detailStr );
   
   m_thisJetInfoSwitch[jetName] = new HelperClasses::JetInfoSwitch( detailStr );
     

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -152,12 +152,12 @@ EL::StatusCode  JetCalibrator :: configure ()
     m_applyFatJetPreSel       = config->GetValue("ApplyFatJetPreSel",       m_applyFatJetPreSel);
 
     m_redoJVT                 = config->GetValue("RedoJVT",         m_redoJVT);
+    
+    //set the flag for trigger jets
+    m_isTrigger                 = config->GetValue("TriggerJets",         m_isTrigger);
 
     config->Print();
-
-    //set the flag for trigger jets
-    if (m_inContainerName.find("HLT") != std::string::npos) m_isTrigger = true;
-        
+      
     delete config; config = nullptr;
   }
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -155,6 +155,9 @@ EL::StatusCode  JetCalibrator :: configure ()
 
     config->Print();
 
+    //set the flag for trigger jets
+    if (m_inContainerName.find("HLT") != std::string::npos) m_isTrigger = true;
+        
     delete config; config = nullptr;
   }
 

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -19,6 +19,7 @@
 #include <xAODAnaHelpers/MuonCalibrator.h>
 /*#include <xAODAnaHelpers/GroomedFatJets.h>*/
 #include <xAODAnaHelpers/HLTJetRoIBuilder.h>
+#include <xAODAnaHelpers/HLTJetGetter.h>
 
 /* Missing Energy Reconstruction */
 #include <xAODAnaHelpers/METConstructor.h>
@@ -68,6 +69,7 @@
 #pragma link C++ class JetCalibrator+;
 #pragma link C++ class HLTJetRoIBuilder+;
 #pragma link C++ class MuonCalibrator+;
+#pragma link C++ class HLTJetGetter+;
 /*#pragma link C++ class GroomedFatJets+;*/
 
 #pragma link C++ class METConstructor+;

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -100,6 +100,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
 
   // get the file we created already
   TFile* treeFile = wk()->getOutputFile ("tree");
+    
   m_helpTree = new HelpTreeBase( m_event, outTree, treeFile, 1e3, m_debug, m_DC14 );
 
   // tell the tree to go into the file
@@ -180,6 +181,7 @@ EL::StatusCode TreeAlgo :: changeInput (bool /*firstFile*/) { return EL::StatusC
 
 EL::StatusCode TreeAlgo :: execute ()
 {
+    
   // Get EventInfo and the PrimaryVertices
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -30,6 +30,7 @@ TreeAlgo :: TreeAlgo (std::string className) :
   m_evtDetailStr            = "";
   m_trigDetailStr           = "";
   m_trigJetDetailStr        = "";
+  m_truthJetDetailStr       = "";
   m_muDetailStr             = "";
   m_elDetailStr             = "";
   m_jetDetailStr            = "";
@@ -115,6 +116,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
   if ( !m_elContainerName.empty() )     {   m_helpTree->AddElectrons  (m_elDetailStr);      }
   if ( !m_jetContainerName.empty() )    {   m_helpTree->AddJets       (m_jetDetailStr, "jet");     }
   if ( !m_trigJetContainerName.empty() ){   m_helpTree->AddJets       (m_trigJetDetailStr, "trigJet");     }
+  if ( !m_truthJetContainerName.empty() ){   m_helpTree->AddJets       (m_truthJetDetailStr, "truthJet");     }
   if ( !m_fatJetContainerName.empty() ) {   m_helpTree->AddFatJets    (m_fatJetDetailStr);  }
   if ( !m_tauContainerName.empty() )    {   m_helpTree->AddTaus       (m_tauDetailStr);     }
   if ( !m_METContainerName.empty() )    {   m_helpTree->AddMET        (m_METDetailStr);     }
@@ -136,6 +138,7 @@ EL::StatusCode TreeAlgo :: configure ()
     m_trigJetDetailStr        = config->GetValue("TrigJetDetailStr",     m_trigJetDetailStr.c_str());
     m_muDetailStr             = config->GetValue("MuonDetailStr",        m_muDetailStr.c_str());
     m_elDetailStr             = config->GetValue("ElectronDetailStr",    m_elDetailStr.c_str());
+    m_truthJetDetailStr       = config->GetValue("TruthJetDetailStr",    m_truthJetDetailStr.c_str());
     m_jetDetailStr            = config->GetValue("JetDetailStr",         m_jetDetailStr.c_str());
     m_fatJetDetailStr         = config->GetValue("FatJetDetailStr",      m_fatJetDetailStr.c_str());
     m_tauDetailStr            = config->GetValue("TauDetailStr",         m_tauDetailStr.c_str());
@@ -149,6 +152,7 @@ EL::StatusCode TreeAlgo :: configure ()
     m_muContainerName         = config->GetValue("MuonContainerName",       m_muContainerName.c_str());
     m_elContainerName         = config->GetValue("ElectronContainerName",   m_elContainerName.c_str());
     m_jetContainerName        = config->GetValue("JetContainerName",        m_jetContainerName.c_str());
+    m_truthJetContainerName   = config->GetValue("TruthJetContainerName",   m_truthJetContainerName.c_str());
     m_trigJetContainerName    = config->GetValue("TrigJetContainerName",    m_trigJetContainerName.c_str());
     m_fatJetContainerName     = config->GetValue("FatJetContainerName",     m_fatJetContainerName.c_str());
     m_tauContainerName        = config->GetValue("TauContainerName",        m_tauContainerName.c_str());
@@ -217,6 +221,11 @@ EL::StatusCode TreeAlgo :: execute ()
     const xAOD::JetContainer* inTrigJets(nullptr);
     RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrigJets, m_trigJetContainerName, m_event, m_store, m_verbose) ,"");
     m_helpTree->FillJets( inTrigJets, HelperFunctions::getPrimaryVertexLocation(vertices), "trigJet" );
+  }
+  if ( !m_truthJetContainerName.empty() ) {
+    const xAOD::JetContainer* inTruthJets(nullptr);
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthJets, m_truthJetContainerName, m_event, m_store, m_verbose) ,"");
+        m_helpTree->FillJets( inTruthJets, HelperFunctions::getPrimaryVertexLocation(vertices), "truthJet" );
   }
   if ( !m_fatJetContainerName.empty() ) {
     const xAOD::JetContainer* inFatJets(nullptr);

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -29,7 +29,7 @@ TreeAlgo :: TreeAlgo (std::string className) :
 
   m_evtDetailStr            = "";
   m_trigDetailStr           = "";
-  m_jetTrigDetailStr        = "";
+  m_trigJetDetailStr        = "";
   m_muDetailStr             = "";
   m_elDetailStr             = "";
   m_jetDetailStr            = "";
@@ -111,10 +111,10 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
   m_helpTree->AddEvent( m_evtDetailStr );
 
   if ( !m_trigDetailStr.empty() )       {   m_helpTree->AddTrigger    (m_trigDetailStr);    }
-  if ( !m_jetTrigDetailStr.empty() )    {   m_helpTree->AddJetTrigger (m_jetTrigDetailStr); }
   if ( !m_muContainerName.empty() )     {   m_helpTree->AddMuons      (m_muDetailStr);      }
   if ( !m_elContainerName.empty() )     {   m_helpTree->AddElectrons  (m_elDetailStr);      }
-  if ( !m_jetContainerName.empty() )    {   m_helpTree->AddJets       (m_jetDetailStr);     }
+  if ( !m_jetContainerName.empty() )    {   m_helpTree->AddJets       (m_jetDetailStr, "jet");     }
+  if ( !m_trigJetContainerName.empty() ){   m_helpTree->AddJets       (m_trigJetDetailStr, "trigJet");     }
   if ( !m_fatJetContainerName.empty() ) {   m_helpTree->AddFatJets    (m_fatJetDetailStr);  }
   if ( !m_tauContainerName.empty() )    {   m_helpTree->AddTaus       (m_tauDetailStr);     }
   if ( !m_METContainerName.empty() )    {   m_helpTree->AddMET        (m_METDetailStr);     }
@@ -133,7 +133,7 @@ EL::StatusCode TreeAlgo :: configure ()
     TEnv* config = new TEnv(getConfig(true).c_str());
     m_evtDetailStr            = config->GetValue("EventDetailStr",       m_evtDetailStr.c_str());
     m_trigDetailStr           = config->GetValue("TrigDetailStr",        m_trigDetailStr.c_str());
-    m_jetTrigDetailStr        = config->GetValue("JetTrigDetailStr",     m_jetTrigDetailStr.c_str());
+    m_trigJetDetailStr        = config->GetValue("TrigJetDetailStr",     m_trigJetDetailStr.c_str());
     m_muDetailStr             = config->GetValue("MuonDetailStr",        m_muDetailStr.c_str());
     m_elDetailStr             = config->GetValue("ElectronDetailStr",    m_elDetailStr.c_str());
     m_jetDetailStr            = config->GetValue("JetDetailStr",         m_jetDetailStr.c_str());
@@ -149,6 +149,7 @@ EL::StatusCode TreeAlgo :: configure ()
     m_muContainerName         = config->GetValue("MuonContainerName",       m_muContainerName.c_str());
     m_elContainerName         = config->GetValue("ElectronContainerName",   m_elContainerName.c_str());
     m_jetContainerName        = config->GetValue("JetContainerName",        m_jetContainerName.c_str());
+    m_trigJetContainerName    = config->GetValue("TrigJetContainerName",    m_trigJetContainerName.c_str());
     m_fatJetContainerName     = config->GetValue("FatJetContainerName",     m_fatJetContainerName.c_str());
     m_tauContainerName        = config->GetValue("TauContainerName",        m_tauContainerName.c_str());
     m_METContainerName        = config->GetValue("METContainerName",        m_METContainerName.c_str());
@@ -190,10 +191,10 @@ EL::StatusCode TreeAlgo :: execute ()
     m_helpTree->FillTrigger( eventInfo );
   }
 
-  // Fill jet trigger information
-  if ( !m_jetTrigDetailStr.empty() ) {
+  // Fill jet trigger information - this can be used if with layer/cleaning info we need to turn off some variables?
+  /*if ( !m_trigJetDetailStr.empty() ) {
     m_helpTree->FillJetTrigger();
-  }
+  }*/
 
   // for the containers the were supplied, fill the appropriate vectors
   if ( !m_muContainerName.empty() ) {
@@ -210,7 +211,12 @@ EL::StatusCode TreeAlgo :: execute ()
   if ( !m_jetContainerName.empty() ) {
     const xAOD::JetContainer* inJets(nullptr);
     RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainerName, m_event, m_store, m_verbose) ,"");
-    m_helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices) );
+    m_helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices), "jet" );
+  }
+  if ( !m_trigJetContainerName.empty() ) {
+    const xAOD::JetContainer* inTrigJets(nullptr);
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrigJets, m_trigJetContainerName, m_event, m_store, m_verbose) ,"");
+    m_helpTree->FillJets( inTrigJets, HelperFunctions::getPrimaryVertexLocation(vertices), "trigJet" );
   }
   if ( !m_fatJetContainerName.empty() ) {
     const xAOD::JetContainer* inFatJets(nullptr);

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -4,6 +4,7 @@ API Reference
 .. toctree::
    :maxdepth: 4
 
+   Getters
    Calibrators
    Correctors
    Selectors

--- a/docs/Algorithms.rst
+++ b/docs/Algorithms.rst
@@ -37,6 +37,20 @@ https://github.com/UCATLAS/xAODAnaHelpers/wiki/xAH\_BasicEventSelection.h
 Jet Related
 -----------
 
+HLTJetGetter
+~~~~~~~~~~~~~
+
+The HLTJetGetter Algorithm retrieves jets from the TrigDecisionTool.
+The output is a shallow copy of the trigger feature that is requested
+via the combination of the name of the jet collection (m_inContainerName) and
+the jet trigger that is selected m_triggerList. The name of the copy
+is chosen via the m_outContainerName.
+The input container name should be given without any HLT_xAOD__JetContainer prefix
+if the collection comes directly from the xAOD.
+The list of triggers must be given as a regular expression using an or (|) if
+more than a trigger is requested. To request all triggers, use \*.
+
+
 JetCalibrator
 ~~~~~~~~~~~~~
 

--- a/docs/Getters.rst
+++ b/docs/Getters.rst
@@ -1,8 +1,8 @@
 Getting Objects
-=================
+===============
 
 .. toctree::
-:maxdepth: 2
+   :maxdepth: 2
 
-HLTJetGetter
+   HLTJetGetter
 

--- a/docs/Getters.rst
+++ b/docs/Getters.rst
@@ -1,0 +1,8 @@
+Getting Objects
+=================
+
+.. toctree::
+:maxdepth: 2
+
+HLTJetGetter
+

--- a/docs/HLTJetGetter.rst
+++ b/docs/HLTJetGetter.rst
@@ -1,0 +1,9 @@
+HLT jet getter
+=====================
+
+.. doxygenclass:: HLTJetGetter
+:members:
+:undoc-members:
+:protected-members:
+:private-members:
+

--- a/docs/HLTJetGetter.rst
+++ b/docs/HLTJetGetter.rst
@@ -1,9 +1,9 @@
 HLT jet getter
-=====================
+==============
 
 .. doxygenclass:: HLTJetGetter
-:members:
-:undoc-members:
-:protected-members:
-:private-members:
+   :members:
+   :undoc-members:
+   :protected-members:
+   :private-members:
 

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -28,13 +28,9 @@ class HLTJetGetter : public xAH::Algorithm
 public:
 
   // configuration variables
-  //std::string m_trigItem;
   std::string m_triggerList; /* List of triggers whose features will be extracted from TDT */
   std::string m_inContainerName; /* input container name */
   std::string m_outContainerName; /* output container name */
-
-  // sort after calibration
-  //bool    m_sort;
 
 private:
 

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -17,8 +17,12 @@
 #include "xAODAnaHelpers/Algorithm.h"
 
 
+namespace TrigConf {
+    class xAODConfigTool;
+}
+
 namespace Trig {
-  class TrigDecisionTool;
+    class TrigDecisionTool;
 }
 
 
@@ -34,7 +38,8 @@ public:
 
 private:
 
-  Trig::TrigDecisionTool*      m_trigDecTool;   //!
+  Trig::TrigDecisionTool*        m_trigDecTool;   //!
+  TrigConf::xAODConfigTool*      m_trigConfTool;   //!
 
 public:
 

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -1,0 +1,65 @@
+/******************************************
+ *
+ * This class gets HLT jets from the TDT and can be expanded to get other features
+ *
+ * Merlin Davies (merlin.davies@cern.ch)
+ * Caterina Doglioni (caterina.doglioni@cern.ch)
+ * John Alison (john.alison@cern.ch)
+ *
+ *
+ ******************************************/
+
+#ifndef xAODAnaHelpers_HLTJetGetter_H
+#define xAODAnaHelpers_HLTJetGetter_H
+
+
+// algorithm wrapper
+#include "xAODAnaHelpers/Algorithm.h"
+
+
+namespace Trig {
+  class TrigDecisionTool;
+}
+
+
+class HLTJetGetter : public xAH::Algorithm
+{
+
+public:
+
+  // configuration variables
+  std::string m_trigItem;
+  std::string m_outContainerName;
+
+  // sort after calibration
+  bool    m_sort;
+
+private:
+
+  Trig::TrigDecisionTool*      m_trigDecTool;   //!
+
+public:
+
+  // this is a standard constructor
+  HLTJetGetter (std::string className = "HLTJetGetter");
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+
+
+  /// @cond
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(HLTJetGetter, 1);
+  /// @endcond
+
+};
+
+#endif

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -27,10 +27,10 @@ class HLTJetGetter : public xAH::Algorithm
 
 public:
 
-  // configuration variables
-  std::string m_triggerList; /* List of triggers whose features will be extracted from TDT */
-  std::string m_inContainerName; /* input container name */
-  std::string m_outContainerName; /* output container name */
+  /* configuration variables */
+  std::string m_triggerList; // List of triggers whose features will be extracted from TDT
+  std::string m_inContainerName; // input container name, WITHOUT the HLT_xAOD__JetContainer_ prefix
+  std::string m_outContainerName; // output container name
 
 private:
 

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -28,11 +28,13 @@ class HLTJetGetter : public xAH::Algorithm
 public:
 
   // configuration variables
-  std::string m_trigItem;
-  std::string m_outContainerName;
+  //std::string m_trigItem;
+  std::string m_triggerList; /* List of triggers whose features will be extracted from TDT */
+  std::string m_inContainerName; /* input container name */
+  std::string m_outContainerName; /* output container name */
 
   // sort after calibration
-  bool    m_sort;
+  //bool    m_sort;
 
 private:
 
@@ -54,6 +56,8 @@ public:
   virtual EL::StatusCode finalize ();
   virtual EL::StatusCode histFinalize ();
 
+  // these are the functions not inherited from Algorithm
+  virtual EL::StatusCode configure ();
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -206,6 +206,9 @@ protected:
   long int m_eventNumber;
   int m_lumiBlock;
   uint32_t m_coreFlags;
+  bool m_TileError;
+  bool m_LArError;
+  bool m_SCTError;
   int m_mcEventNumber;
   int m_mcChannelNumber;
   float m_mcEventWeight;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -51,7 +51,7 @@ public:
 
   HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, bool DC14 = false, xAOD::TStore* store = nullptr );
   HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false, bool DC14 = false );
-  virtual ~HelpTreeBase() {;}
+  virtual ~HelpTreeBase();
 
   void AddEvent       (const std::string detailStr = "");
   void AddTrigger     (const std::string detailStr = "");
@@ -75,7 +75,6 @@ public:
   HelperClasses::MuonInfoSwitch*       m_muInfoSwitch;
   HelperClasses::ElectronInfoSwitch*   m_elInfoSwitch;
   HelperClasses::PhotonInfoSwitch*     m_phInfoSwitch;
-  HelperClasses::JetInfoSwitch*        m_jetInfoSwitch;
   std::map<std::string, HelperClasses::JetInfoSwitch*> m_thisJetInfoSwitch;
   HelperClasses::TruthInfoSwitch*      m_truthInfoSwitch;
   HelperClasses::JetInfoSwitch*        m_fatJetInfoSwitch;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -76,6 +76,7 @@ public:
   HelperClasses::ElectronInfoSwitch*   m_elInfoSwitch;
   HelperClasses::PhotonInfoSwitch*     m_phInfoSwitch;
   HelperClasses::JetInfoSwitch*        m_jetInfoSwitch;
+  std::map<std::string, HelperClasses::JetInfoSwitch*> m_thisJetInfoSwitch;
   HelperClasses::TruthInfoSwitch*      m_truthInfoSwitch;
   HelperClasses::JetInfoSwitch*        m_fatJetInfoSwitch;
   HelperClasses::TauInfoSwitch*        m_tauInfoSwitch;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -123,20 +123,22 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::InfoSwitch` struct for Event Information.
 
-        ============== ============ =======
-        Parameter      Pattern      Match
-        ============== ============ =======
-        m_pileup       pileup       exact
-        m_shapeEM      shapeEM      exact
-        m_shapeLC      shapeLC      exact
-        m_truth        truth        exact
-        m_caloClus     caloClusters exact
-        m_muonSF       muonSF       exact
-        m_electronSF   electronSF   exact
-        ============== ============ =======
+        ================ ============== =======
+        Parameter        Pattern        Match
+        ================ ============== =======
+        m_pileup         pileup         exact
+        m_shapeEM        shapeEM        exact
+        m_shapeLC        shapeLC        exact
+        m_truth          truth          exact
+        m_caloClus       caloClusters   exact
+        m_muonSF         muonSF         exact
+        m_electronSF     electronSF     exact
+        m_eventCleaning  eventCleaning  exact
+        ================ ============== =======
     @endrst
    */
   struct EventInfoSwitch : InfoSwitch {
+    bool m_eventCleaning;
     bool m_pileup;
     bool m_shapeEM;
     bool m_shapeLC;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -46,9 +46,8 @@ public:
   std::string m_JESUncertMCType;
   bool m_setAFII;
     
-  // trigger flag (read from collection name)
-  bool m_isTrigger;
-
+  bool m_isTrigger; // whether the jet collection is trigger or not (soon: different calibrations)
+    
   std::string m_JERUncertConfig;
   bool m_JERFullSys;
   bool m_JERApplyNominal;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -34,7 +34,7 @@ public:
   // configuration variables
   std::string m_inContainerName;
   std::string m_outContainerName;
-
+    
   std::string m_jetAlgo;
   std::string m_outputAlgo;
   std::string m_calibConfigData;
@@ -45,6 +45,9 @@ public:
   std::string m_JESUncertConfig;
   std::string m_JESUncertMCType;
   bool m_setAFII;
+    
+  // trigger flag (read from collection name)
+  bool m_isTrigger;
 
   std::string m_JERUncertConfig;
   bool m_JERFullSys;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -19,7 +19,7 @@ public:
   // holds bools that control which branches are filled
   std::string m_evtDetailStr;
   std::string m_trigDetailStr;
-  std::string m_jetTrigDetailStr;
+  std::string m_trigJetDetailStr;
   std::string m_muDetailStr;
   std::string m_elDetailStr;
   std::string m_jetDetailStr;
@@ -32,6 +32,7 @@ public:
   std::string m_muContainerName;
   std::string m_elContainerName;
   std::string m_jetContainerName;
+  std::string m_trigJetContainerName;
   std::string m_fatJetContainerName;
   std::string m_tauContainerName;
   std::string m_METContainerName;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -23,6 +23,7 @@ public:
   std::string m_muDetailStr;
   std::string m_elDetailStr;
   std::string m_jetDetailStr;
+  std::string m_truthJetDetailStr;
   std::string m_fatJetDetailStr;
   std::string m_tauDetailStr;
   std::string m_METDetailStr;
@@ -32,6 +33,7 @@ public:
   std::string m_muContainerName;
   std::string m_elContainerName;
   std::string m_jetContainerName;
+  std::string m_truthJetContainerName;
   std::string m_trigJetContainerName;
   std::string m_fatJetContainerName;
   std::string m_tauContainerName;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -42,7 +42,7 @@ public:
 
   bool m_DC14;
 
-private:
+protected:
   HelpTreeBase* m_helpTree;            //!
 
 public:


### PR DESCRIPTION
Here's a rather big pull request for some changes that are needed for the Trigger-Level Analysis. 

Here's a summary of the changes:
   * Reco, trigger and truth jets can be in the same tree
   * Added HLTJetGetter class (+some initial docs) to retrieve trigger jets out of the TriggerDecisionTool
   * TriggerDecisionTool initialized in BasicEventSelection only if it's not already in the store
   * Some memory leaks and minor bugs fixed 
   * Allow HelpTreeBase to save the event-level cleaning flags 

The main change of this PR is that one can now extend the number of jet collections by having a different prefix for reco jets, trigger jets and truth jets in the same tree. Nothing will change if only one jet collection is requested, regardless of the type: the prefix in the tree will still be jet_[variable]. If trigger jets are requested in the config file, the prefix will be trigjet_[variable], while if truth jets are requested in the config file, the prefix will be truthjet_[variable]. This mirrors what's done for fat jets, but since the EDM is the same for all these collections the same function is used (just some variables won't be filled or throw an error if they are completely unavailable). 

Everything should be backwards compatible, meaning that the current configuration people use without asking for anything new should still work in the exact same way. In any case, since this is a large chunk of changes, I would appreciate it if other jetty developers also had a quick test within their analysis code before we merge it all in. 

The next PR will fill a few more small bugs and add a few features (e.g. allowing for an 'mjj' variable for various jet collections to be calculated in algorithms inheriting from TreeAlgo, making JetSelector work for trigger jets as well...) but I preferred to get rid of this big chunk first and make smaller incremental changes from now on.  

Thanks!
Caterina, for the TLA team