### PR TITLE
Fix/muon s fs year

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -276,7 +276,7 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 
-  if ( m_LHOperatingPoint != "VeryLoose"       &&
+  if ( // m_LHOperatingPoint != "VeryLoose"       &&
        m_LHOperatingPoint != "Loose"           &&
        m_LHOperatingPoint != "LooseAndBLayer"  &&
        m_LHOperatingPoint != "Medium"          &&
@@ -352,7 +352,8 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   // if not using LH PID, make sure all the decorations will be set ... by choosing the loosest WP!
   //
-  std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "VeryLoose";
+  //std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "VeryLoose";
+  std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "Loose"; 
   m_el_LH_PIDManager = new ElectronLHPIDManager( likelihoodWP, m_debug );
 
   // make sure the actual WP is (VeryLoose || Loose || Medium || Tight)

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -70,6 +70,8 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
 
   m_WorkingPointRecoTrig       = "Loose";
   m_WorkingPointIsoTrig        = "LooseTrackOnly";
+  m_Year                       = "";
+  m_MCCampaign                 = "";
   m_SingleMuTrig               = "HLT_mu20_iloose_L1MU15";
   m_DiMuTrig                   = "HLT_2mu14";
 
@@ -300,6 +302,13 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     m_muTrigSF_tool = new CP::MuonTriggerScaleFactors( m_trigEffSF_tool_name );
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_muTrigSF_tool->setProperty("Isolation", iso_trig_WP ),"Failed to set Isolation property of MuonTriggerScaleFactors");
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_muTrigSF_tool->setProperty("MuonQuality", m_WorkingPointRecoTrig ),"Failed to set MuonQuality property of MuonTriggerScaleFactors");
+    if ( !m_Year.empty() ) {
+      RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_muTrigSF_tool->setProperty("Year", m_Year ),"Failed to set Year property of MuonTriggerScaleFactors");
+    }
+    if ( !m_MCCampaign.empty() ) {
+    RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_muTrigSF_tool->setProperty("mc", m_MCCampaign ),"Failed to set MC Campaign property of MuonTriggerScaleFactors");
+    
+    }
     RETURN_CHECK("MuonEfficiencyCorrector::initialize()", m_muTrigSF_tool->initialize(), "Failed to properly initialize CP::MuonTriggerScaleFactors for trigger efficiency SF");
 
     //  Add the chosen WP to the string labelling the vector<SF>/vector<eff> decoration

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -49,6 +49,8 @@ public:
   bool          m_useRandomRunNumber;
   std::string   m_WorkingPointRecoTrig;
   std::string   m_WorkingPointIsoTrig;
+  std::string   m_Year;
+  std::string   m_MCCampaign;
   std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
   std::string   m_DiMuTrig;          // this can be either a dimuon trigger chain, or an OR of ( N single muon trigger chains, dimuon chain )
 

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -45,11 +45,12 @@ public:
   std::string   m_WorkingPointIso;
 
   // Trigger efficiency SF
-  int           m_runNumber;
+  int           m_runNumber2015;
+  int           m_runNumber2016;
   bool          m_useRandomRunNumber;
   std::string   m_WorkingPointRecoTrig;
   std::string   m_WorkingPointIsoTrig;
-  std::string   m_Year;
+  std::string   m_Years;
   std::string   m_MCCampaign;
   std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
   std::string   m_DiMuTrig;          // this can be either a dimuon trigger chain, or an OR of ( N single muon trigger chains, dimuon chain )
@@ -91,14 +92,15 @@ private:
   std::vector<CP::SystematicSet> m_systListTTVA; //!
 
   // tools
-  CP::MuonEfficiencyScaleFactors* m_muRecoSF_tool;  //!
-  std::string m_recoEffSF_tool_name;                //!
-  CP::MuonEfficiencyScaleFactors* m_muIsoSF_tool;   //!
-  std::string m_isoEffSF_tool_name;                 //!
-  CP::MuonTriggerScaleFactors*  m_muTrigSF_tool;    //!
-  std::string m_trigEffSF_tool_name;                //!
-  CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool;  //!
-  std::string m_TTVAEffSF_tool_name;                //!
+  CP::MuonEfficiencyScaleFactors* m_muRecoSF_tool;                         //!
+  std::string m_recoEffSF_tool_name;                                       //!
+  CP::MuonEfficiencyScaleFactors* m_muIsoSF_tool;                          //!
+  std::string m_isoEffSF_tool_name;                                        //!
+  std::map<std::string, CP::MuonTriggerScaleFactors*>  m_muTrigSF_tools;   //!   
+  std::map<std::string, std::string> m_trigEffSF_tool_names;               //!
+  std::vector<std::string> m_YearsList;                                    //!
+  CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool;                         //!
+  std::string m_TTVAEffSF_tool_name;                                       //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
The MuonTrigger SF tool in MuonEfficiencyCorrector has to be initialized separately for 2015 and 2016. The flag m_Years has been added to the algorithm, which is a string of comma separated years. For each year a tool is initialized. The default value of the string is "2016".

 This has been checked with the Muon Trigger conveners (Lidia dell'Asta)

My email to them:

> Hello Lidia and Savanna,
> I am running a same-sign di-muon analysis with 2015+2016 data and would like to access muon trigger corrections with 2.4.18. In the configuration of the tool (https://svnweb.cern.ch/trac/atlasoff/browser/PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections/tags/MuonEfficiencyCorrections-03-03-10/Root/MuonTriggerScaleFactors.cxx), I see that the property m_year is required, which is set by default to "2016". However, when I throw random instances of runNumbers in 2015+2016 I sometimes see this error message:
> 
> `MuonTriggerScaleFactor... ERROR   /build2/atnight/localbuilds/nightlies/AnalysisBase-2.4.X/AnalysisBase/rel_nightly/MuonEfficiencyCorrections/Root/MuonTriggerScaleFactors.cxx:518 (virtual CP::CorrectionCode CP::MuonTriggerScaleFactors::getMuonEfficiency(Double_t&, const TrigMuonEff::Configuration&, const Muon&, const string&, const string&)): Could not find what you are looking for in the efficiency map. The trigger you are looking for, year and mc are not consistent. Please check how you set up the tool.`
> 
> which disappears when I randomise using only 2016 runs or fixing to 300345. I guess the tool checks the consistency of runNumber and m_year, but if it is so why does one need to specify m_year? Am I supposed to initialise the tool with different m_year configurations depending on the runNumber I throw?
> I'm just puzzled as to why is this not set internally but maybe there is something I don't get...
 
Lidia's answer:

> Ciao Federico, 
> you need to have two tools actually: one for 2016 (default setting) and one for 2015 (that you have to initialize setting the m_year). Then, when you have your random RunNumber, you can check if it's from 2016 and you use the first tool, or from 2015 and you use the second tool.
> There are some reasons why this is not done internally by the tool. But ok... Sooner or later the tool will be improved!
> Please let me know if you still have problems.


In addition to this change the VeryLoose working point for electrons has been removed from the ElectronSelector as no longer present in the ntuples.