### PR TITLE
TTrees produced with systematics!

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -401,23 +401,13 @@ EL::StatusCode JetCalibrator :: initialize ()
     RETURN_CHECK("JetCalibrator::initialize()", m_JVTTool->initialize(), "");
   }
 
-
-  std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-
-
-
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
-
-    vecOutContainerNames->push_back( syst_it.name() );
   }
-
-  // add vector of systematic names to TStore
-  RETURN_CHECK( "JetCalibrator::initialize()", m_store->record( vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -401,13 +401,23 @@ EL::StatusCode JetCalibrator :: initialize ()
     RETURN_CHECK("JetCalibrator::initialize()", m_JVTTool->initialize(), "");
   }
 
+
+  std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
+
+
+
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
     Info("initialize()","\t %s", (syst_it.name()).c_str());
+
+    vecOutContainerNames->push_back( syst_it.name() );
   }
+
+  // add vector of systematic names to TStore
+  RETURN_CHECK( "JetCalibrator::initialize()", m_store->record( vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -139,12 +139,12 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
 
   // get the file we created already
   TFile* treeFile = wk()->getOutputFile ("tree");
+  treeFile->mkdir(m_name.c_str());
 
   // let's make the tdirectory and ttrees
   for(const auto& systName: all_systNames){
     std::string treeName = systName;
     if(systName.empty()) treeName = "nominal";
-    treeName = m_name+"/"+treeName;
 
     Info("treeInitialize()", "Making tree %s", treeName.c_str());
     TTree * outTree = new TTree(treeName.c_str(),treeName.c_str());
@@ -157,9 +157,10 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
     const auto& helpTree = m_trees[systName];
 
     // tell the tree to go into the file
-    outTree->SetDirectory( treeFile );
+    outTree->SetDirectory( treeFile->GetDirectory(m_name.c_str()) );
     // choose if want to add tree to same directory as ouput histograms
     if ( m_outHistDir ) {
+      if(m_trees.size() > 1) Warning("treeInitialize()", "You're running systematics! You may find issues in writing all of the output TTrees to the output histogram file... Set `m_outHistDir = false` if you run into issues!");
       wk()->addOutput( outTree );
     }
 

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -88,6 +88,13 @@ EL::StatusCode TreeAlgo :: initialize ()
   return EL::StatusCode::SUCCESS;
 }
 
+EL::StatusCode TreeAlgo :: histInitialize ()
+{
+  Info("histInitialize()", "%s", m_name.c_str() );
+  RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
+  return EL::StatusCode::SUCCESS;
+}
+
 EL::StatusCode TreeAlgo :: fileExecute () { return EL::StatusCode::SUCCESS; }
 EL::StatusCode TreeAlgo :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
 
@@ -143,6 +150,8 @@ EL::StatusCode TreeAlgo :: execute ()
       photonSystNames.push_back(systName);
     }
   }
+
+  TFile* treeFile = wk()->getOutputFile ("tree");
 
   // let's make the tdirectory and ttrees
   for(const auto& systName: event_systNames){
@@ -296,4 +305,4 @@ EL::StatusCode TreeAlgo :: finalize () {
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TreeAlgo :: treeFinalize () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TreeAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -20,11 +20,7 @@ ClassImp(TreeAlgo)
 
 TreeAlgo :: TreeAlgo (std::string className) :
     Algorithm(className),
-    m_trees({}),
-    m_muSystNames({}),
-    m_elSystNames({}),
-    m_jetSystNames({}),
-    m_photonSystNames({})
+    m_trees({})
 {
   this->SetName("TreeAlgo"); // needed if you want to retrieve this algo with wk()->getAlg(ALG_NAME) downstream
 
@@ -84,71 +80,81 @@ EL::StatusCode TreeAlgo :: initialize ()
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
-  return this->treeInitialize();
+  // get the file we created already
+  TFile* treeFile = wk()->getOutputFile ("tree");
+  treeFile->mkdir(m_name.c_str());
+  treeFile->cd(m_name.c_str());
+
+  return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TreeAlgo :: treeInitialize ()
+EL::StatusCode TreeAlgo :: fileExecute () { return EL::StatusCode::SUCCESS; }
+EL::StatusCode TreeAlgo :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
+
+
+EL::StatusCode TreeAlgo :: execute ()
 {
-  Info("treeInitialize()", "%s", m_name.c_str() );
-  // needed here and not in initalize since this is called first
 
-  // make a tree for every systematic we need to process
-  std::vector<std::string> all_systNames;
-  all_systNames.push_back(""); // handle the nominal case (merge all) specially
+  // what systematics do we need to process for this event?
+  // handle the nominal case (merge all) on every event, always
+  std::vector<std::string> event_systNames({""});
+  std::vector<std::string> muSystNames;
+  std::vector<std::string> elSystNames;
+  std::vector<std::string> jetSystNames;
+  std::vector<std::string> photonSystNames;
 
-  // temporarily hold vector retrieved
+  // this is a temporary pointer that gets switched around to check each of the systematics
   std::vector<std::string>* systNames(nullptr);
 
-  // note that the way we set this up, none of the below m_##SystNames vectors contain the nominal case
+  // note that the way we set this up, none of the below ##SystNames vectors contain the nominal case
+  // TODO: do we really need to check for duplicates? Maybe, maybe not.
   if(!m_muSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::treeInitialize()", HelperFunctions::retrieve(systNames, m_muSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_muSystsVec, 0, m_store, m_verbose) ,"");
     for(const auto& systName: *systNames){
-      if (std::find(all_systNames.begin(), all_systNames.end(), systName) != all_systNames.end()) continue;
-      all_systNames.push_back(systName);
-      m_muSystNames.push_back(systName);
+      if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
+      event_systNames.push_back(systName);
+      muSystNames.push_back(systName);
     }
   }
 
   if(!m_elSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::treeInitialize()", HelperFunctions::retrieve(systNames, m_elSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_elSystsVec, 0, m_store, m_verbose) ,"");
     for(const auto& systName: *systNames){
-      if (std::find(all_systNames.begin(), all_systNames.end(), systName) != all_systNames.end()) continue;
-      all_systNames.push_back(systName);
-      m_elSystNames.push_back(systName);
+      if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
+      event_systNames.push_back(systName);
+      elSystNames.push_back(systName);
     }
   }
 
   if(!m_jetSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::treeInitialize()", HelperFunctions::retrieve(systNames, m_jetSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_jetSystsVec, 0, m_store, m_verbose) ,"");
     for(const auto& systName: *systNames){
-      if (std::find(all_systNames.begin(), all_systNames.end(), systName) != all_systNames.end()) continue;
-      all_systNames.push_back(systName);
-      m_jetSystNames.push_back(systName);
+      if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
+      event_systNames.push_back(systName);
+      jetSystNames.push_back(systName);
     }
   }
 
   if(!m_photonSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::treeInitialize()", HelperFunctions::retrieve(systNames, m_photonSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_photonSystsVec, 0, m_store, m_verbose) ,"");
     for(const auto& systName: *systNames){
-      if (std::find(all_systNames.begin(), all_systNames.end(), systName) != all_systNames.end()) continue;
-      all_systNames.push_back(systName);
-      m_photonSystNames.push_back(systName);
+      if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
+      event_systNames.push_back(systName);
+      photonSystNames.push_back(systName);
     }
   }
 
-  // get the file we created already
-  TFile* treeFile = wk()->getOutputFile ("tree");
-  treeFile->mkdir(m_name.c_str());
-
   // let's make the tdirectory and ttrees
-  for(const auto& systName: all_systNames){
+  for(const auto& systName: event_systNames){
+    // check if we have already created the tree
+    if(m_trees.find(systName) != m_trees.end()) continue;
     std::string treeName = systName;
     if(systName.empty()) treeName = "nominal";
 
-    Info("treeInitialize()", "Making tree %s", treeName.c_str());
+    Info("execute()", "Making tree %s/%s", m_name.c_str(), treeName.c_str());
     TTree * outTree = new TTree(treeName.c_str(),treeName.c_str());
     if ( !outTree ) {
-      Error("treeInitialize()","Failed to instantiate output tree!");
+      Error("execute()","Failed to instantiate output tree!");
       return EL::StatusCode::FAILURE;
     }
 
@@ -159,10 +165,11 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
     outTree->SetDirectory( treeFile->GetDirectory(m_name.c_str()) );
     // choose if want to add tree to same directory as ouput histograms
     if ( m_outHistDir ) {
-      if(m_trees.size() > 1) Warning("treeInitialize()", "You're running systematics! You may find issues in writing all of the output TTrees to the output histogram file... Set `m_outHistDir = false` if you run into issues!");
+      if(m_trees.size() > 1) Warning("execute()", "You're running systematics! You may find issues in writing all of the output TTrees to the output histogram file... Set `m_outHistDir = false` if you run into issues!");
       wk()->addOutput( outTree );
     }
 
+    // initialize all branch addresses since we just added this tree
     helpTree->AddEvent( m_evtDetailStr );
     if ( !m_trigDetailStr.empty() )       {   helpTree->AddTrigger    (m_trigDetailStr);    }
     if ( !m_muContainerName.empty() )     {   helpTree->AddMuons      (m_muDetailStr);      }
@@ -176,17 +183,7 @@ EL::StatusCode TreeAlgo :: treeInitialize ()
     if ( !m_photonContainerName.empty() ) {   helpTree->AddPhotons    (m_photonDetailStr);  }
   }
 
-  Info("treeInitialize()", "Successfully initialized output tree");
-
-  return EL::StatusCode::SUCCESS;
-}
-
-EL::StatusCode TreeAlgo :: fileExecute () { return EL::StatusCode::SUCCESS; }
-EL::StatusCode TreeAlgo :: changeInput (bool /*firstFile*/) { return EL::StatusCode::SUCCESS; }
-
-
-EL::StatusCode TreeAlgo :: execute ()
-{
+  /* THIS IS WHERE WE START PROCESSING THE EVENT AND PLOTTING THINGS */
 
   // Get EventInfo and the PrimaryVertices
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -196,20 +193,25 @@ EL::StatusCode TreeAlgo :: execute ()
   // get the primaryVertex
   const xAOD::Vertex* primaryVertex = HelperFunctions::getPrimaryVertex( vertices );
 
-  for(auto& item: m_trees){
-    auto& systName = item.first;
-    auto& helpTree = item.second;
+  for(const auto& systName: event_systNames){
+    auto& helpTree = m_trees[systName];
 
     // assume the nominal container by default
     std::string muSuffix("");
     std::string elSuffix("");
     std::string jetSuffix("");
     std::string photonSuffix("");
-    // if we find the systematic in the corresponding vector, we will use that container's systematic version instead of nominal version
-    if (std::find(m_muSystNames.begin(), m_muSystNames.end(), systName) != m_muSystNames.end()) muSuffix = systName;
-    if (std::find(m_elSystNames.begin(), m_elSystNames.end(), systName) != m_elSystNames.end()) elSuffix = systName;
-    if (std::find(m_jetSystNames.begin(), m_jetSystNames.end(), systName) != m_jetSystNames.end()) jetSuffix = systName;
-    if (std::find(m_photonSystNames.begin(), m_photonSystNames.end(), systName) != m_photonSystNames.end()) photonSuffix = systName;
+    /*
+       if we find the systematic in the corresponding vector, we will use that container's systematic version instead of nominal version
+        NB: since none of these contain the "" (nominal) case because of how I filter it, we handle the merging.. why?
+        - in each loop to make the ##systNames vectors, we check to see if the systName exists in event_systNames which is initialized
+        -   to {""} - the nominal case. If the systName exists, we do not add it to the corresponding ##systNames vector, otherwise, we do.
+        -   This precludes the nominal case in all of the ##systNames vectors, which means the default will always be to run nominal.
+    */
+    if (std::find(muSystNames.begin(), muSystNames.end(), systName) != muSystNames.end()) muSuffix = systName;
+    if (std::find(elSystNames.begin(), elSystNames.end(), systName) != elSystNames.end()) elSuffix = systName;
+    if (std::find(jetSystNames.begin(), jetSystNames.end(), systName) != jetSystNames.end()) jetSuffix = systName;
+    if (std::find(photonSystNames.begin(), photonSystNames.end(), systName) != photonSystNames.end()) photonSuffix = systName;
 
     helpTree->FillEvent( eventInfo, m_event );
 
@@ -226,18 +228,18 @@ EL::StatusCode TreeAlgo :: execute ()
     // for the containers the were supplied, fill the appropriate vectors
     if ( !m_muContainerName.empty() ) {
       const xAOD::MuonContainer* inMuon(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inMuon, m_muContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inMuon, m_muContainerName+muSuffix, m_event, m_store, m_verbose) ,"");
       helpTree->FillMuons( inMuon, primaryVertex );
     }
 
     if ( !m_elContainerName.empty() ) {
       const xAOD::ElectronContainer* inElec(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inElec, m_elContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inElec, m_elContainerName+elSuffix, m_event, m_store, m_verbose) ,"");
       helpTree->FillElectrons( inElec, primaryVertex );
     }
     if ( !m_jetContainerName.empty() ) {
       const xAOD::JetContainer* inJets(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainerName+jetSuffix, m_event, m_store, m_verbose) ,"");
       helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices), "jet" );
     }
     if ( !m_trigJetContainerName.empty() ) {
@@ -267,7 +269,7 @@ EL::StatusCode TreeAlgo :: execute ()
     }
     if ( !m_photonContainerName.empty() ) {
       const xAOD::PhotonContainer* inPhotons(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inPhotons, m_photonContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inPhotons, m_photonContainerName+photonSuffix, m_event, m_store, m_verbose) ,"");
       helpTree->FillPhotons( inPhotons );
     }
 

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -84,8 +84,7 @@ EL::StatusCode TreeAlgo :: initialize ()
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
-  this->treeInitialize();
-  return EL::StatusCode::SUCCESS;
+  return this->treeInitialize();
 }
 
 EL::StatusCode TreeAlgo :: treeInitialize ()

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -40,11 +40,21 @@ public:
   std::string m_METContainerName;
   std::string m_photonContainerName;
 
+  // if these are set, assume systematics are being processed over
+  std::string m_muSystsVec;
+  std::string m_elSystsVec;
+  std::string m_jetSystsVec;
+  std::string m_photonSystsVec;
+
   bool m_DC14;
   float m_units;
 
 protected:
-  HelpTreeBase* m_helpTree;            //!
+  std::map<std::string, HelpTreeBase*> m_trees;            //!
+  std::vector<std::string> m_muSystNames; //!
+  std::vector<std::string> m_elSystNames; //!
+  std::vector<std::string> m_jetSystNames; //!
+  std::vector<std::string> m_photonSystNames; //!
 
 public:
 

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -60,13 +60,13 @@ public:
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);           //!
   virtual EL::StatusCode fileExecute ();                    //!
-  virtual EL::StatusCode treeInitialize ();                 //!
+  virtual EL::StatusCode histInitialize ();                 //!
   virtual EL::StatusCode changeInput (bool firstFile);      //!
   virtual EL::StatusCode initialize ();                     //!
   virtual EL::StatusCode execute ();                        //!
   virtual EL::StatusCode postExecute ();                    //!
   virtual EL::StatusCode finalize ();                       //!
-  virtual EL::StatusCode treeFinalize ();                   //!
+  virtual EL::StatusCode histFinalize ();                   //!
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -51,10 +51,6 @@ public:
 
 protected:
   std::map<std::string, HelpTreeBase*> m_trees;            //!
-  std::vector<std::string> m_muSystNames; //!
-  std::vector<std::string> m_elSystNames; //!
-  std::vector<std::string> m_jetSystNames; //!
-  std::vector<std::string> m_photonSystNames; //!
 
 public:
 


### PR DESCRIPTION
This should resolve #558 . I tested this locally using the [`gamma_b.py`](https://github.com/US-ATLAS-HFSF/HFSF2015/blob/master/example/gamma_b.py) file. The diff is below:

```
49c49,53
<                            "m_jetAlgo": "AntiKt4EMTopo"
---
>                            "m_JESUncertConfig": "$ROOTCOREBIN/data/JetUncertainties/JES_2015/Prerec/PrerecJES2015_AllNuisanceParameters_25ns.config",
>                            "m_jetAlgo": "AntiKt4EMTopo",
>                            "m_systName": "All",
>                            "m_systVal": 1,
>                            "m_outputAlgo": "JetSysts"
104c108,109
<                       "m_jetContainerName": "AntiKt4EMTopoJetsCalibOR",
---
>                       "m_jetContainerName": "AntiKt4EMTopoJetsCalib",
>                       "m_jetSystsVec": "JetSysts",
```

I didn't want to deal with threading systematics through OR just yet, so I just decided to dump the jets from `JetCalibrator` which looks like it works fine. The output tree file looks like so:

```
root [2] GammaB->ls()
TDirectoryFile*		GammaB	GammaB
 KEY: TTree	nominal;1	nominal
 KEY: TTree	JET_BJES_Response__1up;1	JET_BJES_Response__1up
 KEY: TTree	JET_BJES_Response__1down;1	JET_BJES_Response__1down
 KEY: TTree	JET_EtaIntercalibration_Modelling__1up;1	JET_EtaIntercalibration_Modelling__1up
 KEY: TTree	JET_EtaIntercalibration_Modelling__1down;1	JET_EtaIntercalibration_Modelling__1down
 KEY: TTree	JET_EtaIntercalibration_TotalStat__1up;1	JET_EtaIntercalibration_TotalStat__1up
 KEY: TTree	JET_EtaIntercalibration_TotalStat__1down;1	JET_EtaIntercalibration_TotalStat__1down
 KEY: TTree	JET_Flavor_Composition__1up;1	JET_Flavor_Composition__1up
 KEY: TTree	JET_Flavor_Composition__1down;1	JET_Flavor_Composition__1down
 KEY: TTree	JET_Flavor_Response__1up;1	JET_Flavor_Response__1up
 KEY: TTree	JET_Flavor_Response__1down;1	JET_Flavor_Response__1down
 KEY: TTree	JET_Gjet_Generator__1up;1	JET_Gjet_Generator__1up
 KEY: TTree	JET_Gjet_Generator__1down;1	JET_Gjet_Generator__1down
 KEY: TTree	JET_Gjet_OOC__1up;1	JET_Gjet_OOC__1up
```

and branches are set up correctly

```
root [4] ((TTree*)_file0->Get("GammaB/nominal"))->Scan("njets")
************************
*    Row   *     njets *
************************
*        0 *        10 *
*        1 *         7 *
*        2 *         8 *
*        3 *        11 *
*        4 *         8 *
*        5 *         7 *
*        6 *         9 *
*        7 *         8 *
*        8 *         4 *
*        9 *         5 *
************************
(Long64_t) 10
root [5] ((TTree*)_file0->Get("GammaB/JET_Flavor_Composition__1up"))->Scan("njets")
************************
*    Row   *     njets *
************************
*        0 *        10 *
*        1 *         7 *
*        2 *         8 *
*        3 *        11 *
*        4 *         8 *
*        5 *         7 *
*        6 *         9 *
*        7 *         8 *
*        8 *         4 *
*        9 *         5 *
************************
```

There should be some more sanity checks done, but there are no memory leaks, correct containers appear to be retrieved, and all is pretty good.

This also assumes that all container names being retrieved take the form of `m_inputContainerName+systName` for the most part (for jets, muons, electrons, and photons). This is not the most generic piece of code, but it makes some reasonable assumptions about rational users.