### PR TITLE
Custom options

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -88,9 +88,9 @@ parser.add_argument('-f', '--force', dest='force_overwrite', action='store_true'
 
 parser.add_argument('--version', action='version', version='xAH_run.py {version}'.format(version=__version__), help='{version}'.format(version=__version__))
 parser.add_argument('--mode', dest='access_mode', type=str, metavar='{class, branch, athena}', choices=['class', 'branch', 'athena'], default='class', help='run using class access mode, branch access mode, or athena access mode')
-parser.add_argument( '--treeName', dest="treeName",     default="CollectionTree", help="Tree Name to run on")
-parser.add_argument( '--isMC',     action="store_true", dest="is_MC",    default=False, help="Running MC")
-parser.add_argument( '--isAFII',   action="store_true", dest="is_AFII",  default=False, help="Running on AFII")
+parser.add_argument('--treeName', dest="treeName",     default="CollectionTree", help="Tree Name to run on")
+parser.add_argument('--isMC',     action="store_true", dest="is_MC",    default=False, help="Running MC")
+parser.add_argument('--isAFII',   action="store_true", dest="is_AFII",  default=False, help="Running on AFII")
 
 
 parser.add_argument('--inputList', dest='use_inputFileList', action='store_true', help='If enabled, will read in a text file containing a list of paths/filenames.')
@@ -479,9 +479,9 @@ if __name__ == "__main__":
       for k,v in configLocals.iteritems():
 
         if isinstance(v, xAH_config):
-          
+
           # If we wish to add an NTupleSvc, make sure an output stream (NB: must have the same name of the service itself!)
-          # is created and added to the job *before* the service 
+          # is created and added to the job *before* the service
           #
           for alg in v._algorithms:
             if isinstance(alg, ROOT.EL.NTupleSvc) and not job.outputHas(alg.GetName()):

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -91,7 +91,7 @@ parser.add_argument('--mode', dest='access_mode', type=str, metavar='{class, bra
 parser.add_argument('--treeName', dest="treeName",     default="CollectionTree", help="Tree Name to run on")
 parser.add_argument('--isMC',     action="store_true", dest="is_MC",    default=False, help="Running MC")
 parser.add_argument('--isAFII',   action="store_true", dest="is_AFII",  default=False, help="Running on AFII")
-
+parser.add_argument('--extraOptions', dest="extra_options", metavar="[param=val]", type=str, required=False, help='Pass in extra options straight into the python config file. These can be accessed by using argparse: `parser.parse_args(shlex.split(args.extra_options))`.', default='')
 
 parser.add_argument('--inputList', dest='use_inputFileList', action='store_true', help='If enabled, will read in a text file containing a list of paths/filenames.')
 parser.add_argument('--inputTag', dest='inputTag', default="", help='A wildcarded name of input files to run on.')


### PR DESCRIPTION
This adds the simple functionality to pass in command line options straight to the underlying python config file. Here's how it might work:

```
xAH_run.py --files foo.root --config bar.py --extraOptions="-a -b 2 --c 3 --d=4" direct
```

and then in `bar.py`

```
import shlex
import argparse

parser = argparse.ArgumentParser(description='Test for extra options')
parser.add_argument('-a')
parser.add_argument('-b')
parser.add_argument('--c')
parser.add_argument('--d')

# note "args" is already a variable holding the arguments passed into xAH_run.py
inner_args = parser.parse_args(shlex.split(args.extra_options))
print(inner_args)
```

should do the trick.