### PR TITLE
Has type=none before. Needs to be explicitly set to bool

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -102,7 +102,7 @@ drivers_common.add_argument('--optFilesPerWorker', metavar='', type=float, requi
 drivers_common.add_argument('--optDisableMetrics', metavar='', type=int, required=False, default=None, help='the option to turn off collection of performance data')
 drivers_common.add_argument('--optPrintPerFileStats', metavar='', type=int, required=False, default=None, help='the option to turn on printing of i/o statistics at the end of each file. warning: this is not supported for all drivers.')
 drivers_common.add_argument('--optRemoveSubmitDir', metavar='', type=int, required=False, default=None, help='the name of the option for overwriting the submission directory.  if you set this to a non-zero value it will remove any existing submit-directory before tryingto create a new one. You can also use -f/--force as well in xAH_run.py.')
-drivers_common.add_argument('--optBatchSharedFileSystem', action='store_true', required=False, type=bool, help='enable to signify whether your batch driver is running on a shared filesystem')
+drivers_common.add_argument('--optBatchSharedFileSystem', type=bool, required=False, default=False, help='enable to signify whether your batch driver is running on a shared filesystem')
 drivers_common.add_argument('--optBatchWait', action='store_true', required=False, help='submit using the submit() command. This causes the code to wait until all jobs are finished and then merge all of the outputs automatically')
 
 # These are handled by xAH_run.py at the top level instead of down by drivers

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -102,7 +102,7 @@ drivers_common.add_argument('--optFilesPerWorker', metavar='', type=float, requi
 drivers_common.add_argument('--optDisableMetrics', metavar='', type=int, required=False, default=None, help='the option to turn off collection of performance data')
 drivers_common.add_argument('--optPrintPerFileStats', metavar='', type=int, required=False, default=None, help='the option to turn on printing of i/o statistics at the end of each file. warning: this is not supported for all drivers.')
 drivers_common.add_argument('--optRemoveSubmitDir', metavar='', type=int, required=False, default=None, help='the name of the option for overwriting the submission directory.  if you set this to a non-zero value it will remove any existing submit-directory before tryingto create a new one. You can also use -f/--force as well in xAH_run.py.')
-drivers_common.add_argument('--optBatchSharedFileSystem', action='store_true', required=False, help='enable to signify whether your batch driver is running on a shared filesystem')
+drivers_common.add_argument('--optBatchSharedFileSystem', action='store_true', required=False, type=bool, help='enable to signify whether your batch driver is running on a shared filesystem')
 drivers_common.add_argument('--optBatchWait', action='store_true', required=False, help='submit using the submit() command. This causes the code to wait until all jobs are finished and then merge all of the outputs automatically')
 
 # These are handled by xAH_run.py at the top level instead of down by drivers


### PR DESCRIPTION
@johnda102 caught this bug. Seems to be that on python 3.x -- the type is default to `bool` when `action='store_true'` but otherwise, `type=None` in python 2.x.