### PR TITLE
Making BasicEventSelection cutflow and metadata output stream names configurable

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -66,6 +66,10 @@ BasicEventSelection :: BasicEventSelection (std::string className) :
   // Metadata
   m_useMetaData = true;
 
+  // Output Stream Names
+  m_metaDataStreamName = "metadata";
+  m_cutFlowStreamName = "cutflow";
+
   // Check for duplicated events in Data and MC
   m_checkDuplicatesData = false;
   m_checkDuplicatesMC	= false;
@@ -124,10 +128,12 @@ EL::StatusCode BasicEventSelection :: setupJob (EL::Job& job)
   // let's initialize the algorithm to use the xAODRootAccess package
   xAOD::Init("BasicEventSelection").ignore(); // call before opening first file
 
-  EL::OutputStream outForCFlow("cutflow");
-  job.outputAdd ( outForCFlow );
-  EL::OutputStream outForMetadata("metadata");
-  job.outputAdd ( outForMetadata );
+
+  EL::OutputStream outForCFlow(m_cutFlowStreamName);
+  if(!job.outputHas(m_cutFlowStreamName) ){job.outputAdd ( outForCFlow );}
+
+  EL::OutputStream outForMetadata(m_metaDataStreamName);
+  if(!job.outputHas(m_metaDataStreamName) ){job.outputAdd ( outForMetadata );}
 
   return EL::StatusCode::SUCCESS;
 }
@@ -145,7 +151,7 @@ EL::StatusCode BasicEventSelection :: histInitialize ()
   RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   // write the metadata hist to this file so algos downstream can pick up the pointer
-  TFile *fileMD = wk()->getOutputFile ("metadata");
+  TFile *fileMD = wk()->getOutputFile (m_metaDataStreamName);
   fileMD->cd();
 
   // event counts from meta data
@@ -350,7 +356,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
   // write the cutflows to this file so algos downstream can pick up the pointer
   //
-  TFile *fileCF = wk()->getOutputFile ("cutflow");
+  TFile *fileCF = wk()->getOutputFile (m_cutFlowStreamName);
   fileCF->cd();
 
   // Note: the following code is needed for anyone developing/running in ROOT 6.04.10+

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -75,6 +75,10 @@ class BasicEventSelection : public xAH::Algorithm
     std::string m_derivationName;
     bool m_useMetaData;
 
+    // Output Stream Names
+    std::string m_metaDataStreamName;
+    std::string m_cutFlowStreamName;
+
     /* Check for duplicated events in Data and MC */
     bool m_checkDuplicatesData;
     bool m_checkDuplicatesMC;

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -75,7 +75,14 @@ class BasicEventSelection : public xAH::Algorithm
     std::string m_derivationName;
     bool m_useMetaData;
 
-    // Output Stream Names
+    /* Output Stream Names */
+
+    /*
+        The following public variables allow for rerouting of the 
+        metadata and cutflow histograms to non-default output
+        streams. E.g. can combine all outputs into a single stream
+    */
+    
     std::string m_metaDataStreamName;
     std::string m_cutFlowStreamName;
 


### PR DESCRIPTION
This PR is related to #319. I've simply made the names of the BasicEventSelection output streams ("cutflow" and "metadata") configurable so that those histograms can be sent to other streams that the user might have. It's a small change that should make things a little cleaner for analyses wanting control over the streams.

tl;dr PR let's you cross the streams. 