### PR TITLE
Update JetSelector.cxx

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -517,7 +517,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     }
 
     // event level cut if any of the N leading jets are not clean
-    if ( m_cleanEvtLeadJets > 0 && nObj <= m_cleanEvtLeadJets ) {
+    if ( m_cleanEvtLeadJets > 0 && nObj <= m_cleanEvtLeadJets && passSel) {
       if ( isCleanAcc.isAvailable( *jet_itr ) ) {
         if( !isCleanAcc( *jet_itr ) ) { passEventClean = false; }
       }


### PR DESCRIPTION
According to the current jet cleaning recommendations (https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJets2016), events should be removed if there are jets that pass JVT that are bad. The old functionality would remove an event if it contained a pileup jet that was bad.

@mswiatlo @kratsg @gfacini 