### PR TITLE
no need for dynamic_cast checks at runtime. 

### DIFF
--- a/Root/IParticleHists.cxx
+++ b/Root/IParticleHists.cxx
@@ -99,7 +99,7 @@ StatusCode IParticleHists::execute( const xAOD::IParticleContainer* particles, f
 
 StatusCode IParticleHists::execute( const xAOD::IParticle* particle, float eventWeight) {
 
-  if(m_debug) std::cout << "in execute " <<std::endl;
+  if(m_debug) std::cout << "IParticleHists: in execute " <<std::endl;
 
   //basic
   m_Pt_l ->      Fill( particle->pt()/1e3,    eventWeight );

--- a/Root/IParticleHistsAlgo.cxx
+++ b/Root/IParticleHistsAlgo.cxx
@@ -47,6 +47,7 @@ EL::StatusCode IParticleHistsAlgo::AddHists( std::string name ) {
   std::string fullname(m_name);
   fullname += name; // add systematic
   IParticleHists* particleHists = new IParticleHists( fullname, m_detailStr, m_histPrefix, m_histTitle ); // add systematic
+  particleHists->m_debug = m_debug;
   RETURN_CHECK((m_name+"::AddHists").c_str(), particleHists->initialize(), "");
   particleHists->record( wk() );
   m_plots[name] = particleHists;
@@ -77,7 +78,7 @@ EL::StatusCode IParticleHistsAlgo :: initialize ()
 
 EL::StatusCode IParticleHistsAlgo :: execute ()
 {
-  return execute<xAOD::IParticleContainer>();
+  return execute<IParticleHists, xAOD::IParticleContainer>();
 }
 
 EL::StatusCode IParticleHistsAlgo :: postExecute () { return EL::StatusCode::SUCCESS; }

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -305,10 +305,18 @@ StatusCode JetHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
+StatusCode JetHists::execute( const xAOD::JetContainer* jets, float eventWeight ) {
+  for( const auto& jet : *jets ) {
+    RETURN_CHECK("JetHists::execute()", this->execute( jet, eventWeight), "");
+  }
+
+  return StatusCode::SUCCESS;
+}
+
 StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight ) {
   RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(jet, eventWeight), "");
 
-  if(m_debug) std::cout << "in execute " <<std::endl;
+  if(m_debug) std::cout << "JetHists: in execute " <<std::endl;
 
   // clean
   if( m_infoSwitch->m_clean ) {

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -305,17 +305,10 @@ StatusCode JetHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight ) {
-  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(particle, eventWeight), "");
+StatusCode JetHists::execute( const xAOD::Jet* jet, float eventWeight ) {
+  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(jet, eventWeight), "");
 
   if(m_debug) std::cout << "in execute " <<std::endl;
-
-  const xAOD::Jet* jet=dynamic_cast<const xAOD::Jet*>(particle);
-  if(jet==0)
-    {
-      ::Error( "JetHists::execute()", XAOD_MESSAGE( "Cannot convert IParticle to Jet" ));
-      return StatusCode::FAILURE;
-    }
 
   // clean
   if( m_infoSwitch->m_clean ) {
@@ -715,7 +708,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
 
     if(m_infoSwitch->m_btag_jettrk){
       unsigned trkSum_ntrk   = btag_info->isAvailable<unsigned>("trkSum_ntrk") ? btag_info->auxdata<unsigned>("trkSum_ntrk") : -1;
-      float    trkSum_sPt    = btag_info->isAvailable<float   >("trkSum_SPt" ) ? btag_info->auxdata<float   >("trkSum_SPt" ) : -1000;//<== -1 GeV                         
+      float    trkSum_sPt    = btag_info->isAvailable<float   >("trkSum_SPt" ) ? btag_info->auxdata<float   >("trkSum_SPt" ) : -1000;//<== -1 GeV
       float trkSum_vPt    = 0;
       float trkSum_vAbsEta= -10;
       if (trkSum_ntrk>0) {
@@ -758,29 +751,29 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
 	  const xAOD::TrackParticle* aTemp = **trkIter;
 	  TLorentzVector trk;
 	  trk.SetPtEtaPhiM(aTemp->pt(), aTemp->eta(), aTemp->phi(), 0.);
-	  // no need for a dedicated selection here, the tracks are already                                                                              
-	  // selected by the IP3D algorithm                                                                                                              
+	  // no need for a dedicated selection here, the tracks are already
+	  // selected by the IP3D algorithm
 	  const float d0sig = vectD0Signi.at(trkIndex);
 	  const float z0sig = vectZ0Signi.at(trkIndex);
 	  trkIndex++;
 
 	  if (std::fabs(d0sig) > 1.8)
 	    n_trk_d0cut++;
-	  // track width components                                                                                                                      
+	  // track width components
 	  sum_pt += trk.Pt();
 	  const float dRtoJet = trk.DeltaR(jet->p4());
 	  sum_pt_dr += dRtoJet * trk.Pt();
 
-	  // for 3rd higest d0/z0 significance                                                                                                           
+	  // for 3rd higest d0/z0 significance
 	  trk_d0_z0.push_back(std::make_pair(d0sig, z0sig));
-	} //end of trk loop   
-      
-	// sort by highest signed d0 sig                                                                                                                 
+	} //end of trk loop
+
+	// sort by highest signed d0 sig
 	std::sort(trk_d0_z0.begin(), trk_d0_z0.end(), [](const std::pair<float, float>& a, const std::pair<float, float>& b) {
 	    return a.first > b.first;
 	  } );
 
-	//Assign MVb variables                                                                                                                           
+	//Assign MVb variables
 	float width          = sum_pt > 0 ? sum_pt_dr / sum_pt : 0;
 	int   n_trk_sigd0cut = n_trk_d0cut;
 	float trk3_d0sig     = trk_d0_z0.size() > 2 ? trk_d0_z0[2].first : -100;
@@ -803,7 +796,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
 	m_sv_scaled_efc->Fill(sv_scaled_efc, eventWeight);
 	m_jf_scaled_efc->Fill(jf_scaled_efc, eventWeight);
       }//trkOK
-      
+
     }
 
 
@@ -840,7 +833,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       if(jf_pb.isAvailable            (*btag_info)) m_jf_pb             ->Fill(jf_pb            (*btag_info), eventWeight);
       if(jf_pc.isAvailable            (*btag_info)) m_jf_pc             ->Fill(jf_pc            (*btag_info), eventWeight);
       if(jf_pu.isAvailable            (*btag_info)) m_jf_pu             ->Fill(jf_pu            (*btag_info), eventWeight);
-      
+
 
       float jf_mass_unco; btag_info->variable<float>("JetFitter", "massUncorr" , jf_mass_unco);
       float jf_dR_flight; btag_info->variable<float>("JetFitter", "dRFlightDir", jf_dR_flight);
@@ -867,17 +860,17 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       static SG::AuxElement::ConstAccessor< float   > sv0_efracsvxAcc     ("SV0_efracsvx");                                                                  	/// @brief SV0 : 3D vertex significance
       static SG::AuxElement::ConstAccessor< float   > sv0_normdistAcc     ("SV0_normdist");
 
-      
+
       if(sv0_NGTinSvxAcc .isAvailable(*btag_info)) m_sv0_NGTinSvx -> Fill( sv0_NGTinSvxAcc (*btag_info), eventWeight);
       if(sv0_N2TpairAcc  .isAvailable(*btag_info)) m_sv0_N2Tpair  -> Fill( sv0_N2TpairAcc  (*btag_info), eventWeight);
       if(sv0_masssvxAcc  .isAvailable(*btag_info)) m_sv0_massvx   -> Fill( sv0_masssvxAcc  (*btag_info)/1000, eventWeight);
       if(sv0_efracsvxAcc .isAvailable(*btag_info)) m_sv0_efracsvx -> Fill( sv0_efracsvxAcc (*btag_info), eventWeight);
       if(sv0_normdistAcc .isAvailable(*btag_info)) m_sv0_normdist -> Fill( sv0_normdistAcc (*btag_info), eventWeight);
-      
+
       double sv0;
       btag_info->variable<double>("SV0", "significance3D", sv0);
       m_SV0             ->  Fill( sv0 , eventWeight );
-    
+
 
       //
       // SV1
@@ -892,7 +885,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       /// @brief SV1 : energy fraction
       static SG::AuxElement::ConstAccessor< float   > sv1_efracsvxAcc     ("SV1_efracsvx");                                                                 /// @brief SV1 : 3D vertex significance
       static SG::AuxElement::ConstAccessor< float   > sv1_normdistAcc     ("SV1_normdist");
-	
+
       if(sv1_NGTinSvxAcc .isAvailable(*btag_info)) m_sv1_NGTinSvx -> Fill( sv1_NGTinSvxAcc (*btag_info), eventWeight);
       if(sv1_N2TpairAcc  .isAvailable(*btag_info)) m_sv1_N2Tpair  -> Fill( sv1_N2TpairAcc  (*btag_info), eventWeight);
       if(sv1_masssvxAcc  .isAvailable(*btag_info)) m_sv1_massvx   -> Fill( sv1_masssvxAcc  (*btag_info)/1000, eventWeight);
@@ -902,11 +895,11 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       double sv1_pu = -30;  btag_info->variable<double>("SV1", "pu", sv1_pu);
       double sv1_pb = -30;  btag_info->variable<double>("SV1", "pb", sv1_pb);
       double sv1_pc = -30;  btag_info->variable<double>("SV1", "pc", sv1_pc);
-      
+
       m_SV1_pu         ->  Fill(sv1_pu  , eventWeight );
       m_SV1_pb         ->  Fill(sv1_pb  , eventWeight );
       m_SV1_pc         ->  Fill(sv1_pc  , eventWeight );
-      
+
       m_SV1            ->  Fill( btag_info->calcLLR(sv1_pb,sv1_pu) , eventWeight );
       m_SV1_c          ->  Fill( btag_info->calcLLR(sv1_pb,sv1_pc) , eventWeight );
       m_SV1_cu         ->  Fill( btag_info->calcLLR(sv1_pc,sv1_pu) , eventWeight );
@@ -977,7 +970,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       if(IP2D_weightUofTracksAcc .isAvailable(*btag_info)){
 	for(float weightU : IP2D_weightUofTracksAcc(*btag_info))  m_IP2D_weightUofTracks->Fill(weightU, eventWeight);
       }
-      
+
       double ip2_pu = -30;  btag_info->variable<double>("IP2D", "pu", ip2_pu);
       double ip2_pb = -30;  btag_info->variable<double>("IP2D", "pb", ip2_pb);
       double ip2_pc = -30;  btag_info->variable<double>("IP2D", "pc", ip2_pc);

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -30,5 +30,5 @@ EL::StatusCode JetHistsAlgo::AddHists( std::string name ) {
 
 EL::StatusCode JetHistsAlgo :: execute ()
 {
-  return IParticleHistsAlgo::execute<xAOD::JetContainer>();
+  return IParticleHistsAlgo::execute<JetHists, xAOD::JetContainer>();
 }

--- a/Root/MetHists.cxx
+++ b/Root/MetHists.cxx
@@ -44,7 +44,7 @@ StatusCode MetHists::initialize() {
 
 StatusCode MetHists::execute( const xAOD::MissingETContainer* met, float eventWeight ) {
 
-  if(m_debug) std::cout << "in execute " <<std::endl;
+  if(m_debug) std::cout << "MetHists: in execute " <<std::endl;
 
   //
   // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)

--- a/Root/MuonHists.cxx
+++ b/Root/MuonHists.cxx
@@ -67,10 +67,18 @@ StatusCode MuonHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
+StatusCode MuonHists::execute( const xAOD::MuonContainer* muons, float eventWeight ){
+  for( const auto& muon : *muons ) {
+    RETURN_CHECK("MuonHists::execute()", this->execute( muon, eventWeight), "");
+  }
+
+  return StatusCode::SUCCESS;
+}
+
 StatusCode MuonHists::execute( const xAOD::Muon* muon, float eventWeight) {
   RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(muon, eventWeight), "");
 
-  if(m_debug) std::cout << "in execute " <<std::endl;
+  if(m_debug) std::cout << "MuonHists: in execute " <<std::endl;
 
   if ( m_infoSwitch->m_isolation ) {
 

--- a/Root/MuonHists.cxx
+++ b/Root/MuonHists.cxx
@@ -67,17 +67,10 @@ StatusCode MuonHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode MuonHists::execute( const xAOD::IParticle* particle, float eventWeight) {
-  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(particle, eventWeight), "");
+StatusCode MuonHists::execute( const xAOD::Muon* muon, float eventWeight) {
+  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(muon, eventWeight), "");
 
   if(m_debug) std::cout << "in execute " <<std::endl;
-
-  const xAOD::Muon* muon=dynamic_cast<const xAOD::Muon*>(particle);
-  if(muon==0)
-    {
-      ::Error( "MuonHists::execute()", XAOD_MESSAGE( "Cannot convert IParticle to Muon" ));
-      return StatusCode::FAILURE;
-    }
 
   if ( m_infoSwitch->m_isolation ) {
 

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -29,5 +29,5 @@ EL::StatusCode MuonHistsAlgo::AddHists( std::string name ) {
 }
 
 EL::StatusCode MuonHistsAlgo :: execute () {
-  return IParticleHistsAlgo::execute<xAOD::MuonContainer>();
+  return IParticleHistsAlgo::execute<MuonHists, xAOD::MuonContainer>();
 }

--- a/Root/PhotonHists.cxx
+++ b/Root/PhotonHists.cxx
@@ -32,17 +32,10 @@ StatusCode PhotonHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode PhotonHists::execute( const xAOD::IParticle* particle, float eventWeight ) {
-  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(particle, eventWeight), "");
+StatusCode PhotonHists::execute( const xAOD::Photon* photon, float eventWeight ) {
+  RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(photon, eventWeight), "");
 
   if(m_debug) std::cout << "in execute " <<std::endl;
-
-  const xAOD::Photon* photon=dynamic_cast<const xAOD::Photon*>(particle);
-  if(photon==0)
-    {
-      ::Error( "PhotonHists::execute()", XAOD_MESSAGE( "Cannot convert IParticle to Photon" ));
-      return StatusCode::FAILURE;
-    }
 
   // //basic
   // m_photonPt ->        Fill( photon->pt()/1e3,    eventWeight );

--- a/Root/PhotonHists.cxx
+++ b/Root/PhotonHists.cxx
@@ -32,10 +32,18 @@ StatusCode PhotonHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
+StatusCode PhotonHists::execute( const xAOD::PhotonContainer* photons, float eventWeight ){
+  for( const auto& photon : *photons ) {
+    RETURN_CHECK("PhotonHists::execute()", this->execute( photon, eventWeight), "");
+  }
+
+  return StatusCode::SUCCESS;
+}
+
 StatusCode PhotonHists::execute( const xAOD::Photon* photon, float eventWeight ) {
   RETURN_CHECK("IParticleHists::execute()", IParticleHists::execute(photon, eventWeight), "");
 
-  if(m_debug) std::cout << "in execute " <<std::endl;
+  if(m_debug) std::cout << "PhotonHists: in execute " <<std::endl;
 
   // //basic
   // m_photonPt ->        Fill( photon->pt()/1e3,    eventWeight );

--- a/Root/PhotonHistsAlgo.cxx
+++ b/Root/PhotonHistsAlgo.cxx
@@ -29,5 +29,5 @@ EL::StatusCode PhotonHistsAlgo::AddHists( std::string name ) {
 }
 
 EL::StatusCode PhotonHistsAlgo :: execute () {
-  return IParticleHistsAlgo::execute<xAOD::PhotonContainer>();
+  return IParticleHistsAlgo::execute<PhotonHists, xAOD::PhotonContainer>();
 }

--- a/xAODAnaHelpers/IParticleHistsAlgo.h
+++ b/xAODAnaHelpers/IParticleHistsAlgo.h
@@ -56,15 +56,15 @@ public:
   /**
       @brief Fill histograms with particles in a container
       @rst
-          Tempalated (container type) function that loops over all systematics (or nominal only) 
-	  and fills the corresponding histogram objects. 
-	  
+          Tempalated (container type) function that loops over all systematics (or nominal only)
+	  and fills the corresponding histogram objects.
+
 	  The event weight, in case of Monte Carlo samples, is
 	   mcEventWeight*crossSection*filterEfficiency*kfactor
 	  where the sample-weights are taken from SampleHandler and set to 1 by default.
       @endrst
   */
-  template<class CONT_T> EL::StatusCode execute ()
+  template<class HIST_T, class CONT_T> EL::StatusCode execute ()
   {
     const xAOD::EventInfo* eventInfo(nullptr);
     RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
@@ -90,7 +90,7 @@ public:
       RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName, m_event, m_store, m_verbose) ,("Failed to get "+m_inContainerName).c_str());
 
       // pass the photon collection
-      RETURN_CHECK("IParticleHistsAlgo::execute()", m_plots[""]->execute( inParticles, eventWeight ), "");
+      RETURN_CHECK("IParticleHistsAlgo::execute()", static_cast<HIST_T*>(m_plots[""])->execute( inParticles, eventWeight ), "");
     }
     else { // get the list of systematics to run over
 
@@ -102,7 +102,7 @@ public:
       for( auto systName : *systNames ) {
 	RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
 	if( m_plots.find( systName ) == m_plots.end() ) { this->AddHists( systName ); }
-	RETURN_CHECK("IParticleHistsAlgo::execute()", m_plots[systName]->execute( inParticles, eventWeight ), "");
+	RETURN_CHECK("IParticleHistsAlgo::execute()", static_cast<HIST_T*>(m_plots[systName])->execute( inParticles, eventWeight ), "");
       }
     }
 
@@ -130,10 +130,11 @@ public:
     std::string fullname(m_name);
     fullname += name; // add systematic
     HIST_T* particleHists = new HIST_T( fullname, m_detailStr ); // add systematic
+    particleHists->m_debug = m_debug;
     RETURN_CHECK((m_name+"::AddHists").c_str(), particleHists->initialize(), "");
     particleHists->record( wk() );
     m_plots[name] = particleHists;
-    
+
     return EL::StatusCode::SUCCESS;
   }
 

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -15,11 +15,10 @@ class JetHists : public IParticleHists
     virtual ~JetHists() ;
 
     virtual StatusCode initialize();
-    virtual StatusCode execute( const xAOD::IParticle* jet, float eventWeight );
+    virtual StatusCode execute( const xAOD::Jet* jet, float eventWeight );
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
-    using HistogramManager::execute; // overload
     using IParticleHists::execute; // overload
-    
+
   protected:
 
     // holds bools that control which histograms are filled

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -15,6 +15,7 @@ class JetHists : public IParticleHists
     virtual ~JetHists() ;
 
     virtual StatusCode initialize();
+    virtual StatusCode execute( const xAOD::JetContainer* jets, float eventWeight );
     virtual StatusCode execute( const xAOD::Jet* jet, float eventWeight );
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
     using IParticleHists::execute; // overload

--- a/xAODAnaHelpers/MuonHists.h
+++ b/xAODAnaHelpers/MuonHists.h
@@ -13,9 +13,8 @@ class MuonHists : public IParticleHists
     virtual ~MuonHists() ;
 
     virtual StatusCode initialize();
-    virtual StatusCode execute( const xAOD::IParticle* muon, float eventWeight);
+    virtual StatusCode execute( const xAOD::Muon* muon, float eventWeight);
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
-    using HistogramManager::execute; // overload
     using IParticleHists::execute; // overload
 
   protected:

--- a/xAODAnaHelpers/MuonHists.h
+++ b/xAODAnaHelpers/MuonHists.h
@@ -13,6 +13,7 @@ class MuonHists : public IParticleHists
     virtual ~MuonHists() ;
 
     virtual StatusCode initialize();
+    virtual StatusCode execute( const xAOD::MuonContainer* muons, float eventWeight);
     virtual StatusCode execute( const xAOD::Muon* muon, float eventWeight);
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
     using IParticleHists::execute; // overload

--- a/xAODAnaHelpers/PhotonHists.h
+++ b/xAODAnaHelpers/PhotonHists.h
@@ -15,6 +15,7 @@ class PhotonHists : public IParticleHists
     virtual ~PhotonHists() ;
 
     virtual StatusCode initialize();
+    virtual StatusCode execute( const xAOD::PhotonContainer* photons, float eventWeight );
     virtual StatusCode execute( const xAOD::Photon* photon, float eventWeight);
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
     using IParticleHists::execute; // overload

--- a/xAODAnaHelpers/PhotonHists.h
+++ b/xAODAnaHelpers/PhotonHists.h
@@ -15,9 +15,8 @@ class PhotonHists : public IParticleHists
     virtual ~PhotonHists() ;
 
     virtual StatusCode initialize();
-    virtual StatusCode execute( const xAOD::IParticle* photon, float eventWeight);
+    virtual StatusCode execute( const xAOD::Photon* photon, float eventWeight);
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
-    using HistogramManager::execute; // overload
     using IParticleHists::execute; // overload
 
   protected:


### PR DESCRIPTION
You can explicitly call the parent just fine. The overload resolution works normally.

