### PR TITLE
fix memory leak in jet

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -93,6 +93,9 @@ HelpTreeBase::~HelpTreeBase() {
     for(auto jetInfoSwitch: m_thisJetInfoSwitch)
         delete jetInfoSwitch.second;
 
+    for (auto jet: m_jets)
+      delete jet.second;
+
 }
 
 


### PR DESCRIPTION
The change shouldn't break anything.
I did a test run and valgrind and do see the memory leak associated with disappear.

==17534== 29,960 bytes in 7 blocks are definitely lost in loss record 47,048 of 48,300
==17534==    at 0x4C285FC: operator new(unsigned long) (vg_replace_malloc.c:298)
==17534==    by 0x353BF236: HelpTreeBase::AddJets(std::string, std::string) (HelpTreeBase.cxx:1507)