### PR TITLE
Etmiss syst implementation (for TST met and calo jets)

### DIFF
--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -217,13 +217,17 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
 
   Info("initialize()","Will be using EgammaCalibrationAndSmearingTool systematic:");
+  std::vector< std::string >* SystElectronsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
+    SystElectronsNames->push_back(syst_it.name());
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
+
+  RETURN_CHECK("ElectronCalibrator::initialize()",m_store->record(SystElectronsNames, "ele_Syst" ), "Failed to record vector of ele systs names.");
 
   // ***********************************************************
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -401,13 +401,18 @@ EL::StatusCode JetCalibrator :: initialize ()
     RETURN_CHECK("JetCalibrator::initialize()", m_JVTTool->initialize(), "");
   }
 
+  std::vector< std::string >* SystJetsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
+    SystJetsNames->push_back(syst_it.name());
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
+
+  RETURN_CHECK("JetCalibrator::initialize()",m_store->record(SystJetsNames, "jets_Syst" ), "Failed to record vector of jet systs names.");
+
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -183,13 +183,17 @@ EL::StatusCode MuonCalibrator :: initialize ()
   m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
 
   Info("initialize()","Will be using MuonCalibrationAndSmearingTool systematic:");
+  std::vector< std::string >* SystMuonsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
       Info("initialize()","\t Running w/ nominal configuration only!");
       break;
     }
+    SystMuonsNames->push_back(syst_it.name());
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
+
+  RETURN_CHECK("MuonCalibrator::initialize()",m_store->record(SystMuonsNames, "muons_Syst" ), "Failed to record vector of jet systs names.");
 
   Info("initialize()", "MuonCalibrator Interface succesfully initialized!" );
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -211,9 +211,13 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
 
   Info("initialize()","Will be using EgammaCalibrationAndSmearingTool systematic:");
+
+  std::vector< std::string >* SystPhotonsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
+    SystPhotonsNames->push_back(syst_it.name());
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
+    RETURN_CHECK("PhotonCalibrator::initialize()",m_store->record(SystPhotonsNames, "photons_Syst" ), "Failed to record vector of jet systs names.");
 
   //isEM selector tools
   //------------------

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -8,11 +8,16 @@
 #include "xAODRootAccess/TEvent.h"
 #include "xAODRootAccess/TStore.h"
 
+#include "PATInterfaces/SystematicRegistry.h"
+//look at https://twiki.cern.ch/twiki/bin/view/AtlasComputing/SoftwareTutorialxAODAnalysisInROOT
 
 
 using std::string;
 
-namespace met { class METMaker; }
+namespace met { 
+       class METMaker; 
+       class METSystematicsTool;
+	 }
 namespace TauAnalysisTools { class TauSelectionTool; }
 
 
@@ -36,6 +41,11 @@ public:
   TString m_inputTaus;
   TString m_inputMuons;
 
+  std::string  m_inputAlgoJets;  // name of vector<string> of syst retrieved from TStore
+  std::string  m_inputAlgoSystMuons;  // name of vector<string> of syst retrieved from TStore
+  std::string  m_inputAlgoSystEle;  // name of vector<string> of syst retrieved from TStore
+  std::string m_inputAlgoPhotons; // name of vector<string> of syst retrieved from TStore
+
   bool    m_doElectronCuts;
   bool    m_doPhotonCuts;
   bool    m_doTauCuts;
@@ -48,11 +58,25 @@ public:
   bool    m_useCaloJetTerm;
   bool    m_useTrackJetTerm;
 
+  bool m_runNominal;
+  
+  float m_systVal;
+  std::string m_systName;
+  
+  std::string m_SoftTermSystConfigFile;
+
 private:
 
   // tools
   met::METMaker* m_metmaker; //!
+  met::METSystematicsTool* metSystTool; //!   
+
   TauAnalysisTools::TauSelectionTool* m_tauSelTool; //!
+
+  TString coreMetKey;
+  std::vector<CP::SystematicSet> sysList; //!
+
+  int m_numEvent;         //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
Etmiss systematics are now implemented in METConstructor:
- TST soft term syst are implemented using METSystematicsTool
- systematics for electrons, photons, muons, jets (calo jets) are propagated to the met
- systematics for taus and for track jets are not yet propagated