### PR TITLE
added elInfoSwitch variables for isol and trigger SFs

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -387,7 +387,9 @@ void HelpTreeBase::AddElectrons(const std::string detailStr) {
 
   if ( m_elInfoSwitch->m_effSF && m_isMC ) {
     for (auto& PID : m_PIDWPs) {
+      if (!m_elInfoSwitch->m_PIDWPs[PID]) continue;
       for (auto& isol : m_isolWPs) {
+        if (!m_elInfoSwitch->m_isolWPs[isol]) continue;
         m_tree->Branch( ("el_TrigEff_SF_" + PID + isol).c_str() , &m_el_TrigEff_SF[ PID+isol ] );
         m_tree->Branch( ("el_TrigMCEff_" + PID + isol).c_str() , &m_el_TrigMCEff[ PID+isol ] );
         if(isol.empty()) continue;
@@ -634,7 +636,9 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
       static std::map< std::string, floatAccessor > accTrigSF;
       static std::map< std::string, floatAccessor > accTrigEFF;
       for (auto& PID : m_PIDWPs) {
+        if (!m_elInfoSwitch->m_PIDWPs[PID]) continue;
         for (auto& isol : m_isolWPs) {
+          if (!m_elInfoSwitch->m_isolWPs[isol]) continue;
           accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigMCEffSyst_" + PID + isol ) ) );
           accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigSyst_" + PID + isol ) ) );
           if( (accTrigSF.at( PID+isol )).isAvailable( *el_itr ) ) { (m_el_TrigEff_SF.at( PID+isol )).push_back( (accTrigSF.at( PID+isol ))( *el_itr ) ); }
@@ -752,7 +756,9 @@ void HelpTreeBase::ClearElectrons() {
 
   if( m_elInfoSwitch->m_effSF && m_isMC ) {
     for (auto& PID : m_PIDWPs) {
+      if (!m_elInfoSwitch->m_PIDWPs[PID]) continue;
       for (auto& isol : m_isolWPs) {
+        if (!m_elInfoSwitch->m_isolWPs[isol]) continue;
         (m_el_TrigEff_SF[ PID+isol ]).clear();
         (m_el_TrigMCEff[ PID+isol ]).clear();
         if(isol.empty()) continue;

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -138,6 +138,19 @@ namespace HelperClasses{
     m_trackparams   = has_exact("trackparams");
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
+    // working points for scale-factors    
+    m_PIDWPs["LooseAndBLayerLLH"]  = has_exact("LooseAndBLayerLLH");
+    m_PIDWPs["MediumLLH"]          = has_exact("MediumLLH");
+    m_PIDWPs["TightLLH"]           = has_exact("TightLLH");
+    m_isolWPs["_isolFixedCutLoose"]            = has_exact("isolFixedCutLoose");
+    m_isolWPs["_isolFixedCutTight"]            = has_exact("isolFixedCutTight");
+    m_isolWPs["_isolFixedCutTightTrackOnly"]   = has_exact("isolFixedCutTightTrackOnly");
+    m_isolWPs["_isolGradient"]                 = has_exact("isolGradient");
+    m_isolWPs["_isolGradientLoose"]            = has_exact("isolGradientLoose");
+    m_isolWPs["_isolLoose"]                    = has_exact("isolLoose");
+    m_isolWPs["_isolLooseTrackOnly"]           = has_exact("isolLooseTrackOnly");
+    m_isolWPs["_isolTight"]                    = has_exact("isolTight");
+    m_isolWPs[""]                              = has_exact("isolNoRequirement");
   }
 
   void PhotonInfoSwitch::initialize(){

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -278,6 +278,18 @@ namespace HelperClasses {
         m_trackparams  trackparams  exact
         m_trackhitcont trackhitcont exact
         m_effSF        effSF        exact
+        m_PIDWPs["LooseAndBLayerLLH"]            LooseAndBLayerLLH           exact
+        m_PIDWPs["MediumLLH"]                    MediumLLH                   exact
+        m_PIDWPs["TightLLH"]                     TightLLH                    exact
+        m_isolWPs["_isolFixedCutLoose"]          isolFixedCutLoose           exact
+        m_isolWPs["_isolFixedCutTight"]          isolFixedCutTight           exact
+        m_isolWPs["_isolFixedCutTightTrackOnly"] isolFixedCutTightTrackOnly  exact
+        m_isolWPs["_isolGradient"]               isolGradient                exact
+        m_isolWPs["_isolGradientLoose"]          isolGradientLoose           exact
+        m_isolWPs["_isolLoose"]                  isolLoose                   exact
+        m_isolWPs["_isolLooseTrackOnly"]         isolLooseTrackOnly          exact
+        m_isolWPs["_isolTight"]                  isolTight                   exact
+        m_isolWPs[""]                            isolNoRequirement           exact
         ============== ============ =======
 
     @endrst
@@ -290,6 +302,8 @@ namespace HelperClasses {
     bool m_trackparams;
     bool m_trackhitcont;
     bool m_effSF;
+    std::map<std::string,bool> m_PIDWPs;
+    std::map<std::string,bool> m_isolWPs;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:


### PR DESCRIPTION
Added elInfoSwitch compatibility for the new isolation and trigger scale factor branches. Two std::maps are added to the elInfoSwitch header:
```
+    std::map<std::string,bool> m_PIDWPs;
+    std::map<std::string,bool> m_isolWPs;
```
and configured with logical keywords. An example configuration would look like this:
```
electronWorkingPoints = "MediumLLH TightLLH isolNoRequirement isolFixedCutLoose isolLooseTrackOnly isolGradient isolLoose isolTight " # space at the end
...
"m_elDetailStr"           : electronWorkingPoints + "kinematic trigger isolation PID trackparams effSF",
...
```
Here, the "isolNoRequirement" is for trigger scale-factors without any isolation requirement. The output in this case would look like this:

![electronwps](https://cloud.githubusercontent.com/assets/12948551/19437203/a5196fa4-9474-11e6-9847-ecf2ce698328.png)

We can see, that only [MediumLLH, TightLLH] x [isolNoRequirement, isolFixedCutLoose, isolLooseTrackOnly, isolGradient, isolLoose, isolTight] working points were saved to the output tree instead of all the 3x9 combinations.


