### PR TITLE
xAH_run filelists improvement

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -314,7 +314,26 @@ if __name__ == "__main__":
               else:
                 raise Exception("What just happened?")
         else:
-          ROOT.SH.readFileList(sh_all, "sample", fname)
+          # Sample name
+          sname='.'.join(os.path.basename(fname).split('.')[:-1]) # input filelist name without extension
+          # Read settings
+          fcname=sname+'.config' # replace .txt with .config
+          config={}
+          if os.path.exists(fcname): # load configuration if it exists
+            with open(fcname, 'r') as f:
+              for line in f:
+                line=line.strip()
+                parts=line.split('=')
+                if len(parts)!=2: continue
+                config[parts[0].strip()]=parts[1].strip()
+          xsec   =float(config.get('xsec'   ,1))
+          filteff=float(config.get('filteff',1))
+          nEvents=float(config.get('nEvents',1))
+
+          ROOT.SH.readFileList(sh_all, sname, fname)
+          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.crossSection    ,xsec)
+          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.filterEfficiency,filteff)
+          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.numEvents       ,nEvents)
       else:
 
         if args.use_scanDQ2:


### PR DESCRIPTION
I modified xAH_run such that filelists (list of xrd paths) are assigned to the same sample as the file path (without extension). Also if a file called _samplename_.config exists, cross-section information is loaded from that. This is useful when running with private sample.

See for example:
https://svnweb.cern.ch/trac/atlasphys-exo/browser/Physics/Exotic/JDM/DiJetISR/Run2/Code/ZprimeDM/tags/ZprimeDM-00-00-01/filelists/MC15.999880.MGPy8EG_dmA_dijetgamma_Ph100_mR300_mDM10000_gSM0p30_gDM1p50.TRUTH1.txt
https://svnweb.cern.ch/trac/atlasphys-exo/browser/Physics/Exotic/JDM/DiJetISR/Run2/Code/ZprimeDM/tags/ZprimeDM-00-00-01/filelists/MC15.999880.MGPy8EG_dmA_dijetgamma_Ph100_mR300_mDM10000_gSM0p30_gDM1p50.TRUTH1.config

This creates a sample called MC15.999880.MGPy8EG_dmA_dijetgamma_Ph100_mR300_mDM10000_gSM0p30_gDM1p50.TRUTH1. 

Does no longer having a single sample name for many input filelists break anyone's work flow? If not, I will merge this tomorrow morning (CERN time).