### PR TITLE
fix AddFatJets[User]() to support multiple container names as well.

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1343,7 +1343,8 @@ void HelpTreeBase::ClearTruth(const std::string truthName) {
  *
  ********************/
 
-void HelpTreeBase::AddFatJets(std::string detailStr, std::string fatjetContainerName, std::string suffix) {
+void HelpTreeBase::AddFatJets(const std::string& detailStr, std::string fatjetContainerName,
+        std::string suffix) {
 
   if(m_debug) Info("AddFatJets()", "Adding fat jet variables: %s", detailStr.c_str());
 	if(suffix.empty()){ suffix = fatjetContainerName; }
@@ -1446,9 +1447,9 @@ void HelpTreeBase::AddTruthFatJets(std::string detailStr) {
 }
 
 
- void HelpTreeBase::FillFatJets( const xAOD::JetContainer* fatJets , std::string fatjetName) {
+ void HelpTreeBase::FillFatJets( const xAOD::JetContainer* fatJets , const std::string& fatjetName) {
    this->ClearFatJets(fatjetName);
-   this->ClearFatJetsUser();
+   this->ClearFatJetsUser(fatjetName);
 
   for( auto fatjet_itr : *fatJets ) {
 
@@ -1567,7 +1568,7 @@ void HelpTreeBase::AddTruthFatJets(std::string detailStr) {
       m_fatjet_constituent_e[fatjetName].push_back( e   );
     }
 
-    this->FillFatJetsUser(fatjet_itr);
+    this->FillFatJetsUser(fatjet_itr, fatjetName);
 
     m_nfatjet[fatjetName]++;
 
@@ -1712,7 +1713,7 @@ void HelpTreeBase::FillTruthFatJets( const xAOD::JetContainer* truthTruthFatJets
 
 }
 
-void HelpTreeBase::ClearFatJets(std::string fatjetName) {
+void HelpTreeBase::ClearFatJets(const std::string& fatjetName) {
 
   m_nfatjet[fatjetName] = 0;
   if( m_fatJetInfoSwitch->m_kinematic ){

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1389,7 +1389,7 @@ void HelpTreeBase::AddFatJets(std::string detailStr, std::string fatjetContainer
       m_tree->Branch(("fatjet_constituent_e"+suffix).c_str(),&m_fatjet_constituent_e[suffix]);
     }
 
-    this->AddFatJetsUser();
+    this->AddFatJetsUser(detailStr, fatjetContainerName, suffix);
 }
 
 void HelpTreeBase::AddTruthFatJets(std::string detailStr) {

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -160,7 +160,7 @@ public:
     if(m_debug) Info("AddTruthUser","Empty function called from HelpTreeBase %s %s",truthName.c_str(), detailStr.c_str());
     return;
   };
-  virtual void AddFatJetsUser(const std::string detailStr = "")       {
+  virtual void AddFatJetsUser(const std::string detailStr = "", const std::string fatjetName = "", const std::string suffix = "")       {
     if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
     return;
   };

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -64,7 +64,7 @@ public:
   void AddPhotons     (const std::string detailStr = "");
   void AddJets        (const std::string detailStr = "", const std::string jetName = "jet");
   void AddTruthParts  (const std::string truthName,      const std::string detailStr = "");
-  void AddFatJets     (const std::string detailStr = "", const std::string fatjetName = "", const std::string suffix="");
+  void AddFatJets     (const std::string& detailStr = "", std::string fatjetName = "", std::string suffix="");
   void AddTruthFatJets (const std::string detailStr = "");
   void AddTaus        (const std::string detailStr = "");
   void AddMET         (const std::string detailStr = "");
@@ -106,7 +106,7 @@ public:
 
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
 
-  void FillFatJets( const xAOD::JetContainer* fatJets , const std::string fatjetName = "" );
+  void FillFatJets( const xAOD::JetContainer* fatJets , const std::string& fatjetName = "" );
   void FillTruthFatJets( const xAOD::JetContainer* truthFatJets );
 
   void FillTaus( const xAOD::TauJetContainer* taus );
@@ -121,7 +121,7 @@ public:
   void ClearPhotons();
   void ClearJets(const std::string jetName = "jet");
   void ClearTruth(const std::string truthName);
-  void ClearFatJets(std::string fatjetName);
+  void ClearFatJets(const std::string& fatjetName);
   void ClearTruthFatJets();
   void ClearTaus();
   void ClearMET();
@@ -160,9 +160,8 @@ public:
     if(m_debug) Info("AddTruthUser","Empty function called from HelpTreeBase %s %s",truthName.c_str(), detailStr.c_str());
     return;
   };
-  virtual void AddFatJetsUser(const std::string detailStr = "", const std::string fatjetName = "", const std::string suffix = "")       {
-    if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase %s %s %s",detailStr.c_str(),
-            fatjetName.c_str(), suffix.c_str());
+  virtual void AddFatJetsUser(const std::string& /*detailStr = ""*/, const std::string& /*fatjetName*/, const std::string& /*suffix*/)       {
+    if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase");
     return;
   };
   virtual void AddTruthFatJetsUser(const std::string detailStr = "")       {
@@ -185,7 +184,7 @@ public:
   virtual void ClearPhotonsUser() { return; };
   virtual void ClearTruthUser(const std::string& /*truthName*/) 	    { return; };
   virtual void ClearJetsUser (const std::string /*jetName = "jet"*/ ) 	    { return; };
-  virtual void ClearFatJetsUser()   { return; };
+  virtual void ClearFatJetsUser(const std::string& /*fatjetName = "fatjet"*/ )   { return; };
   virtual void ClearTruthFatJetsUser()   { return; };
   virtual void ClearTausUser() 	    { return; };
   virtual void ClearMETUser()       { return; };
@@ -196,7 +195,7 @@ public:
   virtual void FillPhotonsUser( const xAOD::Photon*  )     { return; };
   virtual void FillJetsUser( const xAOD::Jet*, const std::string /*jetName = "jet"*/  )               { return; };
   virtual void FillTruthUser( const std::string& /*truthName*/, const xAOD::TruthParticle*  )               { return; };
-  virtual void FillFatJetsUser( const xAOD::Jet*  )            { return; };
+  virtual void FillFatJetsUser( const xAOD::Jet*, const std::string& /*fatjetName = "fatjet"*/  )            { return; };
   virtual void FillTruthFatJetsUser( const xAOD::Jet*  )            { return; };
   virtual void FillTausUser( const xAOD::TauJet*  )            { return; };
   virtual void FillMETUser( const xAOD::MissingETContainer*  ) { return; };

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -161,7 +161,8 @@ public:
     return;
   };
   virtual void AddFatJetsUser(const std::string detailStr = "", const std::string fatjetName = "", const std::string suffix = "")       {
-    if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+    if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase %s %s %s",detailStr.c_str(),
+            fatjetName.c_str(), suffix.c_str());
     return;
   };
   virtual void AddTruthFatJetsUser(const std::string detailStr = "")       {


### PR DESCRIPTION
Support for multiple fatjet collections was added in #644 but the relevant arguments were not propagated to `HelpTreeBase::AddFatJetsUser()`, preventing user-added extensions from knowing which jet collection they're supposed to be writing to. This PR fixes things in a functionally backwards-compatible way; however existing users implementing `AddFatJetsUser()` will have to update their function signatures to expect the additional arguments.