### PR TITLE
JetCalibrator Should Calibrate Jets Only Once

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -576,8 +576,6 @@ EL::StatusCode JetCalibrator :: execute ()
   // add vector of systematic names to TStore
   RETURN_CHECK( "JetCalibrator::execute()", m_store->record( vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
 
-  // Store nominal if it has not been saved yet
-
   // look what do we have in TStore
 
   if ( m_verbose ) { m_store->print(); }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -185,9 +185,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     m_outputAlgo = m_jetAlgo + "_Calib_Algo";
   }
 
-  m_outSCContainerName      = m_outContainerName + "ShallowCopy";
-  m_outSCAuxContainerName   = m_outSCContainerName + "Aux."; // the period is very important!
-
   m_numEvent      = 0;
   m_numObject     = 0;
 
@@ -430,6 +427,27 @@ EL::StatusCode JetCalibrator :: execute ()
   const xAOD::JetContainer* inJets(nullptr);
   RETURN_CHECK("JetCalibrator::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, m_verbose) ,"");
 
+  //
+  // Perform nominal calibration
+  std::pair< xAOD::JetContainer*, xAOD::ShallowAuxContainer* > calibJetsSC = xAOD::shallowCopyContainer( *inJets );
+  ConstDataVector<xAOD::JetContainer>* calibJetsCDV = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+  calibJetsCDV->reserve( calibJetsSC.first->size() );
+
+  std::string outSCContainerName=m_outContainerName+"ShallowCopy";
+  std::string outSCAuxContainerName=m_outContainerName+"ShallowCopyAux.";
+  RETURN_CHECK( "JetCalibrator::execute()", m_store->record( calibJetsSC.first,  outSCContainerName),    "Failed to record shallow copy container.");
+  RETURN_CHECK( "JetCalibrator::execute()", m_store->record( calibJetsSC.second, outSCAuxContainerName), "Failed to record shallow copy aux container.");
+
+  for ( auto jet_itr : *(calibJetsSC.first) ) {
+    m_numObject++;
+
+    if ( m_jetCalibration->applyCorrection( *jet_itr ) == CP::CorrectionCode::Error ) {
+      Error("execute()", "JetCalibration tool reported a CP::CorrectionCode::Error");
+      Error("execute()", "%s", m_name.c_str());
+      return StatusCode::FAILURE;
+    }
+  }//for jets
+
   // loop over available systematics - remember syst == "Nominal" --> baseline
   std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
 
@@ -438,31 +456,17 @@ EL::StatusCode JetCalibrator :: execute ()
     unsigned int sysIndex = (&syst_it - &m_systList[0]);
     int thisSysType = m_systType.at(sysIndex);
 
-    std::string outSCContainerName(m_outSCContainerName);
-    std::string outSCAuxContainerName(m_outSCAuxContainerName);
-    std::string outContainerName(m_outContainerName);
-
     // always append the name of the variation, including nominal which is an empty string
-    outSCContainerName    += syst_it.name();
-    outSCAuxContainerName += syst_it.name();
-    outContainerName      += syst_it.name();
+    outSCContainerName   =m_outContainerName+syst_it.name()+"ShallowCopy";
+    outSCAuxContainerName=m_outContainerName+syst_it.name()+"ShallowCopyAux.";
+    std::string outContainerName=m_outContainerName+syst_it.name();
+
     vecOutContainerNames->push_back( syst_it.name() );
 
     // create shallow copy;
-    std::pair< xAOD::JetContainer*, xAOD::ShallowAuxContainer* > calibJetsSC = xAOD::shallowCopyContainer( *inJets );
-    ConstDataVector<xAOD::JetContainer>* calibJetsCDV = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-    calibJetsCDV->reserve( calibJetsSC.first->size() );
-
-    // Nominal calibration for all inputs
-    for ( auto jet_itr : *(calibJetsSC.first) ) {
-      m_numObject++;
-
-      if ( m_jetCalibration->applyCorrection( *jet_itr ) == CP::CorrectionCode::Error ) {
-        Error("execute()", "JetCalibration tool reported a CP::CorrectionCode::Error");
-        Error("execute()", "%s", m_name.c_str());
-        return StatusCode::FAILURE;
-      }
-    }//for jets
+    std::pair< xAOD::JetContainer*, xAOD::ShallowAuxContainer* > uncertCalibJetsSC = (thisSysType==0)? calibJetsSC : xAOD::shallowCopyContainer( *calibJetsSC.first );
+    ConstDataVector<xAOD::JetContainer>* uncertCalibJetsCDV = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+    uncertCalibJetsCDV->reserve( uncertCalibJetsSC.first->size() );
 
     //Apply Uncertainties
     if ( m_runSysts ) {
@@ -474,9 +478,7 @@ EL::StatusCode JetCalibrator :: execute ()
           return EL::StatusCode::FAILURE;
         }
 
-	for ( auto jet_itr : *(calibJetsSC.first) ) {
-          if ( m_runSysts ) {
-
+	for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
 	    if (m_applyFatJetPreSel) {
 	      bool validForJES = (jet_itr->pt() >= 150e3 && jet_itr->pt() < 3000e3);
 	      validForJES &= (jet_itr->m()/jet_itr->pt() >= 0 && jet_itr->m()/jet_itr->pt() < 1);
@@ -487,7 +489,6 @@ EL::StatusCode JetCalibrator :: execute ()
             if ( m_JESUncertTool->applyCorrection( *jet_itr ) == CP::CorrectionCode::Error ) {
               Error("execute()", "JetUncertaintiesTool reported a CP::CorrectionCode::Error");
               Error("execute()", "%s", m_name.c_str());
-            }
           }
         }//for jets
       }//JES
@@ -506,7 +507,7 @@ EL::StatusCode JetCalibrator :: execute ()
           }
         }
         // JER Uncertainty Systematic
-        for ( auto jet_itr : *(calibJetsSC.first) ) {
+        for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
           if ( m_JERSmearTool->applyCorrection( *jet_itr ) == CP::CorrectionCode::Error ) {
             Error("execute()", "JERSmearTool tool reported a CP::CorrectionCode::Error");
             Error("execute()", "%s", m_name.c_str());
@@ -518,7 +519,7 @@ EL::StatusCode JetCalibrator :: execute ()
 
     if(m_doCleaning){
       // decorate with cleaning decision
-      for ( auto jet_itr : *(calibJetsSC.first) ) {
+      for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
 
         static SG::AuxElement::Decorator< char > isCleanDecor( "cleanJet" );
         const xAOD::Jet* jetToClean = jet_itr;
@@ -542,36 +543,40 @@ EL::StatusCode JetCalibrator :: execute ()
       } //end cleaning decision
     }
 
-    if ( !xAOD::setOriginalObjectLink(*inJets, *(calibJetsSC.first)) ) {
+    if ( !xAOD::setOriginalObjectLink(*inJets, *(uncertCalibJetsSC.first)) ) {
       Error("execute()  ", "Failed to set original object links -- MET rebuilding cannot proceed.");
     }
 
     // Recalculate JVT using calibrated Jets
     if(m_redoJVT){
-      for ( auto jet_itr : *(calibJetsSC.first) ) {
+      for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
         jet_itr->auxdata< float >("Jvt") = m_JVTToolHandle->updateJvt(*jet_itr);
       }
     }
 
     // save pointers in ConstDataVector with same order
-    for ( auto jet_itr : *(calibJetsSC.first) ) {
-      calibJetsCDV->push_back( jet_itr );
+    for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
+      uncertCalibJetsCDV->push_back( jet_itr );
     }
 
     // can only sort the CDV - a bit no-no to sort the shallow copies
     if ( m_sort ) {
-      std::sort( calibJetsCDV->begin(), calibJetsCDV->end(), HelperFunctions::sort_pt );
+      std::sort( uncertCalibJetsCDV->begin(), uncertCalibJetsCDV->end(), HelperFunctions::sort_pt );
     }
 
     // add shallow copy to TStore
-    RETURN_CHECK( "JetCalibrator::execute()", m_store->record( calibJetsSC.first, outSCContainerName), "Failed to record shallow copy container.");
-    RETURN_CHECK( "JetCalibrator::execute()", m_store->record( calibJetsSC.second, outSCAuxContainerName), "Failed to record shallow copy aux container.");
+    if(thisSysType!=0) { // nominal is always saved outside of loop
+      RETURN_CHECK( "JetCalibrator::execute()", m_store->record( uncertCalibJetsSC.first, outSCContainerName), "Failed to record shallow copy container.");
+      RETURN_CHECK( "JetCalibrator::execute()", m_store->record( uncertCalibJetsSC.second, outSCAuxContainerName), "Failed to record shallow copy aux container.");
+    }
 
     // add ConstDataVector to TStore
-    RETURN_CHECK( "JetCalibrator::execute()", m_store->record( calibJetsCDV, outContainerName), "Failed to record const data container.");
+    RETURN_CHECK( "JetCalibrator::execute()", m_store->record( uncertCalibJetsCDV, outContainerName), "Failed to record const data container.");
   }
   // add vector of systematic names to TStore
   RETURN_CHECK( "JetCalibrator::execute()", m_store->record( vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
+
+  // Store nominal if it has not been saved yet
 
   // look what do we have in TStore
 

--- a/scripts/getDSInfo.py
+++ b/scripts/getDSInfo.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# @file:    getDSInfo.py
+# @purpose: generate SUSY metadata files
+# @author:  John Alison <john.alison@cern.ch>
+# @date:    January 2016
+#
+# @example:
+# @code
+# getDSInfo.py --help
+# @endcode
+#
+
+try:
+    import pyAMI.client
+except:
+    print "Failed to load pyAMI.client, setting up local PyAMI"
+    import os
+    os.system("localSetupPyAMI")
+    import pyAMI.client
+
+import pyAMI.atlas.api as AtlasAPI
+import argparse
+
+parser = argparse.ArgumentParser(description='Generate SUSY metadata files.')
+parser.add_argument('input',metavar='dslist.txt',help='Distributions to compare')
+parser.add_argument('-o','--output',metavar='output_crosssections_13TeV.txt',type=str,default=None,help='Output file name')
+args=parser.parse_args()
+
+client = pyAMI.client.Client('atlas')
+AtlasAPI.init()
+
+inputDS = []
+
+inputFile = open(args.input,"r")
+
+for line in inputFile:
+    if line.startswith("#"): continue
+    line = line.strip()
+    if line=='': continue
+
+    parts=line.split(':')
+    dsName = parts[-1].rstrip("/")
+    dsID = dsName.split(".")[1]
+    print dsName
+
+    dsProv = AtlasAPI.get_dataset_prov(client,dataset=dsName)
+    for prov in dsProv["node"]:
+        if prov['dataType'] == "EVNT":
+            thisProvDSName = prov['logicalDatasetName']
+            thisProvDSID   = thisProvDSName.split(".")[1]
+            if thisProvDSID == dsID:
+                print "\tUsing ",thisProvDSName
+                inputDS.append(thisProvDSName)
+
+def getUnitSF(unit):
+    if unit == "nano barn":
+        return 1000
+    print "Unknown unit..."
+    return 1.0
+
+fh_out=open(args.output,'w') if args.output!=None else None
+for ds in inputDS:
+    dsList = AtlasAPI.get_dataset_info(client,dataset=ds)
+    dsInfo = dsList[0]
+    #print dsInfo['logicalDatasetName']
+    #print "\tcross section",dsInfo["crossSection_mean"]
+    #print "\tfilter Eff.",dsInfo["GenFiltEff_mean"]
+    unit = dsInfo['crossSection_unit']
+    getSF = getUnitSF(unit)
+    if fh_out==None:
+        print dsInfo['datasetNumber']," ",dsInfo['physicsShort']," ",float(dsInfo["crossSection_mean"])*getSF," 1.  ",float(dsInfo["GenFiltEff_mean"])," 1."
+    else:
+        fh_out.write("%s\t%s\t%e\t1.\t%e\t1.\n"%(dsInfo['datasetNumber'],dsInfo['physicsShort'],float(dsInfo["crossSection_mean"])*getSF,float(dsInfo["GenFiltEff_mean"])))
+
+

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -74,9 +74,6 @@ private:
   bool m_isMC;            //!
   bool m_isFullSim;       //!
 
-  std::string m_outSCContainerName;     //!
-  std::string m_outSCAuxContainerName;  //!
-
   std::vector<CP::SystematicSet> m_systList; //!
   std::vector<int> m_systType; //!
 


### PR DESCRIPTION
The JetCalibrator was recalibrating the jets for all of the systematic variations. Now it calibrates only the nominal collection and making systematic containers a shallow copies of it. This means that the nominal shallow copy is always created and put in TStore. However it is only added to the systematics list (outputAlgo) when requested.

My quick test seems to indicate a factor of 2 speed improvement as a result of this change.