### PR TITLE
Adding recommended isBadMuon check

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -520,7 +520,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     }
 
     // Cleaning Selection must come after kinematic and JVT selections
-    if ( passSel && isCleanAcc.isAvailable( *jet_itr ) ) {
+    if ( m_cleanJets && passSel && isCleanAcc.isAvailable( *jet_itr ) ) {
       if( !isCleanAcc( *jet_itr ) ) { 
         passSel = false;
         if ( m_decorateSelectedObjects )

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -619,7 +619,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
     }
 
     // Remove events with isBadMuon (poor q/p)
-    if( m_removeEventBadMuon && pasSel ){
+    if( m_removeEventBadMuon && passSel ){
       if( m_muonSelectionTool_handle->isBadMuon( *mu_itr ) ){
         if( m_debug )  Info("executeSelection()", "Rejecting event with bad muon (pt = %f)", mu_itr->pt() ); 
         return false;

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -619,7 +619,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
     }
 
     // Remove events with isBadMuon (poor q/p)
-    if( m_removeEventBadMuon ){
+    if( m_removeEventBadMuon && pasSel ){
       if( m_muonSelectionTool_handle->isBadMuon( *mu_itr ) ){
         if( m_debug )  Info("executeSelection()", "Rejecting event with bad muon (pt = %f)", mu_itr->pt() ); 
         return false;

--- a/docs/ToolsUsed.rst
+++ b/docs/ToolsUsed.rst
@@ -17,6 +17,10 @@ Event Level
 -  `ElectronPhotonSelectorTools <https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ElectronPhotonSelectorTools>`__
 -  `IsolationCorrectionTool <https://twiki.cern.ch/twiki/bin/view/AtlasProtected/IsolationLeakageCorrections>`__
 
+:math:`\mu`
+---------
+-  `MuonSelectionTool <https://twiki.cern.ch/twiki/bin/view/Atlas/MuonSelectionTool>`__
+
 :math:`j`
 ---------
 

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -63,6 +63,9 @@ public:
   float          m_d0sig_max; 	             /* require d0 significance (at BL) < m_d0sig_max */
   float	         m_z0sintheta_max;           /* require z0*sin(theta) (at BL - corrected with vertex info) < m_z0sintheta_max */
 
+  /** @brief Remove events with a bad muon, defined by poor q/p */
+  bool           m_removeEventBadMuon;
+
   // isolation
   std::string    m_MinIsoWPCut;              /* reject objects which do not pass this isolation cut - default = "" (no cut) */
   std::string    m_IsoWPList;                /* decorate objects with 'isIsolated_*' flag for each WP in this input list - default = all current ASG WPs */


### PR DESCRIPTION
[It is recommended ](https://twiki.cern.ch/twiki/bin/view/Atlas/MuonSelectionTool#is_BadMuon_Flag_Event_Veto) to remove events where a signal muon has a poor q/p.  An event selection has been added to MuonSelector under the flag ```m_removeEventBadMuon```.  This has been set to true by default due to the recommendation.