### PR TITLE
Bad jet event cleaning

### DIFF
--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -77,6 +77,8 @@ ElectronCalibrator :: ElectronCalibrator (std::string className) :
   m_esModel                 = "";
   m_decorrelationModel      = "";
 
+  m_setAFII                 = false;
+
   m_useDataDrivenLeakageCorr = false;
 
 }
@@ -197,7 +199,8 @@ EL::StatusCode ElectronCalibrator :: initialize ()
     //
     const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
 
-    if ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) {
+    if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ){
+
       Info("initialize()", "Setting simulation flavour to AFII");
       RETURN_CHECK( "ElectronCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", true),"Failed to set property useAFII");
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -401,7 +401,7 @@ EL::StatusCode METConstructor :: execute ()
 
  if( m_inputElectrons.Length() > 0 ) {
    const xAOD::ElectronContainer* eleCont(0);
-   if ( m_store->retrieve(eleCont ,  m_inputElectrons.Data() +sysListItrString ).isSuccess() ) {
+   if ( m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString ) ) {
      RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving electron cont.");
      if (m_debug) cout<< "retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met "<< endl;
    }else{
@@ -425,7 +425,7 @@ EL::StatusCode METConstructor :: execute ()
 
   if( m_inputPhotons.Length() > 0 ) {
    const xAOD::PhotonContainer* phoCont(0);
-   if ( m_store->retrieve(phoCont ,  m_inputPhotons.Data() +sysListItrString ).isSuccess() ) {
+   if ( m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString ) ) {
      RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
      if (m_debug) cout<< "retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met "<< endl;
    }else{
@@ -465,7 +465,7 @@ EL::StatusCode METConstructor :: execute ()
 
   if( m_inputTaus.Length() > 0 ) {
     const xAOD::TauJetContainer* tauCont(0);
-   if ( m_store->retrieve(tauCont ,  m_inputTaus.Data() +sysListItrString ).isSuccess() ) {
+   if ( m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
 
      RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
      if (m_debug) cout<< "retrieving tau container "<<    m_inputTaus.Data() +sysListItrString << " to be added to the met "<< endl;
@@ -496,7 +496,7 @@ EL::StatusCode METConstructor :: execute ()
  if( m_inputMuons.Length() > 0 ) {
    std::string m_inputMuons_Syst =  m_inputMuons.Data() +sysListItrString;
    const xAOD::MuonContainer* muonCont(0);
-   if ( m_store->retrieve(muonCont ,  m_inputMuons.Data() +sysListItrString ).isSuccess() ) {
+   if ( m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
      RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving muon cont.");
    }
    else{
@@ -518,7 +518,7 @@ EL::StatusCode METConstructor :: execute ()
    std::string m_inputJets_Syst =  m_inputJets.Data() +sysListItrString;// just for convenience
    if (m_debug) cout<<" the jet container name is : "<<m_inputJets_Syst<< endl;
 
-   if ( m_store->retrieve(jetCont ,  m_inputJets.Data()+sysListItrString ).isSuccess() ) {
+   if ( m_store->contains<xAOD::JetContainer>(m_inputJets.Data()+sysListItrString ) ) {
      if (m_debug) cout << "syst is = "<<sysListItrString <<endl;
      //RETURN_CHECK( "METConstructor::execute()", metSystTool->evtStore()->retrieve( jetCont,m_inputJets_Syst  ), "");// is this necessary?
      RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, m_debug  ), " Failed retrieving jet cont.");

--- a/docs/ToolsUsed.rst
+++ b/docs/ToolsUsed.rst
@@ -24,7 +24,8 @@ Event Level
 -  `JERSmearingTool <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetResolution2015Prerecom>`__
 -  `JetSelectorTools <https://svnweb.cern.ch/trac/atlasoff/browser/PhysicsAnalysis/JetMissingEtID/JetSelectorTools/trunk/README.rst>`__
 -  `JVT <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration>`__
--  `BTaggingEfficiencyTool <http://atlas.web.cern.ch/Atlas/GROUPS/DATABASE/GroupData/xAODBTaggingEfficiency/13TeV/>`
+-  `BTaggingEfficiencyTool <http://atlas.web.cern.ch/Atlas/GROUPS/DATABASE/GroupData/xAODBTaggingEfficiency/13TeV/>`__
+-  `JetCleaning2016 <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJets2016>`__
 
 
 :math:`\tau` jets

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -39,6 +39,9 @@ public:
   std::string m_esModel;
   std::string m_decorrelationModel;
 
+  /** @brief Force AFII flag in calibration, in case metadata is broken */
+  bool m_setAFII;
+
   // for calo based isolation vars leakage correction
   bool        m_useDataDrivenLeakageCorr;
 

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -2,6 +2,7 @@
  * @file   JetSelector.h
  *
  * @author Gabriel Facini <gabriel.facini@cern.ch>
+ * @author Jeff Dandoy  <jeff.dandoy@cern.ch>
  * @author Marco Milesi <marco.milesi@cern.ch>
  * @author John Alison <john.alison@cern.ch>
  *
@@ -46,6 +47,8 @@ public:
   int m_nToProcess;               // look at n objects
   bool m_cleanJets;               // require cleanJet decoration to not be set and false
   int m_cleanEvtLeadJets;         // kill event if any of the N leading jets are not clean
+  /** @brief Kill event if any passing jets are not clean */
+  bool m_cleanEvent;
   int m_pass_min;                 // minimum number of objects passing cuts
   int m_pass_max;                 // maximum number of objects passing cuts
   float m_pT_max;                 // require pT < pt_max


### PR DESCRIPTION
This update primarily deals with jet cleaning. The [cleaning recommendation](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJets2016) is to reject events with any clean jets after your event selection.  Jet cleaning therefore needs to be the last event selection checked.  I.e. if the jet fails JVT, then cleaning should not be checked.  

A new flag, m_cleanEvent, is introduced to remove events with one bad signal jet.  “m_cleanEvtLeadJets” (only removes event if first N jets are bad) is kept.
This also changes the order of the cutflow, but otherwise does not change the results for anyone who chooses not to use m_cleanEvent.

This update also removed the unprotected retrieve used in the METConstructor.
It also introduces an override of the AFII decision in ElectornCalibrator, in cases where the simulation metadata is not available in the derivation.

