### PR TITLE
Fix Multiple WP sigmas for Jet systematics

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -53,20 +53,18 @@ xAH::Algorithm* xAH::Algorithm::setLevel(int level){
   return this;
 }
 
-xAH::Algorithm* xAH::Algorithm::setSyst(std::string systName){
-  return this->setSyst(systName, 0);
-}
+StatusCode xAH::Algorithm::parseSystValVector(){
 
-xAH::Algorithm* xAH::Algorithm::setSyst(std::string systName, float systVal){
-  m_systName = systName;
-  m_systVal = systVal;
-  return this;
-}
+    std::stringstream ss(m_systValVectorString);
+    float systVal;
+    while( ss >> systVal ){
+      m_systValVector.push_back(systVal);
+      if (ss.peek() == ',')
+        ss.ignore();
+    }
+    ss.str("");
 
-xAH::Algorithm* xAH::Algorithm::setSyst(std::string systName, std::vector<float> systValVector){
-  m_systName = systName;
-  m_systValVector = systValVector;
-  return this;
+    return StatusCode::SUCCESS;
 }
 
 int xAH::Algorithm::isMC(){

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -97,7 +97,7 @@ JetCalibrator :: JetCalibrator (std::string className) :
 
   // Initialize systematics variables
   m_systName                = "";
-  m_systVal                 = 0.;
+  m_systVal                 = 1.;
 }
 
 EL::StatusCode JetCalibrator :: setupJob (EL::Job& job)
@@ -301,6 +301,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     Info("initialize()"," Initializing Jet Systematics :");
 
     //If just one systVal, then push it to the vector
+    this->parseSystValVector();
     if( m_systValVector.size() == 0) {
       if ( m_debug ){ Info("initialize()", "Pushing the following systVal to m_systValVector: %f", m_systVal ); }
       m_systValVector.push_back(m_systVal);

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -580,7 +580,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
            float jvtSF(1.0);
 	   if ( jet->pt() < m_pt_max_JVT && fabs(jet->eta()) < m_eta_max_JVT ) {
              if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
-               Warning( "executeSelection()", "Problem in getEfficiencyScaleFactor");
+               Warning( "executeSelection()", "Problem in JVT Tool getEfficiencyScaleFactor");
                jvtSF = 1.0;
              }
 	   }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -98,26 +98,6 @@ namespace xAH {
          */
         Algorithm* setLevel(int level);
 
-        /**
-            @brief Enable and set the systematic with default value 0
-            @param systName     The name of the systematic
-         */
-        Algorithm* setSyst(std::string systName);
-        /**
-            @brief Enable and set the systematic with the value
-            @param systName     The name of the systematic
-            @param systVal      The value to set the systematic to
-            @rst
-                .. note:: This will set the systematic to the value :math:`\pm x`.
-            @endrst
-         */
-        Algorithm* setSyst(std::string systName, float systVal);
-        /**
-            @brief Enable and set the systemtatic with the vector of values
-            @param systName             The name of the systematic
-            @param systValVector        The values to set the systematic to
-         */
-        Algorithm* setSyst(std::string systName, std::vector<float> systValVector);
 
         /** All algorithms initialized should have a unique name, to differentiate them at the TObject level */
         std::string m_name;
@@ -135,8 +115,16 @@ namespace xAH {
             @endrst
          */
         float m_systVal;
-        /** If running systematics, you can run multiple points and store them in here */
+        /** If running systematics, you can run multiple points and store them in here. 
+            A comma separated list of working points should be given to m_systValVectorString,
+            and then parsed by calling parseSystValVector.
+         */
+        std::string m_systValVectorString;
         std::vector<float> m_systValVector;
+        /**
+            @brief Parse string of systematic sigma levels in m_systValVectorString into m_systValVector 
+         */
+        StatusCode parseSystValVector();
 
         /** If the xAOD has a different EventInfo container name, set it here */
         std::string m_eventInfoContainerName;


### PR DESCRIPTION
Remove the setSyst functions from Algorithm which were only used with the deprecated TEnv method (#573).  Parse the string of systematic sigma values in Algorithm, rather than passing a vector. 