### PR TITLE
Update default m_IsoWPList for photons

### DIFF
--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -98,7 +98,7 @@ PhotonSelector :: PhotonSelector (std::string className) :
   // isolation stuff
   //
   m_MinIsoWPCut             = "";
-  m_IsoWPList		    = "Cone40CaloOnly,Cone40,Cone20";
+  m_IsoWPList		    = "FixedCutTightCaloOnly,FixedCutTight,FixedCutLoose";
 
   // trigger matching stuff
   //


### PR DESCRIPTION
The names of the photon isolation working points were updated in IsolationSelection-00-02-02. This is present since AB 2.3.33.

See https://twiki.cern.ch/twiki/bin/view/AtlasProtected/IsolationSelectionTool#Photons