### PR TITLE
Features/xaodtruth

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1219,13 +1219,18 @@ void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthPart
   this->ClearTruth(truthName);
   this->ClearTruthUser(truthName);
 
+  float truthparticle_ptmax = 5.0;
+  float truthparticle_etamax = 6.0;
+
   for( auto truth_itr : *truthParts ) {
 
     if( m_truthInfoSwitch->m_kinematic ){
-      m_truth[truthName]->pt .push_back  ( truth_itr->pt() / m_units );
-      m_truth[truthName]->eta.push_back  ( truth_itr->eta() );
-      m_truth[truthName]->phi.push_back  ( truth_itr->phi() );
-      m_truth[truthName]->E  .push_back  ( truth_itr->e() / m_units );
+      if(truth_itr->pt() / m_units > truthparticle_ptmax && fabs(truth_itr->eta()) < truthparticle_etamax){
+	m_truth[truthName]->pt .push_back  ( truth_itr->pt() / m_units );
+	m_truth[truthName]->eta.push_back  ( truth_itr->eta() );
+	m_truth[truthName]->phi.push_back  ( truth_itr->phi() );
+	m_truth[truthName]->E  .push_back  ( truth_itr->e() / m_units );
+      }
     }
 
     this->FillTruthUser(truthName, truth_itr);

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1203,6 +1203,8 @@ void HelpTreeBase::AddTruthParts(const std::string truthName, const std::string 
 
   // always
   m_tree->Branch(("n"+truthName).c_str(),    &m_truth[truthName]->N, ("n"+truthName+"/I").c_str());
+  m_tree->Branch((truthName+"_pdgId").c_str(),    &m_truth[truthName]->pdgId);
+  m_tree->Branch((truthName+"_status").c_str(),    &m_truth[truthName]->status);
 
   if ( m_truthInfoSwitch->m_kinematic ) {
     m_tree->Branch((truthName+"_E"  ).c_str(), &m_truth[truthName]->E);
@@ -1219,10 +1221,14 @@ void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthPart
   this->ClearTruth(truthName);
   this->ClearTruthUser(truthName);
 
+  // We need some basic cuts here to avoid many PseudoRapiditity warnings being thrown ...
   float truthparticle_ptmax = 5.0;
   float truthparticle_etamax = 6.0;
 
   for( auto truth_itr : *truthParts ) {
+
+    m_truth[truthName]->pdgId.push_back  ( truth_itr->pdgId() );
+    m_truth[truthName]->status.push_back  ( truth_itr->status() );
 
     if( m_truthInfoSwitch->m_kinematic ){
       if(truth_itr->pt() / m_units > truthparticle_ptmax && fabs(truth_itr->eta()) < truthparticle_etamax){
@@ -1244,6 +1250,8 @@ void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthPart
 void HelpTreeBase::ClearTruth(const std::string truthName) {
 
   m_truth[truthName]->N = 0;
+  m_truth[truthName]->pdgId.clear();
+  m_truth[truthName]->status.clear();
   if( m_truthInfoSwitch->m_kinematic ){
     m_truth[truthName]->pt.clear();
     m_truth[truthName]->eta.clear();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1207,10 +1207,11 @@ void HelpTreeBase::AddTruthParts(const std::string truthName, const std::string 
   m_tree->Branch((truthName+"_status").c_str(),    &m_truth[truthName]->status);
 
   if ( m_truthInfoSwitch->m_kinematic ) {
-    m_tree->Branch((truthName+"_E"  ).c_str(), &m_truth[truthName]->E);
     m_tree->Branch((truthName+"_pt" ).c_str(), &m_truth[truthName]->pt);
-    m_tree->Branch((truthName+"_phi").c_str(), &m_truth[truthName]->phi);
     m_tree->Branch((truthName+"_eta").c_str(), &m_truth[truthName]->eta);
+    m_tree->Branch((truthName+"_phi").c_str(), &m_truth[truthName]->phi);
+    m_tree->Branch((truthName+"_E"  ).c_str(), &m_truth[truthName]->E);
+    m_tree->Branch((truthName+"_m"  ).c_str(), &m_truth[truthName]->m);
   }
 
   this->AddTruthUser(truthName);
@@ -1236,6 +1237,7 @@ void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthPart
 	m_truth[truthName]->eta.push_back  ( truth_itr->eta() );
 	m_truth[truthName]->phi.push_back  ( truth_itr->phi() );
 	m_truth[truthName]->E  .push_back  ( truth_itr->e() / m_units );
+	m_truth[truthName]->m  .push_back  ( truth_itr->m() / m_units );
       }
     }
 
@@ -1257,6 +1259,7 @@ void HelpTreeBase::ClearTruth(const std::string truthName) {
     m_truth[truthName]->eta.clear();
     m_truth[truthName]->phi.clear();
     m_truth[truthName]->E.clear();
+    m_truth[truthName]->m.clear();
   }
 
 }

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -299,7 +299,8 @@ protected:
     std::vector<float> eta;
     std::vector<float> phi;
     std::vector<float> E;
-
+    std::vector<float> m;
+    
     truthInfo(){ }
 
   };

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -292,6 +292,9 @@ protected:
   struct truthInfo{
 
     int  N;
+    std::vector<int> pdgId;
+    std::vector<int> status;
+
     std::vector<float> pt;
     std::vector<float> eta;
     std::vector<float> phi;


### PR DESCRIPTION
Adding some baseline cuts in order to suppress warnings from `PseudoRapidity` ... these are pT > 5 GeV, eta < 6.0; specific values stolen from the top tagging analysis code's truth matching algorithm.

---

Adding a bit more truth info to output trees.

* `pdgId`
* `status`
* `m`