### PR TITLE
Make Multiple Calibrator Algorithms Great Again!

### DIFF
--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -227,7 +227,7 @@ EL::StatusCode ElectronCalibrator :: initialize ()
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
 
-  RETURN_CHECK("ElectronCalibrator::initialize()",m_store->record(SystElectronsNames, "ele_Syst" ), "Failed to record vector of ele systs names.");
+  RETURN_CHECK("ElectronCalibrator::initialize()",m_store->record(SystElectronsNames, "ele_Syst"+m_name ), "Failed to record vector of ele systs names.");
 
   // ***********************************************************
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -454,7 +454,7 @@ EL::StatusCode JetCalibrator :: execute ()
 
       static SG::AuxElement::ConstAccessor<int> TruthLabelID ("TruthLabelID");
       static SG::AuxElement::ConstAccessor<int> PartonTruthLabelID ("PartonTruthLabelID");
-    
+
       if ( TruthLabelID.isAvailable( *jet_itr) ) {
 	this_TruthLabel = TruthLabelID( *jet_itr );
 	if (this_TruthLabel == 21 || this_TruthLabel<4) this_TruthLabel = 0;

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -411,7 +411,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
 
-  RETURN_CHECK("JetCalibrator::initialize()",m_store->record(SystJetsNames, "jets_Syst"+m_outContainerName ), "Failed to record vector of jet systs names.");
+  RETURN_CHECK("JetCalibrator::initialize()",m_store->record(SystJetsNames, "jets_Syst"+m_name ), "Failed to record vector of jet systs names.");
 
 
   return EL::StatusCode::SUCCESS;

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -100,10 +100,10 @@ METConstructor :: METConstructor (std::string className) :
   m_inputAlgoSystEle = "";
   m_inputAlgoPhotons = "";
 
-  m_jetSystematics  = "";
-  m_eleSystematics  = "";
-  m_muonSystematics = "";
-  m_phoSystematics  = "";
+  m_jetSystematics  = "jets_Syst";
+  m_eleSystematics  = "ele_Syst";
+  m_muonSystematics = "muons_Syst";
+  m_phoSystematics  = "photons_Syst";
 }
 
 EL::StatusCode METConstructor :: setupJob (EL::Job& job)

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -193,7 +193,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
 
-  RETURN_CHECK("MuonCalibrator::initialize()",m_store->record(SystMuonsNames, "muons_Syst" ), "Failed to record vector of jet systs names.");
+  RETURN_CHECK("MuonCalibrator::initialize()",m_store->record(SystMuonsNames, "muons_Syst"+m_name ), "Failed to record vector of jet systs names.");
 
   Info("initialize()", "MuonCalibrator Interface succesfully initialized!" );
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -217,7 +217,7 @@ EL::StatusCode PhotonCalibrator :: initialize ()
     SystPhotonsNames->push_back(syst_it.name());
     Info("initialize()","\t %s", (syst_it.name()).c_str());
   }
-    RETURN_CHECK("PhotonCalibrator::initialize()",m_store->record(SystPhotonsNames, "photons_Syst" ), "Failed to record vector of jet systs names.");
+    RETURN_CHECK("PhotonCalibrator::initialize()",m_store->record(SystPhotonsNames, "photons_Syst"+m_name ), "Failed to record vector of jet systs names.");
 
   //isEM selector tools
   //------------------

--- a/docs/HLTJetGetter.rst
+++ b/docs/HLTJetGetter.rst
@@ -1,4 +1,4 @@
-HLT jet getter
+HLT Jet Getter
 ==============
 
 .. doxygenclass:: HLTJetGetter

--- a/docs/METConstructor.rst
+++ b/docs/METConstructor.rst
@@ -1,0 +1,8 @@
+MET Constructor
+===============
+
+.. doxygenclass:: METConstructor
+   :members:
+   :undoc-members:
+   :protected-members:
+   :private-members:

--- a/docs/Utilities.rst
+++ b/docs/Utilities.rst
@@ -7,6 +7,7 @@ Utilities
    DebugTool
    HelperClasses
    HelperFunctions
+   METConstructor
    ParticlePIDManager
    ReturnCheck
    xAHAlgorithm

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -354,16 +354,15 @@ namespace HelperClasses {
         m_area           area           exact
         m_JVC            JVC            exact
         m_tracksInJet    tracksInJet    partial
-	m_trackJetName   trackJetName   partial
+        m_trackJetName   trackJetName   partial
         m_hltVtxComp     hltVtxComp     exact
         m_charge         charge         exact
         m_vsLumiBlock    vsLumiBlock    exact
         ================ ============== =======
 
         .. note::
-            ``sfFTagFix`` and ``sfFTagFlt`` require a string of numbers pairwise ``AABB..MM..YYZZ`` succeeding it. This will create a vector of numbers (AA, BB, CC, ..., ZZ) associated with that variable.
 
-            For example::
+            ``sfFTagFix`` and ``sfFTagFlt`` require a string of numbers pairwise ``AABB..MM..YYZZ`` succeeding it. This will create a vector of numbers (AA, BB, CC, ..., ZZ) associated with that variable. For example::
 
                 m_configStr = "... sfFTagFix010203 ..."
 

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -137,6 +137,7 @@ namespace HelperClasses {
         m_truth          truth          exact
         m_caloClus       caloClusters   exact
         ================ ============== =======
+
     @endrst
    */
   class EventInfoSwitch : public InfoSwitch {
@@ -164,6 +165,7 @@ namespace HelperClasses {
         m_passTriggers passTriggers exact
         m_passTrigBits passTrigBits exact
         ============== ============ =======
+
     @endrst
    */
   class TriggerInfoSwitch : public InfoSwitch {
@@ -187,6 +189,7 @@ namespace HelperClasses {
         m_kinematic    kinematic    exact
         m_clean        clean        exact
         ============== ============ =======
+
     @endrst
    */
 
@@ -218,6 +221,7 @@ namespace HelperClasses {
                 m_configStr = "... NLeading4 ..."
 
             will define :code:`int m_numLeading = 4`.
+
     @endrst
    */
   class IParticleInfoSwitch : public InfoSwitch {
@@ -245,6 +249,7 @@ namespace HelperClasses {
         m_effSF        effSF        exact
         m_energyLoss   energyLoss   exact
         ============== ============ =======
+
     @endrst
    */
   class MuonInfoSwitch : public IParticleInfoSwitch {
@@ -276,6 +281,7 @@ namespace HelperClasses {
         m_trackhitcont trackhitcont exact
         m_effSF        effSF        exact
         ============== ============ =======
+
     @endrst
    */
   class ElectronInfoSwitch : public IParticleInfoSwitch {
@@ -303,6 +309,7 @@ namespace HelperClasses {
         m_PID          PID          exact
         m_purity       purity       exact
         ============== ============ =======
+
     @endrst
    */
   class PhotonInfoSwitch : public IParticleInfoSwitch {
@@ -364,7 +371,6 @@ namespace HelperClasses {
             will define :code:`std::vector<int> m_sfFTagFix = {1,2,3}`.
 
     @endrst
-
    */
   class JetInfoSwitch : public IParticleInfoSwitch {
   public:
@@ -422,6 +428,7 @@ namespace HelperClasses {
         m_parents        parents        exact
         m_children       children       exact
         ================ ============== =======
+
     @endrst
    */
   class TruthInfoSwitch : public InfoSwitch {
@@ -446,6 +453,7 @@ namespace HelperClasses {
         m_trackparams    trackparams    exact
         m_trackhitcont   trackhitcont   exact
         ================ ============== =======
+
     @endrst
    */
   class TauInfoSwitch : public IParticleInfoSwitch {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -36,9 +36,8 @@ namespace HelperClasses {
       DEFAULT
   };
 
-  /* template enum parser
-  copied from: http://stackoverflow.com/a/726681
-  */
+  /** template enum parser. Copied from: http://stackoverflow.com/a/726681
+   */
   template <typename T>
   class EnumParser
   {

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -14,8 +14,8 @@
 
 using std::string;
 
-namespace met { 
-       class METMaker; 
+namespace met {
+       class METMaker;
        class METSystematicsTool;
 	 }
 namespace TauAnalysisTools { class TauSelectionTool; }
@@ -26,9 +26,6 @@ class METConstructor : public xAH::Algorithm
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-
-  xAOD::TEvent *m_event;  //!
-  xAOD::TStore *m_store;  //!
 
   // configuration variables
   TString m_referenceMETContainer;
@@ -41,9 +38,9 @@ public:
   TString m_inputTaus;
   TString m_inputMuons;
 
-  std::string  m_inputAlgoJets;  // name of vector<string> of syst retrieved from TStore
-  std::string  m_inputAlgoSystMuons;  // name of vector<string> of syst retrieved from TStore
-  std::string  m_inputAlgoSystEle;  // name of vector<string> of syst retrieved from TStore
+  std::string m_inputAlgoJets;  // name of vector<string> of syst retrieved from TStore
+  std::string m_inputAlgoSystMuons;  // name of vector<string> of syst retrieved from TStore
+  std::string m_inputAlgoSystEle;  // name of vector<string> of syst retrieved from TStore
   std::string m_inputAlgoPhotons; // name of vector<string> of syst retrieved from TStore
 
   bool    m_doElectronCuts;
@@ -59,17 +56,41 @@ public:
   bool    m_useTrackJetTerm;
 
   bool m_runNominal;
-  
+
   float m_systVal;
   std::string m_systName;
-  
+
   std::string m_SoftTermSystConfigFile;
+
+  /** @rst
+        Name of jet systematics vector from  :cpp:class:`~JetCalibrator`.
+      @endrst
+   */
+  std::string m_jetSystematics;
+  /** @rst
+        Name of electron systematics vector from  :cpp:class:`~ElectronCalibrator`.
+      @endrst
+   */
+  std::string m_eleSystematics;
+  /** @rst
+        Name of muon systematics vector from  :cpp:class:`~MuonCalibrator`.
+      @endrst
+   */
+  std::string m_muonSystematics;
+  /** @rst
+        Name of photon systematics vector from :cpp:class:`~PhotonCalibrator`.
+      @endrst
+   */
+  std::string m_phoSystematics;
 
 private:
 
+  xAOD::TEvent *m_event;  //!
+  xAOD::TStore *m_store;  //!
+
   // tools
   met::METMaker* m_metmaker; //!
-  met::METSystematicsTool* metSystTool; //!   
+  met::METSystematicsTool* metSystTool; //!
 
   TauAnalysisTools::TauSelectionTool* m_tauSelTool; //!
 


### PR DESCRIPTION
This fixes #698, #687. This bug/error was introduced in #685 and partially (yet incorrectly) fixed by @johnda102 in #700.

Also added some extra documentation changes to add METConstructor in the documentation and introduce some interface changes to METConstructor so it can pick up the vector systematics

```
  /** @rst
        Name of jet systematics vector from  :cpp:class:`~JetCalibrator`.
      @endrst
   */
  std::string m_jetSystematics;
  /** @rst
        Name of electron systematics vector from  :cpp:class:`~ElectronCalibrator`.
      @endrst
   */
  std::string m_eleSystematics;
  /** @rst
        Name of muon systematics vector from  :cpp:class:`~MuonCalibrator`.
      @endrst
   */
  std::string m_muonSystematics;
  /** @rst
        Name of photon systematics vector from :cpp:class:`~PhotonCalibrator`.
      @endrst
   */
  std::string m_phoSystematics;
```