### PR TITLE
PR for code improvement/bugfixes on TLA ntuples

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -471,32 +471,32 @@ EL::StatusCode BasicEventSelection :: initialize ()
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
   //
   m_cutflowHist  = new TH1D("cutflow", "cutflow", 1, 1, 2);
-  m_cutflowHist->SetBit(TH1::kCanRebin);
+  m_cutflowHist->SetCanExtend(TH1::kAllAxes);
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
   //
   m_cutflowHistW = new TH1D("cutflow_weighted", "cutflow_weighted", 1, 1, 2);
-  m_cutflowHistW->SetBit(TH1::kCanRebin);
+  m_cutflowHistW->SetCanExtend(TH1::kAllAxes);
 
   // initialise object cutflows, which will be picked by the object selector algos downstream and filled.
   //
   m_el_cutflowHist_1     = new TH1D("cutflow_electrons_1", "cutflow_electrons_1", 1, 1, 2);
-  m_el_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_el_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_el_cutflowHist_2     = new TH1D("cutflow_electrons_2", "cutflow_electrons_2", 1, 1, 2);
-  m_el_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_el_cutflowHist_2->SetCanExtend(TH1::kAllAxes);
   m_mu_cutflowHist_1     = new TH1D("cutflow_muons_1", "cutflow_muons_1", 1, 1, 2);
-  m_mu_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_mu_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_mu_cutflowHist_2     = new TH1D("cutflow_muons_2", "cutflow_muons_2", 1, 1, 2);
-  m_mu_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_mu_cutflowHist_2->SetCanExtend(TH1::kAllAxes);
   m_ph_cutflowHist_1     = new TH1D("cutflow_photons_1", "cutflow_photons_1", 1, 1, 2);
-  m_ph_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_ph_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_tau_cutflowHist_1     = new TH1D("cutflow_taus_1", "cutflow_taus_1", 1, 1, 2);
-  m_tau_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_tau_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_tau_cutflowHist_2     = new TH1D("cutflow_taus_2", "cutflow_taus_2", 1, 1, 2);
-  m_tau_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_tau_cutflowHist_2->SetCanExtend(TH1::kAllAxes);
   m_jet_cutflowHist_1    = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
-  m_jet_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_jet_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
-  m_truth_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_truth_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
 
   // start labelling the bins for the event cutflow
   //
@@ -842,7 +842,7 @@ EL::StatusCode BasicEventSelection :: execute ()
     // save passed triggers in eventInfo
     //
     if ( m_storeTrigDecisions ) {
-
+        
       std::vector<std::string> passTriggers;
       std::vector<float> triggerPrescales;
 
@@ -913,7 +913,7 @@ EL::StatusCode BasicEventSelection :: finalize ()
 
   m_RunNr_VS_EvtNr.clear();
 
-    if ( m_grl )        { delete m_grl; m_grl = nullptr; }
+  if ( m_grl )          { delete m_grl; m_grl = nullptr; }
   if ( m_pileuptool )   { delete m_pileuptool;  m_pileuptool = nullptr; }
   if ( m_trigDecTool )  { delete m_trigDecTool;  m_trigDecTool = nullptr; }
   if ( m_trigConfTool ) { delete m_trigConfTool;  m_trigConfTool = nullptr; }

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -466,7 +466,42 @@ EL::StatusCode BasicEventSelection :: initialize ()
   TFile *fileCF = wk()->getOutputFile ("cutflow");
   fileCF->cd();
 
-  // initialise event cutflow, which will be picked ALSO by the algos downstream where an event selection is applied (or at least can be applied)
+    
+    // initialise event cutflow, which will be picked ALSO by the algos downstream where an event selection is applied (or at least can be applied)
+  //
+  // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
+  //
+  m_cutflowHist  = new TH1D("cutflow", "cutflow", 1, 1, 2);
+  m_cutflowHist->SetBit(TH1::kCanRebin);
+  // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
+  //
+  m_cutflowHistW = new TH1D("cutflow_weighted", "cutflow_weighted", 1, 1, 2);
+  m_cutflowHistW->SetBit(TH1::kCanRebin);
+
+  // initialise object cutflows, which will be picked by the object selector algos downstream and filled.
+  //
+  m_el_cutflowHist_1     = new TH1D("cutflow_electrons_1", "cutflow_electrons_1", 1, 1, 2);
+  m_el_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_el_cutflowHist_2     = new TH1D("cutflow_electrons_2", "cutflow_electrons_2", 1, 1, 2);
+  m_el_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_mu_cutflowHist_1     = new TH1D("cutflow_muons_1", "cutflow_muons_1", 1, 1, 2);
+  m_mu_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_mu_cutflowHist_2     = new TH1D("cutflow_muons_2", "cutflow_muons_2", 1, 1, 2);
+  m_mu_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_ph_cutflowHist_1     = new TH1D("cutflow_photons_1", "cutflow_photons_1", 1, 1, 2);
+  m_ph_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_tau_cutflowHist_1     = new TH1D("cutflow_taus_1", "cutflow_taus_1", 1, 1, 2);
+  m_tau_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_tau_cutflowHist_2     = new TH1D("cutflow_taus_2", "cutflow_taus_2", 1, 1, 2);
+  m_tau_cutflowHist_2->SetBit(TH1::kCanRebin);
+  m_jet_cutflowHist_1    = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
+  m_jet_cutflowHist_1->SetBit(TH1::kCanRebin);
+  m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
+  m_truth_cutflowHist_1->SetBit(TH1::kCanRebin);
+    
+  // Note: the following commented-out code is needed for anyone developing/running in ROOT 6.04.10
+  /*
+  //initialise event cutflow, which will be picked ALSO by the algos downstream where an event selection is applied (or at least can be applied)
   //
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
   //
@@ -496,7 +531,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
   m_jet_cutflowHist_1    = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
   m_jet_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
-  m_truth_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
+  m_truth_cutflowHist_1->SetCanExtend(TH1::kAllAxes);*/
 
   // start labelling the bins for the event cutflow
   //

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -470,7 +470,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
     // initialise event cutflow, which will be picked ALSO by the algos downstream where an event selection is applied (or at least can be applied)
   //
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
-  //
+  
   m_cutflowHist  = new TH1D("cutflow", "cutflow", 1, 1, 2);
   m_cutflowHist->SetBit(TH1::kCanRebin);
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
@@ -479,7 +479,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
   m_cutflowHistW->SetBit(TH1::kCanRebin);
 
   // initialise object cutflows, which will be picked by the object selector algos downstream and filled.
-  //
+  
   m_el_cutflowHist_1     = new TH1D("cutflow_electrons_1", "cutflow_electrons_1", 1, 1, 2);
   m_el_cutflowHist_1->SetBit(TH1::kCanRebin);
   m_el_cutflowHist_2     = new TH1D("cutflow_electrons_2", "cutflow_electrons_2", 1, 1, 2);
@@ -498,9 +498,9 @@ EL::StatusCode BasicEventSelection :: initialize ()
   m_jet_cutflowHist_1->SetBit(TH1::kCanRebin);
   m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
   m_truth_cutflowHist_1->SetBit(TH1::kCanRebin);
-    
-  // Note: the following commented-out code is needed for anyone developing/running in ROOT 6.04.10
   /*
+  // Note: the following commented-out code is needed for anyone developing/running in ROOT 6.04.10
+  
   //initialise event cutflow, which will be picked ALSO by the algos downstream where an event selection is applied (or at least can be applied)
   //
   // use 1,1,2 so Fill(bin) and GetBinContent(bin) refer to the same bin
@@ -531,8 +531,8 @@ EL::StatusCode BasicEventSelection :: initialize ()
   m_jet_cutflowHist_1    = new TH1D("cutflow_jets_1", "cutflow_jets_1", 1, 1, 2);
   m_jet_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
   m_truth_cutflowHist_1  = new TH1D("cutflow_truths_1", "cutflow_truths_1", 1, 1, 2);
-  m_truth_cutflowHist_1->SetCanExtend(TH1::kAllAxes);*/
-
+  m_truth_cutflowHist_1->SetCanExtend(TH1::kAllAxes);
+  */
   // start labelling the bins for the event cutflow
   //
   m_cutflow_all  = m_cutflowHist->GetXaxis()->FindBin("all");

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -50,6 +50,8 @@ m_trigDecTool(nullptr)
     m_inContainerName = "";
     // shallow copies are made with this output container name
     m_outContainerName = "";
+    // flag to own TDT and TCT
+    m_ownTDTAndTCT = false;
 
 }
 
@@ -136,6 +138,7 @@ EL::StatusCode HLTJetGetter :: initialize ()
         m_trigDecTool = asg::ToolStore::get<Trig::TrigDecisionTool>("TrigDecisionTool");
     } else {
         Info ("Initialize()", "the Trigger Decision Tool is not yet initialized...[%s]. Doing so now.", m_name.c_str());
+        m_ownTDTAndTCT = true;
         
         m_trigConfTool = new TrigConf::xAODConfigTool( "xAODConfigTool" );
         RETURN_CHECK("BasicEventSelection::initialize()", m_trigConfTool->initialize(), "Failed to properly initialize TrigConf::xAODConfigTool");
@@ -205,9 +208,12 @@ EL::StatusCode HLTJetGetter :: finalize ()
 {
     Info("finalize()", "Deleting tool instances...");
     
-    //question: are we doing this twice?
-    if ( m_trigDecTool )  {  delete m_trigDecTool; m_trigDecTool = nullptr;  }
-    if ( m_trigConfTool ) {  delete m_trigConfTool; m_trigConfTool = nullptr; }
+    // this is necessary because in most cases the pointer will be set to null
+    // after deletion in BasicEventSelection, but it will not propagate here
+    if ( m_ownTDTAndTCT ) {
+      if ( m_trigDecTool )  { delete m_trigDecTool; m_trigDecTool = nullptr;  }
+      if ( m_trigConfTool ) {  delete m_trigConfTool; m_trigConfTool = nullptr; }
+    }
     
     return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -134,9 +134,11 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
 
   if ( m_eventInfoSwitch->m_eventCleaning ) {
     
-    m_tree->Branch("TileError",          &m_TileError,      "TileError/O");
-    m_tree->Branch("SCTError",           &m_SCTError,      "SCTError/O");
-    m_tree->Branch("LArError",           &m_LArError,      "LArError/O");
+    m_tree->Branch("timeStamp",          &m_timeStamp,         "timeStamp/i");
+    m_tree->Branch("timeStampNSOffset",  &m_timeStampNSOffset, "timeStampNSOffset/i");
+    m_tree->Branch("TileError",          &m_TileError,         "TileError/O");
+    m_tree->Branch("SCTError",           &m_SCTError,          "SCTError/O");
+    m_tree->Branch("LArError",           &m_LArError,          "LArError/O");
 
   }
     
@@ -228,6 +230,10 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
     
     if ( eventInfo->errorState(xAOD::EventInfo::SCT)==xAOD::EventInfo::Error ) m_SCTError = true;
     else m_SCTError = false;
+      
+      
+    m_timeStamp = eventInfo->timeStamp();
+    m_timeStampNSOffset = eventInfo->timeStampNSOffset();
 
   }
 
@@ -3024,6 +3030,8 @@ void HelpTreeBase::ClearEvent() {
   m_SCTError = false;
   m_mcEventWeight = 1.;
   m_weight_pileup = 1.;
+  m_timeStamp = -999;
+  m_timeStampNSOffset = -999;
   // pileup
   m_npv = -999;
   m_actualMu = m_averageMu = -999;

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -139,6 +139,9 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
     m_tree->Branch("TileError",          &m_TileError,         "TileError/O");
     m_tree->Branch("SCTError",           &m_SCTError,          "SCTError/O");
     m_tree->Branch("LArError",           &m_LArError,          "LArError/O");
+    m_tree->Branch("TileFlags",          &m_TileFlags,         "TileFlags/i");
+    m_tree->Branch("SCTFlags",           &m_SCTFlags,          "SCTFlags/i");
+    m_tree->Branch("LArFlags",           &m_LArFlags,          "LArFlags/i");
 
   }
     
@@ -224,12 +227,15 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
       
     if ( eventInfo->errorState(xAOD::EventInfo::LAr)==xAOD::EventInfo::Error ) m_LArError = true;
     else m_LArError = false;
-    
+    m_LArFlags = eventInfo->eventFlags(xAOD::EventInfo::LAr);
+      
     if ( eventInfo->errorState(xAOD::EventInfo::Tile)==xAOD::EventInfo::Error ) m_TileError = true;
     else m_TileError = false;
-    
+    m_TileFlags = eventInfo->eventFlags(xAOD::EventInfo::Tile);
+      
     if ( eventInfo->errorState(xAOD::EventInfo::SCT)==xAOD::EventInfo::Error ) m_SCTError = true;
     else m_SCTError = false;
+    m_SCTFlags = eventInfo->eventFlags(xAOD::EventInfo::SCT);
       
       
     m_timeStamp = eventInfo->timeStamp();
@@ -3028,6 +3034,9 @@ void HelpTreeBase::ClearEvent() {
   m_LArError = false;
   m_TileError = false;
   m_SCTError = false;
+  m_LArFlags = 0;
+  m_TileFlags = 0;
+  m_SCTFlags = 0;
   m_mcEventWeight = 1.;
   m_weight_pileup = 1.;
   m_timeStamp = -999;

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -54,7 +54,11 @@ TreeAlgo :: TreeAlgo (std::string className) :
   // DC14 switch for little things that need to happen to run
   // for those samples with the corresponding packages
   m_DC14                    = false;
-
+    
+  //Units, defaulting to GeV
+  m_units                   = 1e3;
+    
+    
 }
 
 EL::StatusCode TreeAlgo :: setupJob (EL::Job& job)
@@ -101,7 +105,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
   // get the file we created already
   TFile* treeFile = wk()->getOutputFile ("tree");
     
-  m_helpTree = new HelpTreeBase( m_event, outTree, treeFile, 1e3, m_debug, m_DC14 );
+  m_helpTree = new HelpTreeBase( m_event, outTree, treeFile, m_units, m_debug, m_DC14 );
 
   // tell the tree to go into the file
   outTree->SetDirectory( treeFile );

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -330,9 +330,9 @@ if __name__ == "__main__":
 
     # print out the samples we found
     xAH_logger.info("\t%d different dataset(s) found", len(sh_all))
-    if not args.use_scanDQ2:
-      for dataset in sh_all:
-        xAH_logger.info("\t\t%d files in %s", dataset.numFiles(), dataset.name())
+        #if not args.use_scanDQ2:
+        #for dataset in sh_all:
+        #xAH_logger.info("\t\t%d files in %s", dataset.numFiles(), dataset.name())
     sh_all.printContent()
 
     if len(sh_all) == 0:

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -40,6 +40,7 @@ private:
 
   Trig::TrigDecisionTool*        m_trigDecTool;   //!
   TrigConf::xAODConfigTool*      m_trigConfTool;   //!
+  bool                           m_ownTDTAndTCT;   //!
 
 public:
 

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -211,6 +211,9 @@ protected:
   bool m_TileError;
   bool m_LArError;
   bool m_SCTError;
+  uint32_t m_TileFlags;
+  uint32_t m_LArFlags;
+  uint32_t m_SCTFlags;
   int m_mcEventNumber;
   int m_mcChannelNumber;
   float m_mcEventWeight;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -206,6 +206,8 @@ protected:
   long int m_eventNumber;
   int m_lumiBlock;
   uint32_t m_coreFlags;
+  uint32_t m_timeStamp;
+  uint32_t m_timeStampNSOffset;
   bool m_TileError;
   bool m_LArError;
   bool m_SCTError;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -41,6 +41,7 @@ public:
   std::string m_photonContainerName;
 
   bool m_DC14;
+  float m_units;
 
 protected:
   HelpTreeBase* m_helpTree;            //!


### PR DESCRIPTION
This PR should be compatible with Marco's, as it touches different classes. The changes made in here refer to:

   * #440 (addition of timestamp and timestampNS), 
   * #439 (internal change to be able to access what m_units is from TreeAlgo derived classes)
   * #438 (fixing a double-delete when the TDT is created by HLTJetGetter). 

They should be transparent for all users (unless they used the new event cleaning variables added in #431, in which case they will find two more cleaning variables related to the timestamp). 