### PR TITLE
Do not create accessors with empty name

### DIFF
--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -342,7 +342,7 @@ EL::StatusCode ElectronCalibrator :: execute ()
 
     // save pointers in ConstDataVector with same order
     //
-    RETURN_CHECK( "ElectronCalibrator::execute()", HelperFunctions::makeSubsetCont(calibElectronsSC.first, calibElectronsCDV, "", ToolName::CALIBRATOR), "");
+    RETURN_CHECK( "ElectronCalibrator::execute()", HelperFunctions::makeSubsetCont(calibElectronsSC.first, calibElectronsCDV), "");
 
     // Sort after copying to CDV.
     if ( m_sort ) {

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -282,7 +282,7 @@ EL::StatusCode MuonCalibrator :: execute ()
     // save pointers in ConstDataVector with same order
     //
     if ( m_debug ) { Info("execute()", "makeSubsetCont"); }
-    RETURN_CHECK( "MuonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibMuonsSC.first, calibMuonsCDV, "MuonCalibrator", ToolName::CALIBRATOR), "");
+    RETURN_CHECK( "MuonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibMuonsSC.first, calibMuonsCDV), "");
     if ( m_debug ) { Info("execute()", "done makeSubsetCont"); }
 
     // sort after coping to CDV

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -407,7 +407,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
 
     // save pointers in ConstDataVector with same order
     //
-    RETURN_CHECK( "PhotonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibPhotonsSC.first, calibPhotonsCDV, "", ToolName::CALIBRATOR), "");
+    RETURN_CHECK( "PhotonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibPhotonsSC.first, calibPhotonsCDV), "");
 
     // Sort after copying to CDV.
     if ( m_sort ) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -32,6 +32,8 @@ namespace HelperClasses {
       OVERLAPREMOVER,
       CALIBRATOR,
       CORRECTOR,
+      SELECTOR,
+      DEFAULT
   };
 
   /* template enum parser


### PR DESCRIPTION
This resolves issues as reported in here:

https://groups.cern.ch/group/hn-atlas-PATHelp/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-PATHelp%2fLists%2fArchive%2fold%20type%20is%20float%20new%20type%20is%20char&FolderCTID=0x0120020084D7E80CB0C3394A8D54EF07C309B044

by making sure an accessor with empty name in `HelperFunctions::makeSubsetCont()` is **never** created.

Now, the `tool_name` parameter optional in HelperFunctions::makeSubsetCont() is optional, but the function signature doesn't change

@JamesSaxon, @kkrizka , @kratsg , if you are happy with this change, please merge.

Marco