### PR TITLE
Bump to 2.3.45, and start using AnaToolHandle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV=2.3.44
+  - ABV=2.3.45
 
 before_install:
   - ls

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1,18 +1,3 @@
-/********************************************************
- *
- * Basic event selection. Performs general simple cuts
- * (GRL, Event Cleaning, Min nr. Tracks for PV candidate)
- *
- * G. Facini (gabriel.facini@cern.ch)
- * M. Milesi (marco.milesi@cern.ch)
- * J. Dandoy (jeff.dandoy@cern.ch)
- * J. Alison (john.alison@cern.ch)
- *
- *******************************************************/
-
-//#include "PATInterfaces/CorrectionCode.h"
-//#include "AsgTools/StatusCode.h"
-
 // EL include(s):
 #include <EventLoop/Job.h>
 #include <EventLoop/Worker.h>
@@ -31,6 +16,7 @@
 #include "TrigConfxAOD/xAODConfigTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 #include "PATInterfaces/CorrectionCode.h"
+//#include "AsgTools/StatusCode.h"
 
 // ROOT include(s):
 #include "TFile.h"
@@ -46,7 +32,7 @@ BasicEventSelection :: BasicEventSelection (std::string className) :
     Algorithm(className),
     m_PU_default_channel(0),
     m_grl(nullptr),
-    m_pileup_tool_handle("CP::PileupReweightingTool/Pileup"),
+    m_pileup_tool_handle("CP::PileupReweightingTool/PileupToolName"),
     m_trigConfTool(nullptr),
     m_trigDecTool(nullptr),
     m_histEventCount(nullptr),
@@ -603,7 +589,7 @@ EL::StatusCode BasicEventSelection :: execute ()
                                                  //  2.) the corrected mu ("corrected_averageInteractionsPerCrossing")
                                                  //  3.) the random run number ("RandomRunNumber")
                                                  //  4.) the random lumiblock number ("RandomLumiBlockNumber")
-    }
+  }
 
   //------------------------------------------------------------------------------------------
   // Declare an 'eventInfo' decorator with the *total* MC event weight

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -46,7 +46,7 @@ BasicEventSelection :: BasicEventSelection (std::string className) :
     Algorithm(className),
     m_PU_default_channel(0),
     m_grl(nullptr),
-    m_pileuptool(nullptr),
+    m_pileup_tool_handle("CP::PileupReweightingTool/Pileup"),
     m_trigConfTool(nullptr),
     m_trigDecTool(nullptr),
     m_histEventCount(nullptr),
@@ -219,7 +219,7 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
       //
       const xAOD::CutBookkeeperContainer* incompleteCBC(nullptr);
       if ( !m_event->retrieveMetaInput(incompleteCBC, "IncompleteCutBookkeepers").isSuccess() ) {
-	  Error("initializeEvent()","Failed to retrieve IncompleteCutBookkeepers from MetaData! Exiting.");
+	  Error("fileExecute()","Failed to retrieve IncompleteCutBookkeepers from MetaData! Exiting.");
 	  return EL::StatusCode::FAILURE;
       }
       bool allFromUnknownStream(true);
@@ -232,7 +232,7 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
 	      }
 	  }
 	  if ( !allFromUnknownStream ) {
-	      Error("initializeEvent()","Found incomplete Bookkeepers! Check file for corruption.");
+	      Error("fileExecute()","Found incomplete Bookkeepers! Check file for corruption.");
 	      return EL::StatusCode::FAILURE;
 	  }
 
@@ -283,13 +283,13 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
 
       // Write metadata event bookkeepers to histogram
       //
-      Info("histInitialize()", "Meta data from this file:");
-      Info("histInitialize()", "Initial  events	 = %u",            static_cast<unsigned int>(m_MD_initialNevents) );
-      Info("histInitialize()", "Selected events	 = %u",            static_cast<unsigned int>(m_MD_finalNevents) );
-      Info("histInitialize()", "Initial  sum of weights = %f",         m_MD_initialSumW);
-      Info("histInitialize()", "Selected sum of weights = %f",         m_MD_finalSumW);
-      Info("histInitialize()", "Initial  sum of weights squared = %f", m_MD_initialSumWSquared);
-      Info("histInitialize()", "Selected sum of weights squared = %f", m_MD_finalSumWSquared);
+      Info("fileExecute()", "Meta data from this file:");
+      Info("fileExecute()", "Initial  events  = %u",	     static_cast<unsigned int>(m_MD_initialNevents) );
+      Info("fileExecute()", "Selected events  = %u",	     static_cast<unsigned int>(m_MD_finalNevents) );
+      Info("fileExecute()", "Initial  sum of weights = %f",	 m_MD_initialSumW);
+      Info("fileExecute()", "Selected sum of weights = %f",	 m_MD_finalSumW);
+      Info("fileExecute()", "Initial  sum of weights squared = %f", m_MD_initialSumWSquared);
+      Info("fileExecute()", "Selected sum of weights squared = %f", m_MD_finalSumWSquared);
 
       m_histEventCount -> Fill(1, m_MD_initialNevents);
       m_histEventCount -> Fill(2, m_MD_finalNevents);
@@ -329,12 +329,12 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
   // if truth level make sure parameters are set properly
   if( m_truthLevelOnly ) {
-    Info("configure()", "Truth only! Turn off trigger stuff");
+    Info("initialize()", "Truth only! Turn off trigger stuff");
     m_triggerSelection = "";
     m_applyTriggerCut = m_storeTrigDecisions = m_storePassL1 = m_storePassHLT = m_storeTrigKeys = false;
-    Info("configure()", "Truth only! Turn off GRL");
+    Info("initialize()", "Truth only! Turn off GRL");
     m_applyGRLCut = false;
-    Info("configure()", "Truth only! Turn off Pile-up Reweight");
+    Info("initialize()", "Truth only! Turn off Pile-up Reweight");
     m_doPUreweighting = false;
   }
 
@@ -450,9 +450,8 @@ EL::StatusCode BasicEventSelection :: initialize ()
   //
 
   if ( m_doPUreweighting ) {
-    m_pileuptool = new CP::PileupReweightingTool("Pileup");
 
-    //m_pileuptool->EnableDebugging(true);
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.make("CP::PileupReweightingTool/Pileup"), "Failed to create handle to CP::PileupReweightingTool");;
 
     std::vector<std::string> PRWFiles;
     std::vector<std::string> lumiCalcFiles;
@@ -493,15 +492,17 @@ EL::StatusCode BasicEventSelection :: initialize ()
       printf( "\t %s \n", lumiCalcFiles.at(i).c_str() );
     }
 
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("ConfigFiles", PRWFiles), "");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("LumiCalcFiles", lumiCalcFiles), "");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("ConfigFiles", PRWFiles), "");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("LumiCalcFiles", lumiCalcFiles), "");
     if ( m_PU_default_channel ) {
-      RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DefaultChannel", m_PU_default_channel), "");
+      RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("DefaultChannel", m_PU_default_channel), "");
     }
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactor", 1.0/1.16), "Failed to set pileup reweighting data scale factor");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactorUP", 1.0), "Failed to set pileup reweighting data scale factor up");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->setProperty("DataScaleFactorDOWN", 1.0/1.23), "Failed to set pileup reweighting data scale factor down");
-    RETURN_CHECK("BasicEventSelection::initialize()", m_pileuptool->initialize(), "Failed to properly initialize CP::PileupReweightingTool");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("DataScaleFactor", 1.0/1.16), "Failed to set pileup reweighting data scale factor");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("DataScaleFactorUP", 1.0), "Failed to set pileup reweighting data scale factor up");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.setProperty("DataScaleFactorDOWN", 1.0/1.23), "Failed to set pileup reweighting data scale factor down");
+    RETURN_CHECK("BasicEventSelection::initialize()", m_pileup_tool_handle.initialize(), "Failed to properly initialize CP::PileupReweightingTool");
+    //m_pileup_tool_handle->EnableDebugging(true);
+
   }
 
   // 3.
@@ -597,11 +598,11 @@ EL::StatusCode BasicEventSelection :: execute ()
   // Update Pile-Up Reweighting
   //------------------------------------------------------------------------------------------
   if ( m_isMC && m_doPUreweighting ) {
-      m_pileuptool->apply( *eventInfo ); // NB: this call automatically decorates eventInfo with:
-                                         //  1.) the PU weight ("PileupWeight")
-                                         //  2.) the corrected mu ("corrected_averageInteractionsPerCrossing")
-                                         //  3.) the random run number ("RandomRunNumber")
-                                         //  4.) the random lumiblock number ("RandomLumiBlockNumber")
+      m_pileup_tool_handle->apply( *eventInfo ); // NB: this call automatically decorates eventInfo with:
+                                                 //  1.) the PU weight ("PileupWeight")
+                                                 //  2.) the corrected mu ("corrected_averageInteractionsPerCrossing")
+                                                 //  3.) the random run number ("RandomRunNumber")
+                                                 //  4.) the random lumiblock number ("RandomLumiBlockNumber")
     }
 
   //------------------------------------------------------------------------------------------
@@ -824,7 +825,6 @@ EL::StatusCode BasicEventSelection :: finalize ()
   m_RunNr_VS_EvtNr.clear();
 
   if ( m_grl )          { delete m_grl; m_grl = nullptr; }
-  if ( m_pileuptool )   { delete m_pileuptool;  m_pileuptool = nullptr; }
   if ( m_trigDecTool )  { delete m_trigDecTool;  m_trigDecTool = nullptr; }
   if ( m_trigConfTool ) { delete m_trigConfTool;  m_trigConfTool = nullptr; }
 

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -35,3 +35,52 @@ How do I...
     --optGridOutputSampleName="group.phys-exotics.%in:name[1]%.%in:name[2]%.%in:name[3]%.v0.1_20150921/" \
     --optSubmitFlags="--official"
 
+... use ``AnaToolHandle`` for ASG CP tools?
+   Unfortunately there's no much documentation out there, so everything written here comes from direct email question to ASG fellows, or looking at the `source code <https://svnweb.cern.ch/trac/atlasoff/browser/Control/AthToolSupport/AsgTools/trunk/AsgTools/AnaToolHandle.h>`_
+
+   1. Make the tool handle as a member of a xAH algorithm (NB: remember to set the **interface** class of the CP tool. Just prepend an \`I\` to the tool type)::
+
+       class MyAlgo : public xAH::Algorithm
+       {
+         ...
+         private:
+           ...
+           asg::AnaToolHandle<IMyToolType>   m_mytool_handle; //!
+
+       }
+
+   2. In the xAH algorithm initialisation list, call the tool handle constructor. The argument of the constructor must be a string with the tool type and tool name separated by a slash \`/\` . In general, the tool name in the constructor can be just a dummy string, as it can be changed afterwards::
+
+       MyAlgo :: MyAlgo (std::string className) :
+         ...
+         m_mytool_handle("MyToolType/MyToolName"),
+         ...
+        {
+          ...
+        }
+
+   3. In some cases the name of the tool has to be different than the one set in the constructor. E.g., for the efficiency correctors, the tool names must depend on the configuration of the algorithm, which is set only **after** the initialisation list is executed. In such situations, the name of the tool can be modified (typically this would happen in ``EL::initialize()``) with::
+
+       EL::StatusCode BasicEventSelection :: initialize ()
+       {
+         ...
+         m_mytool_handle.make("MyToolType/MyToolNewName");
+         ...
+       }
+
+   4. In ``EL::initialize()``, set the properties and initialise the tool handle. After ``m_mytool_handle.initialize()`` has been called, it will effectively behave like a pointer to the tool itself::
+
+	EL::StatusCode BasicEventSelection :: initialize ()
+        {
+          ...
+          m_mytool_handle.make("MyToolType/MyToolNewName");
+          m_mytool_handle.SetProperty(...);
+          m_mytool_handle.initialize();
+          ...
+        }
+
+   5. In the algorithm, use the tool associated to the handle via calls like ``m_mytool_handle->doStuff()``.
+
+   6. The tool associated to the handle will be automatically destroyed when appropriate. Hence, no need to call ``delete`` anywhere.
+
+   If the same tool (identified by its name) needs to be used in another xAH algorithm downstream, just declare a tool handle member with the same ``IMyToolType``, call its constructor in the initialisation list and (if needed) change its tool name with ``make()``. Then in ``EL::initialize()`` simply call ``m_mytool_handle.initialize()``, without setting any property. It will automagically get the pointer to the correct tool from a registry, and all the tool properties will be preserved from the previous initialisation.

--- a/scripts/checkoutASGtags.py
+++ b/scripts/checkoutASGtags.py
@@ -57,7 +57,8 @@ dict_pkg = {
             '2.3.38': ["atlasoff/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency/tags/xAODBTaggingEfficiency-00-00-26"],
             '2.3.39': ["atlasoff/PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections/tags/MuonEfficiencyCorrections-03-02-03"],
             '2.3.41': [],
-            '2.3.44': []
+            '2.3.44': [],
+            '2.3.45': []
            }
 
 try:

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -1,3 +1,14 @@
+/**
+ * @file   BasicEventSelection.h
+ * @Author Gabriel Facini <gabriel.facini@cern.ch>
+ * @Author Marco Milesi <marco.milesi@cern.ch>
+ * @Author Jeff Dandoy <jeff.dandoy@cern.ch>
+ * @Author John Alison <john.alison@cern.ch>
+ * @brief Algorithm performing general basic cuts for an analysis (GRL, Event Cleaning, Min nr. Tracks for PV candidate).
+ *
+ */
+
+
 #ifndef xAODAnaHelpers_BasicEventSelection_H
 #define xAODAnaHelpers_BasicEventSelection_H
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -7,6 +7,7 @@
 // rootcore includes
 #include "GoodRunsLists/GoodRunsListSelectionTool.h"
 #include "PileupReweighting/PileupReweightingTool.h"
+#include "AsgTools/AnaToolHandle.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -69,9 +70,9 @@ class BasicEventSelection : public xAH::Algorithm
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr;
 
   private:
-    GoodRunsListSelectionTool*   m_grl;        //!
-    CP::PileupReweightingTool*   m_pileuptool; //!
 
+    GoodRunsListSelectionTool*   m_grl;        //!
+    asg::AnaToolHandle<CP::IPileupReweightingTool>   m_pileup_tool_handle; //!
     TrigConf::xAODConfigTool*    m_trigConfTool;  //!
     Trig::TrigDecisionTool*      m_trigDecTool;   //!
 

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -20,6 +20,7 @@
 #include "MuonEfficiencyCorrections/MuonTriggerScaleFactors.h"
 #include "MuonSelectorTools/MuonSelectionTool.h"
 #include "PileupReweighting/PileupReweightingTool.h"
+#include "AsgTools/AnaToolHandle.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -94,7 +95,8 @@ private:
   std::string m_trigEffSF_tool_name;                                   //!
   CP::MuonEfficiencyScaleFactors  *m_asgMuonEffCorrTool_muSF_TTVA;     //!
   std::string m_TTVAEffSF_tool_name;                                   //!
-  CP::PileupReweightingTool       *m_pileuptool;                       //!
+
+  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle; //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -45,6 +45,7 @@ public:
 
   // Trigger efficiency SF
   int           m_runNumber;
+  bool          m_useRandomRunNumber;
   std::string   m_WorkingPointRecoTrig;
   std::string   m_WorkingPointIsoTrig;
   std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
@@ -122,7 +123,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual EL::StatusCode executeSF (  const xAOD::MuonContainer* inputMuons, unsigned int countSyst  );
+  virtual EL::StatusCode executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst  );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers


### PR DESCRIPTION
See commit messages for details.

The bottom line is:

1. make the tool handle as a member of a xAH algorithm
2. in the xAH algorithm initialisation list, call the tool handle constructor. The argument of the constructor must be a string like  "TOOL_TYPE/TOOL_NAME" . In general,  "TOOL_NAME" here can be a dummy string, as it can be changed afterwards.
3. If the name of the tool needs to be changed, e.g. in `EL::initialize()` (this is the case for the efficiency correctors, where tool names get created depending on the configuration), just call `
my_tool_handle.make("TOOL_TYPE/NEW_TOOL_NAME");`

4. In `EL::initialize()` set the properties and initialise the tool handle. A NB: after `initialize()` has been called on the tool handle, it will effectively become a pointer to the tool itself.

5. In `EL::execute()`, use the tool via calls like  `my_tool_handle->doStuff()` If the tool with that given name needs to be used afterwards, just make a tool handle with the *same* tool_type/tool_name as intended, and call `initialize()` on it. It will automagically get the pointer to the correct tool, and all its properties will be preserved from the previous initialisation.

6. The tool will be automatically destroyed at the end of the job. Hence, no need to call `delete` anywhere.

The content of this PR shows an effective example for the above.
