### PR TITLE
Add virtual methods for managing "Lepton" objects in tree class

### DIFF
--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -64,6 +64,7 @@ public:
   void AddFatJets     (const std::string detailStr = "");
   void AddTaus        (const std::string detailStr = "");
   void AddMET         (const std::string detailStr = "");
+  virtual void AddLeptons() { };
 
   xAOD::TEvent* m_event;
   xAOD::TStore* m_store;
@@ -88,20 +89,18 @@ public:
   Trig::TrigDecisionTool*      m_trigDecTool;
 
   void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event = nullptr );
-
   void FillTrigger( const xAOD::EventInfo* eventInfo );
   void FillJetTrigger();
   void FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex );
   void FillElectrons( const xAOD::ElectronContainer* electrons, const xAOD::Vertex* primaryVertex );
   void FillPhotons( const xAOD::PhotonContainer* photons );
-
   void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string jetName = "jet" );
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
-
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillFatJets( const xAOD::JetContainer* fatJets );
   void FillTaus( const xAOD::TauJetContainer* taus );
   void FillMET( const xAOD::MissingETContainer* met );
+  virtual void FillLeptons( const xAOD::IParticleContainer* ) { };
 
   void Fill();
   void ClearEvent();
@@ -115,6 +114,7 @@ public:
   void ClearFatJets();
   void ClearTaus();
   void ClearMET();
+  virtual void ClearLeptons() { };
 
   bool writeTo( TFile *file );
 


### PR DESCRIPTION
In HTopMultilep analysis we have lepton_* branches (for electrons||muons objects) to be saved in the final tree.
This adds a set of virtual methods to the base tree class to be overridden in our derived tree class. The need of having this methods declared also in `HelpTreeBase` is b/c one wants to be able to do something like this in his own derived Tree algorithm class:

```
EL::StatusCode HTopMultilepTreeAlgo :: treeInitialize ()
{

  m_helpTree = new HTopMultilepTree( outTree, treeFile, m_event, m_store, 1e0, m_debug, m_DC14 ); // 1e0 = MeV, default 1e3 = GeV

  ...

  m_helpTree->AddEvent(m_evtDetailStr);
  if ( !m_muContainerName.empty() )      {   m_helpTree->AddMuons      (m_muDetailStr);      }
  if ( !m_elContainerName.empty() )      {   m_helpTree->AddElectrons  (m_elDetailStr);      }
  if ( !m_jetContainerName.empty() )     {   m_helpTree->AddJets       (m_jetDetailStr, "jet"); }
   ...
  if ( !m_lepContainerName.empty() )     {   m_helpTree->AddLeptons    ();                   }
}

```

where `m_helpTree` is the original member of class `xAH::HelpTreeBase`
