### PR TITLE
Changing "private" to "protected" in TreeAlgo

### DIFF
--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -39,7 +39,7 @@ public:
 
   bool m_DC14;
 
-private:
+protected:
   HelpTreeBase* m_helpTree;            //!
 
 public:


### PR DESCRIPTION
This change would allow users who are using derived classes from `xAH::HelpTreeBase` to re-implement *only* what is strictly necessary in their  `xAH::TreeAlgo`-derived algorithms for tree management (i.e., make better use of inheritance).

Making this change would allow something like this:

https://github.com/UCATLAS/ASG_AnalysisFrameworkReview

All in all, This change reflects exactly what has been done already in:

https://github.com/UCATLAS/xAODAnaHelpers/pull/361

@kratsg @gfacini @jdandoy does it make sense to you?
