### PR TITLE
Make private members in OverlapRemover "protected" 

### DIFF
--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -76,7 +76,7 @@ class OverlapRemover : public xAH::Algorithm
 {
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
-public:
+ public:
 
   // configuration variables
 
@@ -125,7 +125,7 @@ public:
   std::string  m_outContainerName_Taus;
   std::string  m_inputAlgoTaus;
 
-private:
+ protected:
 
   /** @brief A counter for the number of processed events */
   int m_numEvent;           //!
@@ -197,12 +197,8 @@ private:
   /** @brief Output auxiliary container name */
   std::string  m_outAuxContainerName_Taus;
 
-  // tools
- protected:
   /** @brief Pointer to the CP Tool which performs the actual OLR. */
   OverlapRemovalTool *m_overlapRemovalTool; //!
-
- private:
 
   /** @brief An enum encoding systematics according to the various objects */
   enum SystType {


### PR DESCRIPTION
After the exorcism #476, some setting in OverlapRemover has been moved from `configure()` to `initialize()`

Since some analyses are using algorithm(s) inherited from OverlapRemover, and overload `initialize()`, I have made this change to allow accessing those data members from the derived class.

If for any reason this is dangerous, I might consider creating an additional method to set those members, and leave them `private`

@kratsg, waiting for your opinion on this. 