### PR TITLE
improved the loops over PID/ISO working points

### DIFF
--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -91,9 +91,9 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
-      const std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
-      const std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
-    
+      std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
+      std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
+      
       // track parameters
       std::vector<float>* m_trkd0;
       std::vector<float>* m_trkd0sig;


### PR DESCRIPTION
Hi @johnda102 , @kratsg this was possible to do with the addition of the ElectronContainer.

This improves the way the loops over PID/iso working points work. Instead of running the loop over all the possible WPs and doing:

```
if (!m_infoSwitch.m_PIDWPs[PID]) continue;
if (!m_infoSwitch.m_isolWPs[isol]) continue;
```

each time, the user requested WPs are formed in the initialization of the ElectronContainer and the loops are therefore much shorter.

This should increase the speed of the algorithm, especially when we add another loop for the trigger names.

P.S.:
I'm sorry for copy-pasting a large chunk of the code, I had some problems with spaces/tabs in my text editor.