### PR TITLE
reordering makeSubsetCont to avoid crash

### DIFF
--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -136,15 +136,17 @@ namespace HelperFunctions {
   template< typename T1, typename T2 >
     StatusCode makeSubsetCont( T1*& intCont, T2*& outCont, const std::string& flagSelect, HelperClasses::ToolName tool_name ){
 
+
+      if (tool_name == HelperClasses::ToolName::CALIBRATOR || tool_name == HelperClasses::ToolName::CORRECTOR) /* copy full container */
+      {
+        for ( auto in_itr : *(intCont) ) outCont->push_back( in_itr );
+        return StatusCode::SUCCESS;
+      }
+
+
      SG::AuxElement::ConstAccessor<char> myAccessor(flagSelect);
 
      for ( auto in_itr : *(intCont) ) {
-
-       if (tool_name == HelperClasses::ToolName::CALIBRATOR || tool_name == HelperClasses::ToolName::CORRECTOR) /* copy full container */
-       {
-         outCont->push_back( in_itr );
-	 continue;
-       }
 
        if ( !myAccessor.isAvailable(*(in_itr)) ) {
          std::stringstream ss; ss << in_itr->type();


### PR DESCRIPTION
This regards the ```makeSubsetCont()``` method.

In earlier versions, like 03-22, the const accessor was created for every item, but after the "continue" for CALIBRATOR: 

```static SG::AuxElement::ConstAccessor<char> myAccessor(flagSelect);```

I get the following error for some derivations, when running ElectronCalibrator: 

```Exception: void EL::Driver::submit(const EL::Job& job, const string& location) =>
    SG::ExcAuxTypeMismatch: Type mismatch for aux variable `::' (525); old type is float new type is char (C++ exception)```

In that case, ```makeSubsetCont()``` is called with ```flagSelect``` empty.  If I sandwich the accessor creator -- now without static -- with error statements, I see that the accessor is indeed the issue..

The issue can be avoided by making a separate loop, and only creating the accessor for subset containers that are not full copies.