### PR TITLE
Update lepton SFs 

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -261,20 +261,21 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   Info("initialize()", "BTaggingSelectionTool initialized : %s ", m_BJetSelectTool->name().c_str() );
 
   //
-  // initialize the BJetEfficiencyCorrectionTool
-  //
-  std::string sf_tool_name = std::string("BJetEfficiencyCorrectionTool_") + m_name;
-  if ( asg::ToolStore::contains<BTaggingEfficiencyTool>( sf_tool_name ) ) {
-    m_BJetEffSFTool = asg::ToolStore::get<BTaggingEfficiencyTool>( sf_tool_name );
-  } else {
-    m_BJetEffSFTool = new BTaggingEfficiencyTool( sf_tool_name );
-  }
-  m_BJetEffSFTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO, ERROR
-
-  //
   //  Configure the BJetEfficiencyCorrectionTool
   //
   if( m_getScaleFactors ) {
+
+    //
+    // initialize the BJetEfficiencyCorrectionTool
+    //
+    std::string sf_tool_name = std::string("BJetEfficiencyCorrectionTool_") + m_name;
+    if ( asg::ToolStore::contains<BTaggingEfficiencyTool>( sf_tool_name ) ) {
+      m_BJetEffSFTool = asg::ToolStore::get<BTaggingEfficiencyTool>( sf_tool_name );
+    } else {
+      m_BJetEffSFTool = new BTaggingEfficiencyTool( sf_tool_name );
+    }
+    m_BJetEffSFTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO, ERROR
+
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("TaggerName",          m_taggerName),"Failed to set property");
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("OperatingPoint",      m_operatingPtCDI),"Failed to set property");
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("JetAuthor",           m_jetAuthor),"Failed to set property");
@@ -408,7 +409,6 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
     //
     if (m_getScaleFactors ) {
 
-
       if (m_BJetEffSFTool->applySystematicVariation(syst_it) != CP::SystematicCode::Ok) {
         Error("initialize()", "Failed to configure BJetEfficiencyCorrections for systematic %s.", syst_it.name().c_str());
         return EL::StatusCode::FAILURE;
@@ -455,7 +455,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
         }
         // if it is out of validity range (jet pt > 1200 GeV), the tools just applies the SF at 200 GeV
         //if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange)
-      }//m_getScaleFacots && eta < 2.5
+      } //m_getScaleFactors && eta < 2.5
 
       // Add it to vector
       sfVec(*jet_itr).push_back(SF);
@@ -463,7 +463,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
       SF_GLOBAL *= SF;
 
       /*
-      if(m_debug){
+      if( m_getScaleFactors && m_debug){
         //
         // directly obtain reco efficiency
         //
@@ -526,9 +526,10 @@ EL::StatusCode BJetEfficiencyCorrector :: postExecute ()
 EL::StatusCode BJetEfficiencyCorrector :: finalize ()
 {
   Info("finalize()", "Deleting tool instances...");
-  if(m_BJetEffSFTool){
-    delete m_BJetEffSFTool; m_BJetEffSFTool = nullptr;
-  }
+
+  if ( m_BJetSelectTool ) { delete m_BJetSelectTool; m_BJetSelectTool = nullptr;  }
+  if ( m_BJetEffSFTool )  { delete m_BJetEffSFTool; m_BJetEffSFTool = nullptr; }
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -597,6 +597,9 @@ EL::StatusCode BasicEventSelection :: initialize ()
     if ( m_PU_default_channel ) {
       RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DefaultChannel", m_PU_default_channel), "");
     }
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactor", 1.0/1.16), "Failed to set pileup reweighting data scale factor");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactorUP", 1.0), "Failed to set pileup reweighting data scale factor up");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactorDOWN", 1.0/1.23), "Failed to set pileup reweighting data scale factor down");
     RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->initialize(), "Failed to properly initialize CP::PileupReweightingTool");
   }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -1020,16 +1020,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
   // Every systematic will correspond to a different SF!
   //
   
-  // Define also an *event* weight
-  //
-  std::string TRIG_SF_NAME_GLOBAL = m_outputSystNamesTrig + "_GLOBAL";
-  SG::AuxElement::Decorator< std::vector<float> > sfVecTrig_GLOBAL ( TRIG_SF_NAME_GLOBAL );
+  // NB: calculation of the event SF is up to the analyzer
   
   for ( const auto& syst_it : m_systListTrig ) {
-
-    // Initialise product of SFs for *this* systematic
-    //
-    float trigEffSF_GLOBAL(1.0);
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElTrigEff_SF
@@ -1102,8 +1095,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        //
        sfVecTrig( *el_itr ).push_back( trigEffSF );
 
-       trigEffSF_GLOBAL *= ( 1.0 - trigEffSF ); // is it the right way? 
-
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
@@ -1119,19 +1110,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        ++idx;
 
     } // close electron loop
-    
-    // For *this* systematic, store the global SF weight for the event
-    //
-    if ( m_debug ) {
-       Info( "executeSF()", "--------------------------------------");
-       Info( "executeSF()", "GLOBAL Trigger efficiency SF for event:");
-       Info( "executeSF()", "\t %f ", trigEffSF_GLOBAL );
-       Info( "executeSF()", "--------------------------------------");
-    }
-    
-    trigEffSF_GLOBAL = 1.0 - trigEffSF_GLOBAL;
-    
-    sfVecTrig_GLOBAL( *eventInfo ).push_back( trigEffSF_GLOBAL );
 
   }  // close loop on Trig efficiency SF systematics
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -677,27 +677,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
   // Every systematic will correspond to a different SF!
   //
 
-  // Define also an *event* weight, which is the product of all the PID eff. SFs for each object in the event
-  //
-  std::string PID_SF_NAME_GLOBAL = m_outputSystNamesPID + "_GLOBAL";
-  SG::AuxElement::Decorator< std::vector<float> > sfVecPID_GLOBAL ( PID_SF_NAME_GLOBAL );
-
   for ( const auto& syst_it : m_systListPID ) {
-
-    // Initialise product of SFs for *this* systematic
-    //
-    float pidEffSF_GLOBAL(1.0);
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElPIDEff_SF
     //
-    std::string sfName  = "ElPIDEff_SF";
+    std::string sfName  = "ElPIDEff_SF_" + m_PID_WP;
 
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
-    if(m_debug) Info("executeSF()", "Electron PID efficiency SF  name is: %s", sfName.c_str());
+    if(m_debug) Info("executeSF()", "Electron PID efficiency sys names vector name is: %s", sfName.c_str());
     sysVariationNamesPID->push_back(sfName);
 
     // apply syst
@@ -758,8 +749,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        //
        sfVecPID( *el_itr ).push_back( pidEffSF );
 
-       pidEffSF_GLOBAL *= pidEffSF;
-
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
@@ -778,16 +767,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
     } // close electron loop
 
-    // For *this* systematic, store the global SF weight for the event
-    //
-    if ( m_debug ) {
-       Info( "executeSF()", "--------------------------------------");
-       Info( "executeSF()", "GLOBAL PID efficiency SF for event:");
-       Info( "executeSF()", "\t %f ", pidEffSF_GLOBAL );
-       Info( "executeSF()", "--------------------------------------");
-    }
-    sfVecPID_GLOBAL( *eventInfo ).push_back( pidEffSF_GLOBAL );
-
   }  // close loop on PID efficiency systematics
 
   // 2.
@@ -797,27 +776,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
   // Every systematic will correspond to a different SF!
   //
 
-  // Define also an *event* weight, which is the product of all the Iso eff. SFs for each object in the event
-  //
-  std::string Iso_SF_NAME_GLOBAL = m_outputSystNamesIso + "_GLOBAL";
-  SG::AuxElement::Decorator< std::vector<float> > sfVecIso_GLOBAL ( Iso_SF_NAME_GLOBAL );
-
   for ( const auto& syst_it : m_systListIso ) {
-
-    // Initialise product of SFs for *this* systematic
-    //
-    float IsoEffSF_GLOBAL(1.0);
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElIsoEff_SF
     //
-    std::string sfName  = "ElIsoEff_SF";
+    std::string sfName  = "ElIsoEff_SF_" + m_Iso_WP;
 
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
-    if(m_debug) Info("executeSF()", "Electron Iso efficiency SF  name is: %s", sfName.c_str());
+    if(m_debug) Info("executeSF()", "Electron Iso efficiency sys names vector name is: %s", sfName.c_str());
     sysVariationNamesIso->push_back(sfName);
 
     // apply syst
@@ -878,8 +848,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        //
        sfVecIso( *el_itr ).push_back( IsoEffSF );
 
-       IsoEffSF_GLOBAL *= IsoEffSF;
-
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
@@ -898,16 +866,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
 
     } // close electron loop
 
-    // For *this* systematic, store the global SF weight for the event
-    //
-    if ( m_debug ) {
-       Info( "executeSF()", "--------------------------------------");
-       Info( "executeSF()", "GLOBAL Iso efficiency SF for event:");
-       Info( "executeSF()", "\t %f ", IsoEffSF_GLOBAL );
-       Info( "executeSF()", "--------------------------------------");
-    }
-    sfVecIso_GLOBAL( *eventInfo ).push_back( IsoEffSF_GLOBAL );
-
   }  // close loop on Iso efficiency systematics
 
   // 3.
@@ -917,16 +875,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
   // Every systematic will correspond to a different SF!
   //
 
-  // Define also an *event* weight, which is the product of all the reco eff. SFs for each object in the event
-  //
-  std::string RECO_SF_NAME_GLOBAL = m_outputSystNamesReco + "_GLOBAL";
-  SG::AuxElement::Decorator< std::vector<float> > sfVecReco_GLOBAL ( RECO_SF_NAME_GLOBAL );
-
   for ( const auto& syst_it : m_systListReco ) {
-
-    // Initialise product of SFs for *this* systematic
-    //
-    float recoEffSF_GLOBAL(1.0);
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElRecoEff_SF
@@ -965,7 +914,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        SG::AuxElement::Decorator< std::vector<float> > sfVecReco ( m_outputSystNamesReco  );
        if ( !sfVecReco.isAvailable( *el_itr )  ) {
          sfVecReco ( *el_itr ) = std::vector<float>();
-       }
+       } 
 
        // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
        //
@@ -998,13 +947,13 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        //
        sfVecReco( *el_itr ).push_back( recoEffSF );
 
-       recoEffSF_GLOBAL *= recoEffSF;
-
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
 	 Info( "executeSF()", "Electron %i, pt = %.2f GeV ", idx, (el_itr->pt() * 1e-3) );
 	 Info( "executeSF()", " ");
+         Info( "executeSF()", "Reco SF decoration: %s", m_outputSystNamesReco.c_str() );
+         Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Reco efficiency SF:");
@@ -1015,16 +964,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        ++idx;
 
     } // close electron loop
-
-    // For *this* systematic, store the global SF weight for the event
-    //
-    if ( m_debug ) {
-       Info( "executeSF()", "--------------------------------------");
-       Info( "executeSF()", "GLOBAL Reco efficiency SF for event:");
-       Info( "executeSF()", "\t %f ", recoEffSF_GLOBAL );
-       Info( "executeSF()", "--------------------------------------");
-    }
-    sfVecReco_GLOBAL( *eventInfo ).push_back( recoEffSF_GLOBAL );
 
   }  // close loop on Reco efficiency systematics
 
@@ -1043,7 +982,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElTrigEff_SF
     //
-    std::string sfName  = "ElTrigEff_SF";
+    std::string sfName  = "ElTrigEff_SF_" + m_WorkingPointIDTrig;
 
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
@@ -1141,7 +1080,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_ElTrigEff_SF
     //
-    std::string sfName  = "ElTrigMCEff_";
+    std::string sfName  = "ElTrigMCEff_" + m_WorkingPointIDTrig;
 
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -1048,7 +1048,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        //
        sfVecTrig( *el_itr ).push_back( trigEffSF );
 
-       trigEffSF_GLOBAL *= trigEffSF; // is it the right way? What if more than one electron per event is trigger-matched?
+       trigEffSF_GLOBAL *= ( 1.0 - trigEffSF ); // is it the right way? 
 
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
@@ -1074,6 +1074,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF (  const xAOD::ElectronC
        Info( "executeSF()", "\t %f ", trigEffSF_GLOBAL );
        Info( "executeSF()", "--------------------------------------");
     }
+    
+    trigEffSF_GLOBAL = 1.0 - trigEffSF_GLOBAL;
+    
     sfVecTrig_GLOBAL( *eventInfo ).push_back( trigEffSF_GLOBAL );
 
   }  // close loop on Trig efficiency systematics

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -201,9 +201,10 @@ EL::StatusCode  ElectronSelector :: configure ()
 
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
-  if ( m_LHOperatingPoint != "VeryLoose" &&
-       m_LHOperatingPoint != "Loose"     &&
-       m_LHOperatingPoint != "Medium"    &&
+  if ( m_LHOperatingPoint != "VeryLoose"    &&
+       m_LHOperatingPoint != "Loose"        &&
+       m_LHOperatingPoint != "Loose_CutBL"  &&
+       m_LHOperatingPoint != "Medium"       &&
        m_LHOperatingPoint != "Tight"     ) {
     Error("configure()", "Unknown electron likelihood PID requested %s!",m_LHOperatingPoint.c_str());
     return EL::StatusCode::FAILURE;
@@ -426,13 +427,13 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   if  ( m_doLHPIDcut ) {
        Info("initialize()", "Cutting on Electron Likelihood PID! \n ********************" );
-       Info("initialize()", "\t Selected LH WP: %s", (m_el_LH_PIDManager->getSelectedWP()).c_str() );
+       Info("initialize()", "\t Input WP: %s corresponding to actual LikeEnum::Menu WP: %s", likelihoodWP.c_str(), (m_el_LH_PIDManager->getSelectedWP()).c_str() );
   } else {
        Info("initialize()", "Will decorate each electron with all Electron Likelihood PID WPs decison (pass/not pass)!" );
   }
 
   bool configTools_LH(false);
-  if ( m_readIDFlagsFromDerivation ) {
+  if ( m_readIDFlagsFromDerivation && likelihoodWP != "Loose_CutBL" ) {
     Info("initialize()", "Reading Electron LH ID from DAODs ..." );
     RETURN_CHECK( "ElectronSelector::initialize()", m_el_LH_PIDManager->setupWPs( configTools_LH ), "Failed to properly setup ElectronLHPIDManager." );
   } else {

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -961,20 +961,44 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
   if ( m_readIDFlagsFromDerivation ) {
 
-    if ( m_doLHPIDcut &&  !electron->auxdata< int >( "DFCommonElectronsLH" + m_LHOperatingPoint ) ) {
+    if ( m_doLHPIDcut ) {
+
+      bool passSelID(false);
+      // need this exception check b/c an interface change in DF happened at some point :(
+      try {
+	passSelID = electron->auxdataConst<int> ( "DFCommonElectronsLH" + m_LHOperatingPoint );
+      }
+      catch(std::exception& e) {
+	passSelID = electron->auxdataConst<char>( "DFCommonElectronsLH" + m_LHOperatingPoint );
+      }
+
+      if ( !passSelID ) {
    	if ( m_debug ) { Info("PassCuts()", "Electron failed likelihood PID cut w/ operating point %s", m_LHOperatingPoint.c_str() ); }
    	return 0;
+      }
     }
 
     const std::set<std::string> myLHWPs = m_el_LH_PIDManager->getValidWPs();
     for ( auto it : (myLHWPs) ) {
+
       const std::string decorWP =  "LH" + it;
+
+      bool passThisID(false);
+      try {
+	passThisID = electron->auxdataConst<int> ( "DFCommonElectrons" + decorWP );
+      }
+      catch(std::exception& e) {
+	passThisID = electron->auxdataConst<char>( "DFCommonElectrons" + decorWP );
+      }
+
       if ( m_debug ) {
    	Info("PassCuts()", "Decorating electron with decison for LH WP : %s ", ( decorWP ).c_str() );
-   	Info("PassCuts()", "\t does electron pass %s ? %i ", ( decorWP ).c_str(), electron->auxdata< int >( "DFCommonElectrons" + decorWP ) );
+   	Info("PassCuts()", "\t does electron pass %s ? %i ", ( decorWP ).c_str(), passThisID );
       }
-      electron->auxdecor<char>(decorWP) = static_cast<char>( electron->auxdata< int >( "DFCommonElectrons" + decorWP ) );
+      electron->auxdecor<char>(decorWP) = static_cast<char>( passThisID );
+
     }
+
   } else {
 
     // retrieve only tools with WP >= selected WP, cut electrons if not satisfying selected WP, and decorate w/ tool decision all the others
@@ -1010,20 +1034,45 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
   if ( m_readIDFlagsFromDerivation ) {
 
-    if ( m_doCutBasedPIDcut &&  !electron->auxdata< int >( "DFCommonElectrons" + m_CutBasedOperatingPoint ) ) {
+    if ( m_doCutBasedPIDcut ) {
+
+      bool passSelID(false);
+      // need this exception check b/c an interface change in DF happened at some point :(
+      try {
+	passSelID = electron->auxdataConst<int> ( "DFCommonElectrons" + m_CutBasedOperatingPoint );
+      }
+      catch(std::exception& e) {
+	passSelID = electron->auxdataConst<char>( "DFCommonElectrons" + m_CutBasedOperatingPoint );
+      }
+
+      if ( !passSelID ) {
    	if ( m_debug ) { Info("PassCuts()", "Electron failed cut-based PID cut w/ operating point %s", m_CutBasedOperatingPoint.c_str() ); }
    	return 0;
+      }
+
     }
 
     const std::set<std::string> myCutBasedWPs = m_el_CutBased_PIDManager->getValidWPs();
     for ( auto it : (myCutBasedWPs) ) {
+
       const std::string decorWP = it.erase(0,4);
+
+      bool passThisID(false);
+      try {
+	passThisID = electron->auxdataConst<int> ( "DFCommonElectronsIsEM" + decorWP );
+      }
+      catch(std::exception& e) {
+	passThisID = electron->auxdataConst<char>( "DFCommonElectronsIsEM" + decorWP );
+      }
+
       if ( m_debug ) {
    	Info("PassCuts()", "Decorating electron with deciison for cut-based WP : %s ", ( decorWP ).c_str() );
-   	Info("PassCuts()", "\t does electron pass %s ? %i ", ( decorWP ).c_str(), electron->auxdata< int >( "DFCommonElectronsIsEM" + decorWP ) );
+   	Info("PassCuts()", "\t does electron pass %s ? %i ", ( decorWP ).c_str(), passThisID );
       }
-      electron->auxdecor<char>(decorWP) = static_cast<char>( electron->auxdata< int >( "DFCommonElectronsIsEM" + decorWP ) );
+      electron->auxdecor<char>(decorWP) = static_cast<char>( passThisID );
+
     }
+
   } else {
 
     // retrieve only tools with WP >= selected WP, cut electrons if not satisfying selected WP, and decorate w/ tool decision all the others

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -109,7 +109,8 @@ ElectronSelector :: ElectronSelector (std::string className) :
   m_z0sintheta_max          = 1e8;
   m_doAuthorCut             = true;
   m_doOQCut                 = true;
-
+  m_doBLTrackQualityCut     = false;
+  
   m_readIDFlagsFromDerivation = false;
   m_confDirPID              = "mc15_20150224";
 
@@ -173,7 +174,8 @@ EL::StatusCode  ElectronSelector :: configure ()
     m_z0sintheta_max          = config->GetValue("z0sinthetaMax", m_z0sintheta_max);
     m_doAuthorCut             = config->GetValue("DoAuthorCut", m_doAuthorCut);
     m_doOQCut                 = config->GetValue("DoOQCut", m_doOQCut);
-
+    m_doBLTrackQualityCut     = config->GetValue("DoBLTrackQualityCut", m_doBLTrackQualityCut);
+    
     m_readIDFlagsFromDerivation = config->GetValue("ReadIDFlagsFromDerivation", m_readIDFlagsFromDerivation);
     m_confDirPID              = config->GetValue("ConfDirPID", m_confDirPID.c_str());
     m_doLHPIDcut              = config->GetValue("DoLHPIDCut", m_doLHPIDcut);
@@ -202,7 +204,7 @@ EL::StatusCode  ElectronSelector :: configure ()
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
   if ( m_LHOperatingPoint != "Loose"        &&
-       m_LHOperatingPoint != "Loose_CutBL"  &&
+       m_LHOperatingPoint != "LooseAndBLayer"  &&
        m_LHOperatingPoint != "Medium"       &&
        m_LHOperatingPoint != "Tight"     ) {
     Error("configure()", "Unknown electron likelihood PID requested %s!",m_LHOperatingPoint.c_str());
@@ -344,26 +346,28 @@ EL::StatusCode ElectronSelector :: initialize ()
     m_el_cutflow_ptmax_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_el_cutflow_ptmin_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
     m_el_cutflow_eta_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
-    m_el_cutflow_PID_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("PID_cut");
     m_el_cutflow_z0sintheta_cut  = m_el_cutflowHist_1->GetXaxis()->FindBin("z0sintheta_cut");
     m_el_cutflow_d0_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("d0_cut");
     m_el_cutflow_d0sig_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("d0sig_cut");
+    m_el_cutflow_BL_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("BL_cut");
+    m_el_cutflow_PID_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("PID_cut");
     m_el_cutflow_iso_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("iso_cut");
 
     if ( m_isUsedBefore ) {
-       m_el_cutflowHist_2 = (TH1D*)file->Get("cutflow_electrons_2");
-
-       m_el_cutflow_all 	    = m_el_cutflowHist_2->GetXaxis()->FindBin("all");
-       m_el_cutflow_author_cut      = m_el_cutflowHist_2->GetXaxis()->FindBin("author_cut");
-       m_el_cutflow_OQ_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("OQ_cut");
-       m_el_cutflow_ptmax_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
-       m_el_cutflow_ptmin_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
-       m_el_cutflow_eta_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
-       m_el_cutflow_PID_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("PID_cut");
-       m_el_cutflow_z0sintheta_cut  = m_el_cutflowHist_2->GetXaxis()->FindBin("z0sintheta_cut");
-       m_el_cutflow_d0_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("d0_cut");
-       m_el_cutflow_d0sig_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("d0sig_cut");
-       m_el_cutflow_iso_cut	    = m_el_cutflowHist_2->GetXaxis()->FindBin("iso_cut");
+      m_el_cutflowHist_2 = (TH1D*)file->Get("cutflow_electrons_2");
+      
+      m_el_cutflow_all  	   = m_el_cutflowHist_2->GetXaxis()->FindBin("all");
+      m_el_cutflow_author_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("author_cut");
+      m_el_cutflow_OQ_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("OQ_cut");
+      m_el_cutflow_ptmax_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
+      m_el_cutflow_ptmin_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
+      m_el_cutflow_eta_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
+      m_el_cutflow_z0sintheta_cut  = m_el_cutflowHist_2->GetXaxis()->FindBin("z0sintheta_cut");
+      m_el_cutflow_d0_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("d0_cut");
+      m_el_cutflow_d0sig_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("d0sig_cut");
+      m_el_cutflow_BL_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("BL_cut");
+      m_el_cutflow_PID_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("PID_cut");
+      m_el_cutflow_iso_cut	   = m_el_cutflowHist_2->GetXaxis()->FindBin("iso_cut");
     }
 
   }
@@ -425,7 +429,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   m_el_LH_PIDManager = new ElectronLHPIDManager( likelihoodWP, m_debug );
 
   // make sure the actual WP is (Loose || Medium || Tight)
-   m_LHOperatingPoint = ( m_LHOperatingPoint == "Loose_CutBL" ) ? "Loose" : m_LHOperatingPoint;
+   m_LHOperatingPoint = ( m_LHOperatingPoint == "LooseAndBLayer" ) ? "Loose" : m_LHOperatingPoint;
 
   if  ( m_doLHPIDcut ) {
        Info("initialize()", "Cutting on Electron Likelihood PID! \n ********************" );
@@ -820,10 +824,10 @@ EL::StatusCode ElectronSelector :: finalize ()
 
   Info("finalize()", "Deleting tool instances...");
 
-  if ( m_el_CutBased_PIDManager ) { m_el_CutBased_PIDManager = nullptr; delete m_el_CutBased_PIDManager;  }
-  if ( m_el_LH_PIDManager )       { m_el_LH_PIDManager = nullptr;       delete m_el_LH_PIDManager;  }
-  if ( m_IsolationSelectionTool ) { m_IsolationSelectionTool = nullptr; delete m_IsolationSelectionTool; }
-  if ( m_trigElMatchTool )        { m_trigElMatchTool = nullptr;        delete m_trigElMatchTool; }
+  if ( m_el_CutBased_PIDManager ) { delete m_el_CutBased_PIDManager;  m_el_CutBased_PIDManager = nullptr; }
+  if ( m_el_LH_PIDManager )       { delete m_el_LH_PIDManager;	      m_el_LH_PIDManager = nullptr;	  }
+  if ( m_IsolationSelectionTool ) { delete m_IsolationSelectionTool;  m_IsolationSelectionTool = nullptr; }
+  if ( m_trigElMatchTool )        { delete m_trigElMatchTool;	      m_trigElMatchTool = nullptr;	  }
 
   if ( m_useCutFlow ) {
     Info("finalize()", "Filling cutflow");
@@ -945,6 +949,87 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   }
   if(m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_eta_cut, 1 );
   if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_eta_cut, 1 ); }
+
+
+  // *********************************************************************************************************************************************************************
+  //
+  // Tracking cuts AFTER acceptance, in case of derivation reduction.
+  //
+
+  const xAOD::TrackParticle* tp  = electron->trackParticle();
+  if ( !tp ) {
+    if ( m_debug ) Info( "PassCuts()", "Electron has no TrackParticle. Won't be selected.");
+    return 0;
+  }
+
+  const xAOD::EventInfo* eventInfo(nullptr);
+  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+
+  double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
+
+  float z0sintheta = 1e8;
+  if (primaryVertex) z0sintheta = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
+
+
+  // z0*sin(theta) cut
+  //
+  if ( m_z0sintheta_max != 1e8 ) {
+    if ( !( fabs(z0sintheta) < m_z0sintheta_max ) ) {
+      if ( m_debug ) { Info("PassCuts()", "Electron failed z0*sin(theta) cut." ); }
+      return 0;
+    }
+  }
+  if ( m_useCutFlow ) m_el_cutflowHist_1->Fill( m_el_cutflow_z0sintheta_cut, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_z0sintheta_cut, 1 ); }
+
+  // d0 cut
+  //
+  if ( m_d0_max != 1e8 ) {
+    if ( !( tp->d0() < m_d0_max ) ) {
+      if ( m_debug ) { Info("PassCuts()", "Electron failed d0 cut."); }
+      return 0;
+    }
+  }
+  if ( m_useCutFlow ) m_el_cutflowHist_1->Fill( m_el_cutflow_d0_cut, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_d0_cut, 1 ); }
+
+  // d0sig cut
+  //
+  if ( m_d0sig_max != 1e8 ) {
+    if ( !( d0_significance < m_d0sig_max ) ) {
+      if ( m_debug ) { Info("PassCuts()", "Electron failed d0 significance cut."); }
+      return 0;
+    }
+  }
+  if ( m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_d0sig_cut, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_d0sig_cut, 1 ); }
+
+  // decorate electron w/ d0sig info
+  static SG::AuxElement::Decorator< float > d0SigDecor("d0sig");
+  d0SigDecor( *electron ) = static_cast<float>(d0_significance);
+  
+  
+  // BLayer track quality cut
+  //
+  if ( m_doBLTrackQualityCut ) {
+  
+    // this is taken from ElectronPhotonSelectorTools/Root/AsgElectronLikelihoodTool.cxx															 
+    
+    uint8_t expectBlayer(true);
+    uint8_t nBlayerHits(0);
+    uint8_t nBlayerOutliers(0);
+    
+    tp->summaryValue(expectBlayer,    xAOD::expectBLayerHit);
+    tp->summaryValue(nBlayerHits,     xAOD::numberOfBLayerHits);
+    tp->summaryValue(nBlayerOutliers, xAOD::numberOfBLayerOutliers);
+    
+    if ( expectBlayer && (nBlayerHits+nBlayerOutliers) < 1 ) {
+      if ( m_debug ) { Info("PassCuts()", "Electron failed BL track quality cut."); }
+      return 0;
+    }
+  }
+  if ( m_useCutFlow ) m_el_cutflowHist_1->Fill( m_el_cutflow_BL_cut, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_BL_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
   //
@@ -1102,65 +1187,6 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   if(m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_PID_cut, 1 );
   if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_PID_cut, 1 ); }
 
-  // *********************************************************************************************************************************************************************
-  //
-  // impact parameter cuts
-  //
-
-  // Tracking cuts AFTER acceptance, in case of derivation reduction.
-
-  const xAOD::TrackParticle* tp  = electron->trackParticle();
-
-  if ( !tp ) {
-    if ( m_debug ) Info( "PassCuts()", "Electron has no TrackParticle. Won't be selected.");
-    return 0;
-  }
-
-  const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
-
-  double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
-
-  float z0sintheta = 1e8;
-  if (primaryVertex) z0sintheta = ( tp->z0() + tp->vz() - primaryVertex->z() ) * sin( tp->theta() );
-
-
-  // z0*sin(theta) cut
-  //
-  if ( m_z0sintheta_max != 1e8 ) {
-    if ( !( fabs(z0sintheta) < m_z0sintheta_max ) ) {
-      if ( m_debug ) { Info("PassCuts()", "Electron failed z0*sin(theta) cut." ); }
-      return 0;
-    }
-  }
-  if(m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_z0sintheta_cut, 1 );
-  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_z0sintheta_cut, 1 ); }
-
-  // d0 cut
-  //
-  if ( m_d0_max != 1e8 ) {
-    if ( !( tp->d0() < m_d0_max ) ) {
-      if ( m_debug ) { Info("PassCuts()", "Electron failed d0 cut."); }
-      return 0;
-    }
-  }
-  if(m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_d0_cut, 1 );
-  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_d0_cut, 1 ); }
-
-  // d0sig cut
-  //
-  if ( m_d0sig_max != 1e8 ) {
-    if ( !( d0_significance < m_d0sig_max ) ) {
-      if ( m_debug ) { Info("PassCuts()", "Electron failed d0 significance cut."); }
-      return 0;
-    }
-  }
-  if(m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_d0sig_cut, 1 );
-  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_d0sig_cut, 1 ); }
-
-  // decorate electron w/ d0sig info
-  static SG::AuxElement::Decorator< float > d0SigDecor("d0sig");
-  d0SigDecor( *electron ) = static_cast<float>(d0_significance);
 
   // *********************************************************************************************************************************************************************
   //

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -201,8 +201,7 @@ EL::StatusCode  ElectronSelector :: configure ()
 
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
-  if ( m_LHOperatingPoint != "VeryLoose"    &&
-       m_LHOperatingPoint != "Loose"        &&
+  if ( m_LHOperatingPoint != "Loose"        &&
        m_LHOperatingPoint != "Loose_CutBL"  &&
        m_LHOperatingPoint != "Medium"       &&
        m_LHOperatingPoint != "Tight"     ) {
@@ -422,8 +421,11 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   // if not using LH PID, make sure all the decorations will be set ... by choosing the loosest WP!
   //
-  std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "VeryLoose";
+  std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "Loose";
   m_el_LH_PIDManager = new ElectronLHPIDManager( likelihoodWP, m_debug );
+
+  // make sure the actual WP is (Loose || Medium || Tight)
+   m_LHOperatingPoint = ( m_LHOperatingPoint == "Loose_CutBL" ) ? "Loose" : m_LHOperatingPoint;
 
   if  ( m_doLHPIDcut ) {
        Info("initialize()", "Cutting on Electron Likelihood PID! \n ********************" );
@@ -433,7 +435,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   }
 
   bool configTools_LH(false);
-  if ( m_readIDFlagsFromDerivation && likelihoodWP != "Loose_CutBL" ) {
+  if ( m_readIDFlagsFromDerivation ) {
     Info("initialize()", "Reading Electron LH ID from DAODs ..." );
     RETURN_CHECK( "ElectronSelector::initialize()", m_el_LH_PIDManager->setupWPs( configTools_LH ), "Failed to properly setup ElectronLHPIDManager." );
   } else {

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -181,8 +181,7 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
   }
 
   if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
-    m_tree->Branch("weight_muon_trig", 				      &m_weight_muon_trig);
-    m_tree->Branch("weight_muon_RecoEff_SF",		   	      &m_weight_muon_RecoEff_SF);
+    m_tree->Branch("weight_muon_RecoEff_SF_Loose",		      &m_weight_muon_RecoEff_SF_Loose);
     m_tree->Branch("weight_muon_IsoEff_SF_LooseTrackOnly", 	      &m_weight_muon_IsoEff_SF_LooseTrackOnly);
     m_tree->Branch("weight_muon_IsoEff_SF_Loose",	    	      &m_weight_muon_IsoEff_SF_Loose);
     m_tree->Branch("weight_muon_IsoEff_SF_Tight",	    	      &m_weight_muon_IsoEff_SF_Tight);
@@ -192,9 +191,9 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
   }
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-    m_tree->Branch("weight_electron_RecoEff_SF"  ,	    &m_weight_electron_RecoEff_SF  );
-    m_tree->Branch("weight_electron_IsoEff_SF_Loose",   &m_weight_electron_IsoEff_SF_Loose);
-    m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",   &m_weight_electron_IsoEff_SF_FixedCutTight);
+    m_tree->Branch("weight_electron_RecoEff_SF"  ,	         &m_weight_electron_RecoEff_SF  );
+    m_tree->Branch("weight_electron_IsoEff_SF_Loose",            &m_weight_electron_IsoEff_SF_Loose);
+    m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",    &m_weight_electron_IsoEff_SF_FixedCutTight);
     m_tree->Branch("weight_electron_PIDEff_SF_LHLooseAndBLayer", &m_weight_electron_PIDEff_SF_LHLooseAndBLayer);
     m_tree->Branch("weight_electron_PIDEff_SF_LHLoose",	    &m_weight_electron_PIDEff_SF_LHLoose);
     m_tree->Branch("weight_electron_PIDEff_SF_LHMedium",    &m_weight_electron_PIDEff_SF_LHMedium);
@@ -339,19 +338,15 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
   if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
 
-    SG::AuxElement::ConstAccessor< std::vector<float> >   muonTrigSFVec( "MuonEfficiencyCorrector_TrigSyst" );
-    SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("MuonEfficiencyCorrector_RecoSyst_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal_Loose("MuonEfficiencyCorrector_RecoSyst_Loose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_LooseTrackOnly("MuonEfficiencyCorrector_IsoSyst_LooseTrackOnly_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("MuonEfficiencyCorrector_IsoSyst_Loose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Tight("MuonEfficiencyCorrector_IsoSyst_Tight_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Gradient("MuonEfficiencyCorrector_IsoSyst_Gradient_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_GradientLoose("MuonEfficiencyCorrector_IsoSyst_GradientLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_FixedCutTightTrackOnly_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_UserDefinedFixEfficiency("MuonEfficiencyCorrector_IsoSyst_UserDefinedFixEfficiency_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_UserDefinedCut("MuonEfficiencyCorrector_IsoSyst_UserDefinedCut_GLOBAL");
 
-    if( muonTrigSFVec.isAvailable( *eventInfo ) ) { m_weight_muon_trig = muonTrigSFVec( *eventInfo ); } else { m_weight_muon_trig.push_back(-999.0); }
-    if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_muon_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_muon_RecoEff_SF.push_back(-999.0); }
+    if( accRecoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_muon_RecoEff_SF_Loose = accRecoSFGlobal_Loose( *eventInfo ); } else { m_weight_muon_RecoEff_SF_Loose.push_back(-999.0); }
     if( accIsoSFGlobal_LooseTrackOnly.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_LooseTrackOnly = accIsoSFGlobal_LooseTrackOnly( *eventInfo ); } else { m_weight_muon_IsoEff_SF_LooseTrackOnly.push_back(-999.0); }
     if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Loose.push_back(-999.0); }
     if( accIsoSFGlobal_Tight.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Tight = accIsoSFGlobal_Tight( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Tight.push_back(-999.0); }
@@ -558,7 +553,11 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
   }
 
   if ( m_muInfoSwitch->m_effSF && m_isMC ) {
-    m_tree->Branch("muon_RecoEff_SF",               &m_muon_RecoEff_SF);
+    m_tree->Branch("muon_RecoEff_SF_Loose",         &m_muon_RecoEff_SF_Loose);
+    m_tree->Branch("muon_TrigEff_SF_Loose_Loose",		    &m_muon_TrigEff_SF_Loose_Loose);
+    m_tree->Branch("muon_TrigEff_SF_Loose_FixedCutTightTrackOnly",  &m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly);
+    m_tree->Branch("muon_TrigMCEff_Loose_Loose",		    &m_muon_TrigMCEff_Loose_Loose);
+    m_tree->Branch("muon_TrigMCEff_Loose_FixedCutTightTrackOnly",   &m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly);
     m_tree->Branch("muon_IsoEff_SF_LooseTrackOnly", &m_muon_IsoEff_SF_LooseTrackOnly);
     m_tree->Branch("muon_IsoEff_SF_Loose",	    &m_muon_IsoEff_SF_Loose);
     m_tree->Branch("muon_IsoEff_SF_Tight",	    &m_muon_IsoEff_SF_Tight);
@@ -773,7 +772,11 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
     if ( m_muInfoSwitch->m_effSF && m_isMC ) {
 
-      static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("MuonEfficiencyCorrector_RecoSyst");
+      static SG::AuxElement::Accessor< std::vector< float > > accRecoSF_Loose("MuonEfficiencyCorrector_RecoSyst_Loose");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Loose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoFixedCutTightTrackOnly");
+      static SG::AuxElement::Accessor< double >               accTrigMCEff_Loose_Loose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoLoose");
+      static SG::AuxElement::Accessor< double >               accTrigMCEff_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoFixedCutTightTrackOnly");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_LooseTrackOnly("MuonEfficiencyCorrector_IsoSyst_LooseTrackOnly");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("MuonEfficiencyCorrector_IsoSyst_Loose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Tight("MuonEfficiencyCorrector_IsoSyst_Tight");
@@ -783,7 +786,11 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
       std::vector<float> junk(1,-999);
 
-      if( accRecoSF.isAvailable( *muon_itr ) )               { m_muon_RecoEff_SF.push_back( accRecoSF( *muon_itr ) ); } else { m_muon_RecoEff_SF.push_back( junk ); }
+      if( accRecoSF_Loose.isAvailable( *muon_itr ) )         { m_muon_RecoEff_SF_Loose.push_back( accRecoSF_Loose( *muon_itr ) ); } else { m_muon_RecoEff_SF_Loose.push_back( junk ); }
+      if ( accTrigSF_Loose_Loose.isAvailable( *muon_itr ) )                     { m_muon_TrigEff_SF_Loose_Loose.push_back( accTrigSF_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_Loose.push_back( junk ); }
+      if ( accTrigSF_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )    { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( accTrigSF_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( junk ); }
+      if ( accTrigMCEff_Loose_Loose.isAvailable( *muon_itr ) )                  { m_muon_TrigMCEff_Loose_Loose.push_back( accTrigMCEff_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_Loose.push_back( 0.0 ); }
+      if ( accTrigMCEff_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) ) { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( accTrigMCEff_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( 0.0 ); }
       if( accIsoSF_LooseTrackOnly.isAvailable( *muon_itr ) ) { m_muon_IsoEff_SF_LooseTrackOnly.push_back( accIsoSF_LooseTrackOnly( *muon_itr ) ); } else { m_muon_IsoEff_SF_LooseTrackOnly.push_back( junk ); }
       if( accIsoSF_Loose.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *muon_itr ) ); } else { m_muon_IsoEff_SF_Loose.push_back( junk ); }
       if( accIsoSF_Tight.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Tight.push_back( accIsoSF_Tight( *muon_itr ) ); } else { m_muon_IsoEff_SF_Tight.push_back( junk ); }
@@ -891,7 +898,11 @@ void HelpTreeBase::ClearMuons() {
   }
 
   if ( m_muInfoSwitch->m_effSF && m_isMC ) {
-    m_muon_RecoEff_SF.clear();
+    m_muon_RecoEff_SF_Loose.clear();
+    m_muon_TrigEff_SF_Loose_Loose.clear();
+    m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.clear();
+    m_muon_TrigMCEff_Loose_Loose.clear();
+    m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.clear();
     m_muon_IsoEff_SF_LooseTrackOnly.clear();
     m_muon_IsoEff_SF_Loose.clear();
     m_muon_IsoEff_SF_Tight.clear();
@@ -986,8 +997,10 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
 
   if ( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_tree->Branch("el_RecoEff_SF"  ,		 &m_el_RecoEff_SF  );
-    m_tree->Branch("el_TrigEff_SF"  ,		 &m_el_TrigEff_SF  );
-    m_tree->Branch("el_TrigMCEff"   ,		 &m_el_TrigMCEff  );
+    m_tree->Branch("el_TrigEff_SF_LHLooseAndBLayer"  ,	 &m_el_TrigEff_SF_LHLooseAndBLayer  );
+    m_tree->Branch("el_TrigEff_SF_LHTight"  ,&m_el_TrigEff_SF_LHTight  );
+    m_tree->Branch("el_TrigMCEff_LHLooseAndBLayer"   ,&m_el_TrigMCEff_LHLooseAndBLayer  );
+    m_tree->Branch("el_TrigMCEff_LHTight"   ,&m_el_TrigMCEff_LHTight  );
     m_tree->Branch("el_IsoEff_SF_Loose"  , &m_el_IsoEff_SF_Loose );
     m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
     m_tree->Branch("el_PIDEff_SF_LHLooseAndBLayer",  &m_el_PIDEff_SF_LHLooseAndBLayer);
@@ -1224,8 +1237,11 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
     if ( m_elInfoSwitch->m_effSF && m_isMC ) {
 
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
-      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF("ElectronEfficiencyCorrector_TrigSyst");
-      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff("ElectronEfficiencyCorrector_TrigMCEffSyst");
+      
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_TrigSyst_LHLooseAndBLayer");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_LHTight("ElectronEfficiencyCorrector_TrigSyst_LHTight");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_LHLooseAndBLayer("ElectronEfficiencyCorrector_TrigMCEffSyst_LHLooseAndBLayer");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_LHTight("ElectronEfficiencyCorrector_TrigMCEffSyst_LHTight");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
@@ -1236,8 +1252,11 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       std::vector<float> junk(1,-999);
 
       if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
-      if( accTrigSF.isAvailable( *el_itr ) ) { m_el_TrigEff_SF.push_back( accTrigSF( *el_itr ) ); } else { m_el_TrigEff_SF.push_back( junk ); }
-      if( accTrigMCEff.isAvailable( *el_itr ) ) { m_el_TrigMCEff.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_TrigMCEff.push_back( junk ); }
+      
+      if( accTrigSF_LHLooseAndBLayer.isAvailable( *el_itr ) )    { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( accTrigSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( junk ); }
+      if( accTrigSF_LHTight.isAvailable( *el_itr ) )             { m_el_TrigEff_SF_LHTight.push_back( accTrigSF_LHTight( *el_itr ) ); } else { m_el_TrigEff_SF_LHTight.push_back( junk ); }
+      if( accTrigMCEff_LHLooseAndBLayer.isAvailable( *el_itr ) ) { m_el_TrigMCEff_LHLooseAndBLayer.push_back( accTrigMCEff_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigMCEff_LHLooseAndBLayer.push_back( junk ); }
+      if( accTrigMCEff_LHTight.isAvailable( *el_itr ) )          { m_el_TrigMCEff_LHTight.push_back( accTrigMCEff_LHTight( *el_itr ) ); } else { m_el_TrigMCEff_LHTight.push_back( junk ); }
       if( accIsoSF_Loose.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *el_itr ) ); } else { m_el_IsoEff_SF_Loose.push_back( junk ); }
       if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
       if( accPIDSF_LHLooseAndBLayer.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( accPIDSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( junk ); }
@@ -1337,8 +1356,10 @@ void HelpTreeBase::ClearElectrons() {
 
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_el_RecoEff_SF.clear();
-    m_el_TrigEff_SF.clear();
-    m_el_TrigMCEff.clear();
+    m_el_TrigEff_SF_LHLooseAndBLayer.clear();    
+    m_el_TrigEff_SF_LHTight.clear();
+    m_el_TrigMCEff_LHLooseAndBLayer.clear();
+    m_el_TrigMCEff_LHTight.clear();
     m_el_IsoEff_SF_Loose.clear();
     m_el_IsoEff_SF_FixedCutTight.clear();
     m_el_PIDEff_SF_LHLooseAndBLayer.clear();
@@ -3067,8 +3088,7 @@ void HelpTreeBase::ClearEvent() {
   }
 
   if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
-    m_weight_muon_trig.clear();
-    m_weight_muon_RecoEff_SF.clear();
+    m_weight_muon_RecoEff_SF_Loose.clear();
     m_weight_muon_IsoEff_SF_LooseTrackOnly.clear();
     m_weight_muon_IsoEff_SF_Loose.clear();
     m_weight_muon_IsoEff_SF_Tight.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -363,9 +363,9 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
 
-    SG::AuxElement::ConstAccessor< std::vector<float> >   electronTrigSFVec( "ElectronEfficiencyCorrector_TrigSyst" );
+    SG::AuxElement::ConstAccessor< std::vector<float> >   electronTrigSFVec( "ElectronEfficiencyCorrector_TrigSyst_GLOBAL" );
     SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_FixedCutTight_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
@@ -973,6 +973,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
 
   if ( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_tree->Branch("el_RecoEff_SF"  ,		 &m_el_RecoEff_SF  );
+    m_tree->Branch("el_TrigEff_SF"  ,		 &m_el_TrigEff_SF  );
     m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
     m_tree->Branch("el_PIDEff_SF_LHVeryLoose",   &m_el_PIDEff_SF_LHVeryLoose);
     m_tree->Branch("el_PIDEff_SF_LHLoose",       &m_el_PIDEff_SF_LHLoose);
@@ -1201,7 +1202,8 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
     if ( m_elInfoSwitch->m_effSF && m_isMC ) {
 
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_FixedCutTight");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigSF("ElectronEfficiencyCorrector_TrigSyst");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium");
@@ -1210,6 +1212,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       std::vector<float> junk(1,-999);
 
       if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
+      if( accTrigSF.isAvailable( *el_itr ) ) { m_el_TrigEff_SF.push_back( accTrigSF( *el_itr ) ); } else { m_el_TrigEff_SF.push_back( junk ); }
       if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
       if( accPIDSF_LHVeryLoose.isAvailable( *el_itr ) ) { m_el_PIDEff_SF_LHVeryLoose.push_back( accPIDSF_LHVeryLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHVeryLoose.push_back( junk ); }
       if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
@@ -1308,6 +1311,7 @@ void HelpTreeBase::ClearElectrons() {
 
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_el_RecoEff_SF.clear();
+    m_el_TrigEff_SF.clear();
     m_el_IsoEff_SF_FixedCutTight.clear();
     m_el_PIDEff_SF_LHVeryLoose.clear();
     m_el_PIDEff_SF_LHLoose.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -196,8 +196,7 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("weight_electron_RecoEff_SF"  ,	    &m_weight_electron_RecoEff_SF  );
     m_tree->Branch("weight_electron_IsoEff_SF_Loose",   &m_weight_electron_IsoEff_SF_Loose);
     m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",   &m_weight_electron_IsoEff_SF_FixedCutTight);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHVeryLoose", &m_weight_electron_PIDEff_SF_LHVeryLoose);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHLooseAndBLayer",	    &m_weight_electron_PIDEff_SF_LHLooseAndBLayer);
+    m_tree->Branch("weight_electron_PIDEff_SF_LHLooseAndBLayer", &m_weight_electron_PIDEff_SF_LHLooseAndBLayer);
     m_tree->Branch("weight_electron_PIDEff_SF_LHLoose",	    &m_weight_electron_PIDEff_SF_LHLoose);
     m_tree->Branch("weight_electron_PIDEff_SF_LHMedium",    &m_weight_electron_PIDEff_SF_LHMedium);
     m_tree->Branch("weight_electron_PIDEff_SF_LHTight",	    &m_weight_electron_PIDEff_SF_LHTight);
@@ -369,7 +368,6 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
@@ -379,7 +377,6 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_electron_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_electron_RecoEff_SF.push_back(-999.0); }
     if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_electron_IsoEff_SF_Loose.push_back(-999.0); }
     if( accIsoSFGlobal_FixedCutTight.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_FixedCutTight = accIsoSFGlobal_FixedCutTight( *eventInfo ); } else { m_weight_electron_IsoEff_SF_FixedCutTight.push_back(-999.0); }
-    if( accPIDSFGlobal_LHVeryLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHVeryLoose = accPIDSFGlobal_LHVeryLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHVeryLoose.push_back(-999.0); }
     if( accPIDSFGlobal_LHLooseAndBLayer.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLooseAndBLayer = accPIDSFGlobal_LHLooseAndBLayer( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLooseAndBLayer.push_back(-999.0); }
     if( accPIDSFGlobal_LHLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLoose = accPIDSFGlobal_LHLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLoose.push_back(-999.0); }
     if( accPIDSFGlobal_LHMedium.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHMedium = accPIDSFGlobal_LHMedium( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHMedium.push_back(-999.0); }
@@ -976,8 +973,6 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
   }
 
   if ( m_elInfoSwitch->m_PID ) {
-    m_tree->Branch("nel_LHVeryLoose",  &m_nel_LHVeryLoose);
-    m_tree->Branch("el_LHVeryLoose",   &m_el_LHVeryLoose);
     m_tree->Branch("nel_LHLoose",      &m_nel_LHLoose);
     m_tree->Branch("el_LHLoose",       &m_el_LHLoose);
     m_tree->Branch("nel_LHMedium",     &m_nel_LHMedium);
@@ -998,7 +993,6 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_TrigMCEff"   ,		 &m_el_TrigMCEff  );
     m_tree->Branch("el_IsoEff_SF_Loose"  , &m_el_IsoEff_SF_Loose );
     m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
-    m_tree->Branch("el_PIDEff_SF_LHVeryLoose",   &m_el_PIDEff_SF_LHVeryLoose);
     m_tree->Branch("el_PIDEff_SF_LHLooseAndBLayer",  &m_el_PIDEff_SF_LHLooseAndBLayer);
     m_tree->Branch("el_PIDEff_SF_LHLoose",       &m_el_PIDEff_SF_LHLoose);
     m_tree->Branch("el_PIDEff_SF_LHMedium",      &m_el_PIDEff_SF_LHMedium);
@@ -1130,7 +1124,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 
     if ( m_elInfoSwitch->m_PID ) {
 
-      static SG::AuxElement::Accessor<char> LHVeryLooseAcc ("LHVeryLoose");
       static SG::AuxElement::Accessor<char> LHLooseAcc ("LHLoose");
       static SG::AuxElement::Accessor<char> LHMediumAcc ("LHMedium");
       static SG::AuxElement::Accessor<char> LHTightAcc ("LHTight");
@@ -1139,10 +1132,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       static SG::AuxElement::Accessor<char> EMMediumAcc ("Medium");
       static SG::AuxElement::Accessor<char> EMTightAcc ("Tight");
 
-      if ( LHVeryLooseAcc.isAvailable( *el_itr ) ) {
-        m_el_LHVeryLoose.push_back( LHVeryLooseAcc( *el_itr ) );
-	if ( LHVeryLooseAcc( *el_itr ) == 1 ) { ++m_nel_LHVeryLoose; }
-      } else { m_el_LHVeryLoose.push_back( -1 ); }
       if ( LHLooseAcc.isAvailable( *el_itr ) ) {
         m_el_LHLoose.push_back( LHLooseAcc( *el_itr ) );
         if ( LHLooseAcc( *el_itr ) == 1 ) { ++m_nel_LHLoose; }
@@ -1242,7 +1231,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff("ElectronEfficiencyCorrector_TrigMCEffSyst");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
-      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium");
@@ -1255,7 +1243,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       if( accTrigMCEff.isAvailable( *el_itr ) ) { m_el_TrigMCEff.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_TrigMCEff.push_back( junk ); }
       if( accIsoSF_Loose.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *el_itr ) ); } else { m_el_IsoEff_SF_Loose.push_back( junk ); }
       if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
-      if( accPIDSF_LHVeryLoose.isAvailable( *el_itr ) ) { m_el_PIDEff_SF_LHVeryLoose.push_back( accPIDSF_LHVeryLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHVeryLoose.push_back( junk ); }
       if( accPIDSF_LHLooseAndBLayer.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( accPIDSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( junk ); }
       if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
       if( accPIDSF_LHMedium.isAvailable( *el_itr ) )    { m_el_PIDEff_SF_LHMedium.push_back( accPIDSF_LHMedium( *el_itr ) ); } else { m_el_PIDEff_SF_LHMedium.push_back( junk ); }
@@ -1311,8 +1298,6 @@ void HelpTreeBase::ClearElectrons() {
   }
 
   if ( m_elInfoSwitch->m_PID ) {
-    m_nel_LHVeryLoose = 0;
-    m_el_LHVeryLoose.clear();
     m_nel_LHLoose = 0;
     m_el_LHLoose.clear();
     m_nel_LHMedium = 0;
@@ -1359,7 +1344,6 @@ void HelpTreeBase::ClearElectrons() {
     m_el_TrigMCEff.clear();
     m_el_IsoEff_SF_Loose.clear();
     m_el_IsoEff_SF_FixedCutTight.clear();
-    m_el_PIDEff_SF_LHVeryLoose.clear();
     m_el_PIDEff_SF_LHLooseAndBLayer.clear();
     m_el_PIDEff_SF_LHLoose.clear();
     m_el_PIDEff_SF_LHMedium.clear();
@@ -3101,7 +3085,6 @@ void HelpTreeBase::ClearEvent() {
     m_weight_electron_RecoEff_SF.clear();
     m_weight_electron_IsoEff_SF_Loose.clear();
     m_weight_electron_IsoEff_SF_FixedCutTight.clear();
-    m_weight_electron_PIDEff_SF_LHVeryLoose.clear();
     m_weight_electron_PIDEff_SF_LHLooseAndBLayer.clear();
     m_weight_electron_PIDEff_SF_LHLoose.clear();
     m_weight_electron_PIDEff_SF_LHMedium.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -180,26 +180,6 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("caloCluster_e",   &m_caloCluster_e);
   }
 
-  if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
-    m_tree->Branch("weight_muon_RecoEff_SF_Loose",		      &m_weight_muon_RecoEff_SF_Loose);
-    m_tree->Branch("weight_muon_IsoEff_SF_LooseTrackOnly", 	      &m_weight_muon_IsoEff_SF_LooseTrackOnly);
-    m_tree->Branch("weight_muon_IsoEff_SF_Loose",	    	      &m_weight_muon_IsoEff_SF_Loose);
-    m_tree->Branch("weight_muon_IsoEff_SF_Tight",	    	      &m_weight_muon_IsoEff_SF_Tight);
-    m_tree->Branch("weight_muon_IsoEff_SF_Gradient",	    	      &m_weight_muon_IsoEff_SF_Gradient);
-    m_tree->Branch("weight_muon_IsoEff_SF_GradientLoose",  	      &m_weight_muon_IsoEff_SF_GradientLoose);
-    m_tree->Branch("weight_muon_IsoEff_SF_FixedCutTightTrackOnly",    &m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly);
-  }
-
-  if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-    m_tree->Branch("weight_electron_RecoEff_SF"  ,	         &m_weight_electron_RecoEff_SF  );
-    m_tree->Branch("weight_electron_IsoEff_SF_Loose",            &m_weight_electron_IsoEff_SF_Loose);
-    m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",    &m_weight_electron_IsoEff_SF_FixedCutTight);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHLooseAndBLayer", &m_weight_electron_PIDEff_SF_LHLooseAndBLayer);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHLoose",	    &m_weight_electron_PIDEff_SF_LHLoose);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHMedium",    &m_weight_electron_PIDEff_SF_LHMedium);
-    m_tree->Branch("weight_electron_PIDEff_SF_LHTight",	    &m_weight_electron_PIDEff_SF_LHTight);
-  }
-
   this->AddEventUser();
 }
 
@@ -333,46 +313,6 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 //        }
 
     }
-
-  }
-
-  if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
-
-    SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal_Loose("MuonEfficiencyCorrector_RecoSyst_Loose_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_LooseTrackOnly("MuonEfficiencyCorrector_IsoSyst_LooseTrackOnly_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("MuonEfficiencyCorrector_IsoSyst_Loose_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Tight("MuonEfficiencyCorrector_IsoSyst_Tight_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Gradient("MuonEfficiencyCorrector_IsoSyst_Gradient_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_GradientLoose("MuonEfficiencyCorrector_IsoSyst_GradientLoose_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_FixedCutTightTrackOnly_GLOBAL");
-
-    if( accRecoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_muon_RecoEff_SF_Loose = accRecoSFGlobal_Loose( *eventInfo ); } else { m_weight_muon_RecoEff_SF_Loose.push_back(-999.0); }
-    if( accIsoSFGlobal_LooseTrackOnly.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_LooseTrackOnly = accIsoSFGlobal_LooseTrackOnly( *eventInfo ); } else { m_weight_muon_IsoEff_SF_LooseTrackOnly.push_back(-999.0); }
-    if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Loose.push_back(-999.0); }
-    if( accIsoSFGlobal_Tight.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Tight = accIsoSFGlobal_Tight( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Tight.push_back(-999.0); }
-    if( accIsoSFGlobal_Gradient.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Gradient = accIsoSFGlobal_Gradient( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Gradient.push_back(-999.0); }
-    if( accIsoSFGlobal_GradientLoose.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_GradientLoose = accIsoSFGlobal_GradientLoose( *eventInfo ); } else { m_weight_muon_IsoEff_SF_GradientLoose.push_back(-999.0); }
-    if( accIsoSFGlobal_FixedCutTightTrackOnly.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly = accIsoSFGlobal_FixedCutTightTrackOnly( *eventInfo ); } else { m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back(-999.0); }
-
-  }
-
-  if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-
-    SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
-    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHTight("ElectronEfficiencyCorrector_PIDSyst_LHTight_GLOBAL");
-
-    if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_electron_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_electron_RecoEff_SF.push_back(-999.0); }
-    if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_electron_IsoEff_SF_Loose.push_back(-999.0); }
-    if( accIsoSFGlobal_FixedCutTight.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_FixedCutTight = accIsoSFGlobal_FixedCutTight( *eventInfo ); } else { m_weight_electron_IsoEff_SF_FixedCutTight.push_back(-999.0); }
-    if( accPIDSFGlobal_LHLooseAndBLayer.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLooseAndBLayer = accPIDSFGlobal_LHLooseAndBLayer( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLooseAndBLayer.push_back(-999.0); }
-    if( accPIDSFGlobal_LHLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLoose = accPIDSFGlobal_LHLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLoose.push_back(-999.0); }
-    if( accPIDSFGlobal_LHMedium.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHMedium = accPIDSFGlobal_LHMedium( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHMedium.push_back(-999.0); }
-    if( accPIDSFGlobal_LHTight.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHTight= accPIDSFGlobal_LHTight( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHTight.push_back(-999.0); }
 
   }
 
@@ -775,28 +715,29 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF_Loose("MuonEfficiencyCorrector_RecoSyst_Loose");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Loose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoFixedCutTightTrackOnly");
-      static SG::AuxElement::Accessor< double >               accTrigMCEff_Loose_Loose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoLoose");
-      static SG::AuxElement::Accessor< double >               accTrigMCEff_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoFixedCutTightTrackOnly");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_Loose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoFixedCutTightTrackOnly");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_LooseTrackOnly("MuonEfficiencyCorrector_IsoSyst_LooseTrackOnly");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("MuonEfficiencyCorrector_IsoSyst_Loose");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Tight("MuonEfficiencyCorrector_IsoSyst_Tight");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Gradient("MuonEfficiencyCorrector_IsoSyst_Gradient");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_GradientLoose("MuonEfficiencyCorrector_IsoSyst_GradientLoose");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_FixedCutTightTrackOnly");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("MuonEfficiencyCorrector_IsoSyst_IsoLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Tight("MuonEfficiencyCorrector_IsoSyst_IsoTight");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Gradient("MuonEfficiencyCorrector_IsoSyst_IsoGradient");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_GradientLoose("MuonEfficiencyCorrector_IsoSyst_IsoGradientLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_IsoFixedCutTightTrackOnly");
 
-      std::vector<float> junk(1,-999);
+      std::vector<float> junkSF(1,1.0);
+      std::vector<float> junkEff(1,0.0);
 
-      if( accRecoSF_Loose.isAvailable( *muon_itr ) )         { m_muon_RecoEff_SF_Loose.push_back( accRecoSF_Loose( *muon_itr ) ); } else { m_muon_RecoEff_SF_Loose.push_back( junk ); }
-      if ( accTrigSF_Loose_Loose.isAvailable( *muon_itr ) )                     { m_muon_TrigEff_SF_Loose_Loose.push_back( accTrigSF_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_Loose.push_back( junk ); }
-      if ( accTrigSF_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )    { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( accTrigSF_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( junk ); }
-      if ( accTrigMCEff_Loose_Loose.isAvailable( *muon_itr ) )                  { m_muon_TrigMCEff_Loose_Loose.push_back( accTrigMCEff_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_Loose.push_back( 0.0 ); }
-      if ( accTrigMCEff_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) ) { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( accTrigMCEff_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( 0.0 ); }
-      if( accIsoSF_LooseTrackOnly.isAvailable( *muon_itr ) ) { m_muon_IsoEff_SF_LooseTrackOnly.push_back( accIsoSF_LooseTrackOnly( *muon_itr ) ); } else { m_muon_IsoEff_SF_LooseTrackOnly.push_back( junk ); }
-      if( accIsoSF_Loose.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *muon_itr ) ); } else { m_muon_IsoEff_SF_Loose.push_back( junk ); }
-      if( accIsoSF_Tight.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Tight.push_back( accIsoSF_Tight( *muon_itr ) ); } else { m_muon_IsoEff_SF_Tight.push_back( junk ); }
-      if( accIsoSF_GradientLoose.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_GradientLoose.push_back( accIsoSF_GradientLoose( *muon_itr ) ); } else {  m_muon_IsoEff_SF_GradientLoose.push_back( junk ); }
-      if( accIsoSF_Gradient.isAvailable( *muon_itr ) )       { m_muon_IsoEff_SF_Gradient.push_back( accIsoSF_Gradient( *muon_itr ) ); } else { m_muon_IsoEff_SF_Gradient.push_back( junk ); }
-      if( accIsoSF_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( accIsoSF_FixedCutTightTrackOnly( *muon_itr ) ); } else {  m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( junk ); }
+      if( accRecoSF_Loose.isAvailable( *muon_itr ) )         { m_muon_RecoEff_SF_Loose.push_back( accRecoSF_Loose( *muon_itr ) ); } else { m_muon_RecoEff_SF_Loose.push_back( junkSF ); }
+      if ( accTrigSF_Loose_Loose.isAvailable( *muon_itr ) )                     { m_muon_TrigEff_SF_Loose_Loose.push_back( accTrigSF_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_Loose.push_back( junkSF ); }
+      if ( accTrigSF_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )    { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( accTrigSF_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly.push_back( junkSF ); }
+      if ( accTrigMCEff_Loose_Loose.isAvailable( *muon_itr ) )                  { m_muon_TrigMCEff_Loose_Loose.push_back( accTrigMCEff_Loose_Loose( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_Loose.push_back( junkEff ); }
+      if ( accTrigMCEff_Loose_FixedCutTightTrackOnly.isAvailable( *muon_itr ) ) { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( accTrigMCEff_Loose_FixedCutTightTrackOnly( *muon_itr ) ); } else { m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly.push_back( junkEff ); }
+      if( accIsoSF_LooseTrackOnly.isAvailable( *muon_itr ) ) { m_muon_IsoEff_SF_LooseTrackOnly.push_back( accIsoSF_LooseTrackOnly( *muon_itr ) ); } else { m_muon_IsoEff_SF_LooseTrackOnly.push_back( junkSF ); }
+      if( accIsoSF_Loose.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *muon_itr ) ); } else { m_muon_IsoEff_SF_Loose.push_back( junkSF ); }
+      if( accIsoSF_Tight.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Tight.push_back( accIsoSF_Tight( *muon_itr ) ); } else { m_muon_IsoEff_SF_Tight.push_back( junkSF ); }
+      if( accIsoSF_GradientLoose.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_GradientLoose.push_back( accIsoSF_GradientLoose( *muon_itr ) ); } else {  m_muon_IsoEff_SF_GradientLoose.push_back( junkSF ); }
+      if( accIsoSF_Gradient.isAvailable( *muon_itr ) )       { m_muon_IsoEff_SF_Gradient.push_back( accIsoSF_Gradient( *muon_itr ) ); } else { m_muon_IsoEff_SF_Gradient.push_back( junkSF ); }
+      if( accIsoSF_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( accIsoSF_FixedCutTightTrackOnly( *muon_itr ) ); } else {  m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( junkSF ); }
 
     }
 
@@ -1237,32 +1178,31 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
     if ( m_elInfoSwitch->m_effSF && m_isMC ) {
 
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
-      
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_TrigSyst_LHLooseAndBLayer");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_LHTight("ElectronEfficiencyCorrector_TrigSyst_LHTight");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_LHLooseAndBLayer("ElectronEfficiencyCorrector_TrigMCEffSyst_LHLooseAndBLayer");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_LHTight("ElectronEfficiencyCorrector_TrigMCEffSyst_LHTight");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
-      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
-      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer");
+      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer");
+      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHTight("ElectronEfficiencyCorrector_PIDSyst_LHTight");
 
-      std::vector<float> junk(1,-999);
+      std::vector<float> junkSF(1,1.0);
+      std::vector<float> junkEff(1,0.0);
 
-      if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
-      
-      if( accTrigSF_LHLooseAndBLayer.isAvailable( *el_itr ) )    { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( accTrigSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( junk ); }
-      if( accTrigSF_LHTight.isAvailable( *el_itr ) )             { m_el_TrigEff_SF_LHTight.push_back( accTrigSF_LHTight( *el_itr ) ); } else { m_el_TrigEff_SF_LHTight.push_back( junk ); }
-      if( accTrigMCEff_LHLooseAndBLayer.isAvailable( *el_itr ) ) { m_el_TrigMCEff_LHLooseAndBLayer.push_back( accTrigMCEff_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigMCEff_LHLooseAndBLayer.push_back( junk ); }
-      if( accTrigMCEff_LHTight.isAvailable( *el_itr ) )          { m_el_TrigMCEff_LHTight.push_back( accTrigMCEff_LHTight( *el_itr ) ); } else { m_el_TrigMCEff_LHTight.push_back( junk ); }
-      if( accIsoSF_Loose.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *el_itr ) ); } else { m_el_IsoEff_SF_Loose.push_back( junk ); }
-      if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
-      if( accPIDSF_LHLooseAndBLayer.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( accPIDSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( junk ); }
-      if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
-      if( accPIDSF_LHMedium.isAvailable( *el_itr ) )    { m_el_PIDEff_SF_LHMedium.push_back( accPIDSF_LHMedium( *el_itr ) ); } else { m_el_PIDEff_SF_LHMedium.push_back( junk ); }
-      if( accPIDSF_LHTight.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHTight.push_back( accPIDSF_LHTight( *el_itr ) ); } else { m_el_PIDEff_SF_LHTight.push_back( junk ); }
+      if( accRecoSF.isAvailable( *el_itr ) )                     { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junkSF ); }
+      if( accTrigSF_LHLooseAndBLayer.isAvailable( *el_itr ) )    { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( accTrigSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigEff_SF_LHLooseAndBLayer.push_back( junkSF ); }
+      if( accTrigSF_LHTight.isAvailable( *el_itr ) )             { m_el_TrigEff_SF_LHTight.push_back( accTrigSF_LHTight( *el_itr ) ); } else { m_el_TrigEff_SF_LHTight.push_back( junkSF ); }
+      if( accTrigMCEff_LHLooseAndBLayer.isAvailable( *el_itr ) ) { m_el_TrigMCEff_LHLooseAndBLayer.push_back( accTrigMCEff_LHLooseAndBLayer( *el_itr ) ); } else { m_el_TrigMCEff_LHLooseAndBLayer.push_back( junkEff ); }
+      if( accTrigMCEff_LHTight.isAvailable( *el_itr ) )          { m_el_TrigMCEff_LHTight.push_back( accTrigMCEff_LHTight( *el_itr ) ); } else { m_el_TrigMCEff_LHTight.push_back( junkEff ); }
+      if( accIsoSF_Loose.isAvailable( *el_itr ) )                { m_el_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *el_itr ) ); } else { m_el_IsoEff_SF_Loose.push_back( junkSF ); }
+      if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) )        { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junkSF ); }
+      if( accPIDSF_LHLooseAndBLayer.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( accPIDSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( junkSF ); }
+      if( accPIDSF_LHLoose.isAvailable( *el_itr ) )              { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junkSF ); }
+      if( accPIDSF_LHMedium.isAvailable( *el_itr ) )             { m_el_PIDEff_SF_LHMedium.push_back( accPIDSF_LHMedium( *el_itr ) ); } else { m_el_PIDEff_SF_LHMedium.push_back( junkSF ); }
+      if( accPIDSF_LHTight.isAvailable( *el_itr ) )              { m_el_PIDEff_SF_LHTight.push_back( accPIDSF_LHTight( *el_itr ) ); } else { m_el_PIDEff_SF_LHTight.push_back( junkSF ); }
 
     }
 
@@ -3085,26 +3025,6 @@ void HelpTreeBase::ClearEvent() {
     m_caloCluster_eta.clear();
     m_caloCluster_phi.clear();
     m_caloCluster_e.clear();
-  }
-
-  if( m_eventInfoSwitch->m_muonSF && m_isMC ) {
-    m_weight_muon_RecoEff_SF_Loose.clear();
-    m_weight_muon_IsoEff_SF_LooseTrackOnly.clear();
-    m_weight_muon_IsoEff_SF_Loose.clear();
-    m_weight_muon_IsoEff_SF_Tight.clear();
-    m_weight_muon_IsoEff_SF_Gradient.clear();
-    m_weight_muon_IsoEff_SF_GradientLoose.clear();
-    m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly.clear();
-  }
-
-  if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-    m_weight_electron_RecoEff_SF.clear();
-    m_weight_electron_IsoEff_SF_Loose.clear();
-    m_weight_electron_IsoEff_SF_FixedCutTight.clear();
-    m_weight_electron_PIDEff_SF_LHLooseAndBLayer.clear();
-    m_weight_electron_PIDEff_SF_LHLoose.clear();
-    m_weight_electron_PIDEff_SF_LHMedium.clear();
-    m_weight_electron_PIDEff_SF_LHTight.clear();
   }
 
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -192,7 +192,6 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
   }
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-    m_tree->Branch("weight_electron_trig", 		    &m_weight_electron_trig);
     m_tree->Branch("weight_electron_RecoEff_SF"  ,	    &m_weight_electron_RecoEff_SF  );
     m_tree->Branch("weight_electron_IsoEff_SF_Loose",   &m_weight_electron_IsoEff_SF_Loose);
     m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",   &m_weight_electron_IsoEff_SF_FixedCutTight);
@@ -364,7 +363,6 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
 
-    SG::AuxElement::ConstAccessor< std::vector<float> >   electronTrigSFVec( "ElectronEfficiencyCorrector_TrigSyst_GLOBAL" );
     SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight_GLOBAL");
@@ -373,7 +371,6 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHTight("ElectronEfficiencyCorrector_PIDSyst_LHTight_GLOBAL");
 
-    if( electronTrigSFVec.isAvailable( *eventInfo ) ) { m_weight_electron_trig = electronTrigSFVec( *eventInfo ); } else { m_weight_electron_trig.push_back(-999); }
     if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_electron_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_electron_RecoEff_SF.push_back(-999.0); }
     if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_electron_IsoEff_SF_Loose.push_back(-999.0); }
     if( accIsoSFGlobal_FixedCutTight.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_FixedCutTight = accIsoSFGlobal_FixedCutTight( *eventInfo ); } else { m_weight_electron_IsoEff_SF_FixedCutTight.push_back(-999.0); }
@@ -3081,7 +3078,6 @@ void HelpTreeBase::ClearEvent() {
   }
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
-    m_weight_electron_trig.clear();
     m_weight_electron_RecoEff_SF.clear();
     m_weight_electron_IsoEff_SF_Loose.clear();
     m_weight_electron_IsoEff_SF_FixedCutTight.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -528,6 +528,8 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
   }
 
   if ( m_muInfoSwitch->m_trigger ){
+    // this is true if there's a match for at least one trigger chain
+    m_tree->Branch("muon_isTrigMatched", &m_muon_isTrigMatched);
     // a vector of trigger match decision for each muon trigger chain
     m_tree->Branch( "muon_isTrigMatchedToChain", &m_muon_isTrigMatchedToChain );
     // a vector of strings for each muon trigger chain - 1:1 correspondence w/ vector above
@@ -630,23 +632,32 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
     if ( m_muInfoSwitch->m_trigger ) {
 
-      // retrieve map<string,char> w/ chain,isMatched
+      // retrieve map<string,char> w/ <chain,isMatched>
       //
       static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapMuAcc("isTrigMatchedMapMu");
+
+      std::vector<int> matches; 
 
       if ( isTrigMatchedMapMuAcc.isAvailable( *muon_itr ) ) {
 	 // loop over map and fill branches
 	 //
 	 for ( auto const &it : (isTrigMatchedMapMuAcc( *muon_itr )) ) {
-  	   m_muon_isTrigMatchedToChain.push_back( static_cast<int>(it.second) );
+  	   matches.push_back( static_cast<int>(it.second) );
 	   m_muon_listTrigChains.push_back( it.first );
 	 }
        } else {
-	 m_muon_isTrigMatchedToChain.push_back( -1 );
+	 matches.push_back( -1 );
 	 m_muon_listTrigChains.push_back("NONE");
        }
-
+       
+       m_muon_isTrigMatchedToChain.push_back(matches);
+       
+       // if at least one match among the chains is found, say this muon is trigger matched
+       if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_muon_isTrigMatched.push_back(1); }
+       else { m_muon_isTrigMatched.push_back(0); }
+       
     }
+
 
     if ( m_muInfoSwitch->m_isolation ) {
 
@@ -820,6 +831,7 @@ void HelpTreeBase::ClearMuons() {
   }
 
   if ( m_muInfoSwitch->m_trigger ) {
+    m_muon_isTrigMatched.clear();
     m_muon_isTrigMatchedToChain.clear();
     m_muon_listTrigChains.clear();
   }
@@ -925,10 +937,12 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
   }
 
   if ( m_elInfoSwitch->m_trigger ){
+    // this is true if there's a match for at least one trigger chain
+    m_tree->Branch("el_isTrigMatched", &m_el_isTrigMatched);
     // a vector of trigger match decision for each electron trigger chain
-    m_tree->Branch( "el_isTrigMatchedToChain", &m_el_isTrigMatchedToChain );
-    // a vector of strings for each electron trigger chain - 1:1 correspondence w/ vector above
-    m_tree->Branch( "el_listTrigChains", &m_el_listTrigChains );
+    m_tree->Branch("el_isTrigMatchedToChain", &m_el_isTrigMatchedToChain);
+    // a vector of strings with the electron trigger chain names - 1:1 correspondence w/ vector above
+    m_tree->Branch("el_listTrigChains", &m_el_listTrigChains);
   }
 
   if ( m_elInfoSwitch->m_isolation ) {
@@ -1038,22 +1052,30 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 
     if ( m_elInfoSwitch->m_trigger ) {
 
-      // retrieve map<string,char> w/ chain,isMatched
+      // retrieve map<string,char> w/ <chain,isMatched>
       //
       static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapElAcc("isTrigMatchedMapEl");
+
+      std::vector<int> matches; 
 
       if ( isTrigMatchedMapElAcc.isAvailable( *el_itr ) ) {
 	 // loop over map and fill branches
 	 //
 	 for ( auto const &it : (isTrigMatchedMapElAcc( *el_itr )) ) {
-  	   m_el_isTrigMatchedToChain.push_back( static_cast<int>(it.second) );
+  	   matches.push_back( static_cast<int>(it.second) );
 	   m_el_listTrigChains.push_back( it.first );
 	 }
        } else {
-	 m_el_isTrigMatchedToChain.push_back( -1 );
+	 matches.push_back( -1 );
 	 m_el_listTrigChains.push_back("NONE");
        }
-
+       
+       m_el_isTrigMatchedToChain.push_back(matches);
+       
+       // if at least one match among the chains is found, say this electron is trigger matched
+       if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_el_isTrigMatched.push_back(1); }
+       else { m_el_isTrigMatched.push_back(0); }
+       
     }
 
     if ( m_elInfoSwitch->m_isolation ) {
@@ -1239,6 +1261,7 @@ void HelpTreeBase::ClearElectrons() {
   }
 
   if ( m_elInfoSwitch->m_trigger ) {
+    m_el_isTrigMatched.clear();
     m_el_isTrigMatchedToChain.clear();
     m_el_listTrigChains.clear();
   }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -988,6 +988,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
   if ( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_tree->Branch("el_RecoEff_SF"  ,		 &m_el_RecoEff_SF  );
     m_tree->Branch("el_TrigEff_SF"  ,		 &m_el_TrigEff_SF  );
+    m_tree->Branch("el_TrigMCEff"   ,		 &m_el_TrigMCEff  );
     m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
     m_tree->Branch("el_PIDEff_SF_LHVeryLoose",   &m_el_PIDEff_SF_LHVeryLoose);
     m_tree->Branch("el_PIDEff_SF_LHLoose",       &m_el_PIDEff_SF_LHLoose);
@@ -1225,6 +1226,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF("ElectronEfficiencyCorrector_TrigSyst");
+      static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff("ElectronEfficiencyCorrector_TrigMCEffSyst");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
@@ -1235,6 +1237,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 
       if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
       if( accTrigSF.isAvailable( *el_itr ) ) { m_el_TrigEff_SF.push_back( accTrigSF( *el_itr ) ); } else { m_el_TrigEff_SF.push_back( junk ); }
+      if( accTrigMCEff.isAvailable( *el_itr ) ) { m_el_TrigMCEff.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_TrigMCEff.push_back( junk ); }
       if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
       if( accPIDSF_LHVeryLoose.isAvailable( *el_itr ) ) { m_el_PIDEff_SF_LHVeryLoose.push_back( accPIDSF_LHVeryLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHVeryLoose.push_back( junk ); }
       if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
@@ -1335,6 +1338,7 @@ void HelpTreeBase::ClearElectrons() {
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_el_RecoEff_SF.clear();
     m_el_TrigEff_SF.clear();
+    m_el_TrigMCEff.clear();
     m_el_IsoEff_SF_FixedCutTight.clear();
     m_el_PIDEff_SF_LHVeryLoose.clear();
     m_el_PIDEff_SF_LHLoose.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -504,6 +504,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
     m_tree->Branch("muon_IsoEff_SF_Gradient",	    &m_muon_IsoEff_SF_Gradient);
     m_tree->Branch("muon_IsoEff_SF_GradientLoose",  &m_muon_IsoEff_SF_GradientLoose);
     m_tree->Branch("muon_IsoEff_SF_FixedCutTightTrackOnly",  &m_muon_IsoEff_SF_FixedCutTightTrackOnly);
+    m_tree->Branch("muon_TTVAEff_SF",  &m_muon_TTVAEff_SF);
   }
 
   if ( m_muInfoSwitch->m_quality ) {
@@ -723,6 +724,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Gradient("MuonEfficiencyCorrector_IsoSyst_IsoGradient");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_GradientLoose("MuonEfficiencyCorrector_IsoSyst_IsoGradientLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_IsoFixedCutTightTrackOnly");
+      static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
 
       std::vector<float> junkSF(1,1.0);
       std::vector<float> junkEff(1,0.0);
@@ -738,6 +740,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       if( accIsoSF_GradientLoose.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_GradientLoose.push_back( accIsoSF_GradientLoose( *muon_itr ) ); } else {  m_muon_IsoEff_SF_GradientLoose.push_back( junkSF ); }
       if( accIsoSF_Gradient.isAvailable( *muon_itr ) )       { m_muon_IsoEff_SF_Gradient.push_back( accIsoSF_Gradient( *muon_itr ) ); } else { m_muon_IsoEff_SF_Gradient.push_back( junkSF ); }
       if( accIsoSF_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( accIsoSF_FixedCutTightTrackOnly( *muon_itr ) ); } else {  m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( junkSF ); }
+      if( accTTVASF.isAvailable( *muon_itr ) )         { m_muon_TTVAEff_SF.push_back( accTTVASF( *muon_itr ) ); } else { m_muon_TTVAEff_SF.push_back( junkSF ); }
 
     }
 
@@ -850,6 +853,7 @@ void HelpTreeBase::ClearMuons() {
     m_muon_IsoEff_SF_Gradient.clear();
     m_muon_IsoEff_SF_GradientLoose.clear();
     m_muon_IsoEff_SF_FixedCutTightTrackOnly.clear();
+    m_muon_TTVAEff_SF.clear();
   }
 
   if ( m_muInfoSwitch->m_energyLoss ) {
@@ -1296,7 +1300,7 @@ void HelpTreeBase::ClearElectrons() {
 
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_el_RecoEff_SF.clear();
-    m_el_TrigEff_SF_LHLooseAndBLayer.clear();    
+    m_el_TrigEff_SF_LHLooseAndBLayer.clear();
     m_el_TrigEff_SF_LHTight.clear();
     m_el_TrigMCEff_LHLooseAndBLayer.clear();
     m_el_TrigMCEff_LHTight.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -58,41 +58,41 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
 }
 
 HelpTreeBase::~HelpTreeBase() {
-    
+
     //delete all the info switches that have been built earlier on
-    
+
     //event
     delete m_eventInfoSwitch;
-    
+
     //trig
     delete m_trigInfoSwitch;
-    
+
     //mu
     delete m_muInfoSwitch;
-    
+
     //el
     delete m_elInfoSwitch;
-    
+
     //ph
     delete m_phInfoSwitch;
-    
+
     //truth
     delete m_truthInfoSwitch;
-    
+
     //fatjet
     delete m_fatJetInfoSwitch;
-    
+
     //tau
     delete m_tauInfoSwitch;
-    
+
     //met
     delete m_metInfoSwitch;
-    
+
     //jet
 
     for(auto jetInfoSwitch: m_thisJetInfoSwitch)
-        delete jetInfoSwitch.second;    
-    
+        delete jetInfoSwitch.second;
+
 }
 
 
@@ -133,7 +133,6 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
   }
 
   if ( m_eventInfoSwitch->m_eventCleaning ) {
-    
     m_tree->Branch("timeStamp",          &m_timeStamp,         "timeStamp/i");
     m_tree->Branch("timeStampNSOffset",  &m_timeStampNSOffset, "timeStampNSOffset/i");
     m_tree->Branch("TileError",          &m_TileError,         "TileError/O");
@@ -142,9 +141,8 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("TileFlags",          &m_TileFlags,         "TileFlags/i");
     m_tree->Branch("SCTFlags",           &m_SCTFlags,          "SCTFlags/i");
     m_tree->Branch("LArFlags",           &m_LArFlags,          "LArFlags/i");
-
   }
-    
+
   if ( m_eventInfoSwitch->m_pileup ) {
     m_tree->Branch("weight_pileup",      &m_weight_pileup,  "weight_pileup/F");
     m_tree->Branch("NPV",                &m_npv,            "NPV/I");
@@ -190,13 +188,13 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("weight_muon_IsoEff_SF_Tight",	    	      &m_weight_muon_IsoEff_SF_Tight);
     m_tree->Branch("weight_muon_IsoEff_SF_Gradient",	    	      &m_weight_muon_IsoEff_SF_Gradient);
     m_tree->Branch("weight_muon_IsoEff_SF_GradientLoose",  	      &m_weight_muon_IsoEff_SF_GradientLoose);
-    m_tree->Branch("weight_muon_IsoEff_SF_UserDefinedFixEfficiency",  &m_weight_muon_IsoEff_SF_UserDefinedFixEfficiency);
-    m_tree->Branch("weight_muon_IsoEff_SF_UserDefinedCut",	      &m_weight_muon_IsoEff_SF_UserDefinedCut);
+    m_tree->Branch("weight_muon_IsoEff_SF_FixedCutTightTrackOnly",    &m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly);
   }
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
     m_tree->Branch("weight_electron_trig", 		    &m_weight_electron_trig);
     m_tree->Branch("weight_electron_RecoEff_SF"  ,	    &m_weight_electron_RecoEff_SF  );
+    m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",   &m_weight_electron_IsoEff_SF_FixedCutTight);
     m_tree->Branch("weight_electron_PIDEff_SF_LHVeryLoose", &m_weight_electron_PIDEff_SF_LHVeryLoose);
     m_tree->Branch("weight_electron_PIDEff_SF_LHLoose",	    &m_weight_electron_PIDEff_SF_LHLoose);
     m_tree->Branch("weight_electron_PIDEff_SF_LHMedium",    &m_weight_electron_PIDEff_SF_LHMedium);
@@ -222,22 +220,21 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
   } else {
     m_bcid                  = eventInfo->bcid();
   }
-    
+
   if ( m_eventInfoSwitch->m_eventCleaning ) {
-      
+
     if ( eventInfo->errorState(xAOD::EventInfo::LAr)==xAOD::EventInfo::Error ) m_LArError = true;
     else m_LArError = false;
     m_LArFlags = eventInfo->eventFlags(xAOD::EventInfo::LAr);
-      
+
     if ( eventInfo->errorState(xAOD::EventInfo::Tile)==xAOD::EventInfo::Error ) m_TileError = true;
     else m_TileError = false;
     m_TileFlags = eventInfo->eventFlags(xAOD::EventInfo::Tile);
-      
+
     if ( eventInfo->errorState(xAOD::EventInfo::SCT)==xAOD::EventInfo::Error ) m_SCTError = true;
     else m_SCTError = false;
     m_SCTFlags = eventInfo->eventFlags(xAOD::EventInfo::SCT);
-      
-      
+
     m_timeStamp = eventInfo->timeStamp();
     m_timeStampNSOffset = eventInfo->timeStampNSOffset();
 
@@ -349,6 +346,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Tight("MuonEfficiencyCorrector_IsoSyst_Tight_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Gradient("MuonEfficiencyCorrector_IsoSyst_Gradient_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_GradientLoose("MuonEfficiencyCorrector_IsoSyst_GradientLoose_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_FixedCutTightTrackOnly_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_UserDefinedFixEfficiency("MuonEfficiencyCorrector_IsoSyst_UserDefinedFixEfficiency_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_UserDefinedCut("MuonEfficiencyCorrector_IsoSyst_UserDefinedCut_GLOBAL");
 
@@ -359,8 +357,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     if( accIsoSFGlobal_Tight.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Tight = accIsoSFGlobal_Tight( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Tight.push_back(-999.0); }
     if( accIsoSFGlobal_Gradient.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_Gradient = accIsoSFGlobal_Gradient( *eventInfo ); } else { m_weight_muon_IsoEff_SF_Gradient.push_back(-999.0); }
     if( accIsoSFGlobal_GradientLoose.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_GradientLoose = accIsoSFGlobal_GradientLoose( *eventInfo ); } else { m_weight_muon_IsoEff_SF_GradientLoose.push_back(-999.0); }
-    if( accIsoSFGlobal_UserDefinedFixEfficiency.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_UserDefinedFixEfficiency = accIsoSFGlobal_UserDefinedFixEfficiency( *eventInfo ); } else { m_weight_muon_IsoEff_SF_UserDefinedFixEfficiency.push_back(-999.0); }
-    if( accIsoSFGlobal_UserDefinedCut.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_UserDefinedCut = accIsoSFGlobal_UserDefinedCut( *eventInfo ); } else { m_weight_muon_IsoEff_SF_UserDefinedCut.push_back(-999.0); }
+    if( accIsoSFGlobal_FixedCutTightTrackOnly.isAvailable( *eventInfo ) ) { m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly = accIsoSFGlobal_FixedCutTightTrackOnly( *eventInfo ); } else { m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back(-999.0); }
 
   }
 
@@ -368,6 +365,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
     SG::AuxElement::ConstAccessor< std::vector<float> >   electronTrigSFVec( "ElectronEfficiencyCorrector_TrigSyst" );
     SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_FixedCutTight_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
@@ -375,6 +373,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
     if( electronTrigSFVec.isAvailable( *eventInfo ) ) { m_weight_electron_trig = electronTrigSFVec( *eventInfo ); } else { m_weight_electron_trig.push_back(-999); }
     if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_electron_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_electron_RecoEff_SF.push_back(-999.0); }
+    if( accIsoSFGlobal_FixedCutTight.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_FixedCutTight = accIsoSFGlobal_FixedCutTight( *eventInfo ); } else { m_weight_electron_IsoEff_SF_FixedCutTight.push_back(-999.0); }
     if( accPIDSFGlobal_LHVeryLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHVeryLoose = accPIDSFGlobal_LHVeryLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHVeryLoose.push_back(-999.0); }
     if( accPIDSFGlobal_LHLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLoose = accPIDSFGlobal_LHLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLoose.push_back(-999.0); }
     if( accPIDSFGlobal_LHMedium.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHMedium = accPIDSFGlobal_LHMedium( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHMedium.push_back(-999.0); }
@@ -541,11 +540,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
     m_tree->Branch("muon_isIsolated_Tight",	     &m_muon_isIsolated_Tight);
     m_tree->Branch("muon_isIsolated_Gradient",	     &m_muon_isIsolated_Gradient);
     m_tree->Branch("muon_isIsolated_GradientLoose",  &m_muon_isIsolated_GradientLoose);
-    m_tree->Branch("muon_isIsolated_GradientT1",     &m_muon_isIsolated_GradientT1);
-    m_tree->Branch("muon_isIsolated_GradientT2",     &m_muon_isIsolated_GradientT2);
-    m_tree->Branch("muon_isIsolated_MU0p06",	     &m_muon_isIsolated_MU0p06);
     m_tree->Branch("muon_isIsolated_FixedCutLoose",	   &m_muon_isIsolated_FixedCutLoose);
-    m_tree->Branch("muon_isIsolated_FixedCutTight",	   &m_muon_isIsolated_FixedCutTight);
     m_tree->Branch("muon_isIsolated_FixedCutTightTrackOnly", &m_muon_isIsolated_FixedCutTightTrackOnly);
     m_tree->Branch("muon_isIsolated_UserDefinedFixEfficiency",    &m_muon_isIsolated_UserDefinedFixEfficiency);
     m_tree->Branch("muon_isIsolated_UserDefinedCut",              &m_muon_isIsolated_UserDefinedCut);
@@ -567,8 +562,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr) {
     m_tree->Branch("muon_IsoEff_SF_Tight",	    &m_muon_IsoEff_SF_Tight);
     m_tree->Branch("muon_IsoEff_SF_Gradient",	    &m_muon_IsoEff_SF_Gradient);
     m_tree->Branch("muon_IsoEff_SF_GradientLoose",  &m_muon_IsoEff_SF_GradientLoose);
-    m_tree->Branch("muon_IsoEff_SF_UserDefinedFixEfficiency", &m_muon_IsoEff_SF_UserDefinedFixEfficiency);
-    m_tree->Branch("muon_IsoEff_SF_UserDefinedCut",           &m_muon_IsoEff_SF_UserDefinedCut);
+    m_tree->Branch("muon_IsoEff_SF_FixedCutTightTrackOnly",  &m_muon_IsoEff_SF_FixedCutTightTrackOnly);
   }
 
   if ( m_muInfoSwitch->m_quality ) {
@@ -661,11 +655,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
       static SG::AuxElement::Accessor<char> isIsoGradientAcc ("isIsolated_Gradient");
       static SG::AuxElement::Accessor<char> isIsoGradientLooseAcc ("isIsolated_GradientLoose");
-      static SG::AuxElement::Accessor<char> isIsoGradientT1Acc ("isIsolated_GradientT1");
-      static SG::AuxElement::Accessor<char> isIsoGradientT2Acc ("isIsolated_GradientT2");
-      static SG::AuxElement::Accessor<char> isIsoMU0p06Acc ("isIsolated_MU0p06");
       static SG::AuxElement::Accessor<char> isIsoFixedCutLooseAcc ("isIsolated_FixedCutLoose");
-      static SG::AuxElement::Accessor<char> isIsoFixedCutTightAcc ("isIsolated_FixedCutTight");
       static SG::AuxElement::Accessor<char> isIsoFixedCutTightTrackOnlyAcc ("isIsolated_FixedCutTightTrackOnly");
       static SG::AuxElement::Accessor<char> isIsoUserDefinedFixEfficiencyAcc ("isIsolated_UserDefinedFixEfficiency");
       static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
@@ -675,12 +665,8 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       if ( isIsoTightAcc.isAvailable( *muon_itr ) )          { m_muon_isIsolated_Tight.push_back( isIsoTightAcc( *muon_itr ) ); } else { m_muon_isIsolated_Tight.push_back( -1 ); }
       if ( isIsoGradientAcc.isAvailable( *muon_itr ) )       { m_muon_isIsolated_Gradient.push_back( isIsoGradientAcc( *muon_itr ) ); } else { m_muon_isIsolated_Gradient.push_back( -1 ); }
       if ( isIsoGradientLooseAcc.isAvailable( *muon_itr ) )  { m_muon_isIsolated_GradientLoose.push_back( isIsoGradientLooseAcc( *muon_itr ) ); } else { m_muon_isIsolated_GradientLoose.push_back( -1 ); }
-      if ( isIsoGradientT1Acc.isAvailable( *muon_itr ) )     { m_muon_isIsolated_GradientT1.push_back( isIsoGradientT1Acc( *muon_itr ) ); } else { m_muon_isIsolated_GradientT1.push_back( -1 ); }
-      if ( isIsoGradientT2Acc.isAvailable( *muon_itr ) )     { m_muon_isIsolated_GradientT2.push_back( isIsoGradientT2Acc( *muon_itr ) ); } else { m_muon_isIsolated_GradientT2.push_back( -1 ); }
-      if ( isIsoMU0p06Acc.isAvailable( *muon_itr ) )          { m_muon_isIsolated_MU0p06.push_back( isIsoMU0p06Acc( *muon_itr ) ); } else { m_muon_isIsolated_MU0p06.push_back( -1 ); }
       if ( isIsoFixedCutLooseAcc.isAvailable( *muon_itr ) )          { m_muon_isIsolated_FixedCutLoose.push_back( isIsoFixedCutLooseAcc( *muon_itr ) ); } else { m_muon_isIsolated_FixedCutLoose.push_back( -1 ); }
-      if ( isIsoFixedCutTightAcc.isAvailable( *muon_itr ) )          { m_muon_isIsolated_FixedCutTight.push_back( isIsoFixedCutTightAcc( *muon_itr ) ); } else { m_muon_isIsolated_FixedCutTight.push_back( -1 ); }
-      if ( isIsoFixedCutTightTrackOnlyAcc.isAvailable( *muon_itr ) )          { m_muon_isIsolated_FixedCutTightTrackOnly.push_back( isIsoFixedCutTightTrackOnlyAcc( *muon_itr ) ); } else { m_muon_isIsolated_FixedCutTightTrackOnly.push_back( -1 ); }
+      if ( isIsoFixedCutTightTrackOnlyAcc.isAvailable( *muon_itr ) )   { m_muon_isIsolated_FixedCutTightTrackOnly.push_back( isIsoFixedCutTightTrackOnlyAcc( *muon_itr ) ); } else { m_muon_isIsolated_FixedCutTightTrackOnly.push_back( -1 ); }
       if ( isIsoUserDefinedFixEfficiencyAcc.isAvailable( *muon_itr ) ) { m_muon_isIsolated_UserDefinedFixEfficiency.push_back( isIsoUserDefinedFixEfficiencyAcc( *muon_itr ) ); } else { m_muon_isIsolated_UserDefinedFixEfficiency.push_back( -1 ); }
       if ( isIsoUserDefinedCutAcc.isAvailable( *muon_itr ) )           { m_muon_isIsolated_UserDefinedCut.push_back( isIsoUserDefinedCutAcc( *muon_itr ) ); } else { m_muon_isIsolated_UserDefinedCut.push_back( -1 ); }
 
@@ -782,8 +768,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Tight("MuonEfficiencyCorrector_IsoSyst_Tight");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Gradient("MuonEfficiencyCorrector_IsoSyst_Gradient");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_GradientLoose("MuonEfficiencyCorrector_IsoSyst_GradientLoose");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_UserDefinedFixEfficiency("MuonEfficiencyCorrector_IsoSyst_UserDefinedFixEfficiency");
-      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_UserDefinedCut("MuonEfficiencyCorrector_IsoSyst_UserDefinedCut");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_FixedCutTightTrackOnly");
 
       std::vector<float> junk(1,-999);
 
@@ -793,8 +778,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       if( accIsoSF_Tight.isAvailable( *muon_itr ) )          { m_muon_IsoEff_SF_Tight.push_back( accIsoSF_Tight( *muon_itr ) ); } else { m_muon_IsoEff_SF_Tight.push_back( junk ); }
       if( accIsoSF_GradientLoose.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_GradientLoose.push_back( accIsoSF_GradientLoose( *muon_itr ) ); } else {  m_muon_IsoEff_SF_GradientLoose.push_back( junk ); }
       if( accIsoSF_Gradient.isAvailable( *muon_itr ) )       { m_muon_IsoEff_SF_Gradient.push_back( accIsoSF_Gradient( *muon_itr ) ); } else { m_muon_IsoEff_SF_Gradient.push_back( junk ); }
-      if( accIsoSF_UserDefinedFixEfficiency.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_UserDefinedFixEfficiency.push_back( accIsoSF_UserDefinedFixEfficiency( *muon_itr ) ); } else { m_muon_IsoEff_SF_UserDefinedFixEfficiency.push_back( junk ); }
-      if( accIsoSF_UserDefinedCut.isAvailable( *muon_itr ) )            { m_muon_IsoEff_SF_UserDefinedCut.push_back( accIsoSF_UserDefinedCut( *muon_itr ) ); } else { m_muon_IsoEff_SF_UserDefinedCut.push_back( junk ); }
+      if( accIsoSF_FixedCutTightTrackOnly.isAvailable( *muon_itr ) )  { m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( accIsoSF_FixedCutTightTrackOnly( *muon_itr ) ); } else {  m_muon_IsoEff_SF_FixedCutTightTrackOnly.push_back( junk ); }
 
     }
 
@@ -845,12 +829,8 @@ void HelpTreeBase::ClearMuons() {
     m_muon_isIsolated_Loose.clear();
     m_muon_isIsolated_Tight.clear();
     m_muon_isIsolated_Gradient.clear();
-    m_muon_isIsolated_GradientT1.clear();
-    m_muon_isIsolated_GradientT2.clear();
-    m_muon_isIsolated_MU0p06.clear();
     m_muon_isIsolated_GradientLoose.clear();
     m_muon_isIsolated_FixedCutLoose.clear();
-    m_muon_isIsolated_FixedCutTight.clear();
     m_muon_isIsolated_FixedCutTightTrackOnly.clear();
     m_muon_isIsolated_UserDefinedFixEfficiency.clear();
     m_muon_isIsolated_UserDefinedCut.clear();
@@ -905,8 +885,7 @@ void HelpTreeBase::ClearMuons() {
     m_muon_IsoEff_SF_Tight.clear();
     m_muon_IsoEff_SF_Gradient.clear();
     m_muon_IsoEff_SF_GradientLoose.clear();
-    m_muon_IsoEff_SF_UserDefinedFixEfficiency.clear();
-    m_muon_IsoEff_SF_UserDefinedCut.clear();
+    m_muon_IsoEff_SF_FixedCutTightTrackOnly.clear();
   }
 
   if ( m_muInfoSwitch->m_energyLoss ) {
@@ -958,9 +937,6 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_isIsolated_Tight",	   &m_el_isIsolated_Tight);
     m_tree->Branch("el_isIsolated_Gradient",	   &m_el_isIsolated_Gradient);
     m_tree->Branch("el_isIsolated_GradientLoose",  &m_el_isIsolated_GradientLoose);
-    m_tree->Branch("el_isIsolated_GradientT1",     &m_el_isIsolated_GradientT1);
-    m_tree->Branch("el_isIsolated_GradientT2",     &m_el_isIsolated_GradientT2);
-    m_tree->Branch("el_isIsolated_EL0p06",	   &m_el_isIsolated_EL0p06);
     m_tree->Branch("el_isIsolated_FixedCutLoose",	   &m_el_isIsolated_FixedCutLoose);
     m_tree->Branch("el_isIsolated_FixedCutTight",	   &m_el_isIsolated_FixedCutTight);
     m_tree->Branch("el_isIsolated_FixedCutTightTrackOnly", &m_el_isIsolated_FixedCutTightTrackOnly);
@@ -997,6 +973,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
 
   if ( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_tree->Branch("el_RecoEff_SF"  ,		 &m_el_RecoEff_SF  );
+    m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
     m_tree->Branch("el_PIDEff_SF_LHVeryLoose",   &m_el_PIDEff_SF_LHVeryLoose);
     m_tree->Branch("el_PIDEff_SF_LHLoose",       &m_el_PIDEff_SF_LHLoose);
     m_tree->Branch("el_PIDEff_SF_LHMedium",      &m_el_PIDEff_SF_LHMedium);
@@ -1085,9 +1062,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
       static SG::AuxElement::Accessor<char> isIsoGradientAcc ("isIsolated_Gradient");
       static SG::AuxElement::Accessor<char> isIsoGradientLooseAcc ("isIsolated_GradientLoose");
-      static SG::AuxElement::Accessor<char> isIsoGradientT1Acc ("isIsolated_GradientT1");
-      static SG::AuxElement::Accessor<char> isIsoGradientT2Acc ("isIsolated_GradientT2");
-      static SG::AuxElement::Accessor<char> isIsoEL0p06Acc ("isIsolated_EL0p06");
       static SG::AuxElement::Accessor<char> isIsoFixedCutLooseAcc ("isIsolated_FixedCutLoose");
       static SG::AuxElement::Accessor<char> isIsoFixedCutTightAcc ("isIsolated_FixedCutTight");
       static SG::AuxElement::Accessor<char> isIsoFixedCutTightTrackOnlyAcc ("isIsolated_FixedCutTightTrackOnly");
@@ -1099,9 +1073,6 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       if ( isIsoTightAcc.isAvailable( *el_itr ) )          { m_el_isIsolated_Tight.push_back( isIsoTightAcc( *el_itr ) ); } else { m_el_isIsolated_Tight.push_back( -1 ); }
       if ( isIsoGradientAcc.isAvailable( *el_itr ) )       { m_el_isIsolated_Gradient.push_back( isIsoGradientAcc( *el_itr ) ); } else { m_el_isIsolated_Gradient.push_back( -1 ); }
       if ( isIsoGradientLooseAcc.isAvailable( *el_itr ) )  { m_el_isIsolated_GradientLoose.push_back( isIsoGradientLooseAcc( *el_itr ) ); } else { m_el_isIsolated_GradientLoose.push_back( -1 ); }
-      if ( isIsoGradientT1Acc.isAvailable( *el_itr ) )     { m_el_isIsolated_GradientT1.push_back( isIsoGradientT1Acc( *el_itr ) ); } else { m_el_isIsolated_GradientT1.push_back( -1 ); }
-      if ( isIsoGradientT2Acc.isAvailable( *el_itr ) )     { m_el_isIsolated_GradientT2.push_back( isIsoGradientT2Acc( *el_itr ) ); } else { m_el_isIsolated_GradientT2.push_back( -1 ); }
-      if ( isIsoEL0p06Acc.isAvailable( *el_itr ) )          { m_el_isIsolated_EL0p06.push_back( isIsoEL0p06Acc( *el_itr ) ); } else { m_el_isIsolated_EL0p06.push_back( -1 ); }
       if ( isIsoFixedCutLooseAcc.isAvailable( *el_itr ) )          { m_el_isIsolated_FixedCutLoose.push_back( isIsoFixedCutLooseAcc( *el_itr ) ); } else { m_el_isIsolated_FixedCutLoose.push_back( -1 ); }
       if ( isIsoFixedCutTightAcc.isAvailable( *el_itr ) )          { m_el_isIsolated_FixedCutTight.push_back( isIsoFixedCutTightAcc( *el_itr ) ); } else { m_el_isIsolated_FixedCutTight.push_back( -1 ); }
       if ( isIsoFixedCutTightTrackOnlyAcc.isAvailable( *el_itr ) )          { m_el_isIsolated_FixedCutTightTrackOnly.push_back( isIsoFixedCutTightTrackOnlyAcc( *el_itr ) ); } else { m_el_isIsolated_FixedCutTightTrackOnly.push_back( -1 ); }
@@ -1230,6 +1201,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
     if ( m_elInfoSwitch->m_effSF && m_isMC ) {
 
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_FixedCutTight");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium");
@@ -1238,6 +1210,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       std::vector<float> junk(1,-999);
 
       if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
+      if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
       if( accPIDSF_LHVeryLoose.isAvailable( *el_itr ) ) { m_el_PIDEff_SF_LHVeryLoose.push_back( accPIDSF_LHVeryLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHVeryLoose.push_back( junk ); }
       if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
       if( accPIDSF_LHMedium.isAvailable( *el_itr ) )    { m_el_PIDEff_SF_LHMedium.push_back( accPIDSF_LHMedium( *el_itr ) ); } else { m_el_PIDEff_SF_LHMedium.push_back( junk ); }
@@ -1273,9 +1246,6 @@ void HelpTreeBase::ClearElectrons() {
     m_el_isIsolated_Tight.clear();
     m_el_isIsolated_Gradient.clear();
     m_el_isIsolated_GradientLoose.clear();
-    m_el_isIsolated_GradientT1.clear();
-    m_el_isIsolated_GradientT2.clear();
-    m_el_isIsolated_EL0p06.clear();
     m_el_isIsolated_FixedCutLoose.clear();
     m_el_isIsolated_FixedCutTight.clear();
     m_el_isIsolated_FixedCutTightTrackOnly.clear();
@@ -1338,6 +1308,7 @@ void HelpTreeBase::ClearElectrons() {
 
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     m_el_RecoEff_SF.clear();
+    m_el_IsoEff_SF_FixedCutTight.clear();
     m_el_PIDEff_SF_LHVeryLoose.clear();
     m_el_PIDEff_SF_LHLoose.clear();
     m_el_PIDEff_SF_LHMedium.clear();
@@ -1533,9 +1504,9 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 {
 
   if(m_debug) Info("AddJets()", "Adding jet %s with variables: %s", jetName.c_str(), detailStr.c_str());
-  
+
   m_thisJetInfoSwitch[jetName] = new HelperClasses::JetInfoSwitch( detailStr );
-    
+
   m_jets[jetName] = new jetInfo();
 
   jetInfo* thisJet = m_jets[jetName];
@@ -1874,7 +1845,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 
 
   this->AddJetsUser(detailStr, jetName);
-    
+
 }
 
 
@@ -1884,7 +1855,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
 
   const xAOD::VertexContainer* vertices(nullptr);
   const xAOD::Vertex *pv = 0;
-    
+
   if( m_thisJetInfoSwitch[jetName]->m_trackPV || m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     HelperFunctions::retrieve( vertices, "PrimaryVertices", m_event, 0 );
     pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
@@ -1984,7 +1955,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
 
 
 void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName ) {
-    
+
   jetInfo* thisJet = m_jets[jetName];
 
   if( m_thisJetInfoSwitch[jetName]->m_kinematic ){
@@ -2140,7 +2111,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
   }
 
-    
+
   if ( m_thisJetInfoSwitch[jetName]->m_trackAll || m_thisJetInfoSwitch[jetName]->m_trackPV ) {
 
     // several moments calculated from all verticies
@@ -2195,7 +2166,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
       } else { thisJet->m_jet_jvf.push_back( junkFlt ); }
 
     } // trackAll
-      
+
     if ( m_thisJetInfoSwitch[jetName]->m_trackPV && pvLocation >= 0 ) {
 
       if ( nTrk1000.isAvailable( *jet_itr ) ) {
@@ -2601,11 +2572,11 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
     }
 
   }
-    
+
   this->FillJetsUser(jet_itr, jetName);
   thisJet->N++;
-    
-  
+
+
   return;
 }
 
@@ -3071,13 +3042,13 @@ void HelpTreeBase::ClearEvent() {
     m_weight_muon_IsoEff_SF_Tight.clear();
     m_weight_muon_IsoEff_SF_Gradient.clear();
     m_weight_muon_IsoEff_SF_GradientLoose.clear();
-    m_weight_muon_IsoEff_SF_UserDefinedFixEfficiency.clear();
-    m_weight_muon_IsoEff_SF_UserDefinedCut.clear();
+    m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly.clear();
   }
 
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
     m_weight_electron_trig.clear();
     m_weight_electron_RecoEff_SF.clear();
+    m_weight_electron_IsoEff_SF_FixedCutTight.clear();
     m_weight_electron_PIDEff_SF_LHVeryLoose.clear();
     m_weight_electron_PIDEff_SF_LHLoose.clear();
     m_weight_electron_PIDEff_SF_LHMedium.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -194,8 +194,10 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
     m_tree->Branch("weight_electron_trig", 		    &m_weight_electron_trig);
     m_tree->Branch("weight_electron_RecoEff_SF"  ,	    &m_weight_electron_RecoEff_SF  );
+    m_tree->Branch("weight_electron_IsoEff_SF_Loose",   &m_weight_electron_IsoEff_SF_Loose);
     m_tree->Branch("weight_electron_IsoEff_SF_FixedCutTight",   &m_weight_electron_IsoEff_SF_FixedCutTight);
     m_tree->Branch("weight_electron_PIDEff_SF_LHVeryLoose", &m_weight_electron_PIDEff_SF_LHVeryLoose);
+    m_tree->Branch("weight_electron_PIDEff_SF_LHLooseAndBLayer",	    &m_weight_electron_PIDEff_SF_LHLooseAndBLayer);
     m_tree->Branch("weight_electron_PIDEff_SF_LHLoose",	    &m_weight_electron_PIDEff_SF_LHLoose);
     m_tree->Branch("weight_electron_PIDEff_SF_LHMedium",    &m_weight_electron_PIDEff_SF_LHMedium);
     m_tree->Branch("weight_electron_PIDEff_SF_LHTight",	    &m_weight_electron_PIDEff_SF_LHTight);
@@ -365,16 +367,20 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
 
     SG::AuxElement::ConstAccessor< std::vector<float> >   electronTrigSFVec( "ElectronEfficiencyCorrector_TrigSyst_GLOBAL" );
     SG::AuxElement::ConstAccessor< std::vector< float > > accRecoSFGlobal("ElectronEfficiencyCorrector_RecoSyst_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accIsoSFGlobal_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose_GLOBAL");
+    SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium_GLOBAL");
     SG::AuxElement::ConstAccessor< std::vector< float > > accPIDSFGlobal_LHTight("ElectronEfficiencyCorrector_PIDSyst_LHTight_GLOBAL");
 
     if( electronTrigSFVec.isAvailable( *eventInfo ) ) { m_weight_electron_trig = electronTrigSFVec( *eventInfo ); } else { m_weight_electron_trig.push_back(-999); }
     if( accRecoSFGlobal.isAvailable( *eventInfo ) ) { m_weight_electron_RecoEff_SF = accRecoSFGlobal( *eventInfo ); } else { m_weight_electron_RecoEff_SF.push_back(-999.0); }
+    if( accIsoSFGlobal_Loose.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_Loose = accIsoSFGlobal_Loose( *eventInfo ); } else { m_weight_electron_IsoEff_SF_Loose.push_back(-999.0); }
     if( accIsoSFGlobal_FixedCutTight.isAvailable( *eventInfo ) ) { m_weight_electron_IsoEff_SF_FixedCutTight = accIsoSFGlobal_FixedCutTight( *eventInfo ); } else { m_weight_electron_IsoEff_SF_FixedCutTight.push_back(-999.0); }
     if( accPIDSFGlobal_LHVeryLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHVeryLoose = accPIDSFGlobal_LHVeryLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHVeryLoose.push_back(-999.0); }
+    if( accPIDSFGlobal_LHLooseAndBLayer.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLooseAndBLayer = accPIDSFGlobal_LHLooseAndBLayer( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLooseAndBLayer.push_back(-999.0); }
     if( accPIDSFGlobal_LHLoose.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHLoose = accPIDSFGlobal_LHLoose( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHLoose.push_back(-999.0); }
     if( accPIDSFGlobal_LHMedium.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHMedium = accPIDSFGlobal_LHMedium( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHMedium.push_back(-999.0); }
     if( accPIDSFGlobal_LHTight.isAvailable( *eventInfo ) ) { m_weight_electron_PIDEff_SF_LHTight= accPIDSFGlobal_LHTight( *eventInfo ); } else { m_weight_electron_PIDEff_SF_LHTight.push_back(-999.0); }
@@ -636,7 +642,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       //
       static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapMuAcc("isTrigMatchedMapMu");
 
-      std::vector<int> matches; 
+      std::vector<int> matches;
 
       if ( isTrigMatchedMapMuAcc.isAvailable( *muon_itr ) ) {
 	 // loop over map and fill branches
@@ -649,13 +655,13 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 	 matches.push_back( -1 );
 	 m_muon_listTrigChains.push_back("NONE");
        }
-       
+
        m_muon_isTrigMatchedToChain.push_back(matches);
-       
+
        // if at least one match among the chains is found, say this muon is trigger matched
        if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_muon_isTrigMatched.push_back(1); }
        else { m_muon_isTrigMatched.push_back(0); }
-       
+
     }
 
 
@@ -990,8 +996,10 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_RecoEff_SF"  ,		 &m_el_RecoEff_SF  );
     m_tree->Branch("el_TrigEff_SF"  ,		 &m_el_TrigEff_SF  );
     m_tree->Branch("el_TrigMCEff"   ,		 &m_el_TrigMCEff  );
+    m_tree->Branch("el_IsoEff_SF_Loose"  , &m_el_IsoEff_SF_Loose );
     m_tree->Branch("el_IsoEff_SF_FixedCutTight"  , &m_el_IsoEff_SF_FixedCutTight );
     m_tree->Branch("el_PIDEff_SF_LHVeryLoose",   &m_el_PIDEff_SF_LHVeryLoose);
+    m_tree->Branch("el_PIDEff_SF_LHLooseAndBLayer",  &m_el_PIDEff_SF_LHLooseAndBLayer);
     m_tree->Branch("el_PIDEff_SF_LHLoose",       &m_el_PIDEff_SF_LHLoose);
     m_tree->Branch("el_PIDEff_SF_LHMedium",      &m_el_PIDEff_SF_LHMedium);
     m_tree->Branch("el_PIDEff_SF_LHTight",       &m_el_PIDEff_SF_LHTight);
@@ -1050,7 +1058,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       m_el_eta.push_back( (el_itr)->eta() );
       m_el_phi.push_back( (el_itr)->phi() );
       m_el_m.push_back  ( (el_itr)->m() / m_units );
-      
+
       float calo_eta   = ( el_itr->caloCluster() ) ? el_itr->caloCluster()->etaBE(2) : -999.0;
       m_el_caloCluster_eta.push_back( calo_eta );
 
@@ -1062,7 +1070,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       //
       static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapElAcc("isTrigMatchedMapEl");
 
-      std::vector<int> matches; 
+      std::vector<int> matches;
 
       if ( isTrigMatchedMapElAcc.isAvailable( *el_itr ) ) {
 	 // loop over map and fill branches
@@ -1075,13 +1083,13 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
 	 matches.push_back( -1 );
 	 m_el_listTrigChains.push_back("NONE");
        }
-       
+
        m_el_isTrigMatchedToChain.push_back(matches);
-       
+
        // if at least one match among the chains is found, say this electron is trigger matched
        if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_el_isTrigMatched.push_back(1); }
        else { m_el_isTrigMatched.push_back(0); }
-       
+
     }
 
     if ( m_elInfoSwitch->m_isolation ) {
@@ -1232,9 +1240,11 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigSF("ElectronEfficiencyCorrector_TrigSyst");
       static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff("ElectronEfficiencyCorrector_TrigMCEffSyst");
+      static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("ElectronEfficiencyCorrector_IsoSyst_IsoLoose");
       static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTight("ElectronEfficiencyCorrector_IsoSyst_IsoFixedCutTight");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHVeryLoose("ElectronEfficiencyCorrector_PIDSyst_LHVeryLoose");
-      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LHLoose");
+      static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LHLooseAndBLayer");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_LHMedium");
       static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHTight("ElectronEfficiencyCorrector_PIDSyst_LHTight");
 
@@ -1243,8 +1253,10 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       if( accRecoSF.isAvailable( *el_itr ) ) { m_el_RecoEff_SF.push_back( accRecoSF( *el_itr ) ); } else { m_el_RecoEff_SF.push_back( junk ); }
       if( accTrigSF.isAvailable( *el_itr ) ) { m_el_TrigEff_SF.push_back( accTrigSF( *el_itr ) ); } else { m_el_TrigEff_SF.push_back( junk ); }
       if( accTrigMCEff.isAvailable( *el_itr ) ) { m_el_TrigMCEff.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_TrigMCEff.push_back( junk ); }
+      if( accIsoSF_Loose.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_Loose.push_back( accIsoSF_Loose( *el_itr ) ); } else { m_el_IsoEff_SF_Loose.push_back( junk ); }
       if( accIsoSF_FixedCutTight.isAvailable( *el_itr ) ) { m_el_IsoEff_SF_FixedCutTight.push_back( accIsoSF_FixedCutTight( *el_itr ) ); } else { m_el_IsoEff_SF_FixedCutTight.push_back( junk ); }
       if( accPIDSF_LHVeryLoose.isAvailable( *el_itr ) ) { m_el_PIDEff_SF_LHVeryLoose.push_back( accPIDSF_LHVeryLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHVeryLoose.push_back( junk ); }
+      if( accPIDSF_LHLooseAndBLayer.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( accPIDSF_LHLooseAndBLayer( *el_itr ) ); } else { m_el_PIDEff_SF_LHLooseAndBLayer.push_back( junk ); }
       if( accPIDSF_LHLoose.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHLoose.push_back( accPIDSF_LHLoose( *el_itr ) ); } else { m_el_PIDEff_SF_LHLoose.push_back( junk ); }
       if( accPIDSF_LHMedium.isAvailable( *el_itr ) )    { m_el_PIDEff_SF_LHMedium.push_back( accPIDSF_LHMedium( *el_itr ) ); } else { m_el_PIDEff_SF_LHMedium.push_back( junk ); }
       if( accPIDSF_LHTight.isAvailable( *el_itr ) )     { m_el_PIDEff_SF_LHTight.push_back( accPIDSF_LHTight( *el_itr ) ); } else { m_el_PIDEff_SF_LHTight.push_back( junk ); }
@@ -1345,8 +1357,10 @@ void HelpTreeBase::ClearElectrons() {
     m_el_RecoEff_SF.clear();
     m_el_TrigEff_SF.clear();
     m_el_TrigMCEff.clear();
+    m_el_IsoEff_SF_Loose.clear();
     m_el_IsoEff_SF_FixedCutTight.clear();
     m_el_PIDEff_SF_LHVeryLoose.clear();
+    m_el_PIDEff_SF_LHLooseAndBLayer.clear();
     m_el_PIDEff_SF_LHLoose.clear();
     m_el_PIDEff_SF_LHMedium.clear();
     m_el_PIDEff_SF_LHTight.clear();
@@ -3085,8 +3099,10 @@ void HelpTreeBase::ClearEvent() {
   if( m_eventInfoSwitch->m_electronSF && m_isMC ) {
     m_weight_electron_trig.clear();
     m_weight_electron_RecoEff_SF.clear();
+    m_weight_electron_IsoEff_SF_Loose.clear();
     m_weight_electron_IsoEff_SF_FixedCutTight.clear();
     m_weight_electron_PIDEff_SF_LHVeryLoose.clear();
+    m_weight_electron_PIDEff_SF_LHLooseAndBLayer.clear();
     m_weight_electron_PIDEff_SF_LHLoose.clear();
     m_weight_electron_PIDEff_SF_LHMedium.clear();
     m_weight_electron_PIDEff_SF_LHTight.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -934,6 +934,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
     m_tree->Branch("el_phi", &m_el_phi);
     m_tree->Branch("el_eta", &m_el_eta);
     m_tree->Branch("el_m",   &m_el_m);
+    m_tree->Branch("el_caloCluster_eta", &m_el_caloCluster_eta);
   }
 
   if ( m_elInfoSwitch->m_trigger ){
@@ -1049,6 +1050,10 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       m_el_eta.push_back( (el_itr)->eta() );
       m_el_phi.push_back( (el_itr)->phi() );
       m_el_m.push_back  ( (el_itr)->m() / m_units );
+      
+      float calo_eta   = ( el_itr->caloCluster() ) ? el_itr->caloCluster()->etaBE(2) : -999.0;
+      m_el_caloCluster_eta.push_back( calo_eta );
+
     }
 
     if ( m_elInfoSwitch->m_trigger ) {
@@ -1261,6 +1266,7 @@ void HelpTreeBase::ClearElectrons() {
     m_el_eta.clear();
     m_el_phi.clear();
     m_el_m.clear();
+    m_el_caloCluster_eta.clear();
   }
 
   if ( m_elInfoSwitch->m_trigger ) {

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -89,8 +89,6 @@ namespace HelperClasses{
     m_shapeLC       = has_exact("shapeLC");
     m_truth         = has_exact("truth");
     m_caloClus      = has_exact("caloClusters");
-    m_muonSF        = has_exact("muonSF");
-    m_electronSF    = has_exact("electronSF");
   }
 
   void TriggerInfoSwitch::initialize(){

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -84,13 +84,13 @@ namespace HelperClasses{
 
   void EventInfoSwitch::initialize(){
     m_pileup        = has_exact("pileup");
+    m_eventCleaning = has_exact("eventCleaning");
     m_shapeEM       = has_exact("shapeEM");
     m_shapeLC       = has_exact("shapeLC");
     m_truth         = has_exact("truth");
     m_caloClus      = has_exact("caloClusters");
     m_muonSF        = has_exact("muonSF");
     m_electronSF    = has_exact("electronSF");
-    m_eventCleaning = has_exact("eventCleaning");
   }
 
   void TriggerInfoSwitch::initialize(){

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -427,6 +427,8 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   if ( m_inputAlgoSystNames.empty() ) {
 
     RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+      
+   if ( m_debug ) { Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); }
 
     // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
     //
@@ -448,7 +450,9 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
            RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
 
     	   if ( m_debug ){
-    	     unsigned int idx(0);
+	     Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); 
+	     Info( "execute", "Input syst: %s", systName.c_str() );
+	     unsigned int idx(0);
     	     for ( auto mu : *(inputMuons) ) {
     	       Info( "execute", "Input muon %i, pt = %.2f GeV ", idx, (mu->pt() * 1e-3) );
     	       ++idx;
@@ -795,7 +799,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
     // and now apply trigger efficiency SF!
     //
     unsigned int nMuons = inputMuons->size();
-    if ( m_debug ) { Info( "executeSF", "Applying trigger efficiency SF: \n Number of muons : %u", nMuons); }
+    if ( m_debug ) { Info( "executeSF", "Applying trigger efficiency SF"); }
 
     // obtain trigger efficiency SF
     //

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -46,6 +46,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
     m_asgMuonEffCorrTool_muSF_Reco(nullptr),
     m_asgMuonEffCorrTool_muSF_Iso(nullptr),
     m_asgMuonEffCorrTool_muSF_Trig(nullptr),
+    m_asgMuonEffCorrTool_muSF_TTVA(nullptr),
     m_pileuptool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
@@ -63,6 +64,8 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   //
   m_inContainerName            = "";
 
+  m_calibRelease               = "Data15_allPeriods_241115";
+
   // Reco efficiency SF
   //
   m_WorkingPointReco           = "Loose";
@@ -79,18 +82,25 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   m_SingleMuTrig               = "HLT_mu20_iloose_L1MU15";
   m_DiMuTrig                   = "HLT_2mu14";
 
+  // TTVA SF
+  //
+  m_WorkingPointTTVA           = "TTVA";
+
   // Systematics stuff
   //
   m_inputAlgoSystNames         = "";
   m_systValReco 	       = 0.0;
   m_systValIso 	               = 0.0;
   m_systValTrig 	       = 0.0;
+  m_systValTTVA 	       = 0.0;
   m_systNameReco	       = "";
   m_systNameIso	               = "";
   m_systNameTrig	       = "";
+  m_systNameTTVA	       = "";
   m_outputSystNamesReco        = "MuonEfficiencyCorrector_RecoSyst";
   m_outputSystNamesIso         = "MuonEfficiencyCorrector_IsoSyst";
   m_outputSystNamesTrig        = "MuonEfficiencyCorrector_TrigSyst";
+  m_outputSystNamesTTVA        = "MuonEfficiencyCorrector_TTVASyst";
 
 }
 
@@ -128,6 +138,10 @@ EL::StatusCode  MuonEfficiencyCorrector :: configure ()
     m_SingleMuTrig               = config->GetValue("SingleMuTrig", m_SingleMuTrig.c_str());
     m_DiMuTrig                   = config->GetValue("DiMuTrig", m_DiMuTrig.c_str());
 
+    // TTVA SF
+    //
+    m_WorkingPointTTVA           = config->GetValue("WorkingPointTTVA", m_WorkingPointTTVA.c_str());
+
     // Systematics stuff
     m_inputAlgoSystNames         = config->GetValue("InputAlgoSystNames",  m_inputAlgoSystNames.c_str());
     m_systValReco 		 = config->GetValue("SystValReco" , m_systValReco);
@@ -139,6 +153,7 @@ EL::StatusCode  MuonEfficiencyCorrector :: configure ()
     m_outputSystNamesReco        = config->GetValue("OutputSystNamesReco", m_outputSystNamesReco.c_str());
     m_outputSystNamesIso         = config->GetValue("OutputSystNamesIso",  m_outputSystNamesIso.c_str());
     m_outputSystNamesTrig        = config->GetValue("OutputSystNamesTrig", m_outputSystNamesTrig.c_str());
+    m_outputSystNamesTTVA        = config->GetValue("OutputSystNamesTTVA",  m_outputSystNamesTTVA.c_str());
 
     config->Print();
 
@@ -249,6 +264,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     m_asgMuonEffCorrTool_muSF_Reco = new CP::MuonEfficiencyScaleFactors(recoEffSF_tool_name);
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->setProperty("WorkingPoint", m_WorkingPointReco ),"Failed to set Working Point property of MuonEfficiencyScaleFactors for reco efficiency SF");
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->setProperty("doAudit", false),"Failed to set doAudit property of MuonEfficiencyScaleFactors");
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->setProperty("CalibrationRelease", m_calibRelease ),"Failed to set calibration release property of MuonEfficiencyScaleFactors for reco efficiency SF");
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for reco efficiency SF");
   }
 
@@ -256,7 +272,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //  Add the chosen WP to the string labelling the vector<SF> decoration
   //
   m_outputSystNamesReco = m_outputSystNamesReco + "_" + m_WorkingPointReco;
-    
+
   if ( m_debug ) {
 
     // Get a list of affecting systematics
@@ -292,16 +308,17 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //
 
   std::string isoEffSF_tool_name = "MuonEfficiencyScaleFactors_effSF_Iso_" + m_WorkingPointIso;
-  
+
   if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>(isoEffSF_tool_name) ) {
     m_asgMuonEffCorrTool_muSF_Iso = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>(isoEffSF_tool_name);
-  } else {  
+  } else {
     m_asgMuonEffCorrTool_muSF_Iso = new CP::MuonEfficiencyScaleFactors(isoEffSF_tool_name);
     std::string tool_WP = m_WorkingPointIso + "Iso";
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->setProperty("WorkingPoint", tool_WP ), "Failed to set Working Point property of MuonEfficiencyScaleFactors for iso efficiency SF");
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->setProperty("CalibrationRelease", m_calibRelease ),"Failed to set calibration release property of MuonEfficiencyScaleFactors for iso efficiency SF");
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for iso efficiency SF");
   }
-  
+
   //
   //  Add the chosen WP to the string labelling the vector<SF> decoration
   //
@@ -335,14 +352,14 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   // 3.
   // Initialise the CP::MuonTriggerScaleFactors tool
-  //  
+  //
   //
 
   std::string trigEff_tool_name = "MuonTriggerScaleFactors_effSF_Trig_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-  
+
   if ( asg::ToolStore::contains<CP::MuonTriggerScaleFactors>(trigEff_tool_name) ) {
     m_asgMuonEffCorrTool_muSF_Trig = asg::ToolStore::get<CP::MuonTriggerScaleFactors>(trigEff_tool_name);
-  } else { 
+  } else {
     m_asgMuonEffCorrTool_muSF_Trig = new CP::MuonTriggerScaleFactors(trigEff_tool_name);
 
     int runNumber(m_runNumber);
@@ -363,11 +380,11 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     if( m_asgMuonEffCorrTool_muSF_Trig->setRunNumber( runNumber ) == CP::CorrectionCode::Error ) {
       Warning("initialize()","Cannot set RunNumber for MuonTriggerScaleFactors tool");
     }
-    
+
     // Add an "Iso" prefix to the WP (required for tool configuration)
     //
-    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;  
-    
+    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;
+
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("Isolation", iso_trig_WP ),"Failed to set Isolation property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("MuonQuality", m_WorkingPointRecoTrig ),"Failed to set MuonQuality property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->initialize(), "Failed to properly initialize MuonTriggerScaleFactors");
@@ -376,7 +393,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //  Add the chosen WP to the string labelling the vector<SF> decoration
   //
   m_outputSystNamesTrig = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-  
+
   if ( m_debug ) {
 
     // Get a list of affecting systematics
@@ -397,6 +414,52 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   Info("initialize()","Will be using MuonEfficiencyScaleFactors tool trigger efficiency systematic:");
   for ( const auto& syst_it : m_systListTrig ) {
     if ( m_systNameTrig.empty() ) {
+      Info("initialize()","\t Running w/ nominal configuration only!");
+      break;
+    }
+    Info("initialize()","\t %s", (syst_it.name()).c_str());
+  }
+
+  // 4.
+  // initialize the CP::MuonEfficiencyScaleFactors Tool for track-to-vertex association (TTVA) SF
+  //
+
+  std::string TTVAEffSF_tool_name = "MuonEfficiencyScaleFactors_effSF_" + m_WorkingPointTTVA;
+
+  if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>(TTVAEffSF_tool_name) ) {
+    m_asgMuonEffCorrTool_muSF_TTVA = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>(TTVAEffSF_tool_name);
+  } else {
+    m_asgMuonEffCorrTool_muSF_TTVA = new CP::MuonEfficiencyScaleFactors(TTVAEffSF_tool_name);
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_TTVA->setProperty("WorkingPoint", m_WorkingPointTTVA ), "Failed to set Working Point property of MuonEfficiencyScaleFactors for TTVA efficiency SF");
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_TTVA->setProperty("CalibrationRelease", m_calibRelease ),"Failed to set calibration release property of MuonEfficiencyScaleFactors for TTVA efficiency SF");
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_TTVA->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for TTVA efficiency SF");
+  }
+
+  //
+  //  Add the chosen WP to the string labelling the vector<SF> decoration
+  //
+  m_outputSystNamesTTVA = m_outputSystNamesTTVA + "_" + m_WorkingPointTTVA;
+
+  if ( m_debug ) {
+
+    // Get a list of affecting systematics
+   //
+    CP::SystematicSet affectSystsTTVA = m_asgMuonEffCorrTool_muSF_TTVA->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsTTVA ) { Info("initialize()","MuonEfficiencyScaleFactors tool can be affected by TTVA efficiency systematic: %s", (syst_it.name()).c_str()); }
+  }
+  //
+  // Make a list of systematics to be used, based on configuration input
+  // Use HelperFunctions::getListofSystematics() for this!
+  //
+  const CP::SystematicSet recSystsTTVA = m_asgMuonEffCorrTool_muSF_TTVA->recommendedSystematics();
+  m_systListTTVA = HelperFunctions::getListofSystematics( recSystsTTVA, m_systNameTTVA, m_systValTTVA, m_debug );
+
+  Info("initialize()","Will be using MuonEfficiencyScaleFactors tool TTVA efficiency systematic:");
+  for ( const auto& syst_it : m_systListTTVA ) {
+    if ( m_systNameTTVA.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
@@ -446,12 +509,12 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   if ( m_inputAlgoSystNames.empty() ) {
 
     RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
-      
+
    if ( m_debug ) { Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); }
 
     // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
     //
-    this->executeSF( inputMuons, eventInfo, countInputCont );
+    this->executeSF( inputMuons, countInputCont );
 
   } else {
   // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo. This is the case of calibrators: one different SC
@@ -469,7 +532,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
            RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
 
     	   if ( m_debug ){
-	     Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); 
+	     Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) );
 	     Info( "execute", "Input syst: %s", systName.c_str() );
 	     unsigned int idx(0);
     	     for ( auto mu : *(inputMuons) ) {
@@ -480,7 +543,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
 	   // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
 	   //
-	   this->executeSF( inputMuons, eventInfo, countInputCont );
+	   this->executeSF( inputMuons, countInputCont );
 
 	   // increment counter
 	   //
@@ -529,6 +592,7 @@ EL::StatusCode MuonEfficiencyCorrector :: finalize ()
   if ( m_asgMuonEffCorrTool_muSF_Reco )  { m_asgMuonEffCorrTool_muSF_Reco = nullptr; delete m_asgMuonEffCorrTool_muSF_Reco; }
   if ( m_asgMuonEffCorrTool_muSF_Iso )   { m_asgMuonEffCorrTool_muSF_Iso = nullptr;  delete m_asgMuonEffCorrTool_muSF_Iso;  }
   if ( m_asgMuonEffCorrTool_muSF_Trig )  { m_asgMuonEffCorrTool_muSF_Trig = nullptr; delete m_asgMuonEffCorrTool_muSF_Trig; }
+  if ( m_asgMuonEffCorrTool_muSF_TTVA )  { m_asgMuonEffCorrTool_muSF_TTVA = nullptr;  delete m_asgMuonEffCorrTool_muSF_TTVA;  }
   if ( m_pileuptool )                    { m_pileuptool = nullptr;                   delete m_pileuptool; }
 
   return EL::StatusCode::SUCCESS;
@@ -553,7 +617,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer* inputMuons, const xAOD::EventInfo* eventInfo, unsigned int countSyst  )
+EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer* inputMuons, unsigned int countSyst  )
 {
 
   //
@@ -569,6 +633,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
   std::vector< std::string >* sysVariationNamesReco  = new std::vector< std::string >;
   std::vector< std::string >* sysVariationNamesIso   = new std::vector< std::string >;
   std::vector< std::string >* sysVariationNamesTrig  = new std::vector< std::string >;
+  std::vector< std::string >* sysVariationNamesTTVA  = new std::vector< std::string >;
 
   // 1.
   // Reco efficiency SFs - this is a per-MUON weight
@@ -749,7 +814,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 
   // 3.
   // Trigger efficiency SF - this is in principle given by the MCP tool as a per-EVENT weight
-  // 
+  //
   // To allow more freedom to the user, we calculate it as a per-muon weight with a trick
   // We store also the MC efficiency per-muon
 
@@ -758,10 +823,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
   //
   // NB: calculation of the event SF is up to the analyzer
 
-  // decoration name for muon MC trigger efficiency 
+  // decoration name for muon MC trigger efficiency
   //
   std::string eff_decor = "MuonEfficiencyCorrector_TrigMCEff_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-   
+
   for ( const auto& syst_it : m_systListIso ) {
 
     // Create the name of the SF weight to be recorded
@@ -793,40 +858,40 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        // Pass a container with only the muon in question to the tool
        // (use a view container to be light weight)
        //
-       ConstDataVector<xAOD::MuonContainer> mySingleMuonCont(SG::VIEW_ELEMENTS); 
+       ConstDataVector<xAOD::MuonContainer> mySingleMuonCont(SG::VIEW_ELEMENTS);
        mySingleMuonCont.push_back( mu_itr );
-       
+
        //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
        //
        SG::AuxElement::Decorator< std::vector<float> > sfVecTrig( m_outputSystNamesTrig );
        if ( !sfVecTrig.isAvailable( *mu_itr ) ) {
 	 sfVecTrig( *mu_itr ) = std::vector<float>();
-       }  
+       }
        SG::AuxElement::Decorator< std::vector<float> > effMC( eff_decor );
        if ( !effMC.isAvailable( *mu_itr ) ) {
 	 effMC( *mu_itr ) = std::vector<float>();
-       }        
-       
-       double triggerEffSF(1.0); // tool wants a double  
+       }
+
+       double triggerEffSF(1.0); // tool wants a double
        if ( !m_SingleMuTrig.empty() && m_asgMuonEffCorrTool_muSF_Trig->getTriggerScaleFactor( *mySingleMuonCont.asDataVector(), triggerEffSF, m_SingleMuTrig ) != CP::CorrectionCode::Ok ) {
 	 Warning( "executeSF()", "Problem in getTriggerScaleFactor - single muon trigger(s)");
 	 triggerEffSF = 1.0;
        }
-        
+
        // Add it to decoration vector
        //
        sfVecTrig( *mu_itr ).push_back(triggerEffSF);
 
-       double triggerMCEff(0.0); // tool wants a double 
+       double triggerMCEff(0.0); // tool wants a double
        if ( !m_SingleMuTrig.empty() && m_asgMuonEffCorrTool_muSF_Trig->getTriggerEfficiency( *mu_itr, triggerMCEff, m_SingleMuTrig, !m_isMC ) != CP::CorrectionCode::Ok ) {
          Warning( "executeSF()", "Problem in getTriggerEfficiency - single muon trigger(s)");
          triggerMCEff = 0.0;
        }
-       
+
        // Add it to decoration vector
        //
        effMC( *mu_itr ).push_back(triggerMCEff);
-       
+
        if ( m_debug ) {
          Info( "executeSF()", "===>>>");
          Info( "executeSF()", " ");
@@ -840,18 +905,104 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
          Info( "executeSF()", "Trigger efficiency SF:");
          Info( "executeSF()", "\t %f (from getTriggerScaleFactor())", triggerEffSF );
          Info( "executeSF()", "Trigger MC efficiency:");
-         Info( "executeSF()", "\t %f (from getTriggerEfficiency())", triggerMCEff );	 
+         Info( "executeSF()", "\t %f (from getTriggerEfficiency())", triggerMCEff );
          Info( "executeSF()", "--------------------------------------");
        }
 
        ++idx;
 
     } // close muon loop
-    
+
   }  // close loop on trigger efficiency SF systematics
 
 
-  // add list of reco/iso/trigger efficiency SF systematics names to TStore
+  // 4.
+  // TTVA efficiency SFs - this is a per-MUON weight
+  //
+  // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
+  // Every systematic will correspond to a different SF!
+  //
+
+  for ( const auto& syst_it : m_systListTTVA ) {
+
+    // Create the name of the SF weight to be recorded
+    //   template:  SYSNAME_MuTTVAEff_SF_WP
+    //
+    std::string sfName = "MuTTVAEff_SF_" + m_WorkingPointTTVA;
+    if ( !syst_it.name().empty() ) {
+       std::string prepend = syst_it.name() + "_";
+       sfName.insert( 0, prepend );
+    }
+    if ( m_debug ) { Info("executeSF()", "Muon iso efficiency SF sys names vector name is: %s", sfName.c_str()); }
+    sysVariationNamesTTVA->push_back(sfName);
+
+    // apply syst
+    //
+    if ( m_asgMuonEffCorrTool_muSF_TTVA->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
+      Error("executeSF()", "Failed to configure MuonEfficiencyScaleFactors for systematic %s", syst_it.name().c_str());
+      return EL::StatusCode::FAILURE;
+    }
+    if ( m_debug ) { Info("executeSF()", "Successfully applied systematic: %s", syst_it.name().c_str()); }
+
+    // and now apply TTVA efficiency SF!
+    //
+    unsigned int idx(0);
+    for ( auto mu_itr : *(inputMuons) ) {
+
+       if ( m_debug ) { Info( "executeSF()", "Applying TTVA efficiency SF" ); }
+
+       // a)
+       // decorate directly the muon with TTVA efficiency (useful at all?), and the corresponding SF
+       //
+       if ( m_asgMuonEffCorrTool_muSF_TTVA->applyRecoEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+         Warning( "executeSF()", "Problem in applyTTVAEfficiency");
+       }
+       if ( m_asgMuonEffCorrTool_muSF_TTVA->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+         Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor");
+       }
+
+       // b)
+       // obtain TTVA efficiency SF as a float (to be stored away separately)
+       //
+       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
+       //
+       SG::AuxElement::Decorator< std::vector<float> > sfVecTTVA( m_outputSystNamesTTVA );
+       if ( !sfVecTTVA.isAvailable( *mu_itr ) ) {
+	 sfVecTTVA( *mu_itr ) = std::vector<float>();
+       }
+
+       float TTVAEffSF(1.0);
+       if ( m_asgMuonEffCorrTool_muSF_TTVA->getEfficiencyScaleFactor( *mu_itr, TTVAEffSF ) != CP::CorrectionCode::Ok ) {
+         Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+	 TTVAEffSF = 1.0;
+       }
+       //
+       // Add it to decoration vector
+       //
+       sfVecTTVA( *mu_itr ).push_back(TTVAEffSF);
+
+       if ( m_debug ) {
+         Info( "executeSF()", "===>>>");
+         Info( "executeSF()", " ");
+	 Info( "executeSF()", "Muon %i, pt = %.2f GeV ", idx, (mu_itr->pt() * 1e-3) );
+	 Info( "executeSF()", " ");
+	 Info( "executeSF()", "TTVA SF decoration: %s", m_outputSystNamesTTVA.c_str() );
+	 Info( "executeSF()", " ");
+         Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
+         Info( "executeSF()", " ");
+         Info( "executeSF()", "TTVA efficiency SF:");
+         Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", TTVAEffSF );
+         Info( "executeSF()", "--------------------------------------");
+       }
+
+       ++idx;
+
+    } // close muon loop
+
+  }  // close loop on TTVA efficiency SF systematics
+
+
+  // add list of reco/iso/trigger/TTVA efficiency SF systematics names to TStore
   //
   // NB: we need to make sure that this is not pushed more than once in TStore!
   // This will be the case when this executeSF() function gets called for every syst varied input container,
@@ -863,6 +1014,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesReco) ) { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesReco, m_outputSystNamesReco), "Failed to record vector of systematic names for muon reco efficiency SF" ); }
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesIso) )  { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesIso, m_outputSystNamesIso),   "Failed to record vector of systematic names for muon iso efficiency SF" ); }
     if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesTrig) ) { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig), "Failed to record vector of systematic names for muon trigger efficiency  SF" ); }
+    if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesTTVA) ) { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesTTVA, m_outputSystNamesTTVA), "Failed to record vector of systematic names for muon TTVA efficiency  SF" ); }
   }
 
   return EL::StatusCode::SUCCESS;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -241,16 +241,22 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // 1.
   // initialize the CP::MuonEfficiencyScaleFactors Tool for reco efficiency SF
   //
+  std::string recoEffSF_tool_name = "MuonEfficiencyScaleFactors_effSF_Reco_" + m_WorkingPointReco;
 
-  if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>("MuonEfficiencyScaleFactors_effSF_Reco") ) {
-    m_asgMuonEffCorrTool_muSF_Reco = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>("MuonEfficiencyScaleFactors_effSF_Reco");
+  if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>(recoEffSF_tool_name) ) {
+    m_asgMuonEffCorrTool_muSF_Reco = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>(recoEffSF_tool_name);
   } else {
-    m_asgMuonEffCorrTool_muSF_Reco = new CP::MuonEfficiencyScaleFactors("MuonEfficiencyScaleFactors_effSF_Reco");
+    m_asgMuonEffCorrTool_muSF_Reco = new CP::MuonEfficiencyScaleFactors(recoEffSF_tool_name);
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->setProperty("WorkingPoint", m_WorkingPointReco ),"Failed to set Working Point property of MuonEfficiencyScaleFactors for reco efficiency SF");
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->setProperty("doAudit", false),"Failed to set doAudit property of MuonEfficiencyScaleFactors");
     RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Reco->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for reco efficiency SF");
   }
 
+  //
+  //  Add the chosen WP to the string labelling the vector<SF> decoration
+  //
+  m_outputSystNamesReco = m_outputSystNamesReco + "_" + m_WorkingPointReco;
+    
   if ( m_debug ) {
 
     // Get a list of affecting systematics
@@ -284,13 +290,18 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   //
   // Add an "Iso" suffix to the WP (required for tool configuration)
   //
-  std::string tool_WP = m_WorkingPointIso + "Iso";
 
   std::string isoEffSF_tool_name = "MuonEfficiencyScaleFactors_effSF_Iso_" + m_WorkingPointIso;
-  m_asgMuonEffCorrTool_muSF_Iso = new CP::MuonEfficiencyScaleFactors(isoEffSF_tool_name);
-  RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->setProperty("WorkingPoint", tool_WP ), "Failed to set Working Point property of MuonEfficiencyScaleFactors for iso efficiency SF");
-  RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for iso efficiency SF");
-
+  
+  if ( asg::ToolStore::contains<CP::MuonEfficiencyScaleFactors>(isoEffSF_tool_name) ) {
+    m_asgMuonEffCorrTool_muSF_Iso = asg::ToolStore::get<CP::MuonEfficiencyScaleFactors>(isoEffSF_tool_name);
+  } else {  
+    m_asgMuonEffCorrTool_muSF_Iso = new CP::MuonEfficiencyScaleFactors(isoEffSF_tool_name);
+    std::string tool_WP = m_WorkingPointIso + "Iso";
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->setProperty("WorkingPoint", tool_WP ), "Failed to set Working Point property of MuonEfficiencyScaleFactors for iso efficiency SF");
+    RETURN_CHECK( "MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Iso->initialize(), "Failed to properly initialize MuonEfficiencyScaleFactors for iso efficiency SF");
+  }
+  
   //
   //  Add the chosen WP to the string labelling the vector<SF> decoration
   //
@@ -324,12 +335,15 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   // 3.
   // Initialise the CP::MuonTriggerScaleFactors tool
+  //  
   //
 
-  if ( asg::ToolStore::contains<CP::MuonTriggerScaleFactors>("MuonTriggerScaleFactors_effSF_Trig") ) {
-    m_asgMuonEffCorrTool_muSF_Trig = asg::ToolStore::get<CP::MuonTriggerScaleFactors>("MuonTriggerScaleFactors_effSF_Trig");
-  } else {
-    m_asgMuonEffCorrTool_muSF_Trig = new CP::MuonTriggerScaleFactors("MuonTriggerScaleFactors_effSF_Trig");
+  std::string trigEff_tool_name = "MuonTriggerScaleFactors_effSF_Trig_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+  
+  if ( asg::ToolStore::contains<CP::MuonTriggerScaleFactors>(trigEff_tool_name) ) {
+    m_asgMuonEffCorrTool_muSF_Trig = asg::ToolStore::get<CP::MuonTriggerScaleFactors>(trigEff_tool_name);
+  } else { 
+    m_asgMuonEffCorrTool_muSF_Trig = new CP::MuonTriggerScaleFactors(trigEff_tool_name);
 
     int runNumber(m_runNumber);
     if ( asg::ToolStore::contains<CP::PileupReweightingTool>("Pileup") ) {
@@ -349,15 +363,20 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     if( m_asgMuonEffCorrTool_muSF_Trig->setRunNumber( runNumber ) == CP::CorrectionCode::Error ) {
       Warning("initialize()","Cannot set RunNumber for MuonTriggerScaleFactors tool");
     }
-    //
+    
     // Add an "Iso" prefix to the WP (required for tool configuration)
     //
-    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;
+    std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;  
+    
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("Isolation", iso_trig_WP ),"Failed to set Isolation property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->setProperty("MuonQuality", m_WorkingPointRecoTrig ),"Failed to set MuonQuality property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_asgMuonEffCorrTool_muSF_Trig->initialize(), "Failed to properly initialize MuonTriggerScaleFactors");
   }
 
+  //  Add the chosen WP to the string labelling the vector<SF> decoration
+  //
+  m_outputSystNamesTrig = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+  
   if ( m_debug ) {
 
     // Get a list of affecting systematics
@@ -572,12 +591,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_MuRecoEff_SF
     //
-    std::string sfName = "MuRecoEff_SF";
+    std::string sfName = "MuRecoEff_SF_" + m_WorkingPointReco;;
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
-    if ( m_debug ) { Info("executeSF()", "Muon reco efficiency SF decoration name is: %s", sfName.c_str()); }
+    if ( m_debug ) { Info("executeSF()", "Muon reco efficiency SF sys names vector name is: %s", sfName.c_str()); }
     sysVariationNamesReco->push_back(sfName);
 
     // apply syst
@@ -632,6 +651,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
          Info( "executeSF()", " ");
 	 Info( "executeSF()", "Muon %i, pt = %.2f GeV ", idx, (mu_itr->pt() * 1e-3) );
 	 Info( "executeSF()", " ");
+	 Info( "executeSF()", "Reco eff. SF decoration: %s", m_outputSystNamesReco.c_str() );
+	 Info( "executeSF()", " ");
          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
          Info( "executeSF()", " ");
          Info( "executeSF()", "Reco efficiency:");
@@ -684,7 +705,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
-    if ( m_debug ) { Info("executeSF()", "Muon iso efficiency SF decoration name is: %s", sfName.c_str()); }
+    if ( m_debug ) { Info("executeSF()", "Muon iso efficiency SF sys names vector name is: %s", sfName.c_str()); }
     sysVariationNamesIso->push_back(sfName);
 
     // apply syst
@@ -767,25 +788,29 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
 
   }  // close loop on isolation efficiency SF systematics
 
-  // 3.
-  // Trigger efficiency SF - this is a per-EVENT weight
-  //
-  SG::AuxElement::Decorator< std::vector<float> > sfVecTrig( m_outputSystNamesTrig );
 
-  // Loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
+  // 3.
+  // Trigger efficiency SF - this is in principle given by the MCP tool as a per-EVENT weight
+  // 
+  // To allow more freedom to the user, we calculate it as a per-muon weight with a trick
+  // We store also the MC efficiency per-muon
+
+  // Firstly, loop over available systematics for this tool - remember: syst == EMPTY_STRING --> nominal
   // Every systematic will correspond to a different SF!
   //
-  for ( const auto& syst_it : m_systListTrig ) {
+  // NB: calculation of the event SF is up to the analyzer
+   
+  for ( const auto& syst_it : m_systListIso ) {
 
     // Create the name of the SF weight to be recorded
     //   template:  SYSNAME_MuTrigEff_SF
     //
-    std::string sfName = "MuTrigEff_SF";
+    std::string sfName = "MuTrigEff_SF_" + m_WorkingPointRecoTrig + "_" + m_WorkingPointIsoTrig;
     if ( !syst_it.name().empty() ) {
        std::string prepend = syst_it.name() + "_";
        sfName.insert( 0, prepend );
     }
-    if ( m_debug ) { Info("executeSF()", "Trigger efficiency SF decoration name is: %s", sfName.c_str()); }
+    if ( m_debug ) { Info("executeSF()", "Trigger efficiency SF sys names vector name is: %s", sfName.c_str()); }
     sysVariationNamesTrig->push_back(sfName);
 
     // apply syst
@@ -796,58 +821,76 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF (  const xAOD::MuonContainer
     }
     if ( m_debug ) { Info("executeSF()", "Successfully applied systematic: %s", syst_it.name().c_str()); }
 
+
+    // decoration for muon MC trigger efficiency 
+    // (NB: it's assumed to be w/o syst, hence it's a flat "double". All uncertainties are in the SF) 
+    //
+    std::string eff_decor = "MuonEfficiencyCorrector_TrigMCEff_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+    SG::AuxElement::Decorator< double > effMC( eff_decor );
+    
     // and now apply trigger efficiency SF!
     //
-    unsigned int nMuons = inputMuons->size();
-    if ( m_debug ) { Info( "executeSF", "Applying trigger efficiency SF"); }
+    unsigned int idx(0);
+    for ( auto mu_itr : *(inputMuons) ) {
 
-    // obtain trigger efficiency SF
-    //
-    double triggerEffSF(1.0); // tool wants a double
-    if ( nMuons > 0 ) {
-      if ( !m_SingleMuTrig.empty() ) {
-	if ( m_asgMuonEffCorrTool_muSF_Trig->getTriggerScaleFactor( *inputMuons, triggerEffSF, m_SingleMuTrig ) != CP::CorrectionCode::Ok ) {
-	  Warning( "executeSF()", "Problem in getTriggerScaleFactor - single muon trigger(s)");
-	  triggerEffSF = 1.0;
-	}
-        if ( m_debug ) {
-          Info( "executeSF()", "===>>>");
-          Info( "executeSF()", " ");
-          Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
-          Info( "executeSF()", " ");
-          Info( "executeSF()", "Trigger efficiency SF:");
-          Info( "executeSF()", "\t %f (from getTriggerScaleFactor())", triggerEffSF );
-          Info( "executeSF()", "--------------------------------------");
-        }
-      }
-      /*
-      if ( nMuons == 2 ) {
-        if ( !m_DiMuTrig.empty() ) {
-          if ( m_asgMuonEffCorrTool_muSF_Trig->getTriggerScaleFactor( *inputMuons, triggerEffSF, m_DiMuTrig ) != CP::CorrectionCode::Ok ) {
-	    Warning( "executeSF()", "Problem in getTriggerScaleFactor - dimuon trigger(s)");
-	    triggerEffSF = 1.0;
-          }
-          if ( m_debug ) {
-            Info( "executeSF()", "===>>>");
-            Info( "executeSF()", " ");
-            Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
-            Info( "executeSF()", " ");
-            Info( "executeSF()", "Trigger efficiency SF:");
-            Info( "executeSF()", "\t %f (from getTriggerScaleFactor())", triggerEffSF );
-            Info( "executeSF()", "--------------------------------------");
-          }
-        }
-      }
-      */
-    }
-    //
-    // Add trigger SF to event decoration vector
-    //
-    sfVecTrig( *eventInfo ).push_back( triggerEffSF );
+       if ( m_debug ) { Info( "executeSF()", "Applying trigger efficiency SF and MC efficiency" ); }
 
+       // Pass a container with only the muon in question to the tool
+       // (use a view container to be light weight)
+       //
+       ConstDataVector<xAOD::MuonContainer> mySingleMuonCont(SG::VIEW_ELEMENTS); 
+       mySingleMuonCont.push_back( mu_itr );
+       
+       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
+       //
+       SG::AuxElement::Decorator< std::vector<float> > sfVecTrig( m_outputSystNamesTrig );
+       if ( !sfVecTrig.isAvailable( *mu_itr ) ) {
+	 sfVecTrig( *mu_itr ) = std::vector<float>();
+       }  
+       
+       double triggerEffSF(1.0); // tool wants a double  
+       if ( !m_SingleMuTrig.empty() && m_asgMuonEffCorrTool_muSF_Trig->getTriggerScaleFactor( *mySingleMuonCont.asDataVector(), triggerEffSF, m_SingleMuTrig ) != CP::CorrectionCode::Ok ) {
+	 Warning( "executeSF()", "Problem in getTriggerScaleFactor - single muon trigger(s)");
+	 triggerEffSF = 1.0;
+       }
+        
+       // Add it to decoration vector
+       //
+       sfVecTrig( *mu_itr ).push_back(triggerEffSF);
+
+       double triggerMCEff(0.0); // tool wants a double 
+       if ( !m_SingleMuTrig.empty() && m_asgMuonEffCorrTool_muSF_Trig->getTriggerEfficiency( *mu_itr, triggerMCEff, m_SingleMuTrig, !m_isMC ) != CP::CorrectionCode::Ok ) {
+         Warning( "executeSF()", "Problem in getTriggerEfficiency - single muon trigger(s)");
+         triggerMCEff = 0.0;
+       }
+       // Decorate muon (only once)
+       //
+       if ( !effMC.isAvailable( *mu_itr ) ) { effMC( *mu_itr ) = triggerMCEff; }
+
+       if ( m_debug ) {
+         Info( "executeSF()", "===>>>");
+         Info( "executeSF()", " ");
+	 Info( "executeSF()", "Muon %i, pt = %.2f GeV ", idx, (mu_itr->pt() * 1e-3) );
+	 Info( "executeSF()", " ");
+	 Info( "executeSF()", "Trigger efficiency SF decoration: %s", m_outputSystNamesTrig.c_str() );
+	 Info( "executeSF()", "Trigger MC efficiency decoration: %s", eff_decor.c_str() );
+	 Info( "executeSF()", " ");
+         Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
+         Info( "executeSF()", " ");
+         Info( "executeSF()", "Trigger efficiency SF:");
+         Info( "executeSF()", "\t %f (from getTriggerScaleFactor())", triggerEffSF );
+         Info( "executeSF()", "Trigger MC efficiency:");
+         Info( "executeSF()", "\t %f (from getTriggerEfficiency())", triggerMCEff );	 
+         Info( "executeSF()", "--------------------------------------");
+       }
+
+       ++idx;
+
+    } // close muon loop
+    
   }  // close loop on trigger efficiency SF systematics
 
-  //
+
   // add list of reco/iso/trigger efficiency SF systematics names to TStore
   //
   // NB: we need to make sure that this is not pushed more than once in TStore!

--- a/scripts/checkoutASGtags.py
+++ b/scripts/checkoutASGtags.py
@@ -55,6 +55,7 @@ dict_pkg = {
                        "atlasoff/Trigger/TrigAnalysis/TrigEgammaMatchingTool/tags/TrigEgammaMatchingTool-00-00-11"
                       ],
             '2.3.38': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency/tags/xAODBTaggingEfficiency-00-00-26"],
+            '2.3.39': ["atlasoff/PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections/tags/MuonEfficiencyCorrections-03-02-03"],
             '2.3.41': []
            }
 

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -35,7 +35,7 @@ public:
   float m_systValTrigMCEff;
   std::string m_systNamePID;
   std::string m_systNameReco;
-  std::string m_systNameIso;  
+  std::string m_systNameIso;
   std::string m_systNameTrig;
   std::string m_systNameTrigMCEff;
   std::string m_outputSystNamesPID;
@@ -48,7 +48,7 @@ public:
   std::string m_corrFileNameIso;
   std::string m_corrFileNameTrig;
   std::string m_corrFileNameTrigMCEff;
-  
+
   std::string   m_WorkingPointIDTrig;
 
 private:
@@ -99,7 +99,7 @@ public:
 
   // these are the functions not inherited from Algorithm
   virtual EL::StatusCode configure ();
-  virtual EL::StatusCode executeSF (  const xAOD::ElectronContainer* inputElectrons, const xAOD::EventInfo* eventInfo, unsigned int countSyst  );
+  virtual EL::StatusCode executeSF ( const xAOD::ElectronContainer* inputElectrons, unsigned int countSyst );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -30,16 +30,20 @@ public:
 
   float m_systValPID;
   float m_systValReco;
+  float m_systValIso;
   float m_systValTrig;
   std::string m_systNamePID;
   std::string m_systNameReco;
+  std::string m_systNameIso;  
   std::string m_systNameTrig;
   std::string m_outputSystNamesPID;
   std::string m_outputSystNamesReco;
+  std::string m_outputSystNamesIso;
   std::string m_outputSystNamesTrig;
 
   std::string m_corrFileNamePID;
   std::string m_corrFileNameReco;
+  std::string m_corrFileNameIso;
   std::string m_corrFileNameTrig;
 
 private:
@@ -49,14 +53,17 @@ private:
   bool m_isMC;            //!
 
   std::string m_PID_WP;   //!
+  std::string m_Iso_WP;   //!
 
-  std::vector<CP::SystematicSet> m_systListPID; //!
+  std::vector<CP::SystematicSet> m_systListPID;  //!
   std::vector<CP::SystematicSet> m_systListReco; //!
+  std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
 
   // tools
-  AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID; //!
+  AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID;  //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Reco; //!
+  AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Iso;  //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Trig; //!
 
   // variables that don't get filled at submission time should be

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -32,19 +32,22 @@ public:
   float m_systValReco;
   float m_systValIso;
   float m_systValTrig;
+  float m_systValTrigMCEff;
   std::string m_systNamePID;
   std::string m_systNameReco;
   std::string m_systNameIso;  
   std::string m_systNameTrig;
+  std::string m_systNameTrigMCEff;
   std::string m_outputSystNamesPID;
   std::string m_outputSystNamesReco;
   std::string m_outputSystNamesIso;
   std::string m_outputSystNamesTrig;
-
+  std::string m_outputSystNamesTrigMCEff;
   std::string m_corrFileNamePID;
   std::string m_corrFileNameReco;
   std::string m_corrFileNameIso;
   std::string m_corrFileNameTrig;
+  std::string m_corrFileNameTrigMCEff;
 
 private:
   int m_numEvent;         //!
@@ -59,12 +62,14 @@ private:
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
+  std::vector<CP::SystematicSet> m_systListTrigMCEff; //!
 
   // tools
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID;  //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Reco; //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Iso;  //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_Trig; //!
+  AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_TrigMCEff; //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -48,6 +48,8 @@ public:
   std::string m_corrFileNameIso;
   std::string m_corrFileNameTrig;
   std::string m_corrFileNameTrigMCEff;
+  
+  std::string   m_WorkingPointIDTrig;
 
 private:
   int m_numEvent;         //!

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -59,7 +59,8 @@ public:
   float	     	 m_z0sintheta_max;	     /* require z0*sin(theta) (at BL - corrected with vertex info) < m_z0sintheta_max */
   bool           m_doAuthorCut;
   bool           m_doOQCut;
-
+  bool           m_doBLTrackQualityCut;
+ 
   /* electron PID */
 
   bool           m_readIDFlagsFromDerivation;
@@ -117,10 +118,11 @@ private:
   int   m_el_cutflow_ptmax_cut;        //!
   int   m_el_cutflow_ptmin_cut;        //!
   int   m_el_cutflow_eta_cut;          //!
-  int   m_el_cutflow_PID_cut;          //!
   int   m_el_cutflow_z0sintheta_cut;   //!
   int   m_el_cutflow_d0_cut;           //!
   int   m_el_cutflow_d0sig_cut;        //!
+  int   m_el_cutflow_BL_cut;           //!
+  int   m_el_cutflow_PID_cut;          //!
   int   m_el_cutflow_iso_cut;          //!
 
   std::vector<std::string> m_IsoKeys;  //!

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -249,22 +249,6 @@ protected:
   std::vector<float> m_caloCluster_phi;
   std::vector<float> m_caloCluster_e;
 
-  // lepton SFs per event (product of each object SF)
-  std::vector<float> m_weight_muon_RecoEff_SF_Loose;
-  std::vector<float> m_weight_muon_IsoEff_SF_LooseTrackOnly;
-  std::vector<float> m_weight_muon_IsoEff_SF_Loose;
-  std::vector<float> m_weight_muon_IsoEff_SF_Tight;
-  std::vector<float> m_weight_muon_IsoEff_SF_Gradient;
-  std::vector<float> m_weight_muon_IsoEff_SF_GradientLoose;
-  std::vector<float> m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly;
-  std::vector<float> m_weight_electron_RecoEff_SF;
-  std::vector<float> m_weight_electron_IsoEff_SF_Loose;
-  std::vector<float> m_weight_electron_IsoEff_SF_FixedCutTight;
-  std::vector<float> m_weight_electron_PIDEff_SF_LHLooseAndBLayer;
-  std::vector<float> m_weight_electron_PIDEff_SF_LHLoose;
-  std::vector<float> m_weight_electron_PIDEff_SF_LHMedium;
-  std::vector<float> m_weight_electron_PIDEff_SF_LHTight;
-
   // trigger
   int m_passL1;
   int m_passHLT;
@@ -600,8 +584,8 @@ protected:
   std::vector< std::vector< float > > m_muon_RecoEff_SF_Loose;
   std::vector< std::vector< float > > m_muon_TrigEff_SF_Loose_Loose;
   std::vector< std::vector< float > > m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly;
-  std::vector< float >                m_muon_TrigMCEff_Loose_Loose;
-  std::vector< float >                m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly;
+  std::vector< std::vector< float > > m_muon_TrigMCEff_Loose_Loose;
+  std::vector< std::vector< float > > m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_LooseTrackOnly;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Loose;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Tight;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -262,8 +262,10 @@ protected:
   std::vector<float> m_weight_muon_IsoEff_SF_GradientLoose;
   std::vector<float> m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly;
   std::vector<float> m_weight_electron_RecoEff_SF;
+  std::vector<float> m_weight_electron_IsoEff_SF_Loose;
   std::vector<float> m_weight_electron_IsoEff_SF_FixedCutTight;
   std::vector<float> m_weight_electron_PIDEff_SF_LHVeryLoose;
+  std::vector<float> m_weight_electron_PIDEff_SF_LHLooseAndBLayer;
   std::vector<float> m_weight_electron_PIDEff_SF_LHLoose;
   std::vector<float> m_weight_electron_PIDEff_SF_LHMedium;
   std::vector<float> m_weight_electron_PIDEff_SF_LHTight;
@@ -606,7 +608,7 @@ protected:
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Tight;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Gradient;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_GradientLoose;
-  std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutLoose;  
+  std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutLoose;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutTightTrackOnly;
 
   // track parameters
@@ -699,8 +701,10 @@ protected:
   std::vector< std::vector< float > > m_el_RecoEff_SF;
   std::vector< std::vector< float > > m_el_TrigEff_SF;
   std::vector< std::vector< float > > m_el_TrigMCEff;
+  std::vector< std::vector< float > > m_el_IsoEff_SF_Loose;
   std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHVeryLoose;
+  std::vector< std::vector< float > > m_el_PIDEff_SF_LHLooseAndBLayer;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHMedium;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHTight;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -694,6 +694,7 @@ protected:
   // scale factors w/ sys
   // per object
   std::vector< std::vector< float > > m_el_RecoEff_SF;
+  std::vector< std::vector< float > > m_el_TrigEff_SF;
   std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHVeryLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLoose;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -251,7 +251,6 @@ protected:
 
   // trigger scale factors
   std::vector<float> m_weight_muon_trig;
-  std::vector<float> m_weight_electron_trig;
 
   // lepton SFs per event (product of each object SF)
   std::vector<float> m_weight_muon_RecoEff_SF;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -649,6 +649,7 @@ protected:
   std::vector<float> m_el_phi;
   std::vector<float> m_el_eta;
   std::vector<float> m_el_m;
+  std::vector<float> m_el_caloCluster_eta;
 
   // trigger
   std::vector<int> m_el_isTrigMatched;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -264,7 +264,6 @@ protected:
   std::vector<float> m_weight_electron_RecoEff_SF;
   std::vector<float> m_weight_electron_IsoEff_SF_Loose;
   std::vector<float> m_weight_electron_IsoEff_SF_FixedCutTight;
-  std::vector<float> m_weight_electron_PIDEff_SF_LHVeryLoose;
   std::vector<float> m_weight_electron_PIDEff_SF_LHLooseAndBLayer;
   std::vector<float> m_weight_electron_PIDEff_SF_LHLoose;
   std::vector<float> m_weight_electron_PIDEff_SF_LHMedium;
@@ -681,8 +680,6 @@ protected:
   std::vector<float> m_el_topoetcone40;
 
   // PID
-  int m_nel_LHVeryLoose;
-  std::vector<int>   m_el_LHVeryLoose;
   int m_nel_LHLoose;
   std::vector<int>   m_el_LHLoose;
   int m_nel_LHMedium;
@@ -703,7 +700,6 @@ protected:
   std::vector< std::vector< float > > m_el_TrigMCEff;
   std::vector< std::vector< float > > m_el_IsoEff_SF_Loose;
   std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
-  std::vector< std::vector< float > > m_el_PIDEff_SF_LHVeryLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLooseAndBLayer;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHMedium;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -260,9 +260,9 @@ protected:
   std::vector<float> m_weight_muon_IsoEff_SF_Tight;
   std::vector<float> m_weight_muon_IsoEff_SF_Gradient;
   std::vector<float> m_weight_muon_IsoEff_SF_GradientLoose;
-  std::vector<float> m_weight_muon_IsoEff_SF_UserDefinedFixEfficiency;
-  std::vector<float> m_weight_muon_IsoEff_SF_UserDefinedCut;
+  std::vector<float> m_weight_muon_IsoEff_SF_FixedCutTightTrackOnly;
   std::vector<float> m_weight_electron_RecoEff_SF;
+  std::vector<float> m_weight_electron_IsoEff_SF_FixedCutTight;
   std::vector<float> m_weight_electron_PIDEff_SF_LHVeryLoose;
   std::vector<float> m_weight_electron_PIDEff_SF_LHLoose;
   std::vector<float> m_weight_electron_PIDEff_SF_LHMedium;
@@ -577,11 +577,7 @@ protected:
   std::vector<int>   m_muon_isIsolated_Tight;
   std::vector<int>   m_muon_isIsolated_Gradient;
   std::vector<int>   m_muon_isIsolated_GradientLoose;
-  std::vector<int>   m_muon_isIsolated_GradientT1;
-  std::vector<int>   m_muon_isIsolated_GradientT2;
-  std::vector<int>   m_muon_isIsolated_MU0p06;
   std::vector<int>   m_muon_isIsolated_FixedCutLoose;
-  std::vector<int>   m_muon_isIsolated_FixedCutTight;
   std::vector<int>   m_muon_isIsolated_FixedCutTightTrackOnly;
   std::vector<int>   m_muon_isIsolated_UserDefinedFixEfficiency;
   std::vector<int>   m_muon_isIsolated_UserDefinedCut;
@@ -609,8 +605,8 @@ protected:
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Tight;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Gradient;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_GradientLoose;
-  std::vector< std::vector< float > > m_muon_IsoEff_SF_UserDefinedFixEfficiency;
-  std::vector< std::vector< float > > m_muon_IsoEff_SF_UserDefinedCut;
+  std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutLoose;  
+  std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutTightTrackOnly;
 
   // track parameters
   std::vector<float> m_muon_trkd0;
@@ -663,9 +659,6 @@ protected:
   std::vector<int>   m_el_isIsolated_Tight;
   std::vector<int>   m_el_isIsolated_Gradient;
   std::vector<int>   m_el_isIsolated_GradientLoose;
-  std::vector<int>   m_el_isIsolated_GradientT1;
-  std::vector<int>   m_el_isIsolated_GradientT2;
-  std::vector<int>   m_el_isIsolated_EL0p06;
   std::vector<int>   m_el_isIsolated_FixedCutLoose;
   std::vector<int>   m_el_isIsolated_FixedCutTight;
   std::vector<int>   m_el_isIsolated_FixedCutTightTrackOnly;
@@ -701,6 +694,7 @@ protected:
   // scale factors w/ sys
   // per object
   std::vector< std::vector< float > > m_el_RecoEff_SF;
+  std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHVeryLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHMedium;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -568,7 +568,8 @@ protected:
   std::vector<float> m_muon_m;
 
   // trigger
-  std::vector<int> m_muon_isTrigMatchedToChain;
+  std::vector<int> m_muon_isTrigMatched;
+  std::vector<std::vector<int> > m_muon_isTrigMatchedToChain;
   std::vector<std::string> m_muon_listTrigChains;
 
   // isolation
@@ -650,8 +651,9 @@ protected:
   std::vector<float> m_el_m;
 
   // trigger
-  std::vector<int> m_el_isTrigMatchedToChain;
-  std::vector<std::string> m_el_listTrigChains;
+  std::vector<int> m_el_isTrigMatched;
+  std::vector<std::vector<int> > m_el_isTrigMatchedToChain;
+  std::vector<std::string>       m_el_listTrigChains;
 
   // isolation
   std::vector<int>   m_el_isIsolated_LooseTrackOnly;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -697,6 +697,7 @@ protected:
   // per object
   std::vector< std::vector< float > > m_el_RecoEff_SF;
   std::vector< std::vector< float > > m_el_TrigEff_SF;
+  std::vector< std::vector< float > > m_el_TrigMCEff;
   std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHVeryLoose;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLoose;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -593,6 +593,7 @@ protected:
   std::vector< std::vector< float > > m_muon_IsoEff_SF_GradientLoose;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutLoose;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_FixedCutTightTrackOnly;
+  std::vector< std::vector< float > > m_muon_TTVAEff_SF;
 
   // track parameters
   std::vector<float> m_muon_trkd0;
@@ -681,7 +682,7 @@ protected:
   // per object
   std::vector< std::vector< float > > m_el_RecoEff_SF;
   std::vector< std::vector< float > > m_el_TrigEff_SF_LHLooseAndBLayer;
-  std::vector< std::vector< float > > m_el_TrigEff_SF_LHTight;  
+  std::vector< std::vector< float > > m_el_TrigEff_SF_LHTight;
   std::vector< std::vector< float > > m_el_TrigMCEff_LHLooseAndBLayer;
   std::vector< std::vector< float > > m_el_TrigMCEff_LHTight;
   std::vector< std::vector< float > > m_el_IsoEff_SF_Loose;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -249,11 +249,8 @@ protected:
   std::vector<float> m_caloCluster_phi;
   std::vector<float> m_caloCluster_e;
 
-  // trigger scale factors
-  std::vector<float> m_weight_muon_trig;
-
   // lepton SFs per event (product of each object SF)
-  std::vector<float> m_weight_muon_RecoEff_SF;
+  std::vector<float> m_weight_muon_RecoEff_SF_Loose;
   std::vector<float> m_weight_muon_IsoEff_SF_LooseTrackOnly;
   std::vector<float> m_weight_muon_IsoEff_SF_Loose;
   std::vector<float> m_weight_muon_IsoEff_SF_Tight;
@@ -600,7 +597,11 @@ protected:
 
   // scale factors w/ sys
   // per object
-  std::vector< std::vector< float > > m_muon_RecoEff_SF;
+  std::vector< std::vector< float > > m_muon_RecoEff_SF_Loose;
+  std::vector< std::vector< float > > m_muon_TrigEff_SF_Loose_Loose;
+  std::vector< std::vector< float > > m_muon_TrigEff_SF_Loose_FixedCutTightTrackOnly;
+  std::vector< float >                m_muon_TrigMCEff_Loose_Loose;
+  std::vector< float >                m_muon_TrigMCEff_Loose_FixedCutTightTrackOnly;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_LooseTrackOnly;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Loose;
   std::vector< std::vector< float > > m_muon_IsoEff_SF_Tight;
@@ -695,8 +696,10 @@ protected:
   // scale factors w/ sys
   // per object
   std::vector< std::vector< float > > m_el_RecoEff_SF;
-  std::vector< std::vector< float > > m_el_TrigEff_SF;
-  std::vector< std::vector< float > > m_el_TrigMCEff;
+  std::vector< std::vector< float > > m_el_TrigEff_SF_LHLooseAndBLayer;
+  std::vector< std::vector< float > > m_el_TrigEff_SF_LHTight;  
+  std::vector< std::vector< float > > m_el_TrigMCEff_LHLooseAndBLayer;
+  std::vector< std::vector< float > > m_el_TrigMCEff_LHTight;
   std::vector< std::vector< float > > m_el_IsoEff_SF_Loose;
   std::vector< std::vector< float > > m_el_IsoEff_SF_FixedCutTight;
   std::vector< std::vector< float > > m_el_PIDEff_SF_LHLooseAndBLayer;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -132,9 +132,6 @@ namespace HelperClasses {
         m_shapeLC        shapeLC        exact
         m_truth          truth          exact
         m_caloClus       caloClusters   exact
-        m_muonSF         muonSF         exact
-        m_electronSF     electronSF     exact
-        m_eventCleaning  eventCleaning  exact
         ================ ============== =======
     @endrst
    */
@@ -145,8 +142,6 @@ namespace HelperClasses {
     bool m_shapeLC;
     bool m_truth;
     bool m_caloClus;
-    bool m_muonSF;
-    bool m_electronSF;
     void initialize();
     EventInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   };

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -27,6 +27,8 @@ public:
   // configuration variables
   std::string   m_inContainerName;
 
+  std::string   m_calibRelease;
+
   // Reco efficiency SF
   std::string   m_WorkingPointReco;
 
@@ -40,6 +42,9 @@ public:
   std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
   std::string   m_DiMuTrig;          // this can be either a dimuon trigger chain, or an OR of ( N single muon trigger chains, dimuon chain )
 
+  // TTVA efficiency SF
+  std::string   m_WorkingPointTTVA;
+
   // systematics
   std::string   m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
   			               // upstream algo (e.g., the SC containers with calibration systematics)
@@ -47,12 +52,15 @@ public:
   float         m_systValReco;
   float         m_systValIso;
   float         m_systValTrig;
+  float         m_systValTTVA;
   std::string   m_systNameReco;
   std::string   m_systNameIso;
   std::string   m_systNameTrig;
+  std::string   m_systNameTTVA;
   std::string   m_outputSystNamesReco;
   std::string   m_outputSystNamesIso;
   std::string   m_outputSystNamesTrig;
+  std::string   m_outputSystNamesTTVA;
 
 private:
 
@@ -67,11 +75,13 @@ private:
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
+  std::vector<CP::SystematicSet> m_systListTTVA; //!
 
   // tools
   CP::MuonEfficiencyScaleFactors  *m_asgMuonEffCorrTool_muSF_Reco;     //!
   CP::MuonEfficiencyScaleFactors  *m_asgMuonEffCorrTool_muSF_Iso;      //!
   CP::MuonTriggerScaleFactors     *m_asgMuonEffCorrTool_muSF_Trig ;    //!
+  CP::MuonEfficiencyScaleFactors  *m_asgMuonEffCorrTool_muSF_TTVA;     //!
   CP::PileupReweightingTool       *m_pileuptool;                       //!
 
   // variables that don't get filled at submission time should be
@@ -82,7 +92,6 @@ public:
 
   // Tree *myTree; //!
   // TH1 *myHist;  //!
-
 
   // this is a standard constructor
   MuonEfficiencyCorrector (std::string className = "MuonEfficiencyCorrector");
@@ -101,7 +110,7 @@ public:
   // these are the functions not inherited from Algorithm
   virtual EL::StatusCode configure ();
 
-  virtual EL::StatusCode executeSF (  const xAOD::MuonContainer* inputMuons, const xAOD::EventInfo* eventInfo, unsigned int countSyst  );
+  virtual EL::StatusCode executeSF (  const xAOD::MuonContainer* inputMuons, unsigned int countSyst  );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -51,15 +51,15 @@ class ElectronLHPIDManager
 
      ~ElectronLHPIDManager()
      {
-     	if ( m_asgElectronLikelihoodTool_Loose )       { m_asgElectronLikelihoodTool_Loose = nullptr;	delete m_asgElectronLikelihoodTool_Loose;     }
-     	if ( m_asgElectronLikelihoodTool_Medium )      { m_asgElectronLikelihoodTool_Medium = nullptr;	delete m_asgElectronLikelihoodTool_Medium;    }
-     	if ( m_asgElectronLikelihoodTool_Tight )       { m_asgElectronLikelihoodTool_Tight = nullptr;	delete m_asgElectronLikelihoodTool_Tight;     }
+     	if ( m_asgElectronLikelihoodTool_Loose )  { delete m_asgElectronLikelihoodTool_Loose;	 m_asgElectronLikelihoodTool_Loose = nullptr;  }
+     	if ( m_asgElectronLikelihoodTool_Medium ) { delete m_asgElectronLikelihoodTool_Medium;   m_asgElectronLikelihoodTool_Medium = nullptr; }
+     	if ( m_asgElectronLikelihoodTool_Tight )  { delete m_asgElectronLikelihoodTool_Tight;	 m_asgElectronLikelihoodTool_Tight = nullptr;  }
      };
 
 
      StatusCode setupWPs( bool configTools, std::string selector_name = "", std::string confDir = "", std::string year = "" ) {
 	
-	const std::string selectedWP = ( m_selectedWP == "Loose_CutBL" ) ? "Loose" : m_selectedWP;
+	const std::string selectedWP = ( m_selectedWP == "LooseAndBLayer" ) ? "Loose" : m_selectedWP;
 
         HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
         unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(selectedWP) );
@@ -78,7 +78,7 @@ class ElectronLHPIDManager
 	      /* instantiate tools (do it for all) */
 
 	      const std::string WP            = it.first;
-	      const std::string extra_string  = ( m_selectedWP == "Loose_CutBL" && (WP.find("Loose") != std::string::npos) ) ? "_CutBL" : "";
+	      const std::string extra_string  = ( m_selectedWP == "LooseAndBLayer" && (WP.find("Loose") != std::string::npos) ) ? "_CutBL" : "";
 
 	      std::string tool_name = selector_name + "_" + WP + extra_string; 
 	      
@@ -142,7 +142,7 @@ class ElectronLHPIDManager
 
      const std::string getSelectedWP () { 
        
-       const std::string WP = ( m_selectedWP == "Loose_CutBL" ) ? "Loose" : m_selectedWP;
+       const std::string WP = ( m_selectedWP == "LooseAndBLayer" ) ? "Loose" : m_selectedWP;
        return WP; 
        
      }

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -88,7 +88,11 @@ class ElectronLHPIDManager
 	      std::string WP            = ( it.first == "Loose_CutBL" ) ? "Loose" : it.first;
 	      std::string extra_string  = ( it.first == "Loose_CutBL" ) ? "_CutBL" : "";
 
-	      it.second =  new AsgElectronLikelihoodTool( (WP + selector_name).c_str() );
+	      std::string tool_name     = selector_name + "_" + WP + extra_string; 
+	      
+	      Info("setupWPs()", "initialising AsgElectronLikelihoodTool w/ name: %s", tool_name.c_str() );
+
+	      it.second =  new AsgElectronLikelihoodTool( tool_name.c_str() );
 
               HelperClasses::EnumParser<LikeEnum::Menu>  WP_parser;
               unsigned int WP_enum = static_cast<unsigned int>( WP_parser.parseEnum(WP) );

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -29,19 +29,15 @@ class ElectronLHPIDManager
    public:
      ElectronLHPIDManager ();
      ElectronLHPIDManager ( std::string WP, bool debug = false ) :
-        m_asgElectronLikelihoodTool_VeryLoose(nullptr),
 	m_asgElectronLikelihoodTool_Loose(nullptr),
-	m_asgElectronLikelihoodTool_Loose_CutBL(nullptr),
 	m_asgElectronLikelihoodTool_Medium(nullptr),
 	m_asgElectronLikelihoodTool_Tight(nullptr)
      {
-	m_selectedWP = ( WP == "Loose_CutBL" ) ? "Loose" : WP;
+	m_selectedWP = WP;
 	m_debug      = debug;
 
         /*  fill the multimap with WPs and corresponding tools */
-	std::pair < std::string, AsgElectronLikelihoodTool* > veryloose = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
-        m_allWPTools.insert(veryloose);
-	m_allWPs.insert("VeryLoose");
+
 	std::pair < std::string, AsgElectronLikelihoodTool* > loose = std::make_pair( std::string("Loose"), m_asgElectronLikelihoodTool_Loose );
         m_allWPTools.insert(loose);
 	m_allWPs.insert("Loose");
@@ -51,26 +47,22 @@ class ElectronLHPIDManager
 	std::pair < std::string, AsgElectronLikelihoodTool* > tight = std::make_pair( std::string("Tight"), m_asgElectronLikelihoodTool_Tight );
         m_allWPTools.insert(tight);
 	m_allWPs.insert("Tight");
-
-	std::pair < std::string, AsgElectronLikelihoodTool* > loose_CutBL = std::make_pair( std::string("Loose_CutBL"), m_asgElectronLikelihoodTool_Loose_CutBL );
-        m_allWPTools.insert(loose_CutBL);
-
      };
 
      ~ElectronLHPIDManager()
      {
-     	if ( m_asgElectronLikelihoodTool_VeryLoose )   { m_asgElectronLikelihoodTool_VeryLoose = nullptr; delete m_asgElectronLikelihoodTool_VeryLoose; }
      	if ( m_asgElectronLikelihoodTool_Loose )       { m_asgElectronLikelihoodTool_Loose = nullptr;	delete m_asgElectronLikelihoodTool_Loose;     }
-	if ( m_asgElectronLikelihoodTool_Loose_CutBL ) { m_asgElectronLikelihoodTool_Loose_CutBL = nullptr;	delete m_asgElectronLikelihoodTool_Loose_CutBL; }
      	if ( m_asgElectronLikelihoodTool_Medium )      { m_asgElectronLikelihoodTool_Medium = nullptr;	delete m_asgElectronLikelihoodTool_Medium;    }
      	if ( m_asgElectronLikelihoodTool_Tight )       { m_asgElectronLikelihoodTool_Tight = nullptr;	delete m_asgElectronLikelihoodTool_Tight;     }
      };
 
 
      StatusCode setupWPs( bool configTools, std::string selector_name = "", std::string confDir = "", std::string year = "" ) {
+	
+	const std::string selectedWP = ( m_selectedWP == "Loose_CutBL" ) ? "Loose" : m_selectedWP;
 
         HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
-        unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
+        unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(selectedWP) );
 
         /*
 	/
@@ -85,10 +77,10 @@ class ElectronLHPIDManager
 
 	      /* instantiate tools (do it for all) */
 
-	      std::string WP            = ( it.first == "Loose_CutBL" ) ? "Loose" : it.first;
-	      std::string extra_string  = ( it.first == "Loose_CutBL" ) ? "_CutBL" : "";
+	      const std::string WP            = it.first;
+	      const std::string extra_string  = ( m_selectedWP == "Loose_CutBL" && (WP.find("Loose") != std::string::npos) ) ? "_CutBL" : "";
 
-	      std::string tool_name     = selector_name + "_" + WP + extra_string; 
+	      std::string tool_name = selector_name + "_" + WP + extra_string; 
 	      
 	      Info("setupWPs()", "initialising AsgElectronLikelihoodTool w/ name: %s", tool_name.c_str() );
 
@@ -148,7 +140,12 @@ class ElectronLHPIDManager
        return StatusCode::SUCCESS;
      }
 
-     const std::string getSelectedWP ( ) { return m_selectedWP; }
+     const std::string getSelectedWP () { 
+       
+       const std::string WP = ( m_selectedWP == "Loose_CutBL" ) ? "Loose" : m_selectedWP;
+       return WP; 
+       
+     }
 
      /* returns a map containing all the tools */
      std::multimap< std::string, AsgElectronLikelihoodTool* > getAllWPTools()   { return m_allWPTools; };
@@ -168,9 +165,7 @@ class ElectronLHPIDManager
      std::set<std::string> m_allWPs;
      std::set<std::string> m_validWPs;
 
-     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLoose;
      AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose;
-     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose_CutBL;
      AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Medium;
      AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Tight;
 


### PR DESCRIPTION
This is a rather big PR. A short summary of the main changes:

- move on to 2.3.39 and update package script
- add isolation SF for electrons.
- add electron trigger MC efficiency (not SF!) and dump it in tree.
- fix a logic bug in electron trigger SF: in the way the egamma CP tool works, the SF is a **per-electron** weight, hence it must be saved for every electron in the event. I still calculate a global SF according to the formula:

event SF = 1 - Prod( 1 - SF(i) )
(the product is over electrons in the event)

, but it must be taken with a grain of salt. In principle, people should re-calculate their own event SF according to each analysis recommendations: all the ingredients (namely, per-electron SFs  and MC efficiencies) are stored as decorations and also are dumped to the final tree. 
- add "Loose_CutBL" in the list of available WPs for electron LH in `ElectronSelector`
- general cleanup of `ParticlePIDManager.h`
- add `_isTrigMatched` branches for electrons and muons in tree (they are true if at least one match with the input chains is found)

@gfacini @kratsg @jdandoy @johnda102 

Marco