### PR TITLE
Fix default pt selection for JVT to 60 GeV

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -94,14 +94,15 @@ JetSelector :: JetSelector (std::string className) :
   m_truthLabel 	            = -1;
   m_useHadronConeExcl       = true;
 
-  m_doJVF 		    = false;
+  m_doJVF 		              = false;
   m_pt_max_JVF 	            = 50e3;
-  m_eta_max_JVF 	    = 2.4;
-  m_JVFCut 		    = 0.5;
-  m_doJVT 		    = false;
-  m_pt_max_JVT 	            = 50e3;
-  m_eta_max_JVT 	    = 2.4;
-  m_JVTCut 		    = -1.0;
+  m_eta_max_JVF 	          = 2.4;
+  m_JVFCut 		              = 0.5;
+  m_doJVT 		              = false;
+
+  m_pt_max_JVT 	            = 60e3;
+  m_eta_max_JVT 	          = 2.4;
+  m_JVTCut 		              = -1.0;
   m_WorkingPointJVT         = "Medium";
 
   m_systValJVT 	            = 0.0;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -94,15 +94,15 @@ JetSelector :: JetSelector (std::string className) :
   m_truthLabel 	            = -1;
   m_useHadronConeExcl       = true;
 
-  m_doJVF 		              = false;
-  m_pt_max_JVF 	            = 50e3;
-  m_eta_max_JVF 	          = 2.4;
-  m_JVFCut 		              = 0.5;
-  m_doJVT 		              = false;
+  m_doJVF                   = false;
+  m_pt_max_JVF              = 50e3;
+  m_eta_max_JVF             = 2.4;
+  m_JVFCut                  = 0.5;
+  m_doJVT                   = false;
 
-  m_pt_max_JVT 	            = 60e3;
-  m_eta_max_JVT 	          = 2.4;
-  m_JVTCut 		              = -1.0;
+  m_pt_max_JVT              = 60e3;
+  m_eta_max_JVT             = 2.4;
+  m_JVTCut                  = -1.0;
   m_WorkingPointJVT         = "Medium";
 
   m_systValJVT 	            = 0.0;
@@ -110,7 +110,7 @@ JetSelector :: JetSelector (std::string className) :
   m_outputSystNamesJVT      = "JetJvtEfficiency_JVTSyst";
 
   // Btag quality
-  m_doBTagCut 		    = false;
+  m_doBTagCut               = false;
   m_corrFileName            = "$ROOTCOREBIN/data/xAODBTaggingEfficiency/cutprofiles_22072015.root";
   m_taggerName              = "MV2c20";
   m_operatingPt             = "FixedCutBEff_70";


### PR DESCRIPTION
As detailed at https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration