### PR TITLE
MinixAOD CutBookkeeper function shouldn't call TEvent::fill.

### DIFF
--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -151,7 +151,6 @@ EL::StatusCode MinixAOD :: initialize ()
 
     m_event->recordMeta(output,"CutBookkeepers");
     m_event->recordMeta(output_aux,"CutBookkeepersAux.");
-    m_event->fill();
   }
 
   // parse and split by comma


### PR DESCRIPTION
This fixes a problem with the `checkxAOD.py` script reporting an error that occurs when reporting an error about a problematic xAOD made by MinixAOD. The problem was that the `m_copyCutBookkeeper` option was calling `TEvent:fill`, which made an empty entry in `CollectionTree`. I removed this call.

Please note that the `m_copyCutBookkeeper` implementation is still not fully correct. I will make a ticket about this. But at least valid xAODs are output.