### PR TITLE
Protect Warnings

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -698,7 +698,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 double pidEffSF(1.0); // tool wants a double
     	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_PID->getEfficiencyScaleFactor( *el_itr, pidEffSF ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+    	   Warning( "executeSF()", "Problem in PID getEfficiencyScaleFactor Tool");
   	   pidEffSF = 1.0;
     	 }
     	 //
@@ -813,7 +813,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 double IsoEffSF(1.0); // tool wants a double
     	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_Iso->getEfficiencyScaleFactor( *el_itr, IsoEffSF ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+    	   Warning( "executeSF()", "Problem in Iso getEfficiencyScaleFactor Tool");
   	   IsoEffSF = 1.0;
     	 }
     	 //
@@ -928,7 +928,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 double recoEffSF(1.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Reco->getEfficiencyScaleFactor( *el_itr, recoEffSF ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+    	   Warning( "executeSF()", "Problem in Reco getEfficiencyScaleFactor Tool");
   	   recoEffSF = 1.0;
     	 }
     	 //
@@ -1045,7 +1045,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 double trigEffSF(1.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Trig->getEfficiencyScaleFactor( *el_itr, trigEffSF ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+    	   Warning( "executeSF()", "Problem in Trig getEfficiencyScaleFactor Tool");
   	   isBadElectron = true;
   	   trigEffSF = 1.0;
     	 }
@@ -1159,7 +1159,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 double trigMCEff(0.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_TrigMCEff->getEfficiencyScaleFactor( *el_itr, trigMCEff ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in getEfficiencyScaleFactor");
+    	   Warning( "executeSF()", "Problem in TrigMCEff getEfficiencyScaleFactor Tool");
   	   isBadElectron = true;
   	   trigMCEff = 0.0;
     	 }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -852,8 +852,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
     } else {
       
-      Warning("executeSF()", "Random runNumber generated outside hardcoded run number ranges");
-      Warning("executeSF()", "Setting the year as randomly chosen in the years list");
+      if ( m_debug ) Warning("executeSF()", "Random runNumber generated outside hardcoded run number ranges");
+      if ( m_debug ) Warning("executeSF()", "Setting the year as randomly chosen in the years list");
       std::srand ( unsigned ( std::time(0) ) ); 
       std::vector<std::string> randomYearsList = m_YearsList;
       std::random_shuffle ( randomYearsList.begin(), randomYearsList.end() ); 

--- a/docs/ToolsUsed.rst
+++ b/docs/ToolsUsed.rst
@@ -23,8 +23,7 @@ Event Level
 -  `JetCalibrationTool <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/ApplyJetCalibration2014>`__
 -  `JERSmearingTool <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetResolution2015Prerecom>`__
 -  `JetSelectorTools <https://svnweb.cern.ch/trac/atlasoff/browser/PhysicsAnalysis/JetMissingEtID/JetSelectorTools/trunk/README.rst>`__
--  `JVT <https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/JetVertexTaggerTool>`__
--  `JVT (NEW: selection and SF) <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration>`__
+-  `JVT <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration>`__
 -  `BTaggingEfficiencyTool <http://atlas.web.cern.ch/Atlas/GROUPS/DATABASE/GroupData/xAODBTaggingEfficiency/13TeV/>`
 
 


### PR DESCRIPTION
Protect warnings from #676 

When the PRW tool returns a random run number of 0 the else statement produces a bunch of Warnings, though the behavior is expected.  
```
MuonEfficiencyCorrecto... WARNING Random runNumber generated outside hardcoded run number ranges
MuonEfficiencyCorrecto... WARNING Setting the year as randomly chosen in the years list
```