### PR TITLE
Fix crash introduced by fixing the memory leak

### DIFF
--- a/Root/IParticleHistsAlgo.cxx
+++ b/Root/IParticleHistsAlgo.cxx
@@ -85,12 +85,10 @@ EL::StatusCode IParticleHistsAlgo :: postExecute () { return EL::StatusCode::SUC
 
 EL::StatusCode IParticleHistsAlgo :: finalize () {
   if(m_debug) Info("finalize()", m_name.c_str());
-  if(!m_plots.empty()){
-    for( auto plots : m_plots ) {
-      if(plots.second){
-        plots.second->finalize();
-        delete plots.second;
-      }
+  for( auto plots : m_plots ) {
+    if(plots.second){
+      plots.second->finalize();
+      delete plots.second;
     }
   }
   return EL::StatusCode::SUCCESS;

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -8,7 +8,8 @@ using std::vector;
 
 JetHists :: JetHists (std::string name, std::string detailStr) :
   IParticleHists(name, detailStr, "jet", "jet"),
-  m_infoSwitch(new HelperClasses::JetInfoSwitch(m_detailStr))
+  m_infoSwitch(new HelperClasses::JetInfoSwitch(m_detailStr)),
+  m_tracksInJet(0)
 { }
 
 JetHists :: ~JetHists () {
@@ -1154,6 +1155,5 @@ StatusCode JetHists::finalize() {
         m_tracksInJet->finalize();
         delete m_tracksInJet;
     }
-    IParticleHists::finalize();
-    return StatusCode::SUCCESS;
+    return IParticleHists::finalize();
 }


### PR DESCRIPTION
One must initialize JetHists::m_tracksInJet to 0 in constructor, otherwise it is set to a random number and making it useless for checking of validity of the object stored there. This should fix #513 .