### PR TITLE
Fix for missing primaryVertex

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1869,7 +1869,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
   if( m_thisJetInfoSwitch[jetName]->m_trackPV || m_thisJetInfoSwitch[jetName]->m_allTrack ) {
     HelperFunctions::retrieve( vertices, "PrimaryVertices", m_event, 0 );
     pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
-    pv = vertices->at( pvLocation );
+    if ( pvLocation >= 0 ) pv = vertices->at( pvLocation );
   }
 
   jetInfo* thisJet = m_jets[jetName];

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -48,6 +48,7 @@ int HelperFunctions::getPrimaryVertexLocation(const xAOD::VertexContainer* verte
     }
     location++;
   }
+  Warning("HelperFunctions::getPrimaryVertexLocation()","No primary vertex location was found! Returning -1");
   return -1;
 }
 
@@ -320,6 +321,7 @@ const xAOD::Vertex* HelperFunctions::getPrimaryVertex(const xAOD::VertexContaine
     if(vtx_itr->vertexType() != xAOD::VxType::VertexType::PriVtx) { continue; }
     return vtx_itr;
   }
+  Warning("HelperFunctions::getPrimaryVertex()","No primary vertex was found! Returning nullptr");
 
   return 0;
 }


### PR DESCRIPTION
Need to make sure the vertex is retrieved ONLY if the index is not -1

Unfortunately I have found in my latest DAODs that a few events do not have a primary vertex (which is a bit worrying, but that's it...NB: in our analysis we do not apply the event cut on the priVtx quality), so this check is vital.

I have also added some warning messages in case the primary vertex is not found.
