### PR TITLE
Updated overlap removal tool

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -447,7 +447,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
       //
       // Add decorator for decision
       //
-      SG::AuxElement::Decorator< int > isBTag( m_decor );
+      SG::AuxElement::Decorator< char > isBTag( m_decor );
       if( m_BJetSelectTool->accept( *jet_itr ) ) {
         isBTag( *jet_itr ) = 1;
         tagged = true;

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -852,22 +852,22 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       
       uint32_t lumiBlock = eventInfo->lumiBlock();
       
-      bool passMV2c2040 = false; //(MV2c20 >  0.9540);
-      bool passMV2c2050 = false; //(MV2c20 >  0.7535);
-      bool passMV2c2060 = false; //(MV2c20 >  0.4496);
-      bool passMV2c2070 = false; //(MV2c20 > -0.0436);
-      bool passMV2c2077 = false; //(MV2c20 > -0.4434);
-      bool passMV2c2085 = false; //(MV2c20 > -0.7887);
+      bool passMV2c2040 = (MV2c20 >  0.9540);
+      bool passMV2c2050 = (MV2c20 >  0.7535);
+      bool passMV2c2060 = (MV2c20 >  0.4496);
+      bool passMV2c2070 = (MV2c20 > -0.0436);
+      bool passMV2c2077 = (MV2c20 > -0.4434);
+      bool passMV2c2085 = (MV2c20 > -0.7887);
 
 
-//      if(m_infoSwitch->m_flavTagHLT){
-//	      passMV2c2040 = (MV2c20 > 0.75);
-//	      passMV2c2050 = (MV2c20 > 0.50);
-//	      passMV2c2060 = (MV2c20 > -0.022472);
-//	      passMV2c2070 = (MV2c20 > -0.509032);
-//	      passMV2c2077 = (MV2c20 > -0.764668);
-//	      passMV2c2085 = (MV2c20 > -0.938441);
-//      }
+      if(m_infoSwitch->m_flavTagHLT){
+	      passMV2c2040 = (MV2c20 > 0.75);
+	      passMV2c2050 = (MV2c20 > 0.50);
+	      passMV2c2060 = (MV2c20 > -0.022472);
+	      passMV2c2070 = (MV2c20 > -0.509032);
+	      passMV2c2077 = (MV2c20 > -0.764668);
+	      passMV2c2085 = (MV2c20 > -0.938441);
+      }
 
       m_frac_MV2c2040_vs_lBlock  -> Fill(lumiBlock, passMV2c2040,  eventWeight);
       m_frac_MV2c2050_vs_lBlock  -> Fill(lumiBlock, passMV2c2050,  eventWeight);
@@ -1483,22 +1483,22 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       
 	uint32_t lumiBlock = eventInfo->m_lumiBlock;
       
-	bool passMV2c2040 = false; //(MV2c20 >  0.9540);
-	bool passMV2c2050 = false; //(MV2c20 >  0.7535);
-	bool passMV2c2060 = false; //(MV2c20 >  0.4496);
-	bool passMV2c2070 = false; //(MV2c20 > -0.0436);
-	bool passMV2c2077 = false; //(MV2c20 > -0.4434);
-	bool passMV2c2085 = false; //(MV2c20 > -0.7887);
+	bool passMV2c2040 = (MV2c20 >  0.9540);
+	bool passMV2c2050 = (MV2c20 >  0.7535);
+	bool passMV2c2060 = (MV2c20 >  0.4496);
+	bool passMV2c2070 = (MV2c20 > -0.0436);
+	bool passMV2c2077 = (MV2c20 > -0.4434);
+	bool passMV2c2085 = (MV2c20 > -0.7887);
 
 
-//	if(m_infoSwitch->m_flavTagHLT){
-//	  passMV2c2040 = (MV2c20 > 0.75);
-//	  passMV2c2050 = (MV2c20 > 0.50);
-//	  passMV2c2060 = (MV2c20 > -0.022472);
-//	  passMV2c2070 = (MV2c20 > -0.509032);
-//	  passMV2c2077 = (MV2c20 > -0.764668);
-//	  passMV2c2085 = (MV2c20 > -0.938441);
-//	}
+	if(m_infoSwitch->m_flavTagHLT){
+	  passMV2c2040 = (MV2c20 > 0.75);
+	  passMV2c2050 = (MV2c20 > 0.50);
+	  passMV2c2060 = (MV2c20 > -0.022472);
+	  passMV2c2070 = (MV2c20 > -0.509032);
+	  passMV2c2077 = (MV2c20 > -0.764668);
+	  passMV2c2085 = (MV2c20 > -0.938441);
+	}
 
 	m_frac_MV2c2040_vs_lBlock  -> Fill(lumiBlock, passMV2c2040,  eventWeight);
 	m_frac_MV2c2050_vs_lBlock  -> Fill(lumiBlock, passMV2c2050,  eventWeight);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -852,23 +852,22 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       
       uint32_t lumiBlock = eventInfo->lumiBlock();
       
-      bool passMV2c2040 = (MV2c20 >  0.9540);
-      bool passMV2c2050 = (MV2c20 >  0.7535);
-      bool passMV2c2060 = (MV2c20 >  0.4496);
-      bool passMV2c2070 = (MV2c20 > -0.0436);
-      bool passMV2c2077 = (MV2c20 > -0.4434);
-      bool passMV2c2085 = (MV2c20 > -0.7887);
+      bool passMV2c2040 = false; //(MV2c20 >  0.9540);
+      bool passMV2c2050 = false; //(MV2c20 >  0.7535);
+      bool passMV2c2060 = false; //(MV2c20 >  0.4496);
+      bool passMV2c2070 = false; //(MV2c20 > -0.0436);
+      bool passMV2c2077 = false; //(MV2c20 > -0.4434);
+      bool passMV2c2085 = false; //(MV2c20 > -0.7887);
 
 
-      if(m_infoSwitch->m_flavTagHLT){
-	passMV2c2040 = (MV2c20 > 0.75);
-	passMV2c2050 = (MV2c20 > 0.50);
-	passMV2c2060 = (MV2c20 > -0.022472);
-	passMV2c2070 = (MV2c20 > -0.509032);
-	passMV2c2077 = (MV2c20 > -0.764668);
-	passMV2c2085 = (MV2c20 > -0.938441);
-
-      }
+//      if(m_infoSwitch->m_flavTagHLT){
+//	      passMV2c2040 = (MV2c20 > 0.75);
+//	      passMV2c2050 = (MV2c20 > 0.50);
+//	      passMV2c2060 = (MV2c20 > -0.022472);
+//	      passMV2c2070 = (MV2c20 > -0.509032);
+//	      passMV2c2077 = (MV2c20 > -0.764668);
+//	      passMV2c2085 = (MV2c20 > -0.938441);
+//      }
 
       m_frac_MV2c2040_vs_lBlock  -> Fill(lumiBlock, passMV2c2040,  eventWeight);
       m_frac_MV2c2050_vs_lBlock  -> Fill(lumiBlock, passMV2c2050,  eventWeight);
@@ -1484,22 +1483,22 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       
 	uint32_t lumiBlock = eventInfo->m_lumiBlock;
       
-	bool passMV2c2040 = (MV2c20 >  0.9540);
-	bool passMV2c2050 = (MV2c20 >  0.7535);
-	bool passMV2c2060 = (MV2c20 >  0.4496);
-	bool passMV2c2070 = (MV2c20 > -0.0436);
-	bool passMV2c2077 = (MV2c20 > -0.4434);
-	bool passMV2c2085 = (MV2c20 > -0.7887);
+	bool passMV2c2040 = false; //(MV2c20 >  0.9540);
+	bool passMV2c2050 = false; //(MV2c20 >  0.7535);
+	bool passMV2c2060 = false; //(MV2c20 >  0.4496);
+	bool passMV2c2070 = false; //(MV2c20 > -0.0436);
+	bool passMV2c2077 = false; //(MV2c20 > -0.4434);
+	bool passMV2c2085 = false; //(MV2c20 > -0.7887);
 
 
-	if(m_infoSwitch->m_flavTagHLT){
-	  passMV2c2040 = (MV2c20 > 0.75);
-	  passMV2c2050 = (MV2c20 > 0.50);
-	  passMV2c2060 = (MV2c20 > -0.022472);
-	  passMV2c2070 = (MV2c20 > -0.509032);
-	  passMV2c2077 = (MV2c20 > -0.764668);
-	  passMV2c2085 = (MV2c20 > -0.938441);
-	}
+//	if(m_infoSwitch->m_flavTagHLT){
+//	  passMV2c2040 = (MV2c20 > 0.75);
+//	  passMV2c2050 = (MV2c20 > 0.50);
+//	  passMV2c2060 = (MV2c20 > -0.022472);
+//	  passMV2c2070 = (MV2c20 > -0.509032);
+//	  passMV2c2077 = (MV2c20 > -0.764668);
+//	  passMV2c2085 = (MV2c20 > -0.938441);
+//	}
 
 	m_frac_MV2c2040_vs_lBlock  -> Fill(lumiBlock, passMV2c2040,  eventWeight);
 	m_frac_MV2c2050_vs_lBlock  -> Fill(lumiBlock, passMV2c2050,  eventWeight);

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -668,37 +668,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the electron syst loop ...
-      //
-      if ( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
-      } else {
-        Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
-        return EL::StatusCode::FAILURE;
-      }
-      if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useMuons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_usePhotons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useTaus ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
 
       for ( auto systName : *sysVec) {
 
@@ -707,12 +683,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the electron input container will be different for each syst
         //
         std::string el_syst_cont_name = m_inContainerName_Electrons + systName;
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(el_syst_cont_name) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find syst container %s in xAOD::TStore. Aborting", el_syst_cont_name.c_str());
-          return EL::StatusCode::FAILURE;
-        }
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Electrons syst container "+el_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -775,37 +746,14 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the muon syst loop ...
-      //
-      if ( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
-      } else {
-        Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
-        return EL::StatusCode::FAILURE;
-      }
-      if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useElectrons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_usePhotons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useTaus ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
+
 
       for ( auto systName : *sysVec) {
 
@@ -814,12 +762,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the muon input container will be different for each syst
         //
         std::string mu_syst_cont_name = m_inContainerName_Muons + systName;
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(mu_syst_cont_name) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find syst container %s in xAOD::TStore. Aborting",mu_syst_cont_name.c_str());
-          return EL::StatusCode::FAILURE;
-        }
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Muons Systematic container "+mu_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -882,39 +825,14 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the jet syst loop ...
-      //
-      if ( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
-      if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-          return EL::StatusCode::FAILURE;
-        }
-      }
+      if ( m_useMuons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useElectrons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_usePhotons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useTaus ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -923,12 +841,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the jet input container will be different for each syst
         //
         std::string jet_syst_cont_name = m_inContainerName_Jets + systName;
-        if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(jet_syst_cont_name) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find syst container %s in xAOD::TStore. Aborting",jet_syst_cont_name.c_str());
-          return EL::StatusCode::FAILURE;
-        }
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name,, 0, m_store, m_verbose) , ("Could not find Jets container "+jet_syst_cont_name,+" in xAOD::TStore. Aborting") .c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -992,17 +905,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the photon syst loop ...
-      //
-      if ( m_useElectrons ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
-      }
-
-      if ( m_useMuons ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
-      }
-
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
-      if ( m_useTaus )     RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useElectrons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useMuons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useTaus ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -1011,12 +920,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the photon input container will be different for each syst
         //
         std::string photon_syst_cont_name = m_inContainerName_Photons + systName;
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(photon_syst_cont_name) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ photon systematics. Could not find syst container %s in xAOD::TStore. Aborting",photon_syst_cont_name.c_str());
-          return EL::StatusCode::FAILURE;
-        }
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Photons systematic container "+photon_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
 
         if ( m_debug ) {
           Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
@@ -1084,20 +988,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the tau syst loop ...
-      //
-      if ( m_useElectrons ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
-      }
-
-      if ( m_useMuons ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
-      }
-
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
-
-      if ( m_usePhotons ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-      }
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useElectrons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_useMuons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+      if ( m_usePhotons ) 
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -1106,12 +1003,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the tau input container will be different for each syst
         //
         std::string tau_syst_cont_name = m_inContainerName_Taus + systName;
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(tau_syst_cont_name) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, m_event, m_store, m_verbose) ,"");
-        } else {
-          Error("executeOR()", "Attempt at running w/ tau systematics. Could not find syst container %s in xAOD::TStore. Aborting", tau_syst_cont_name.c_str());
-          return EL::StatusCode::FAILURE;
-        }
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Taus container "+tau_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
 
         if ( m_debug ) {
           Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -668,13 +668,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the electron syst loop ...
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useMuons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_usePhotons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useTaus ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting").c_str() );
 
       for ( auto systName : *sysVec) {
 
@@ -683,7 +683,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the electron input container will be different for each syst
         //
         std::string el_syst_cont_name = m_inContainerName_Electrons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Electrons syst container "+el_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Electrons syst container "+el_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -746,13 +746,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the muon syst loop ...
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useElectrons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_usePhotons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useTaus ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting").c_str() );
 
 
       for ( auto systName : *sysVec) {
@@ -762,7 +762,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the muon input container will be different for each syst
         //
         std::string mu_syst_cont_name = m_inContainerName_Muons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Muons Systematic container "+mu_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Muons Systematic container "+mu_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -826,13 +826,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the jet syst loop ...
       if ( m_useMuons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useElectrons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_usePhotons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useTaus ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting").c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -841,7 +841,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the jet input container will be different for each syst
         //
         std::string jet_syst_cont_name = m_inContainerName_Jets + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name,, 0, m_store, m_verbose) , ("Could not find Jets container "+jet_syst_cont_name,+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Jets container "+jet_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
@@ -905,13 +905,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the photon syst loop ...
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useElectrons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useMuons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useTaus ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, 0, m_store, m_verbose) , ("Could not find Taus container "+m_inContainerName_Taus+" in xAOD::TStore. Aborting").c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -920,7 +920,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the photon input container will be different for each syst
         //
         std::string photon_syst_cont_name = m_inContainerName_Photons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Photons systematic container "+photon_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Photons systematic container "+photon_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         if ( m_debug ) {
           Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
@@ -988,13 +988,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       // these input containers won't change in the tau syst loop ...
-      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting") .c_str() );
+      RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, 0, m_store, m_verbose) , ("Could not find Jets container "+m_inContainerName_Jets+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useElectrons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, 0, m_store, m_verbose) , ("Could not find Electrons container "+m_inContainerName_Electrons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_useMuons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, 0, m_store, m_verbose) , ("Could not find Muons container "+m_inContainerName_Muons+" in xAOD::TStore. Aborting").c_str() );
       if ( m_usePhotons ) 
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, 0, m_store, m_verbose) , ("Could not find Photons container "+m_inContainerName_Photons+" in xAOD::TStore. Aborting").c_str() );
 
       for( auto systName : *sysVec ) {
 
@@ -1003,7 +1003,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the tau input container will be different for each syst
         //
         std::string tau_syst_cont_name = m_inContainerName_Taus + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Taus container "+tau_syst_cont_name+" in xAOD::TStore. Aborting") .c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Taus container "+tau_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         if ( m_debug ) {
           Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -4,6 +4,7 @@
  ( applying recommendations from Harmonisation TF ).
  *
  * M. Milesi (marco.milesi@cern.ch)
+ * J. Dandoy
  *
  ************************************************/
 
@@ -51,7 +52,6 @@ OverlapRemover :: OverlapRemover (std::string className) :
     m_useTaus(false),
     m_dummyElectronContainer(nullptr),
     m_dummyMuonContainer(nullptr),
-    m_overlapRemovalTool(nullptr),
     m_el_cutflowHist_1(nullptr),
     m_mu_cutflowHist_1(nullptr),
     m_jet_cutflowHist_1(nullptr),
@@ -72,7 +72,6 @@ OverlapRemover :: OverlapRemover (std::string className) :
   m_useCutFlow    = true;
 
   // input container(s) to be read from TEvent or TStore
-
   m_outputAlgo                  = "OR_Algo";                   // name of vector<string> of combined syst pushed in TStore. 
 
   /* Muons */
@@ -103,15 +102,16 @@ OverlapRemover :: OverlapRemover (std::string className) :
   m_createSelectedContainers    = false;
 
   m_useSelected = false;
+  m_bTagWP      = "";  // Decoration name like "BTag", potentially from BJetEfficiencyCorrector
+  m_linkOverlapObjects = true;
+  m_useBoostedLeptons  = false;
+  m_doEleEleOR = false;
+
 
   m_outContainerName_Electrons  = "";
-
   m_outContainerName_Muons      = "";
-
   m_outContainerName_Jets       = "";
-
   m_outContainerName_Photons    = "";
-
   m_outContainerName_Taus       = "";
 
 }
@@ -222,17 +222,26 @@ EL::StatusCode OverlapRemover :: initialize ()
   }
 
   // initialize ASG overlap removal tool
-  //
-  m_overlapRemovalTool = new OverlapRemovalTool( "OverlapRemovalTool" );
-  m_overlapRemovalTool->msg().setLevel( MSG::INFO ); // VERBOSE, INFO, DEBUG
-
-  // set input object "selection" decoration
-  //
   const std::string selected_label = ( m_useSelected ) ? "passSel" : "";  // set with decoration flag you use for selected objects if want to consider only selected objects in OR, otherwise it will perform OR on all objects
-  RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->setProperty("InputLabel",  selected_label), "");
-  RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->setProperty("LinkOverlapObjects", true), "Failed to set property LinkOverlapObjects"); // tool will link to overlap objects
-  RETURN_CHECK( "OverlapRemover::initialize()", m_overlapRemovalTool->initialize(), "Failed to properly initialize the OverlapRemovalTool.");
 
+  //Set Flags for recommended overlap procedures
+  ORUtils::ORFlags orFlags("OverlapRemovalTool", selected_label, "passOR");
+
+  orFlags.outputPassValue     = true; 
+  orFlags.linkOverlapObjects  = m_linkOverlapObjects; 
+  orFlags.bJetLabel           = m_bTagWP; 
+  orFlags.boostedLeptons      = m_useBoostedLeptons; 
+  orFlags.doEleEleOR          = m_doEleEleOR; 
+
+  orFlags.doJets      = true;
+  orFlags.doMuons     = m_useMuons;
+  orFlags.doElectrons = m_useElectrons;
+  orFlags.doTaus      = m_useTaus;
+  orFlags.doPhotons   = m_usePhotons;
+  orFlags.doFatJets   = false;
+
+  RETURN_CHECK( "OverlapRemover::initialize()", ORUtils::recommendedTools(orFlags, m_ORToolbox), "Failed to get recommended tools in Overlap Removal Tool." );
+  RETURN_CHECK( "OverlapRemover::initialize()", m_ORToolbox.initialize(), "Failed to initialize Overlap Removal Tool." );
   Info("initialize()", "OverlapRemover Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
@@ -406,7 +415,6 @@ EL::StatusCode OverlapRemover :: finalize ()
 
   Info("finalize()", "Deleting tool instances...");
 
-  if ( m_overlapRemovalTool    ){ delete m_overlapRemovalTool;     m_overlapRemovalTool     = nullptr; }
   if ( m_dummyElectronContainer){ delete m_dummyElectronContainer; m_dummyElectronContainer = nullptr; }
   if ( m_dummyMuonContainer    ){ delete m_dummyMuonContainer;     m_dummyMuonContainer     = nullptr; }
 
@@ -483,16 +491,21 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const xAOD::IParticleContain
     }
 
     if ( m_debug ) {
+      SG::AuxElement::Decorator< char > isBTag( m_bTagWP );
+      int isBTagged = 0;
+      if( isBTag.isAvailable( *obj_itr ) && isBTag(*obj_itr)==true )
+        isBTagged = 1;
+
       if ( selectAcc.isAvailable( *obj_itr) ){
-        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f selected %i overlaps %i ", type.c_str(), (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), selectAcc( *obj_itr ), overlapAcc( *obj_itr ) );
+        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f btagged %i selected %i passesOR %i ", type.c_str(), (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), isBTagged, selectAcc( *obj_itr ), overlapAcc( *obj_itr ) );
       } else {
-        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f overlaps %i ", type.c_str(), (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), overlapAcc( *obj_itr) );
+        Info("fillObjectCutflow()", "  %s pt %6.2f eta %5.2f phi %5.2f btagged %i passesOR %i ", type.c_str(), (obj_itr)->pt()/1000., (obj_itr)->eta(), (obj_itr)->phi(), isBTagged, overlapAcc( *obj_itr) );
       }
       // Check for overlap object link
       if ( objLinkAcc.isAvailable( *obj_itr ) && objLinkAcc( *obj_itr ).isValid() ) {
         const xAOD::IParticle* overlapObj = *objLinkAcc( *obj_itr );
         std::stringstream ss_or; ss_or << overlapObj->type();
-        Info("fillObjectCutflow()", "	Overlap: type %s pt %6.2f", (ss_or.str()).c_str(), overlapObj->pt()/1e3);
+        Info("fillObjectCutflow()", " Overlap: type %s pt %6.2f", (ss_or.str()).c_str(), overlapObj->pt()/1e3);
       }
     }
 
@@ -504,17 +517,17 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const xAOD::IParticleContain
 
 
 EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inElectrons, const xAOD::MuonContainer* inMuons, const xAOD::JetContainer* inJets,
-					     const xAOD::PhotonContainer* inPhotons,   const xAOD::TauJetContainer* inTaus,
-					     SystType syst_type, std::vector<std::string>* sysVec)
+               const xAOD::PhotonContainer* inPhotons,   const xAOD::TauJetContainer* inTaus,
+               SystType syst_type, std::vector<std::string>* sysVec)
 {
 
   // instantiate output container(s)
   //
   ConstDataVector<xAOD::ElectronContainer> *selectedElectrons   (nullptr);
-  ConstDataVector<xAOD::MuonContainer>     *selectedMuons	(nullptr);
-  ConstDataVector<xAOD::JetContainer>      *selectedJets	(nullptr);
-  ConstDataVector<xAOD::PhotonContainer>   *selectedPhotons	(nullptr);
-  ConstDataVector<xAOD::TauJetContainer>   *selectedTaus	(nullptr);
+  ConstDataVector<xAOD::MuonContainer>     *selectedMuons (nullptr);
+  ConstDataVector<xAOD::JetContainer>      *selectedJets  (nullptr);
+  ConstDataVector<xAOD::PhotonContainer>   *selectedPhotons (nullptr);
+  ConstDataVector<xAOD::TauJetContainer>   *selectedTaus  (nullptr);
 
   // Set input containers to dummys if not using particles
   //
@@ -532,64 +545,64 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       bool nomContainerNotFound(false);
 
       if( m_useElectrons ) {
-	if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-	  RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
-	} else {
-	  nomContainerNotFound = true;
-	  if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Electrons.c_str());  }
-	}
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+        } else {
+          nomContainerNotFound = true;
+          if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Electrons.c_str());  }
+        }
       }
 
       if( m_useMuons ) {
-	if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-	  RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
-	} else {
-	  nomContainerNotFound = true;
-	  if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Muons.c_str()); }
-	}
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+        } else {
+          nomContainerNotFound = true;
+          if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Muons.c_str()); }
+        }
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Jets.c_str()); }
       }
 
       if ( m_usePhotons ) {
-         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-         } else {
-           nomContainerNotFound = true;
-           if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Photons.c_str()); }
-         }
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+        } else {
+          nomContainerNotFound = true;
+          if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Photons.c_str()); }
+        }
       }
 
       if ( m_useTaus ) {
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-         } else {
-           nomContainerNotFound = true;
-	   if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Taus.c_str()); }
-	 }
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+        } else {
+          nomContainerNotFound = true;
+          if ( m_numEvent == 1 ) { Warning("executeOR()", "Could not find nominal container %s in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...", m_inContainerName_Taus.c_str()); }
+        }
       }
 
       if ( nomContainerNotFound ) {return EL::StatusCode::SUCCESS;}
 
       if ( m_debug ) {
-	if ( m_useElectrons ) { Info("execute()",  "inElectrons : %lu", inElectrons->size()); }
-	if ( m_useMuons )     { Info("execute()",  "inMuons : %lu", inMuons->size()); }
-	Info("execute()",  "inJets : %lu", inJets->size() );
-	if ( m_usePhotons )   { Info("execute()",  "inPhotons : %lu", inPhotons->size());  }
-	if ( m_useTaus    )   { Info("execute()",  "inTaus : %lu",    inTaus->size());  }
+        if ( m_useElectrons ) { Info("execute()",  "inElectrons : %lu", inElectrons->size()); }
+        if ( m_useMuons )     { Info("execute()",  "inMuons : %lu", inMuons->size()); }
+        Info("execute()",  "inJets : %lu", inJets->size() );
+        if ( m_usePhotons )   { Info("execute()",  "inPhotons : %lu", inPhotons->size());  }
+        if ( m_useTaus    )   { Info("execute()",  "inTaus : %lu",    inTaus->size());  }
       }
 
       // do the actual OR
       //
       if ( m_debug ) { Info("execute()",  "Calling removeOverlaps()"); }
-      RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
+      RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
-      std::string ORdecor("overlaps");
+      std::string ORdecor("passOR");
       if(m_useCutFlow){
         // fill cutflow histograms
         //
@@ -604,40 +617,40 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // make a copy of input container(s) with selected objects
       //
       if ( m_createSelectedContainers ) {
-	if ( m_debug ) { Info("execute()",  "Creating selected Containers"); }
+        if ( m_debug ) { Info("execute()",  "Creating selected Containers"); }
         if( m_useElectrons ) selectedElectrons  = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
         if( m_useMuons )     selectedMuons      = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-        selectedJets	    = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-        if ( m_usePhotons )  selectedPhotons	= new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-        if ( m_useTaus )     selectedTaus	= new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+        selectedJets      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+        if ( m_usePhotons )  selectedPhotons  = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+        if ( m_useTaus )     selectedTaus = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
       }
 
       // resize containers basd on OR decision:
       //
-      // if an object has been flagged as 'overlaps', it won't be stored in the 'selected' container
+      // if an object has been flagged as 'passOR', it will be stored in the 'selected' container
       //
       if ( m_debug ) { Info("execute()",  "Resizing"); }
-      if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-      if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-      RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-      if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-      if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
+      if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+      if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
       if ( m_debug ) {
-	if ( m_useElectrons) { Info("execute()",  "selectedElectrons : %lu", selectedElectrons->size()); }
-	if ( m_useMuons )    { Info("execute()",  "selectedMuons : %lu",     selectedMuons->size()); }
-	Info("execute()",  "selectedJets : %lu", selectedJets->size());
-	if ( m_usePhotons )  { Info("execute()",  "selectedPhotons : %lu", selectedPhotons->size()); }
+        if ( m_useElectrons) { Info("execute()",  "selectedElectrons : %lu", selectedElectrons->size()); }
+        if ( m_useMuons )    { Info("execute()",  "selectedMuons : %lu",     selectedMuons->size()); }
+        Info("execute()",  "selectedJets : %lu", selectedJets->size());
+        if ( m_usePhotons )  { Info("execute()",  "selectedPhotons : %lu", selectedPhotons->size()); }
         if ( m_useTaus )     { Info("execute()",  "selectedTaus : %lu", selectedTaus->size() ); }
       }
 
       // add ConstDataVector to TStore
       //
       if ( m_createSelectedContainers ) {
-	if ( m_debug ) { Info("execute()",  "Recording"); }
+        if ( m_debug ) { Info("execute()",  "Recording"); }
         if ( m_useElectrons ){ RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons,   m_outContainerName_Electrons ), "Failed to store const data container"); }
-        if ( m_useMuons )    { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,	 m_outContainerName_Muons ), "Failed to store const data container"); }
-        RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,	 m_outContainerName_Jets ), "Failed to store const data container");
+        if ( m_useMuons )    { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,  m_outContainerName_Muons ), "Failed to store const data container"); }
+        RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,  m_outContainerName_Jets ), "Failed to store const data container");
         if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedPhotons, m_outContainerName_Photons ), "Failed to store const data container"); }
         if ( m_useTaus )     { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus ), "Failed to store const data container"); }
       }
@@ -645,13 +658,13 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       m_vecOutContainerNames->push_back("");
       break;
     }
- case ELSYST : // electron syst
+    case ELSYST : // electron syst
     {
       if ( m_debug ) { Info("execute()",  "Doing electron systematics"); }
       // just to check everything is fine
       if ( m_debug ) {
            Info("execute()","will consider the following ELECTRON systematics:" );
-           for ( auto it : *sysVec ) {	Info("execute()" ,"\t %s ", it.c_str()); }
+           for ( auto it : *sysVec ) {  Info("execute()" ,"\t %s ", it.c_str()); }
       }
 
       // these input containers won't change in the electron syst loop ...
@@ -661,53 +674,53 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
         } else {
           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
-      	  return EL::StatusCode::FAILURE;
+          return EL::StatusCode::FAILURE;
         }
       }
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
         RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
       } else {
         Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
-	return EL::StatusCode::FAILURE;
+        return EL::StatusCode::FAILURE;
       }
       if ( m_usePhotons ) {
-         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-	   return EL::StatusCode::FAILURE;
-         }
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
       if ( m_useTaus ) {
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-	   return EL::StatusCode::FAILURE;
-	 }
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
 
       for ( auto systName : *sysVec) {
 
-	if ( systName.empty() ) continue;
+        if ( systName.empty() ) continue;
 
         // ... instead, the electron input container will be different for each syst
-	//
-	std::string el_syst_cont_name = m_inContainerName_Electrons + systName;
+        //
+        std::string el_syst_cont_name = m_inContainerName_Electrons + systName;
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(el_syst_cont_name) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, m_event, m_store, m_verbose) ,"");
         } else {
-           Error("executeOR()", "Attempt at running w/ electron systematics. Could not find syst container %s in xAOD::TStore. Aborting", el_syst_cont_name.c_str());
-	   return EL::StatusCode::FAILURE;
-	}
+          Error("executeOR()", "Attempt at running w/ electron systematics. Could not find syst container %s in xAOD::TStore. Aborting", el_syst_cont_name.c_str());
+          return EL::StatusCode::FAILURE;
+        }
 
-	if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  }
+        if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
         // do the actual OR
-	//
-        RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
-        std::string ORdecor("overlaps");
+        std::string ORdecor("passOR");
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -716,28 +729,28 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           fillObjectCutflow(inJets);
           if ( m_usePhotons ) fillObjectCutflow(inPhotons);
           if ( m_useTaus )    fillObjectCutflow(inTaus);
-	}
+        }
 
         // make a copy of input container(s) with selected objects
-	//
+        //
         if ( m_createSelectedContainers ) {
           selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-          if ( m_useMuons )    selectedMuons	= new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-          selectedJets	      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-          if ( m_usePhotons )  selectedPhotons	= new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-          if ( m_useTaus )     selectedTaus	= new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useMuons )    selectedMuons  = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
+          selectedJets        = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+          if ( m_usePhotons )  selectedPhotons  = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useTaus )     selectedTaus = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
         }
 
         // resize containers basd on OR decision
-	//
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-        if ( m_useMuons )  {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-        if ( m_usePhotons ){ RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        if ( m_useTaus )   {	RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_useMuons )  {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons ){ RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )   {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
-	//
+        //
         if ( m_createSelectedContainers ) {
           // a different syst varied container will be stored for each syst variation
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container");
@@ -747,18 +760,18 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           if ( m_useTaus )   { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); }
         }
 
-	m_vecOutContainerNames->push_back(systName);
+        m_vecOutContainerNames->push_back(systName);
       } // close loop on systematic sets available from upstream algo (Electrons)
 
       break;
     }
- case MUSYST: // muon syst
+    case MUSYST: // muon syst
     {
       if ( m_debug ) { Info("execute()",  "Doing  muon systematics"); }
       // just to check everything is fine
       if ( m_debug ) {
          Info("execute()","will consider the following MUON systematics:" );
-         for ( auto it : *sysVec ){	Info("execute()" ,"\t %s ", it.c_str()); }
+         for ( auto it : *sysVec ){ Info("execute()" ,"\t %s ", it.c_str()); }
       }
 
       // these input containers won't change in the muon syst loop ...
@@ -768,53 +781,53 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
         } else {
           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
-      	  return EL::StatusCode::FAILURE;
+          return EL::StatusCode::FAILURE;
         }
       }
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
         RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
       } else {
         Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Jets.c_str());
-	return EL::StatusCode::FAILURE;
+        return EL::StatusCode::FAILURE;
       }
       if ( m_usePhotons ) {
-         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-	   return EL::StatusCode::FAILURE;
-         }
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
       if ( m_useTaus ) {
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-	   return EL::StatusCode::FAILURE;
-	 }
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
 
       for ( auto systName : *sysVec) {
 
-	if ( systName.empty() ) continue;
+        if ( systName.empty() ) continue;
 
-	// ... instead, the muon input container will be different for each syst
-	//
-	std::string mu_syst_cont_name = m_inContainerName_Muons + systName;
+        // ... instead, the muon input container will be different for each syst
+        //
+        std::string mu_syst_cont_name = m_inContainerName_Muons + systName;
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(mu_syst_cont_name) ) {
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, m_event, m_store, m_verbose) ,"");
         } else {
-           Error("executeOR()", "Attempt at running w/ muon systematics. Could not find syst container %s in xAOD::TStore. Aborting",mu_syst_cont_name.c_str());
-	   return EL::StatusCode::FAILURE;
-	}
+          Error("executeOR()", "Attempt at running w/ muon systematics. Could not find syst container %s in xAOD::TStore. Aborting",mu_syst_cont_name.c_str());
+          return EL::StatusCode::FAILURE;
+        }
 
-         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
+        if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
         // do the actual OR
-	//
-        RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
-        std::string ORdecor("overlaps");
+        std::string ORdecor("passOR");
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -825,28 +838,28 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           if( m_useTaus )       fillObjectCutflow(inTaus);
         }
         // make a copy of input container(s) with selected objects
-	//
+        //
         if ( m_createSelectedContainers ) {
           if ( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-          selectedMuons	      = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-          selectedJets	      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-          if ( m_usePhotons )   selectedPhotons	= new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-          if ( m_useTaus )      selectedTaus	= new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+          selectedMuons       = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
+          selectedJets        = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+          if ( m_usePhotons )   selectedPhotons = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useTaus )      selectedTaus  = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
         }
 
         // resize containers based on OR decision
-	//
-        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        if ( m_useTaus )      {	RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
+        //
+        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), "");
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
-	//
+        //
         if ( m_createSelectedContainers ) {
           // a different syst varied container will be stored for each syst variation
-	  //
+          //
           if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container"); }
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container");
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
@@ -854,12 +867,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); }
         }
 
-	m_vecOutContainerNames->push_back(systName);
+        m_vecOutContainerNames->push_back(systName);
       } // close loop on systematic sets available from upstream algo (Muons)
 
       break;
     }
- case JETSYST: // jet systematics
+    case JETSYST: // jet systematics
     {
       if ( m_debug ) { Info("execute()",  "Doing  jet systematics"); }
       // just to check everything is fine
@@ -875,7 +888,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
         } else {
           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Electrons.c_str());
-      	  return EL::StatusCode::FAILURE;
+          return EL::StatusCode::FAILURE;
         }
       }
       if ( m_useMuons ) {
@@ -883,93 +896,93 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
         } else {
           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Muons.c_str());
-      	  return EL::StatusCode::FAILURE;
+          return EL::StatusCode::FAILURE;
         }
       }
       if ( m_usePhotons ) {
-         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
-	   return EL::StatusCode::FAILURE;
-         }
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Photons.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
       if ( m_useTaus ) {
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-	   RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
-         } else {
-           Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
-	   return EL::StatusCode::FAILURE;
-	 }
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find nominal container %s in xAOD::TStore. Aborting", m_inContainerName_Taus.c_str());
+          return EL::StatusCode::FAILURE;
+        }
       }
 
       for( auto systName : *sysVec ) {
 
-	 if ( systName.empty() ) continue;
+        if ( systName.empty() ) continue;
 
-	 // ... instead, the jet input container will be different for each syst
-	 //
-	 std::string jet_syst_cont_name = m_inContainerName_Jets + systName;
-         if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(jet_syst_cont_name) ) {
-           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, m_event, m_store, m_verbose) ,"");
-         } else {
-            Error("executeOR()", "Attempt at running w/ jet systematics. Could not find syst container %s in xAOD::TStore. Aborting",jet_syst_cont_name.c_str());
-	    return EL::StatusCode::FAILURE;
-	 }
-
-         if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
-
-         // do the actual OR
-	 //
-         RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
-
-         std::string ORdecor("overlaps");
-         if(m_useCutFlow){
-           // fill cutflow histograms
-           //
-           if ( m_useElectrons ) fillObjectCutflow(inElectrons);
-           if ( m_useMuons )     fillObjectCutflow(inMuons);
-           fillObjectCutflow(inJets);
-           if( m_usePhotons )    fillObjectCutflow(inPhotons);
-           if( m_useTaus )       fillObjectCutflow(inTaus);
+        // ... instead, the jet input container will be different for each syst
+        //
+        std::string jet_syst_cont_name = m_inContainerName_Jets + systName;
+        if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(jet_syst_cont_name) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ jet systematics. Could not find syst container %s in xAOD::TStore. Aborting",jet_syst_cont_name.c_str());
+          return EL::StatusCode::FAILURE;
         }
 
-	 // make a copy of input container(s) with selected objects
-	 //
-	 if ( m_createSelectedContainers ) {
-	   if ( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-	   if ( m_useMuons )     selectedMuons	    = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-	   selectedJets	      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-	   if ( m_usePhotons )   selectedPhotons	= new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-	   if ( m_useTaus )      selectedTaus	= new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
-	 }
+        if ( m_debug ) { Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu ", inElectrons->size(), inMuons->size(),  inJets->size() );  }
 
-	 // resize containers basd on OR decision
-	 //
-	 if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-	 if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-	 RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-	 if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-	 if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
+        // do the actual OR
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
-	 // add ConstDataVector to TStore
-	 //
-	 if ( m_createSelectedContainers ) {
-	   // a different syst varied container will be stored for each syst variation
-	   //
-	   if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container"); }
-	   if ( m_useMuons )	 { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container"); }
-	   RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
-	   if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedPhotons, m_outContainerName_Photons + systName ), "Failed to store const data container"); }
-	   if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); }
-	 }
+        std::string ORdecor("passOR");
+        if(m_useCutFlow){
+          // fill cutflow histograms
+          //
+          if ( m_useElectrons ) fillObjectCutflow(inElectrons);
+          if ( m_useMuons )     fillObjectCutflow(inMuons);
+          fillObjectCutflow(inJets);
+          if( m_usePhotons )    fillObjectCutflow(inPhotons);
+          if( m_useTaus )       fillObjectCutflow(inTaus);
+        }
 
-	m_vecOutContainerNames->push_back(systName);
+        // make a copy of input container(s) with selected objects
+        //
+        if ( m_createSelectedContainers ) {
+          if ( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useMuons )     selectedMuons      = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
+          selectedJets       = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+          if ( m_usePhotons )   selectedPhotons  = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useTaus )      selectedTaus = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+        }
+
+        // resize containers basd on OR decision
+        //
+        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+
+        // add ConstDataVector to TStore
+        //
+        if ( m_createSelectedContainers ) {
+          // a different syst varied container will be stored for each syst variation
+          //
+          if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container"); }
+          if ( m_useMuons )   { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container"); }
+          RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
+          if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedPhotons, m_outContainerName_Photons + systName ), "Failed to store const data container"); }
+          if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); }
+        }
+
+        m_vecOutContainerNames->push_back(systName);
       } // close loop on systematic sets available from upstream algo (Jets)
 
       break;
     }
- case PHSYST : // photon systematics
+    case PHSYST : // photon systematics
     {
       if ( m_debug ) { Info("execute()",  "Doing  photon systematics"); }
       // just to check everything is fine
@@ -981,11 +994,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the photon syst loop ...
       //
       if ( m_useElectrons ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
       }
 
       if ( m_useMuons ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
       }
 
       RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
@@ -993,61 +1006,61 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       for( auto systName : *sysVec ) {
 
-	 if ( systName.empty() ) continue;
+        if ( systName.empty() ) continue;
 
-	 // ... instead, the photon input container will be different for each syst
-	 //
-	 std::string photon_syst_cont_name = m_inContainerName_Photons + systName;
-         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(photon_syst_cont_name) ) {
-           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, m_event, m_store, m_verbose) ,"");
-         } else {
-            Error("executeOR()", "Attempt at running w/ photon systematics. Could not find syst container %s in xAOD::TStore. Aborting",photon_syst_cont_name.c_str());
-	    return EL::StatusCode::FAILURE;
-	 }
+        // ... instead, the photon input container will be different for each syst
+        //
+        std::string photon_syst_cont_name = m_inContainerName_Photons + systName;
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(photon_syst_cont_name) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ photon systematics. Could not find syst container %s in xAOD::TStore. Aborting",photon_syst_cont_name.c_str());
+          return EL::StatusCode::FAILURE;
+        }
 
-         if ( m_debug ) {
-	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
-	 }
+        if ( m_debug ) {
+          Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
+        }
 
-         // do the actual OR
-	 //
-         RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
+        // do the actual OR
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
 
-         std::string ORdecor = std::string("overlaps");
-         if(m_useCutFlow){
-           // fill cutflow histograms
-           //
-           if( m_useElectrons ) fillObjectCutflow(inElectrons);
-           if( m_useMuons     ) fillObjectCutflow(inMuons);
-           fillObjectCutflow(inJets);
-           fillObjectCutflow(inPhotons);
-           if( m_useTaus )      fillObjectCutflow(inTaus);
+        std::string ORdecor = std::string("passOR");
+        if(m_useCutFlow){
+          // fill cutflow histograms
+          //
+          if( m_useElectrons ) fillObjectCutflow(inElectrons);
+          if( m_useMuons     ) fillObjectCutflow(inMuons);
+          fillObjectCutflow(inJets);
+          fillObjectCutflow(inPhotons);
+          if( m_useTaus )      fillObjectCutflow(inTaus);
         }
 
         // make a copy of input container(s) with selected objects
-	//
+        //
         if ( m_createSelectedContainers ) {
           if( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
           if( m_useMuons     ) selectedMuons       = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-          selectedJets	      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-	  selectedPhotons     = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-          if ( m_useTaus )     selectedTaus	   = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+          selectedJets        = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+          selectedPhotons     = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+          if ( m_useTaus )     selectedTaus    = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
         }
 
         // resize containers based on OR decision
-	//
-        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-	RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-        if ( m_useTaus )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
+        //
+        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_useTaus )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
-	//
+        //
         if ( m_createSelectedContainers ) {
           // a different syst varied container will be stored for each syst variation
-	  //
+          //
           if( m_useElectrons ){ RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container"); }
           if( m_useMuons )    { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container"); }
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
@@ -1055,12 +1068,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           if ( m_useTaus )    { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container"); }
         }
 
-	m_vecOutContainerNames->push_back(systName);
+        m_vecOutContainerNames->push_back(systName);
       } // close loop on systematic sets available from upstream algo (Photons)
 
       break;
     }
-  case TAUSYST : // tau systematics
+    case TAUSYST : // tau systematics
     {
       if ( m_debug ) { Info("execute()",  "Doing tau systematics"); }
 
@@ -1073,75 +1086,75 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the tau syst loop ...
       //
       if ( m_useElectrons ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
       }
 
       if ( m_useMuons ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
       }
 
       RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
 
       if ( m_usePhotons ) {
-	RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
       }
 
       for( auto systName : *sysVec ) {
 
-	 if ( systName.empty() ) continue;
+        if ( systName.empty() ) continue;
+      
+        // ... instead, the tau input container will be different for each syst
+        //
+        std::string tau_syst_cont_name = m_inContainerName_Taus + systName;
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(tau_syst_cont_name) ) {
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, m_event, m_store, m_verbose) ,"");
+        } else {
+          Error("executeOR()", "Attempt at running w/ tau systematics. Could not find syst container %s in xAOD::TStore. Aborting", tau_syst_cont_name.c_str());
+          return EL::StatusCode::FAILURE;
+        }
 
-	 // ... instead, the tau input container will be different for each syst
-	 //
-	 std::string tau_syst_cont_name = m_inContainerName_Taus + systName;
-         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(tau_syst_cont_name) ) {
-           RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, m_event, m_store, m_verbose) ,"");
-         } else {
-            Error("executeOR()", "Attempt at running w/ tau systematics. Could not find syst container %s in xAOD::TStore. Aborting", tau_syst_cont_name.c_str());
-	    return EL::StatusCode::FAILURE;
-	 }
+        if ( m_debug ) {
+          Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
+        }
 
-         if ( m_debug ) {
-	   Info("execute()",  "inElectrons : %lu, inMuons : %lu, inJets : %lu", inElectrons->size(), inMuons->size(),  inJets->size() );
-	 }
+        // do the actual OR
+        //
+        RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
 
-         // do the actual OR
-	 //
-         RETURN_CHECK( "OverlapRemover::execute()", m_overlapRemovalTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
+        std::string ORdecor = std::string("passOR");
+        if(m_useCutFlow){
+          // fill cutflow histograms
+          //
+          if( m_useElectrons ) fillObjectCutflow(inElectrons);
+          if( m_useMuons     ) fillObjectCutflow(inMuons);
+          fillObjectCutflow(inJets);
+          if( m_usePhotons ) fillObjectCutflow(inPhotons);
+          fillObjectCutflow(inTaus);
+        }
 
-         std::string ORdecor = std::string("overlaps");
-         if(m_useCutFlow){
-           // fill cutflow histograms
-           //
-           if( m_useElectrons ) fillObjectCutflow(inElectrons);
-           if( m_useMuons     ) fillObjectCutflow(inMuons);
-           fillObjectCutflow(inJets);
-           if( m_usePhotons ) fillObjectCutflow(inPhotons);
-           fillObjectCutflow(inTaus);
-	 }
-
-	 // make a copy of input container(s) with selected objects
-	 //
-	 if ( m_createSelectedContainers ) {
-	   if( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
-	   if( m_useMuons )     selectedMuons       = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
-	   selectedJets	      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
-	   if ( m_usePhotons )  selectedPhotons     = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
-	   selectedTaus	      = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
+        // make a copy of input container(s) with selected objects
+        //
+        if ( m_createSelectedContainers ) {
+          if( m_useElectrons ) selectedElectrons   = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
+          if( m_useMuons )     selectedMuons       = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
+          selectedJets       = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
+          if ( m_usePhotons )  selectedPhotons     = new ConstDataVector<xAOD::PhotonContainer>(SG::VIEW_ELEMENTS);
+          selectedTaus       = new ConstDataVector<xAOD::TauJetContainer>(SG::VIEW_ELEMENTS);
         }
 
         // resize containers based on OR decision
-	//
-        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
-	if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::OVERLAPREMOVER), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::OVERLAPREMOVER), "");
+        //
+        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), "");
 
         // add ConstDataVector to TStore
-	//
+        //
         if ( m_createSelectedContainers ) {
           // a different syst varied container will be stored for each syst variation
-	  //
+          //
           if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons, m_outContainerName_Electrons + systName ), "Failed to store const data container"); }
           if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,     m_outContainerName_Muons + systName ), "Failed to store const data container"); }
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,      m_outContainerName_Jets + systName ), "Failed to store const data container");
@@ -1149,12 +1162,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
           RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedTaus, m_outContainerName_Taus + systName ), "Failed to store const data container");
         }
 
-	m_vecOutContainerNames->push_back(systName);
+        m_vecOutContainerNames->push_back(systName);
       } // close loop on systematic sets available from upstream algo (Taus)
 
       break;
     }
- default :
+    default :
     {
       Error("OverlapRemover::execute()","Unknown systematics type. Aborting");
       return EL::StatusCode::FAILURE;
@@ -1169,25 +1182,25 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 EL::StatusCode OverlapRemover :: setCutFlowHist( )
 {
 
- if ( m_useCutFlow ) {
+  if ( m_useCutFlow ) {
 
-   // retrieve the file in which the cutflow hists are stored
-   //
-   TFile *file     = wk()->getOutputFile ("cutflow");
+    // retrieve the file in which the cutflow hists are stored
+    //
+    TFile *file     = wk()->getOutputFile ("cutflow");
 
-   // retrieve the object cutflow
-   //
-   m_el_cutflowHist_1	 = (TH1D*)file->Get("cutflow_electrons_1");
-   m_el_cutflow_OR_cut   = m_el_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
-   m_mu_cutflowHist_1	 = (TH1D*)file->Get("cutflow_muons_1");
-   m_mu_cutflow_OR_cut   = m_mu_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
-   m_jet_cutflowHist_1   = (TH1D*)file->Get("cutflow_jets_1");
-   m_jet_cutflow_OR_cut  = m_jet_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
-   m_ph_cutflowHist_1	 = (TH1D*)file->Get("cutflow_photons_1");
-   m_ph_cutflow_OR_cut   = m_ph_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
-   m_tau_cutflowHist_1   = (TH1D*)file->Get("cutflow_taus_1");
-   m_tau_cutflow_OR_cut  = m_tau_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
- }
+    // retrieve the object cutflow
+    //
+    m_el_cutflowHist_1  = (TH1D*)file->Get("cutflow_electrons_1");
+    m_el_cutflow_OR_cut   = m_el_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
+    m_mu_cutflowHist_1  = (TH1D*)file->Get("cutflow_muons_1");
+    m_mu_cutflow_OR_cut   = m_mu_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
+    m_jet_cutflowHist_1   = (TH1D*)file->Get("cutflow_jets_1");
+    m_jet_cutflow_OR_cut  = m_jet_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
+    m_ph_cutflowHist_1  = (TH1D*)file->Get("cutflow_photons_1");
+    m_ph_cutflow_OR_cut   = m_ph_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
+    m_tau_cutflowHist_1   = (TH1D*)file->Get("cutflow_taus_1");
+    m_tau_cutflow_OR_cut  = m_tau_cutflowHist_1->GetXaxis()->FindBin("OR_cut");
+  }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -29,7 +29,6 @@ namespace HelperClasses {
       PHOTONSELECTOR,
       JETSELECTOR,
       BJETSELECTOR,
-      OVERLAPREMOVER,
       CALIBRATOR,
       CORRECTOR,
       SELECTOR,

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -157,7 +157,7 @@ namespace HelperFunctions {
      }
 
      if ( flagSelect.empty() ) {
-       Error("HelperFunctions::makeSubsetCont()", "flagSelect is an empty string, and passing a non-DEFAULT tool (presumably a SELECTOR, or OVERLAPREMOVER). Please pass a non-empty flagSelect!" );
+       Error("HelperFunctions::makeSubsetCont()", "flagSelect is an empty string, and passing a non-DEFAULT tool (presumably a SELECTOR). Please pass a non-empty flagSelect!" );
        return StatusCode::FAILURE;
      }
 
@@ -171,11 +171,7 @@ namespace HelperFunctions {
      	 return StatusCode::FAILURE;
        }
 
-       if ( tool_name == HelperClasses::ToolName::OVERLAPREMOVER ){ /* this tool uses reverted logic for "flagSelect", that's why I put this check */
-     	 if ( !myAccessor(*(in_itr)) ){ outCont->push_back( in_itr ); }
-       } else {
      	 if ( myAccessor(*(in_itr)) ) { outCont->push_back( in_itr ); }
-       }
 
      }
 

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -37,7 +37,7 @@ namespace xAH {
       virtual void updateParticle(uint idx, Jet& jet);
 
 //template<typename T>
-//	void setBranch(TTree* tree, std::string varName, std::vector<T>* localVectorPtr);
+//  void setBranch(TTree* tree, std::string varName, std::vector<T>* localVectorPtr);
     
     private:
 
@@ -236,15 +236,15 @@ namespace xAH {
 
       std::vector<float> *m_vtxOnlineValid;
       std::vector<float> *m_vtxHadDummy;
-			 
+       
       std::vector<float> *m_vtx_offline_x0;
       std::vector<float> *m_vtx_offline_y0;
       std::vector<float> *m_vtx_offline_z0;
-			 
+       
       std::vector<float> *m_vtx_online_x0;
       std::vector<float> *m_vtx_online_y0;
       std::vector<float> *m_vtx_online_z0;
-			 
+       
       std::vector<float> *m_vtx_online_bkg_x0;
       std::vector<float> *m_vtx_online_bkg_y0;
       std::vector<float> *m_vtx_online_bkg_z0;
@@ -259,15 +259,15 @@ namespace xAH {
         std::vector<float>                 m_weight_sf;
         std::vector< std::vector<float> >* m_sf;
 
-      btagOpPoint(std::string name, bool mc, std::string acessorName, std::string tagger="mv2c20"): m_name(name), m_mc(mc), m_acessorName(acessorName), m_tagger(tagger) {
-	  m_isTag = new std::vector<int>();
-	  m_sf    = new std::vector< std::vector<float> >();
-	}
+        btagOpPoint(std::string name, bool mc, std::string acessorName, std::string tagger="mv2c10"): m_name(name), m_mc(mc), m_acessorName(acessorName), m_tagger(tagger) {
+          m_isTag = new std::vector<int>();
+          m_sf    = new std::vector< std::vector<float> >();
+        }
 
-	~btagOpPoint(){
-	  delete m_isTag;
-	  delete m_sf;
-	}
+        ~btagOpPoint(){
+          delete m_isTag;
+          delete m_sf;
+        }
 
         void setTree(TTree *tree, std::string jetName){
           //tree->SetBranchStatus  (("n"+jetName+"s_"+m_tagger+"_"+m_name).c_str(), 1);
@@ -275,63 +275,63 @@ namespace xAH {
           tree->SetBranchStatus  (("n"+jetName+"s_"+m_name).c_str(), 1);
           tree->SetBranchAddress (("n"+jetName+"s_"+m_name).c_str(), &m_njets);
 
-	  HelperFunctions::connectBranch<int>     (jetName, tree,"is"+m_name,      &m_isTag);
+          HelperFunctions::connectBranch<int>     (jetName, tree,"is"+m_name,      &m_isTag);
           if(m_mc) HelperFunctions::connectBranch<std::vector<float> >(jetName, tree,"SF"+m_name,       &m_sf);
         }
 
 
         void setBranch(TTree *tree, std::string jetName){
-	  tree->Branch(("n"+jetName+"s_"+m_name).c_str(), &m_njets, ("n"+jetName+"s_"+m_name+"/I").c_str());
-	  tree->Branch((jetName+"_is"+m_name).c_str(),        &m_isTag);
+          tree->Branch(("n"+jetName+"s_"+m_name).c_str(), &m_njets, ("n"+jetName+"s_"+m_name+"/I").c_str());
+          tree->Branch((jetName+"_is"+m_name).c_str(),        &m_isTag);
 
-	  if ( m_mc ) {
-	    tree->Branch((jetName+"_SF"+m_name).c_str(),        &m_sf);
-	    tree->Branch(("weight_"+jetName+"SF"+m_name).c_str(), &m_weight_sf);
-	  }
+          if ( m_mc ) {
+            tree->Branch((jetName+"_SF"+m_name).c_str(),        &m_sf);
+            tree->Branch(("weight_"+jetName+"SF"+m_name).c_str(), &m_weight_sf);
+          }
         }
 
 
-	void clear(){
-	  m_njets = 0;
-	  m_isTag->clear();
-	  m_weight_sf.clear();
-	  m_sf->clear();
-	}
+        void clear(){
+          m_njets = 0;
+          m_isTag->clear();
+          m_weight_sf.clear();
+          m_sf->clear();
+        }
 
-	void Fill( const xAOD::Jet* jet ) {
-
-	  SG::AuxElement::ConstAccessor< int > isTag("BTag_"+m_acessorName);
-	  if( isTag.isAvailable( *jet ) ) {
-	    if ( isTag( *jet ) == 1 ) ++m_njets;
-	    m_isTag->push_back( isTag( *jet ) );
-	  } else { 
-	    m_isTag->push_back( -1 ); 
-	  }
-	  
-	  if(!m_mc) { return; }
-	  SG::AuxElement::ConstAccessor< std::vector<float> > sf("BTag_SF_"+m_acessorName);
-	  if ( sf.isAvailable( *jet ) ) {
-	    m_sf->push_back( sf( *jet ) );
-	  } else {
-	    std::vector<float> junk(1,-999);
-	    m_sf->push_back(junk);
-	  }
-
-	  return;
-	}
-
-	void FillGlobalSF( const xAOD::EventInfo* eventInfo ) {
-	  SG::AuxElement::ConstAccessor< std::vector<float> > sf_GLOBAL("BTag_SF_"+m_acessorName+"_GLOBAL");
-	  if ( sf_GLOBAL.isAvailable( *eventInfo ) ) { 
-	    m_weight_sf = sf_GLOBAL( *eventInfo ); 
-	  } else { 
-	    m_weight_sf.push_back(-999.0); 
-	  }
-
-	  return;
-	}
-	
-      };
+        void Fill( const xAOD::Jet* jet ) {
+      
+          SG::AuxElement::ConstAccessor< char > isTag("BTag_"+m_acessorName);
+          if( isTag.isAvailable( *jet ) ) {
+            if ( isTag( *jet ) == 1 ) ++m_njets;
+            m_isTag->push_back( isTag( *jet ) );
+          } else { 
+            m_isTag->push_back( -1 ); 
+          }
+          
+          if(!m_mc) { return; }
+          SG::AuxElement::ConstAccessor< std::vector<float> > sf("BTag_SF_"+m_acessorName);
+          if ( sf.isAvailable( *jet ) ) {
+            m_sf->push_back( sf( *jet ) );
+          } else {
+            std::vector<float> junk(1,-999);
+            m_sf->push_back(junk);
+          }
+      
+          return;
+        } // Fill
+      
+        void FillGlobalSF( const xAOD::EventInfo* eventInfo ) {
+          SG::AuxElement::ConstAccessor< std::vector<float> > sf_GLOBAL("BTag_SF_"+m_acessorName+"_GLOBAL");
+          if ( sf_GLOBAL.isAvailable( *eventInfo ) ) { 
+            m_weight_sf = sf_GLOBAL( *eventInfo ); 
+          } else { 
+            m_weight_sf.push_back(-999.0); 
+          }
+      
+          return;
+        }
+  
+      };  //struct btagOpPoint
       
       btagOpPoint* m_btag_Fix30;
       btagOpPoint* m_btag_Fix50;
@@ -383,17 +383,17 @@ namespace xAH {
       std::vector<float> *m_GhostBHadronsFinalPt;
       std::vector<float> *m_GhostBHadronsInitialPt;
       std::vector<float> *m_GhostBQuarksFinalPt;
-			 
+       
       std::vector<int>   *m_GhostCHadronsFinalCount;
       std::vector<int>   *m_GhostCHadronsInitialCount;
       std::vector<int>   *m_GhostCQuarksFinalCount;
       std::vector<float> *m_GhostCHadronsFinalPt;
       std::vector<float> *m_GhostCHadronsInitialPt;
       std::vector<float> *m_GhostCQuarksFinalPt;
-			 
+       
       std::vector<int>   *m_GhostTausFinalCount;
       std::vector<float> *m_GhostTausFinalPt;
-			 
+       
       std::vector<int>   *m_truth_pdgId;
       std::vector<float> *m_truth_partonPt;
       std::vector<float> *m_truth_partonDR;

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -163,6 +163,8 @@ class JetHists : public IParticleHists
     TProfile* m_vtxEff1_raw_vs_lBlock; //!
     TProfile* m_vtxEff10_noDummy_vs_lBlock; //!
     TProfile* m_vtxEff1_noDummy_vs_lBlock; //!
+    /** @brief Histograms to check beamspot offline vs. online 
+     *  @note MV2c20 b-tagging values may be incorrect and should not be relied on */
     TProfile* m_frac_MV2c2040_vs_lBlock; //!
     TProfile* m_frac_MV2c2050_vs_lBlock; //!
     TProfile* m_frac_MV2c2060_vs_lBlock; //!

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -1,6 +1,7 @@
 /**
  * @file OverlapRemover.h
  * @author Marco Milesi <marco.milesi@cern.ch>
+ * @author Jeff Dandoy
  * @brief |xAH| algorithm to perform overlap removal between reconstructed physics objects.
  */
 
@@ -17,7 +18,10 @@
 #include "xAODTau/TauJetContainer.h"
 
 // external tools include(s):
+#include "AssociationUtils/OverlapRemovalInit.h"
 #include "AssociationUtils/OverlapRemovalTool.h"
+#include "AssociationUtils/ToolBox.h"
+
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -93,6 +97,15 @@ class OverlapRemover : public xAH::Algorithm
   bool     m_createSelectedContainers;
   /** @brief In the OLR, consider only objects passing a (pre)selection */
   bool     m_useSelected;
+  /** @brief Use b-tagging decision, set previously with the given decoration name, to remove electrons and muons 
+   * @note This is automatically set by BJetEfficiencyCorrector */
+  std::string m_bTagWP;
+  /** @brief Create a link between overlapped objects */
+  bool m_linkOverlapObjects;
+  /** @brief Use boosted object working point */
+  bool m_useBoostedLeptons;
+  /** @brief Do overlap removal between electrons (HSG2 prescription) */
+  bool m_doEleEleOR;
 
   /** @brief Output systematics list container name */
   std::string  m_outputAlgo;
@@ -198,7 +211,7 @@ class OverlapRemover : public xAH::Algorithm
   std::string  m_outAuxContainerName_Taus;
 
   /** @brief Pointer to the CP Tool which performs the actual OLR. */
-  OverlapRemovalTool *m_overlapRemovalTool; //!
+  ORUtils::ToolBox m_ORToolbox;        //!
 
   /** @brief An enum encoding systematics according to the various objects */
   enum SystType {
@@ -262,11 +275,11 @@ public:
   /**
      @brief Fill the cutflow histograms
      @param objCont          The `xAOD` container to be considered
-     @param overlapFlag      The string identifying objects overlapping with another object, to be removed (default is `"overlaps"`)
+     @param overlapFlag      The string identifying objects not overlapping with another object, to be kept (default is `"passOR"`)
      @param selectFlag       The string identifying selected objects (default is `"passSel"`)
   */
   virtual EL::StatusCode fillObjectCutflow (const xAOD::IParticleContainer* objCont,
-					    const std::string& overlapFlag = "overlaps",
+					    const std::string& overlapFlag = "passOR",
 					    const std::string& selectFlag = "passSel");
 
   /**


### PR DESCRIPTION
Updates the overlap removal tool from the legacy configuration to the new version (requested in #434 ).  This also increases the user's functionality, introducing the following optional configurations:
 * m_bTagWP:  Decoration name of a b-tagging decision, altering overlap decision between b-tagged jets and leptons ("" by default).
 * m_linkOverlapObjects: Links the two overlapping objects (true by default)
 * m_useBoostedLeptons: Changes overlap decision for boosted leptons (false by default)
 * m_doEleEleOR:  Overlap removal between electrons, following HSG2 prescription (false by default)

[Relevant link to tool
](https://svnweb.cern.ch/trac/atlasoff/browser/PhysicsAnalysis/AnalysisCommon/AssociationUtils/trunk/doc/README.rst)

This update removed HelperClasses::ToolName::OVERLAPREMOVER because the flag is no longer flipped in the CP tool.

This edits the B-tagging decision decoration of BJetEfficiencyCorrector (and grabbed by JetContainer) to be a char rather than an int.  This is required by the Overlap Removal Tool, and also mirrors the behavior of the truth "IsBJet" required by Jet calibration uncertainties.  This could potentially break anyone's code who grabs the BJetEfficiencyCorrector decision in their private algorithm, but is easily fixed by changing int to char (and ASG error output is pretty specific on this type of issue). 

This also protects (but does not fix) outdated JetHists issue #704 .

@mmilesi  as a primary user of the overlap tool, could you try this out before we merge?  Thanks!