### PR TITLE
Muon corrections for all triggers and iso+reco WPs

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -839,14 +839,14 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       
       for (auto& isol : m_isolWPs) {
 
-       accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigSyst_" + PID + isol ) ) );
+       accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_TrigSyst_" + PID + isol ) ) );
        if( (accTrigSF.at( PID+isol )).isAvailable( *elec ) ) { 
          m_TrigEff_SF->at( PID+isol ).push_back( (accTrigSF.at( PID+isol ))( *elec ) ); 
        }else { 
          m_TrigEff_SF->at( PID+isol ).push_back( junkSF ); 
        }
 
-       accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigMCEffSyst_" + PID + isol ) ) );
+       accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_TrigMCEffSyst_" + PID + isol ) ) );
        if( (accTrigEFF.at( PID+isol )).isAvailable( *elec ) ) { 
          m_TrigMCEff->at( PID+isol ).push_back( (accTrigEFF.at( PID+isol ))( *elec ) ); 
        } else { 
@@ -854,7 +854,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
        }
 
        if(isol.empty()) continue;
-       accIsoSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_IsoSyst_" + PID + isol ) ) );
+       accIsoSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_IsoSyst_" + PID + isol ) ) );
        if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) { 
          m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) ); 
        } else { 
@@ -863,11 +863,11 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
      }
    }
 
-   static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElectronEfficiencyCorrector_RecoSyst");
-   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("ElectronEfficiencyCorrector_PIDSyst_LooseAndBLayerLLH");
-   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("ElectronEfficiencyCorrector_PIDSyst_LooseLLh");
-   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("ElectronEfficiencyCorrector_PIDSyst_MediumLLH");
-   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHTight("ElectronEfficiencyCorrector_PIDSyst_TightLLH");
+   static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("EleEffCorr_RecoSyst");
+   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("EleEffCorr_PIDSyst_LooseAndBLayerLLH");
+   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLoose("EleEffCorr_PIDSyst_LooseLLh");
+   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHMedium("EleEffCorr_PIDSyst_MediumLLH");
+   static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHTight("EleEffCorr_PIDSyst_TightLLH");
 
    if( accRecoSF.isAvailable( *elec ) )                     { m_RecoEff_SF->push_back( accRecoSF( *elec ) ); } else { m_RecoEff_SF->push_back( junkSF ); }
    if( accPIDSF_LHLooseAndBLayer.isAvailable( *elec ) )     { m_PIDEff_SF_LHLooseAndBLayer->push_back( accPIDSF_LHLooseAndBLayer( *elec ) ); } else { m_PIDEff_SF_LHLooseAndBLayer->push_back( junkSF ); }

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -839,14 +839,14 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       
       for (auto& isol : m_isolWPs) {
 
-       accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigMCEffSyst_" + PID + isol ) ) );
+       accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigSyst_" + PID + isol ) ) );
        if( (accTrigSF.at( PID+isol )).isAvailable( *elec ) ) { 
          m_TrigEff_SF->at( PID+isol ).push_back( (accTrigSF.at( PID+isol ))( *elec ) ); 
        }else { 
          m_TrigEff_SF->at( PID+isol ).push_back( junkSF ); 
        }
 
-       accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigSyst_" + PID + isol ) ) );
+       accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "ElectronEfficiencyCorrector_TrigMCEffSyst_" + PID + isol ) ) );
        if( (accTrigEFF.at( PID+isol )).isAvailable( *elec ) ) { 
          m_TrigMCEff->at( PID+isol ).push_back( (accTrigEFF.at( PID+isol ))( *elec ) ); 
        } else { 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -64,11 +64,11 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string classNam
   m_systNameTrig            = "";
   m_systNameReco            = "";
   m_systNameTrigMCEff       = "";
-  m_outputSystNamesPID      = "ElectronEfficiencyCorrector_PIDSyst";
-  m_outputSystNamesIso      = "ElectronEfficiencyCorrector_IsoSyst";
-  m_outputSystNamesReco     = "ElectronEfficiencyCorrector_RecoSyst";
-  m_outputSystNamesTrig     = "ElectronEfficiencyCorrector_TrigSyst";
-  m_outputSystNamesTrigMCEff = "ElectronEfficiencyCorrector_TrigMCEffSyst";
+  m_outputSystNamesPID      = "EleEffCorr_PIDSyst";
+  m_outputSystNamesIso      = "EleEffCorr_IsoSyst";
+  m_outputSystNamesReco     = "EleEffCorr_RecoSyst";
+  m_outputSystNamesTrig     = "EleEffCorr_TrigSyst";
+  m_outputSystNamesTrigMCEff = "EleEffCorr_TrigMCEffSyst";
 
   // file(s) containing corrections
   //

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -129,47 +129,64 @@ namespace HelperClasses{
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
     m_energyLoss    = has_exact("energyLoss");
+   
+    // working points combinations for trigger corrections 
+    std::vector< std::string > triggers = {
+                                              "HLT_mu10",
+                                              "HLT_mu14",
+                                              "HLT_mu18",
+                                              "HLT_mu20",
+                                              "HLT_mu22",
+                                              "HLT_mu24",
+                                              "HLT_mu26",
+                                              "HLT_mu40", 
+                                              "HLT_mu50",
+                                              "HLT_mu8noL1", 
+                                              "HLT_mu20_iloose_L1MU15",
+                                              "HLT_mu24_iloose_L1MU15",
+                                              "HLT_mu24_imedium",
+                                              "HLT_mu26_imedium",
+                                              "HLT_mu20_iloose_L1MU15_OR_HLT_mu50",
+                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu50",
+                                              "HLT_mu24_imedium_OR_HLT_mu50",
+                                              "HLT_mu26_imedium_OR_HLT_mu50",
+                                              "HLT_mu20_iloose_L1MU15_OR_HLT_mu40",
+                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu40",
+                                              "HLT_mu24_imedium_OR_HLT_mu40",
+                                              "HLT_mu26_imedium_OR_HLT_mu40",
+                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose",
+                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40",
+                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50",
+                                              "HLT_mu24_ivarmedium",
+                                              "HLT_mu24_ivarmedium_OR_HLT_mu40",
+                                              "HLT_mu24_ivarmedium_OR_HLT_mu50",
+                                              "HLT_mu26_ivarmedium",
+                                              "HLT_mu26_ivarmedium_OR_HLT_mu40",
+                                              "HLT_mu26_ivarmedium_OR_HLT_mu50",
+                                              };
+
+    std::vector< std::string > recoWPs = {"RecoLoose","RecoMedium","RecoTight"};
+    std::vector< std::string > isolWPs = {"IsoLoose","IsoFixedCutTightTrackOnly","IsoGradient","IsoGradientLoose"};
+    std::vector< std::string > trigWPs;
+
+
+    for (auto& trig : triggers) {
+      for (auto& reco : recoWPs) {
+        for (auto& isol : isolWPs) {
+          std::string trigStr = "";
+          trigStr.append(trig);
+          trigStr.append("_");
+          trigStr.append(reco); 
+          trigStr.append("_"); 
+          trigStr.append(isol);
+          trigWPs.push_back(trigStr);
+        }
+      }
+    }
     
-    m_recoWPs["Loose"]  = has_exact("Loose");
-    m_recoWPs["Medium"] = has_exact("Medium");
-    m_recoWPs["Tight"]  = has_exact("Tight");
-
-    m_isolWPs["Loose"]                  = has_exact("Loose");
-    m_isolWPs["FixedCutTightTrackOnly"] = has_exact("FixedCutTightTrackOnly");
-    m_isolWPs["Gradient"]               = has_exact("Gradient");
-    m_isolWPs["GradientLoose"]          = has_exact("GradientLoose");
-
-    m_triggers["HLT_mu10"]                                                = has_exact("HLT_mu10");
-    m_triggers["HLT_mu14"]                                                = has_exact("HLT_mu14");
-    m_triggers["HLT_mu18"]                                                = has_exact("HLT_mu18");
-    m_triggers["HLT_mu20"]                                                = has_exact("HLT_mu20");
-    m_triggers["HLT_mu22"]                                                = has_exact("HLT_mu22");
-    m_triggers["HLT_mu24"]                                                = has_exact("HLT_mu24");
-    m_triggers["HLT_mu26"]                                                = has_exact("HLT_mu26");
-    m_triggers["HLT_mu40"]                                                = has_exact("HLT_mu40");
-    m_triggers["HLT_mu50"]                                                = has_exact("HLT_mu50");
-    m_triggers["HLT_mu8noL1"]                                             = has_exact("HLT_mu8noL1");
-    m_triggers["HLT_mu20_iloose_L1MU15"]                                  = has_exact("HLT_mu20_iloose_L1MU15");
-    m_triggers["HLT_mu24_iloose_L1MU15"]                                  = has_exact("HLT_mu24_iloose_L1MU15");
-    m_triggers["HLT_mu24_imedium"]                                        = has_exact("HLT_mu24_imedium");
-    m_triggers["HLT_mu26_imedium"]                                        = has_exact("HLT_mu26_imedium");
-    m_triggers["HLT_mu20_iloose_L1MU15_OR_HLT_mu50"]                      = has_exact("HLT_mu20_iloose_L1MU15_OR_HLT_mu50");
-    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu50"]                      = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu50");
-    m_triggers["HLT_mu24_imedium_OR_HLT_mu50"]                            = has_exact("HLT_mu24_imedium_OR_HLT_mu50");
-    m_triggers["HLT_mu26_imedium_OR_HLT_mu50"]                            = has_exact("HLT_mu26_imedium_OR_HLT_mu50");
-    m_triggers["HLT_mu20_iloose_L1MU15_OR_HLT_mu40"]                      = has_exact("HLT_mu20_iloose_L1MU15_OR_HLT_mu40");
-    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu40"]                      = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu40");
-    m_triggers["HLT_mu24_imedium_OR_HLT_mu40"]                            = has_exact("HLT_mu24_imedium_OR_HLT_mu40");
-    m_triggers["HLT_mu26_imedium_OR_HLT_mu40"]                            = has_exact("HLT_mu26_imedium_OR_HLT_mu40");
-    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose"]               = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose");
-    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40"]   = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40");
-    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50"]   = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50");
-    m_triggers["HLT_mu24_ivarmedium"]                                     = has_exact("HLT_mu24_ivarmedium");
-    m_triggers["HLT_mu24_ivarmedium_OR_HLT_mu40"]                         = has_exact("HLT_mu24_ivarmedium_OR_HLT_mu40");
-    m_triggers["HLT_mu24_ivarmedium_OR_HLT_mu50"]                         = has_exact("HLT_mu24_ivarmedium_OR_HLT_mu50");
-    m_triggers["HLT_mu26_ivarmedium"]                                     = has_exact("HLT_mu26_ivarmedium");
-    m_triggers["HLT_mu26_ivarmedium_OR_HLT_mu40"]                         = has_exact("HLT_mu26_ivarmedium_OR_HLT_mu40");
-    m_triggers["HLT_mu26_ivarmedium_OR_HLT_mu50"]                         = has_exact("HLT_mu26_ivarmedium_OR_HLT_mu50");                        
+    for (const auto& isol : isolWPs) { m_isolWPsMap[isol] = has_exact(isol); }                        
+    for (const auto& reco : recoWPs) { m_recoWPsMap[reco] = has_exact(reco); }                        
+    for (const auto& trig : trigWPs) { m_trigWPsMap[trig] = has_exact(trig); }                        
 
   }
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -129,6 +129,48 @@ namespace HelperClasses{
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
     m_energyLoss    = has_exact("energyLoss");
+    
+    m_recoWPs["Loose"]  = has_exact("Loose");
+    m_recoWPs["Medium"] = has_exact("Medium");
+    m_recoWPs["Tight"]  = has_exact("Tight");
+
+    m_isolWPs["Loose"]                  = has_exact("Loose");
+    m_isolWPs["FixedCutTightTrackOnly"] = has_exact("FixedCutTightTrackOnly");
+    m_isolWPs["Gradient"]               = has_exact("Gradient");
+    m_isolWPs["GradientLoose"]          = has_exact("GradientLoose");
+
+    m_triggers["HLT_mu10"]                                                = has_exact("HLT_mu10");
+    m_triggers["HLT_mu14"]                                                = has_exact("HLT_mu14");
+    m_triggers["HLT_mu18"]                                                = has_exact("HLT_mu18");
+    m_triggers["HLT_mu20"]                                                = has_exact("HLT_mu20");
+    m_triggers["HLT_mu22"]                                                = has_exact("HLT_mu22");
+    m_triggers["HLT_mu24"]                                                = has_exact("HLT_mu24");
+    m_triggers["HLT_mu26"]                                                = has_exact("HLT_mu26");
+    m_triggers["HLT_mu40"]                                                = has_exact("HLT_mu40");
+    m_triggers["HLT_mu50"]                                                = has_exact("HLT_mu50");
+    m_triggers["HLT_mu8noL1"]                                             = has_exact("HLT_mu8noL1");
+    m_triggers["HLT_mu20_iloose_L1MU15"]                                  = has_exact("HLT_mu20_iloose_L1MU15");
+    m_triggers["HLT_mu24_iloose_L1MU15"]                                  = has_exact("HLT_mu24_iloose_L1MU15");
+    m_triggers["HLT_mu24_imedium"]                                        = has_exact("HLT_mu24_imedium");
+    m_triggers["HLT_mu26_imedium"]                                        = has_exact("HLT_mu26_imedium");
+    m_triggers["HLT_mu20_iloose_L1MU15_OR_HLT_mu50"]                      = has_exact("HLT_mu20_iloose_L1MU15_OR_HLT_mu50");
+    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu50"]                      = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu50");
+    m_triggers["HLT_mu24_imedium_OR_HLT_mu50"]                            = has_exact("HLT_mu24_imedium_OR_HLT_mu50");
+    m_triggers["HLT_mu26_imedium_OR_HLT_mu50"]                            = has_exact("HLT_mu26_imedium_OR_HLT_mu50");
+    m_triggers["HLT_mu20_iloose_L1MU15_OR_HLT_mu40"]                      = has_exact("HLT_mu20_iloose_L1MU15_OR_HLT_mu40");
+    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu40"]                      = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu40");
+    m_triggers["HLT_mu24_imedium_OR_HLT_mu40"]                            = has_exact("HLT_mu24_imedium_OR_HLT_mu40");
+    m_triggers["HLT_mu26_imedium_OR_HLT_mu40"]                            = has_exact("HLT_mu26_imedium_OR_HLT_mu40");
+    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose"]               = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose");
+    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40"]   = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40");
+    m_triggers["HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50"]   = has_exact("HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50");
+    m_triggers["HLT_mu24_ivarmedium"]                                     = has_exact("HLT_mu24_ivarmedium");
+    m_triggers["HLT_mu24_ivarmedium_OR_HLT_mu40"]                         = has_exact("HLT_mu24_ivarmedium_OR_HLT_mu40");
+    m_triggers["HLT_mu24_ivarmedium_OR_HLT_mu50"]                         = has_exact("HLT_mu24_ivarmedium_OR_HLT_mu50");
+    m_triggers["HLT_mu26_ivarmedium"]                                     = has_exact("HLT_mu26_ivarmedium");
+    m_triggers["HLT_mu26_ivarmedium_OR_HLT_mu40"]                         = has_exact("HLT_mu26_ivarmedium_OR_HLT_mu40");
+    m_triggers["HLT_mu26_ivarmedium_OR_HLT_mu50"]                         = has_exact("HLT_mu26_ivarmedium_OR_HLT_mu50");                        
+
   }
 
   void ElectronInfoSwitch::initialize(){

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -131,62 +131,21 @@ namespace HelperClasses{
     m_energyLoss    = has_exact("energyLoss");
    
     // working points combinations for trigger corrections 
-    std::vector< std::string > triggers = {
-                                              "HLT_mu10",
-                                              "HLT_mu14",
-                                              "HLT_mu18",
-                                              "HLT_mu20",
-                                              "HLT_mu22",
-                                              "HLT_mu24",
-                                              "HLT_mu26",
-                                              "HLT_mu40", 
-                                              "HLT_mu50",
-                                              "HLT_mu8noL1", 
-                                              "HLT_mu20_iloose_L1MU15",
-                                              "HLT_mu24_iloose_L1MU15",
-                                              "HLT_mu24_imedium",
-                                              "HLT_mu26_imedium",
-                                              "HLT_mu20_iloose_L1MU15_OR_HLT_mu50",
-                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu50",
-                                              "HLT_mu24_imedium_OR_HLT_mu50",
-                                              "HLT_mu26_imedium_OR_HLT_mu50",
-                                              "HLT_mu20_iloose_L1MU15_OR_HLT_mu40",
-                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu40",
-                                              "HLT_mu24_imedium_OR_HLT_mu40",
-                                              "HLT_mu26_imedium_OR_HLT_mu40",
-                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose",
-                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40",
-                                              "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50",
-                                              "HLT_mu24_ivarmedium",
-                                              "HLT_mu24_ivarmedium_OR_HLT_mu40",
-                                              "HLT_mu24_ivarmedium_OR_HLT_mu50",
-                                              "HLT_mu26_ivarmedium",
-                                              "HLT_mu26_ivarmedium_OR_HLT_mu40",
-                                              "HLT_mu26_ivarmedium_OR_HLT_mu50",
-                                              };
-
-    std::vector< std::string > recoWPs = {"RecoLoose","RecoMedium","RecoTight"};
-    std::vector< std::string > isolWPs = {"IsoLoose","IsoFixedCutTightTrackOnly","IsoGradient","IsoGradientLoose"};
-    std::vector< std::string > trigWPs;
-
-
-    for (auto& trig : triggers) {
-      for (auto& reco : recoWPs) {
-        for (auto& isol : isolWPs) {
-          std::string trigStr = "";
-          trigStr.append(trig);
-          trigStr.append("_");
-          trigStr.append(reco); 
-          trigStr.append("_"); 
-          trigStr.append(isol);
-          trigWPs.push_back(trigStr);
-        }
-      }
-    }
+    std::string token;
+    std::string reco_prfx = "Reco";
+    std::string isol_prfx = "Iso";
+    std::string trig_prfx = "HLT";
     
-    for (const auto& isol : isolWPs) { m_isolWPsMap[isol] = has_exact(isol); }                        
-    for (const auto& reco : recoWPs) { m_recoWPsMap[reco] = has_exact(reco); }                        
-    for (const auto& trig : trigWPs) { m_trigWPsMap[trig] = has_exact(trig); }                        
+    std::istringstream ss(m_configStr);
+    while ( std::getline(ss, token, ' ') ) {
+      if ( token.compare( 0, reco_prfx.length(), reco_prfx ) == 0 ) { m_recoWPs.push_back(token); }
+      if ( token.compare( 0, isol_prfx.length(), isol_prfx ) == 0 ) { m_isolWPs.push_back(token); }
+      if ( token.compare( 0, trig_prfx.length(), trig_prfx ) == 0 ) { m_trigWPs.push_back(token); }
+    }  
+    
+    //for (const auto& isol : isolWPs) { m_isolWPsMap[isol] = has_exact(isol); }                        
+    //for (const auto& reco : recoWPs) { m_recoWPsMap[reco] = has_exact(reco); }                        
+    //for (const auto& trig : trigWPs) { m_trigWPsMap[trig] = has_exact(trig); }                        
 
   }
 

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -13,7 +13,7 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
   // trigger
   if ( m_infoSwitch.m_trigger ) {
     m_isTrigMatched          = new     vector<int>               ();
-    m_isTrigMatchedToChain   = new     vector<vector<int> > ();
+    m_isTrigMatchedToChain   = new     vector<vector<int> >      ();
     m_listTrigChains         = new     vector<std::string>       ();
   }
     
@@ -55,56 +55,9 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_IsoEff_SF  = new std::map< std::string, std::vector< std::vector< float > > >();
     m_TrigEff_SF = new std::map< std::string, std::vector< std::vector< float > > >();
     m_TrigMCEff  = new std::map< std::string, std::vector< std::vector< float > > >();
-    
+  
     m_TTVAEff_SF = new vector< vector< float > > ();
   
-    // build reco WP 
-    for (auto& reco : m_reco) {
-        std::string recoStr = "";
-        recoStr.append(reco); 
-        if (m_infoSwitch.m_recoWPsMap[ recoStr ]) {
-          m_recoWPs.push_back(recoStr); 
-        } else continue;
-    }
-    if (m_recoWPs.empty()) { m_recoWPs = m_reco;}  
-
-    // build iso WP 
-    for (auto& isol : m_isol) {
-        std::string isolStr = "";
-        isolStr.append(isol); 
-        if (m_infoSwitch.m_isolWPsMap[ isolStr ]) {
-          m_isolWPs.push_back(isolStr); 
-        } else continue;
-    }
-    if (m_isolWPs.empty()) { m_isolWPs = m_isol;}  
-  
-    // build trigger WP 
-    for (auto& trig : m_triggers) {
-      for (auto& reco : m_reco) {
-        for (auto& isol : m_isol) {
-          std::string trigStr = "";
-          trigStr.append(trig); trigStr.append("_");trigStr.append(reco);trigStr.append("_");trigStr.append(isol);
-          if (m_infoSwitch.m_trigWPsMap[ trigStr ]) {
-            m_trigWPs.push_back(trigStr); 
-          } else continue;
-        }
-      }
-    }
-    
-    if (m_trigWPs.empty()) {
-      for (auto& trig : m_triggers) {
-        for (auto& reco : m_reco) {
-          for (auto& isol : m_isol) {
-            std::string trigStr = "";
-            trigStr.append(trig); trigStr.append("_");trigStr.append(reco);trigStr.append("_");trigStr.append(isol);
-            if (!m_infoSwitch.m_trigWPsMap[ trigStr ]) {
-              m_trigWPs.push_back(trigStr); 
-            } else continue;
-          }
-        }
-      }
-    }
-    
   }
       // track parameters
   if ( m_infoSwitch.m_trackparams ) {
@@ -270,17 +223,17 @@ void MuonContainer::setTree(TTree *tree)
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
     
-    for (auto& reco : m_recoWPs) {
+    for (auto& reco : m_infoSwitch.m_recoWPs) {
       std::string recoEffSF = "muon_RecoEff_SF_" + reco; 
       tree->SetBranchAddress( recoEffSF.c_str() , & (*m_RecoEff_SF)[ reco ] );
     }
     
-    for (auto& isol : m_isolWPs) {
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
       std::string isolEffSF = "muon_IsoEff_SF_" + isol; 
       tree->SetBranchAddress( isolEffSF.c_str() , & (*m_IsoEff_SF)[ isol ] );
     }
     
-    for (auto& trig : m_trigWPs) {
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
       std::string trigEffSF = "muon_TrigEff_SF_" + trig; 
       tree->SetBranchAddress( trigEffSF.c_str() , & (*m_TrigEff_SF)[ trig ] );
       
@@ -382,15 +335,15 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
   // per object
   if ( m_infoSwitch.m_effSF && m_mc ) {
     
-    for (auto& reco : m_recoWPs) {
+    for (auto& reco : m_infoSwitch.m_recoWPs) {
       muon.RecoEff_SF[ reco ] = (*m_RecoEff_SF)[ reco ].at(idx);
     }
     
-    for (auto& isol : m_isolWPs) {
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
       muon.IsoEff_SF[ isol ] = (*m_IsoEff_SF)[ isol ].at(idx);
     }
     
-    for (auto& trig : m_trigWPs) {
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
       muon.TrigEff_SF[ trig ] = (*m_TrigEff_SF)[ trig ].at(idx);
       muon.TrigMCEff [ trig ] = (*m_TrigMCEff )[ trig ].at(idx);
     }
@@ -474,17 +427,18 @@ void MuonContainer::setBranches(TTree *tree)
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
     
-    for (auto& reco : m_recoWPs) {
+    for (auto& reco : m_infoSwitch.m_recoWPs) {
       std::string recoEffSF = "muon_RecoEff_SF_" + reco;
       tree->Branch( recoEffSF.c_str() , & (*m_RecoEff_SF)[ reco ] );
+
     }
     
-    for (auto& isol : m_isolWPs) {
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
       std::string isolEffSF = "muon_IsoEff_SF_" + isol;
       tree->Branch( isolEffSF.c_str() , & (*m_IsoEff_SF)[ isol ] );
     }
     
-    for (auto& trig : m_trigWPs) {
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
       std::string trigEffSF = "muon_TrigEff_SF_" + trig;
       std::string trigMCEff = "muon_TrigMCEff_" + trig; 
       tree->Branch( trigEffSF.c_str() , & (*m_TrigEff_SF)[ trig ] );
@@ -607,15 +561,15 @@ void MuonContainer::clear()
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
     
-    for (auto& reco : m_recoWPs) {
+    for (auto& reco : m_infoSwitch.m_recoWPs) {
       (*m_RecoEff_SF)[ reco ].clear();
     }
     
-    for (auto& isol : m_isolWPs) {
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
       (*m_IsoEff_SF)[ isol ].clear();
     }
     
-    for (auto& trig : m_trigWPs) {
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
       (*m_TrigEff_SF)[ trig ].clear();
       (*m_TrigMCEff)[ trig ].clear();
     }
@@ -809,12 +763,12 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     
     static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
     
-    static std::map< std::string, floatAccessor > accRecoSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accRecoSF;
     
-    for (auto& reco : m_recoWPs) {
+    for (auto& reco : m_infoSwitch.m_recoWPs) {
             
       std::string recoEffSF = "MuonEfficiencyCorrector_RecoSyst_" + reco;
-      accRecoSF.insert( std::pair<std::string, floatAccessor > ( reco , floatAccessor( recoEffSF ) ) );
+      accRecoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( reco , SG::AuxElement::Accessor< std::vector< float > >( recoEffSF ) ) );
       if( (accRecoSF.at( reco  )).isAvailable( *muon ) ) { 
         m_RecoEff_SF->at( reco ).push_back( (accRecoSF.at( reco ))( *muon ) ); 
       }else { 
@@ -822,12 +776,12 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
       }
     }
     
-    static std::map< std::string, floatAccessor > accIsoSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accIsoSF;
     
-    for (auto& isol : m_isolWPs) {
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
             
       std::string isolEffSF = "MuonEfficiencyCorrector_IsoSyst_" + isol;
-      accIsoSF.insert( std::pair<std::string, floatAccessor > ( isol , floatAccessor( isolEffSF ) ) );
+      accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( isol , SG::AuxElement::Accessor< std::vector< float > >( isolEffSF ) ) );
       if( (accIsoSF.at( isol  )).isAvailable( *muon ) ) { 
         m_IsoEff_SF->at( isol ).push_back( (accIsoSF.at( isol ))( *muon ) ); 
       }else { 
@@ -835,13 +789,13 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
       }
     }
     
-    static std::map< std::string, floatAccessor > accTrigSF;
-    static std::map< std::string, floatAccessor > accTrigEFF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigEFF;
     
-    for (auto& trig : m_trigWPs) {
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
             
       std::string trigEffSF = "MuonEfficiencyCorrector_TrigSyst_" + trig;
-      accTrigSF.insert( std::pair<std::string, floatAccessor > ( trig , floatAccessor( trigEffSF ) ) );
+      accTrigSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig , SG::AuxElement::Accessor< std::vector< float > >( trigEffSF ) ) );
       if( (accTrigSF.at( trig  )).isAvailable( *muon ) ) { 
         m_TrigEff_SF->at( trig ).push_back( (accTrigSF.at( trig ))( *muon ) ); 
       }else { 
@@ -849,7 +803,7 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
       }
       
       std::string trigMCEff = "MuonEfficiencyCorrector_TrigMCEff_" + trig;
-      accTrigEFF.insert( std::pair<std::string, floatAccessor > ( trig , floatAccessor( trigMCEff ) ) );
+      accTrigEFF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig , SG::AuxElement::Accessor< std::vector< float > >( trigMCEff ) ) );
       if( (accTrigEFF.at( trig  )).isAvailable( *muon ) ) { 
         m_TrigMCEff->at( trig  ).push_back( (accTrigEFF.at( trig  ))( *muon ) ); 
       } else { 

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -52,22 +52,25 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
   if ( m_infoSwitch.m_effSF && m_mc ) {
     m_RecoEff_SF_Loose                              = new vector< vector< float > > ();
     m_RecoEff_SF_Medium                             = new vector< vector< float > > ();
+
+    m_TrigEff_SF = new std::map< std::string, std::vector< std::vector< float > > >();
+    m_TrigMCEff  = new std::map< std::string, std::vector< std::vector< float > > >();
+
+   // m_TrigEff_SF_Loose_Loose                        = new vector< vector< float > > ();
+   // m_TrigEff_SF_Loose_FixedCutTightTrackOnly       = new vector< vector< float > > ();
+   // m_TrigEff_SF_Loose_Gradient                     = new vector< vector< float > > ();
+   // m_TrigEff_SF_Loose_GradientLoose                = new vector< vector< float > > ();
+   // m_TrigEff_SF_Medium_FixedCutTightTrackOnly      = new vector< vector< float > > ();
+   // m_TrigEff_SF_Medium_Gradient                    = new vector< vector< float > > ();
+   // m_TrigEff_SF_Medium_GradientLoose               = new vector< vector< float > > ();
     
-    m_TrigEff_SF_Loose_Loose                        = new vector< vector< float > > ();
-    m_TrigEff_SF_Loose_FixedCutTightTrackOnly       = new vector< vector< float > > ();
-    m_TrigEff_SF_Loose_Gradient                     = new vector< vector< float > > ();
-    m_TrigEff_SF_Loose_GradientLoose                = new vector< vector< float > > ();
-    m_TrigEff_SF_Medium_FixedCutTightTrackOnly      = new vector< vector< float > > ();
-    m_TrigEff_SF_Medium_Gradient                    = new vector< vector< float > > ();
-    m_TrigEff_SF_Medium_GradientLoose               = new vector< vector< float > > ();
-    
-    m_TrigMCEff_Loose_Loose                         = new vector< vector< float > > ();
-    m_TrigMCEff_Loose_FixedCutTightTrackOnly        = new vector< vector< float > > ();
-    m_TrigMCEff_Loose_Gradient                      = new vector< vector< float > > ();
-    m_TrigMCEff_Loose_GradientLoose                 = new vector< vector< float > > ();
-    m_TrigMCEff_Medium_FixedCutTightTrackOnly       = new vector< vector< float > > ();
-    m_TrigMCEff_Medium_Gradient                     = new vector< vector< float > > ();
-    m_TrigMCEff_Medium_GradientLoose                = new vector< vector< float > > ();
+   //  m_TrigMCEff_Loose_Loose                         = new vector< vector< float > > ();
+   //  m_TrigMCEff_Loose_FixedCutTightTrackOnly        = new vector< vector< float > > ();
+   //  m_TrigMCEff_Loose_Gradient                      = new vector< vector< float > > ();
+   //  m_TrigMCEff_Loose_GradientLoose                 = new vector< vector< float > > ();
+   //  m_TrigMCEff_Medium_FixedCutTightTrackOnly       = new vector< vector< float > > ();
+   //  m_TrigMCEff_Medium_Gradient                     = new vector< vector< float > > ();
+   //  m_TrigMCEff_Medium_GradientLoose                = new vector< vector< float > > ();
     
     m_IsoEff_SF_LooseTrackOnly                      = new vector< vector< float > > ();
     m_IsoEff_SF_Loose                               = new vector< vector< float > > ();
@@ -78,6 +81,34 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_IsoEff_SF_FixedCutTightTrackOnly              = new vector< vector< float > > ();
     
     m_TTVAEff_SF                                    = new vector< vector< float > > ();
+  
+    auto reco_it = std::begin(m_recoWPs);
+    auto iso_it  = std::begin(m_isolWPs);
+    auto trig_it = std::begin(m_triggers);
+
+    while ( reco_it != std::end(m_recoWPs) ) {
+      if (!m_infoSwitch.m_recoWPs[ *reco_it ]) reco_it = m_recoWPs.erase( reco_it );
+      else reco_it++;
+    }
+    while ( iso_it != std::end(m_isolWPs) ) {
+      if (!m_infoSwitch.m_isolWPs[ *iso_it ]) iso_it = m_isolWPs.erase( iso_it );
+      else iso_it++;
+    }
+    while ( trig_it != std::end(m_triggers) ) {
+      if (!m_infoSwitch.m_triggers[ *trig_it ]) trig_it = m_triggers.erase( trig_it );
+      else trig_it++;
+    }
+    if (m_debug) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& isol : m_isolWPs) {
+          for (auto& trig : m_triggers) {
+            Info("MuonConainer()", "Used trigger working points: %s %s %s", trig.c_str(), reco.c_str(), isol.c_str() );
+          }
+        }
+      }
+    }
+  
+  
   }
       // track parameters
   if ( m_infoSwitch.m_trackparams ) {
@@ -163,22 +194,25 @@ MuonContainer::~MuonContainer()
   if ( m_infoSwitch.m_effSF && m_mc ) {
     delete m_RecoEff_SF_Loose                              ;
     delete m_RecoEff_SF_Medium                             ;
-
-    delete m_TrigEff_SF_Loose_Loose                        ;
-    delete m_TrigEff_SF_Loose_FixedCutTightTrackOnly       ;
-    delete m_TrigEff_SF_Loose_Gradient                     ;
-    delete m_TrigEff_SF_Loose_GradientLoose                ;
-    delete m_TrigEff_SF_Medium_FixedCutTightTrackOnly      ;
-    delete m_TrigEff_SF_Medium_Gradient                    ;
-    delete m_TrigEff_SF_Medium_GradientLoose               ;
     
-    delete m_TrigMCEff_Loose_Loose                         ;
-    delete m_TrigMCEff_Loose_FixedCutTightTrackOnly        ;
-    delete m_TrigMCEff_Loose_Gradient                      ;
-    delete m_TrigMCEff_Loose_GradientLoose                 ;
-    delete m_TrigMCEff_Medium_FixedCutTightTrackOnly       ;
-    delete m_TrigMCEff_Medium_Gradient                     ;
-    delete m_TrigMCEff_Medium_GradientLoose                ;
+    delete m_TrigEff_SF ;
+    delete m_TrigMCEff  ;
+
+    // delete m_TrigEff_SF_Loose_Loose                        ;
+    // delete m_TrigEff_SF_Loose_FixedCutTightTrackOnly       ;
+    // delete m_TrigEff_SF_Loose_Gradient                     ;
+    // delete m_TrigEff_SF_Loose_GradientLoose                ;
+    // delete m_TrigEff_SF_Medium_FixedCutTightTrackOnly      ;
+    // delete m_TrigEff_SF_Medium_Gradient                    ;
+    // delete m_TrigEff_SF_Medium_GradientLoose               ;
+    
+    // delete m_TrigMCEff_Loose_Loose                         ;
+    // delete m_TrigMCEff_Loose_FixedCutTightTrackOnly        ;
+    // delete m_TrigMCEff_Loose_Gradient                      ;
+    // delete m_TrigMCEff_Loose_GradientLoose                 ;
+    // delete m_TrigMCEff_Medium_FixedCutTightTrackOnly       ;
+    // delete m_TrigMCEff_Medium_Gradient                     ;
+    // delete m_TrigMCEff_Medium_GradientLoose                ;
     
     delete m_IsoEff_SF_LooseTrackOnly                      ;
     delete m_IsoEff_SF_Loose                               ;
@@ -265,21 +299,40 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<vector<float> >(tree,"RecoEff_SF_Loose",         &m_RecoEff_SF_Loose);
     connectBranch<vector<float> >(tree,"RecoEff_SF_Medium",         &m_RecoEff_SF_Loose);
     
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_Loose",		    &m_TrigEff_SF_Loose_Loose);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_FixedCutTightTrackOnly",  &m_TrigEff_SF_Loose_FixedCutTightTrackOnly);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_Gradient",  &m_TrigEff_SF_Loose_Gradient);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_GradientLoose",  &m_TrigEff_SF_Loose_GradientLoose);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_FixedCutTightTrackOnly",  &m_TrigEff_SF_Medium_FixedCutTightTrackOnly);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_Gradient",  &m_TrigEff_SF_Medium_Gradient);
-    connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_GradientLoose",  &m_TrigEff_SF_Medium_GradientLoose);
+    for (auto& trig : m_triggers) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& isol : m_isolWPs) {
+
+          std::string trigEffSF = "TrigEff_SF"; trigEffSF.append("_"); trigEffSF.append(trig);trigEffSF.append(reco); trigEffSF.append("_"); trigEffSF.append(isol);
+          tree->SetBranchStatus ( trigEffSF.c_str() , 1 );
+          tree->SetBranchAddress( trigEffSF.c_str() , & (*m_TrigEff_SF)[ trig+reco+isol ] );
+          std::string trigMCEff = "TrigMCEff"; trigMCEff.append("_"); trigMCEff.append(trig);trigMCEff.append(reco); trigMCEff.append("_"); trigMCEff.append(isol);
+          tree->SetBranchStatus ( trigMCEff.c_str() , 1 );
+          tree->SetBranchAddress( trigMCEff.c_str() , & (*m_TrigMCEff)[ trig+reco+isol ] );
+          
+          //tree->SetBranchStatus ( ("TrigEff_SF" + "_" + trig + "_" + reco + "_" + isol).c_str() , 1 );
+          //tree->SetBranchAddress( ("TrigEff_SF" + "_" + trig + "_" + reco + "_" + isol).c_str() , & (*m_TrigEff_SF)[ trig+reco+isol ] );
+          //tree->SetBranchStatus ( ("TrigMCEff" + "_" + trig + "_" + reco + "_" + isol).c_str() , 1 );
+          //tree->SetBranchAddress( ("TrigMCEff" + "_" + trig + "_" + reco + "_" + isol).c_str() , & (*m_TrigMCEff) [ trig+reco+isol ] );
+        }
+      }
+    }
     
-    connectBranch<vector<float> >(tree,"TrigMCEff_Loose_Loose",		    &m_TrigMCEff_Loose_Loose);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Loose_FixedCutTightTrackOnly",  &m_TrigMCEff_Loose_FixedCutTightTrackOnly);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Loose_Gradient",  &m_TrigMCEff_Loose_Gradient);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Loose_GradientLoose",  &m_TrigMCEff_Loose_GradientLoose);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Medium_FixedCutTightTrackOnly",  &m_TrigMCEff_Medium_FixedCutTightTrackOnly);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Medium_Gradient",  &m_TrigMCEff_Medium_Gradient);
-    connectBranch<vector<float> >(tree,"TrigMCEff_Medium_GradientLoose",  &m_TrigMCEff_Medium_GradientLoose);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_Loose",		    &m_TrigEff_SF_Loose_Loose);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_FixedCutTightTrackOnly",  &m_TrigEff_SF_Loose_FixedCutTightTrackOnly);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_Gradient",  &m_TrigEff_SF_Loose_Gradient);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Loose_GradientLoose",  &m_TrigEff_SF_Loose_GradientLoose);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_FixedCutTightTrackOnly",  &m_TrigEff_SF_Medium_FixedCutTightTrackOnly);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_Gradient",  &m_TrigEff_SF_Medium_Gradient);
+    // connectBranch<vector<float> >(tree,"TrigEff_SF_Medium_GradientLoose",  &m_TrigEff_SF_Medium_GradientLoose);
+    
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Loose_Loose",		    &m_TrigMCEff_Loose_Loose);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Loose_FixedCutTightTrackOnly",  &m_TrigMCEff_Loose_FixedCutTightTrackOnly);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Loose_Gradient",  &m_TrigMCEff_Loose_Gradient);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Loose_GradientLoose",  &m_TrigMCEff_Loose_GradientLoose);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Medium_FixedCutTightTrackOnly",  &m_TrigMCEff_Medium_FixedCutTightTrackOnly);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Medium_Gradient",  &m_TrigMCEff_Medium_Gradient);
+    // connectBranch<vector<float> >(tree,"TrigMCEff_Medium_GradientLoose",  &m_TrigMCEff_Medium_GradientLoose);
    
     connectBranch<vector<float> >(tree,"IsoEff_SF_LooseTrackOnly", &m_IsoEff_SF_LooseTrackOnly);
     connectBranch<vector<float> >(tree,"IsoEff_SF_Loose",	    &m_IsoEff_SF_Loose);
@@ -382,21 +435,30 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.RecoEff_SF_Loose                               = m_RecoEff_SF_Loose                              ->at(idx);
     muon.RecoEff_SF_Medium                              = m_RecoEff_SF_Medium                             ->at(idx);
     
-    muon.TrigEff_SF_Loose_Loose                         = m_TrigEff_SF_Loose_Loose                        ->at(idx);
-    muon.TrigEff_SF_Loose_FixedCutTightTrackOnly        = m_TrigEff_SF_Loose_FixedCutTightTrackOnly       ->at(idx);
-    muon.TrigEff_SF_Loose_Gradient                      = m_TrigEff_SF_Loose_Gradient                     ->at(idx);
-    muon.TrigEff_SF_Loose_GradientLoose                 = m_TrigEff_SF_Loose_GradientLoose                ->at(idx);
-    muon.TrigEff_SF_Medium_FixedCutTightTrackOnly       = m_TrigEff_SF_Medium_FixedCutTightTrackOnly      ->at(idx);
-    muon.TrigEff_SF_Medium_Gradient                     = m_TrigEff_SF_Medium_Gradient                    ->at(idx);
-    muon.TrigEff_SF_Medium_GradientLoose                = m_TrigEff_SF_Medium_GradientLoose               ->at(idx);
+    for (auto& trig : m_triggers) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& iso : m_isolWPs) {
+          muon.TrigEff_SF[ trig+reco+iso ] = (*m_TrigEff_SF)[ trig+reco+iso ].at(idx);
+          muon.TrigMCEff [ trig+reco+iso ] = (*m_TrigMCEff )[ trig+reco+iso ].at(idx);
+        }
+      }
+    }
+
+    // muon.TrigEff_SF_Loose_Loose                         = m_TrigEff_SF_Loose_Loose                        ->at(idx);
+    // muon.TrigEff_SF_Loose_FixedCutTightTrackOnly        = m_TrigEff_SF_Loose_FixedCutTightTrackOnly       ->at(idx);
+    // muon.TrigEff_SF_Loose_Gradient                      = m_TrigEff_SF_Loose_Gradient                     ->at(idx);
+    // muon.TrigEff_SF_Loose_GradientLoose                 = m_TrigEff_SF_Loose_GradientLoose                ->at(idx);
+    // muon.TrigEff_SF_Medium_FixedCutTightTrackOnly       = m_TrigEff_SF_Medium_FixedCutTightTrackOnly      ->at(idx);
+    // muon.TrigEff_SF_Medium_Gradient                     = m_TrigEff_SF_Medium_Gradient                    ->at(idx);
+    // muon.TrigEff_SF_Medium_GradientLoose                = m_TrigEff_SF_Medium_GradientLoose               ->at(idx);
     
-    muon.TrigMCEff_Loose_Loose                          = m_TrigMCEff_Loose_Loose                         ->at(idx);
-    muon.TrigMCEff_Loose_FixedCutTightTrackOnly         = m_TrigMCEff_Loose_FixedCutTightTrackOnly        ->at(idx);
-    muon.TrigMCEff_Loose_Gradient                       = m_TrigMCEff_Loose_Gradient                      ->at(idx);
-    muon.TrigMCEff_Loose_GradientLoose                  = m_TrigMCEff_Loose_GradientLoose                 ->at(idx);
-    muon.TrigMCEff_Medium_FixedCutTightTrackOnly        = m_TrigMCEff_Medium_FixedCutTightTrackOnly       ->at(idx);
-    muon.TrigMCEff_Medium_Gradient                      = m_TrigMCEff_Medium_Gradient                     ->at(idx);
-    muon.TrigMCEff_Medium_GradientLoose                 = m_TrigMCEff_Medium_GradientLoose                ->at(idx);
+    // muon.TrigMCEff_Loose_Loose                          = m_TrigMCEff_Loose_Loose                         ->at(idx);
+    // muon.TrigMCEff_Loose_FixedCutTightTrackOnly         = m_TrigMCEff_Loose_FixedCutTightTrackOnly        ->at(idx);
+    // muon.TrigMCEff_Loose_Gradient                       = m_TrigMCEff_Loose_Gradient                      ->at(idx);
+    // muon.TrigMCEff_Loose_GradientLoose                  = m_TrigMCEff_Loose_GradientLoose                 ->at(idx);
+    // muon.TrigMCEff_Medium_FixedCutTightTrackOnly        = m_TrigMCEff_Medium_FixedCutTightTrackOnly       ->at(idx);
+    // muon.TrigMCEff_Medium_Gradient                      = m_TrigMCEff_Medium_Gradient                     ->at(idx);
+    // muon.TrigMCEff_Medium_GradientLoose                 = m_TrigMCEff_Medium_GradientLoose                ->at(idx);
     
     muon.IsoEff_SF_LooseTrackOnly                       = m_IsoEff_SF_LooseTrackOnly                      ->at(idx);
     muon.IsoEff_SF_Loose                                = m_IsoEff_SF_Loose                               ->at(idx);
@@ -486,21 +548,37 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<vector<float> >(tree,"RecoEff_SF_Loose",         m_RecoEff_SF_Loose);
     setBranch<vector<float> >(tree,"RecoEff_SF_Medium",         m_RecoEff_SF_Medium);
     
-    setBranch<vector<float> >(tree,"TrigEff_SF_Loose_Loose",		    m_TrigEff_SF_Loose_Loose);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Loose_FixedCutTightTrackOnly",  m_TrigEff_SF_Loose_FixedCutTightTrackOnly);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Loose_Gradient",  m_TrigEff_SF_Loose_Gradient);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Loose_GradientLoose",  m_TrigEff_SF_Loose_GradientLoose);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Medium_FixedCutTightTrackOnly",  m_TrigEff_SF_Medium_FixedCutTightTrackOnly);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Medium_Gradient",  m_TrigEff_SF_Medium_Gradient);
-    setBranch<vector<float> >(tree,"TrigEff_SF_Medium_GradientLoose",  m_TrigEff_SF_Medium_GradientLoose);
+    for (auto& trig : m_triggers) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& isol : m_isolWPs) {
+
+          std::string trigEffSF = "TrigEff_SF"; trigEffSF.append("_"); trigEffSF.append(trig);trigEffSF.append(reco); trigEffSF.append("_"); trigEffSF.append(isol);
+          std::string trigMCEff = "TrigMCEff"; trigMCEff.append("_"); trigMCEff.append(trig);trigMCEff.append(reco); trigMCEff.append("_"); trigMCEff.append(isol);
+          tree->Branch( trigMCEff.c_str() , & (*m_TrigMCEff)[ trig+reco+isol ] );
+          tree->Branch( trigEffSF.c_str() , & (*m_TrigEff_SF)[ trig+reco+isol ] );
+
+          //tree->Branch( ("TrigEff_SF" + "_" + trig + "_" + reco + "_" + isol).c_str() , & (*m_TrigEff_SF)[ trig+reco+isol ] );
+          //tree->Branch( ("TrigMCEff"  + "_" + trig  + "_" + reco + "_" + isol).c_str() , & (*m_TrigMCEff) [ trig+reco+isol ] );
+        }
+      }
+    }
     
-    setBranch<vector<float> >(tree,"TrigMCEff_Loose_Loose",		    m_TrigMCEff_Loose_Loose);
-    setBranch<vector<float> >(tree,"TrigMCEff_Loose_FixedCutTightTrackOnly",  m_TrigMCEff_Loose_FixedCutTightTrackOnly);
-    setBranch<vector<float> >(tree,"TrigMCEff_Loose_Gradient",  m_TrigMCEff_Loose_Gradient);
-    setBranch<vector<float> >(tree,"TrigMCEff_Loose_GradientLoose",  m_TrigMCEff_Loose_GradientLoose);
-    setBranch<vector<float> >(tree,"TrigMCEff_Medium_FixedCutTightTrackOnly",  m_TrigMCEff_Medium_FixedCutTightTrackOnly);
-    setBranch<vector<float> >(tree,"TrigMCEff_Medium_Gradient",  m_TrigMCEff_Medium_Gradient);
-    setBranch<vector<float> >(tree,"TrigMCEff_Medium_GradientLoose",  m_TrigMCEff_Medium_GradientLoose);
+    
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Loose_Loose",		    m_TrigEff_SF_Loose_Loose);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Loose_FixedCutTightTrackOnly",  m_TrigEff_SF_Loose_FixedCutTightTrackOnly);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Loose_Gradient",  m_TrigEff_SF_Loose_Gradient);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Loose_GradientLoose",  m_TrigEff_SF_Loose_GradientLoose);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Medium_FixedCutTightTrackOnly",  m_TrigEff_SF_Medium_FixedCutTightTrackOnly);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Medium_Gradient",  m_TrigEff_SF_Medium_Gradient);
+    // setBranch<vector<float> >(tree,"TrigEff_SF_Medium_GradientLoose",  m_TrigEff_SF_Medium_GradientLoose);
+    
+    // setBranch<vector<float> >(tree,"TrigMCEff_Loose_Loose",		    m_TrigMCEff_Loose_Loose);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Loose_FixedCutTightTrackOnly",  m_TrigMCEff_Loose_FixedCutTightTrackOnly);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Loose_Gradient",  m_TrigMCEff_Loose_Gradient);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Loose_GradientLoose",  m_TrigMCEff_Loose_GradientLoose);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Medium_FixedCutTightTrackOnly",  m_TrigMCEff_Medium_FixedCutTightTrackOnly);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Medium_Gradient",  m_TrigMCEff_Medium_Gradient);
+    // setBranch<vector<float> >(tree,"TrigMCEff_Medium_GradientLoose",  m_TrigMCEff_Medium_GradientLoose);
     
     setBranch<vector<float> >(tree,"IsoEff_SF_LooseTrackOnly", m_IsoEff_SF_LooseTrackOnly);
     setBranch<vector<float> >(tree,"IsoEff_SF_Loose",	    m_IsoEff_SF_Loose);
@@ -625,21 +703,30 @@ void MuonContainer::clear()
     m_RecoEff_SF_Loose->clear();
     m_RecoEff_SF_Medium->clear();
     
-    m_TrigEff_SF_Loose_Loose->clear();
-    m_TrigEff_SF_Loose_FixedCutTightTrackOnly->clear();
-    m_TrigEff_SF_Loose_Gradient->clear();
-    m_TrigEff_SF_Loose_GradientLoose->clear();
-    m_TrigEff_SF_Medium_FixedCutTightTrackOnly->clear();
-    m_TrigEff_SF_Medium_Gradient->clear();
-    m_TrigEff_SF_Medium_GradientLoose->clear();
+    for (auto& trig : m_triggers) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& isol : m_isolWPs) {
+          (*m_TrigEff_SF)[ trig+reco+isol ].clear();
+          (*m_TrigMCEff)[ trig+reco+isol ].clear();
+        }
+      }
+    }
     
-    m_TrigMCEff_Loose_Loose->clear();
-    m_TrigMCEff_Loose_FixedCutTightTrackOnly->clear();
-    m_TrigMCEff_Loose_Gradient->clear();
-    m_TrigMCEff_Loose_GradientLoose->clear();
-    m_TrigMCEff_Medium_FixedCutTightTrackOnly->clear();
-    m_TrigMCEff_Medium_Gradient->clear();
-    m_TrigMCEff_Medium_GradientLoose->clear();
+    // m_TrigEff_SF_Loose_Loose->clear();
+    // m_TrigEff_SF_Loose_FixedCutTightTrackOnly->clear();
+    // m_TrigEff_SF_Loose_Gradient->clear();
+    // m_TrigEff_SF_Loose_GradientLoose->clear();
+    // m_TrigEff_SF_Medium_FixedCutTightTrackOnly->clear();
+    // m_TrigEff_SF_Medium_Gradient->clear();
+    // m_TrigEff_SF_Medium_GradientLoose->clear();
+    
+    // m_TrigMCEff_Loose_Loose->clear();
+    // m_TrigMCEff_Loose_FixedCutTightTrackOnly->clear();
+    // m_TrigMCEff_Loose_Gradient->clear();
+    // m_TrigMCEff_Loose_GradientLoose->clear();
+    // m_TrigMCEff_Medium_FixedCutTightTrackOnly->clear();
+    // m_TrigMCEff_Medium_Gradient->clear();
+    // m_TrigMCEff_Medium_GradientLoose->clear();
     
     m_IsoEff_SF_LooseTrackOnly->clear();
     m_IsoEff_SF_Loose->clear();
@@ -834,21 +921,54 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     static SG::AuxElement::Accessor< std::vector< float > > accRecoSF_Loose("MuonEfficiencyCorrector_RecoSyst_Loose");
     static SG::AuxElement::Accessor< std::vector< float > > accRecoSF_Medium("MuonEfficiencyCorrector_RecoSyst_Medium");
     
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Loose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoLoose");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoFixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Gradient("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoGradient");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_GradientLoose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoGradientLoose");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoFixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_Gradient("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoGradient");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_GradientLoose("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoGradientLoose");
+    static std::map< std::string, floatAccessor > accTrigSF;
+    static std::map< std::string, floatAccessor > accTrigEFF;
+
+    std::vector<float> junkSF(1,1.0);
+    std::vector<float> junkEff(1,0.0);
     
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_Loose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoLoose");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoFixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_Gradient("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoGradient");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_GradientLoose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoGradientLoose");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoFixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_Gradient("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoGradient");
-    static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_GradientLoose("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoGradientLoose");
+    for (auto& trig : m_triggers) {
+      for (auto& reco : m_recoWPs) {
+        for (auto& isol : m_isolWPs) {
+                
+          std::string trigEffSF = "MuonEfficiencyCorrector_TrigSyst"; trigEffSF.append("_"); trigEffSF.append(trig);trigEffSF.append(reco); trigEffSF.append("_"); trigEffSF.append(isol);
+          //accTrigSF.insert( std::pair<std::string, floatAccessor > ( trig+reco+isol , floatAccessor( "MuonEfficiencyCorrector_TrigSyst" + "_" + trig + "_" + reco + "_" + isol ) ) );
+          accTrigSF.insert( std::pair<std::string, floatAccessor > ( trig+reco+isol , floatAccessor( trigEffSF ) ) );
+          if( (accTrigSF.at( trig+reco+isol )).isAvailable( *muon ) ) { 
+            m_TrigEff_SF->at( trig+reco+isol ).push_back( (accTrigSF.at( trig+reco+isol ))( *muon ) ); 
+          }else { 
+            m_TrigEff_SF->at( trig+reco+isol ).push_back( junkSF ); 
+          }
+          
+          std::string trigMCEff = "MuonEfficiencyCorrector_TrigMCEffSyst"; trigMCEff.append("_"); trigMCEff.append(trig); trigMCEff.append(reco); trigMCEff.append("_"); trigMCEff.append(isol);
+          //accTrigEFF.insert( std::pair<std::string, floatAccessor > ( trig+reco+isol , floatAccessor( "MuonEfficiencyCorrector_TrigMCEffSyst" + "_" + trig + "_" + reco + "_" + isol ) ) );
+          accTrigEFF.insert( std::pair<std::string, floatAccessor > ( trig+reco+isol , floatAccessor( trigMCEff ) ) );
+          if( (accTrigEFF.at( trig+reco+isol )).isAvailable( *muon ) ) { 
+            m_TrigMCEff->at( trig+reco+isol ).push_back( (accTrigEFF.at( trig+reco+isol ))( *muon ) ); 
+          } else { 
+            m_TrigMCEff->at( trig+reco+isol ).push_back( junkEff ); 
+          }
+      
+        }
+      }
+    }
+    
+    
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Loose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoLoose");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoFixedCutTightTrackOnly");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_Gradient("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoGradient");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Loose_GradientLoose("MuonEfficiencyCorrector_TrigSyst_RecoLoose_IsoGradientLoose");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoFixedCutTightTrackOnly");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_Gradient("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoGradient");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigSF_Medium_GradientLoose("MuonEfficiencyCorrector_TrigSyst_RecoMedium_IsoGradientLoose");
+    
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_Loose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoLoose");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoFixedCutTightTrackOnly");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_Gradient("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoGradient");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Loose_GradientLoose("MuonEfficiencyCorrector_TrigMCEff_RecoLoose_IsoGradientLoose");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_FixedCutTightTrackOnly("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoFixedCutTightTrackOnly");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_Gradient("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoGradient");
+    // static SG::AuxElement::Accessor< std::vector< float > > accTrigMCEff_Medium_GradientLoose("MuonEfficiencyCorrector_TrigMCEff_RecoMedium_IsoGradientLoose");
     
     static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_LooseTrackOnly("MuonEfficiencyCorrector_IsoSyst_LooseTrackOnly");
     static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_Loose("MuonEfficiencyCorrector_IsoSyst_IsoLoose");
@@ -858,27 +978,25 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     static SG::AuxElement::Accessor< std::vector< float > > accIsoSF_FixedCutTightTrackOnly("MuonEfficiencyCorrector_IsoSyst_IsoFixedCutTightTrackOnly");
     static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
 
-    std::vector<float> junkSF(1,1.0);
-    std::vector<float> junkEff(1,0.0);
 
     if( accRecoSF_Loose.isAvailable( *muon ) )         { m_RecoEff_SF_Loose->push_back( accRecoSF_Loose( *muon ) ); } else { m_RecoEff_SF_Loose->push_back( junkSF ); }
     if( accRecoSF_Medium.isAvailable( *muon ) )         { m_RecoEff_SF_Medium->push_back( accRecoSF_Medium( *muon ) ); } else { m_RecoEff_SF_Medium->push_back( junkSF ); }
     
-    if ( accTrigSF_Loose_Loose.isAvailable( *muon ) )                     { m_TrigEff_SF_Loose_Loose->push_back( accTrigSF_Loose_Loose( *muon ) ); } else { m_TrigEff_SF_Loose_Loose->push_back( junkSF ); }
-    if ( accTrigSF_Loose_FixedCutTightTrackOnly.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_FixedCutTightTrackOnly->push_back( accTrigSF_Loose_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigEff_SF_Loose_FixedCutTightTrackOnly->push_back( junkSF ); }
-    if ( accTrigSF_Loose_Gradient.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_Gradient->push_back( accTrigSF_Loose_Gradient( *muon ) ); } else { m_TrigEff_SF_Loose_Gradient->push_back( junkSF ); }
-    if ( accTrigSF_Loose_GradientLoose.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_GradientLoose->push_back( accTrigSF_Loose_GradientLoose( *muon ) ); } else { m_TrigEff_SF_Loose_GradientLoose->push_back( junkSF ); }
-    if ( accTrigSF_Medium_FixedCutTightTrackOnly.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_FixedCutTightTrackOnly->push_back( accTrigSF_Medium_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigEff_SF_Medium_FixedCutTightTrackOnly->push_back( junkSF ); }
-    if ( accTrigSF_Medium_Gradient.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_Gradient->push_back( accTrigSF_Medium_Gradient( *muon ) ); } else { m_TrigEff_SF_Medium_Gradient->push_back( junkSF ); }
-    if ( accTrigSF_Medium_GradientLoose.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_GradientLoose->push_back( accTrigSF_Medium_GradientLoose( *muon ) ); } else { m_TrigEff_SF_Medium_GradientLoose->push_back( junkSF ); }
+    // if ( accTrigSF_Loose_Loose.isAvailable( *muon ) )                     { m_TrigEff_SF_Loose_Loose->push_back( accTrigSF_Loose_Loose( *muon ) ); } else { m_TrigEff_SF_Loose_Loose->push_back( junkSF ); }
+    // if ( accTrigSF_Loose_FixedCutTightTrackOnly.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_FixedCutTightTrackOnly->push_back( accTrigSF_Loose_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigEff_SF_Loose_FixedCutTightTrackOnly->push_back( junkSF ); }
+    // if ( accTrigSF_Loose_Gradient.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_Gradient->push_back( accTrigSF_Loose_Gradient( *muon ) ); } else { m_TrigEff_SF_Loose_Gradient->push_back( junkSF ); }
+    // if ( accTrigSF_Loose_GradientLoose.isAvailable( *muon ) )    { m_TrigEff_SF_Loose_GradientLoose->push_back( accTrigSF_Loose_GradientLoose( *muon ) ); } else { m_TrigEff_SF_Loose_GradientLoose->push_back( junkSF ); }
+    // if ( accTrigSF_Medium_FixedCutTightTrackOnly.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_FixedCutTightTrackOnly->push_back( accTrigSF_Medium_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigEff_SF_Medium_FixedCutTightTrackOnly->push_back( junkSF ); }
+    // if ( accTrigSF_Medium_Gradient.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_Gradient->push_back( accTrigSF_Medium_Gradient( *muon ) ); } else { m_TrigEff_SF_Medium_Gradient->push_back( junkSF ); }
+    // if ( accTrigSF_Medium_GradientLoose.isAvailable( *muon ) )    { m_TrigEff_SF_Medium_GradientLoose->push_back( accTrigSF_Medium_GradientLoose( *muon ) ); } else { m_TrigEff_SF_Medium_GradientLoose->push_back( junkSF ); }
     
-    if ( accTrigMCEff_Loose_Loose.isAvailable( *muon ) )                  { m_TrigMCEff_Loose_Loose->push_back( accTrigMCEff_Loose_Loose( *muon ) ); } else { m_TrigMCEff_Loose_Loose->push_back( junkEff ); }
-    if ( accTrigMCEff_Loose_FixedCutTightTrackOnly.isAvailable( *muon ) ) { m_TrigMCEff_Loose_FixedCutTightTrackOnly->push_back( accTrigMCEff_Loose_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigMCEff_Loose_FixedCutTightTrackOnly->push_back( junkEff ); }
-    if ( accTrigMCEff_Loose_Gradient.isAvailable( *muon ) ) { m_TrigMCEff_Loose_Gradient->push_back( accTrigMCEff_Loose_Gradient( *muon ) ); } else { m_TrigMCEff_Loose_Gradient->push_back( junkEff ); }
-    if ( accTrigMCEff_Loose_GradientLoose.isAvailable( *muon ) ) { m_TrigMCEff_Loose_GradientLoose->push_back( accTrigMCEff_Loose_GradientLoose( *muon ) ); } else { m_TrigMCEff_Loose_GradientLoose->push_back( junkEff ); }
-    if ( accTrigMCEff_Medium_FixedCutTightTrackOnly.isAvailable( *muon ) ) { m_TrigMCEff_Medium_FixedCutTightTrackOnly->push_back( accTrigMCEff_Medium_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigMCEff_Medium_FixedCutTightTrackOnly->push_back( junkEff ); }
-    if ( accTrigMCEff_Medium_Gradient.isAvailable( *muon ) ) { m_TrigMCEff_Medium_Gradient->push_back( accTrigMCEff_Medium_Gradient( *muon ) ); } else { m_TrigMCEff_Medium_Gradient->push_back( junkEff ); }
-    if ( accTrigMCEff_Medium_GradientLoose.isAvailable( *muon ) ) { m_TrigMCEff_Medium_GradientLoose->push_back( accTrigMCEff_Medium_GradientLoose( *muon ) ); } else { m_TrigMCEff_Medium_GradientLoose->push_back( junkEff ); }
+    // if ( accTrigMCEff_Loose_Loose.isAvailable( *muon ) )                  { m_TrigMCEff_Loose_Loose->push_back( accTrigMCEff_Loose_Loose( *muon ) ); } else { m_TrigMCEff_Loose_Loose->push_back( junkEff ); }
+    // if ( accTrigMCEff_Loose_FixedCutTightTrackOnly.isAvailable( *muon ) ) { m_TrigMCEff_Loose_FixedCutTightTrackOnly->push_back( accTrigMCEff_Loose_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigMCEff_Loose_FixedCutTightTrackOnly->push_back( junkEff ); }
+    // if ( accTrigMCEff_Loose_Gradient.isAvailable( *muon ) ) { m_TrigMCEff_Loose_Gradient->push_back( accTrigMCEff_Loose_Gradient( *muon ) ); } else { m_TrigMCEff_Loose_Gradient->push_back( junkEff ); }
+    // if ( accTrigMCEff_Loose_GradientLoose.isAvailable( *muon ) ) { m_TrigMCEff_Loose_GradientLoose->push_back( accTrigMCEff_Loose_GradientLoose( *muon ) ); } else { m_TrigMCEff_Loose_GradientLoose->push_back( junkEff ); }
+    // if ( accTrigMCEff_Medium_FixedCutTightTrackOnly.isAvailable( *muon ) ) { m_TrigMCEff_Medium_FixedCutTightTrackOnly->push_back( accTrigMCEff_Medium_FixedCutTightTrackOnly( *muon ) ); } else { m_TrigMCEff_Medium_FixedCutTightTrackOnly->push_back( junkEff ); }
+    // if ( accTrigMCEff_Medium_Gradient.isAvailable( *muon ) ) { m_TrigMCEff_Medium_Gradient->push_back( accTrigMCEff_Medium_Gradient( *muon ) ); } else { m_TrigMCEff_Medium_Gradient->push_back( junkEff ); }
+    // if ( accTrigMCEff_Medium_GradientLoose.isAvailable( *muon ) ) { m_TrigMCEff_Medium_GradientLoose->push_back( accTrigMCEff_Medium_GradientLoose( *muon ) ); } else { m_TrigMCEff_Medium_GradientLoose->push_back( junkEff ); }
     
     if( accIsoSF_LooseTrackOnly.isAvailable( *muon ) ) { m_IsoEff_SF_LooseTrackOnly->push_back( accIsoSF_LooseTrackOnly( *muon ) ); } else { m_IsoEff_SF_LooseTrackOnly->push_back( junkSF ); }
     if( accIsoSF_Loose.isAvailable( *muon ) )          { m_IsoEff_SF_Loose->push_back( accIsoSF_Loose( *muon ) ); } else { m_IsoEff_SF_Loose->push_back( junkSF ); }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -78,11 +78,9 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   // list of comma-separated years
   m_Years                      = "2016"; 
   m_MCCampaign                 = "";
-  m_SingleMuTrig               = "HLT_mu20_iloose_L1MU15";
-  m_DiMuTrig                   = "HLT_2mu14";
   
   // list of trigger legs. For di-mu triggers pass individual legs  
-  m_SingleMuTrigList           = "HLT_mu26_imedium";
+  m_MuTrigLegs                 = "HLT_mu26_imedium";
 
   // TTVA SF
   //
@@ -360,7 +358,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   
   } 
   
-  std::string tmp_triggers = m_SingleMuTrigList;
+  std::string tmp_triggers = m_MuTrigLegs;
  
   // Parse all comma seperated trigger corrections
   //

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -223,7 +223,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
     //
-    m_outputSystNamesReco = m_outputSystNamesReco + "_" + m_WorkingPointReco;
+    m_outputSystNamesReco = m_outputSystNamesReco + "_Reco" + m_WorkingPointReco;
 
     if ( m_debug ) {
       CP::SystematicSet affectSystsReco = m_muRecoSF_tool->affectingSystematics();
@@ -970,9 +970,6 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
              i += outsfstr.length();
            } 
            
-           std::cout << "Fucking here " << sf_string << " " << std::endl;
-           std::cout << "and here " << eff_string << " " << std::endl;
-
            SG::AuxElement::Decorator< std::vector<float> > effMC( eff_string );
            if ( !effMC.isAvailable( *mu_itr ) ) {
              effMC( *mu_itr ) = std::vector<float>();

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -358,21 +358,11 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   
   } 
   
-  std::string tmp_triggers = m_MuTrigLegs;
- 
-  // Parse all comma seperated trigger corrections
-  //
-  while ( tmp_triggers.size() > 0) {
-    size_t pos = tmp_triggers.find_first_of(',');
-    if ( pos == std::string::npos ) {
-      pos = tmp_triggers.size();
-      m_SingleMuTriggers.push_back(tmp_triggers.substr(0, pos));
-      tmp_triggers.erase(0, pos);
-    } else {
-      m_SingleMuTriggers.push_back(tmp_triggers.substr(0, pos));
-      tmp_triggers.erase(0, pos+1);
-    }
-  }
+  std::string token;
+  std::istringstream ss(m_MuTrigLegs);
+  while ( std::getline(ss, token, ',') ) {
+    m_SingleMuTriggers.push_back(token);
+  } 
   
   //  Add the chosen WP to the string labelling the vector<SF>/vector<eff> decoration
   //

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -259,9 +259,14 @@ namespace HelperClasses {
     bool m_trackhitcont;
     bool m_effSF;
     bool m_energyLoss;
-    std::map<std::string,bool> m_recoWPsMap;
-    std::map<std::string,bool> m_isolWPsMap;
-    std::map<std::string,bool> m_trigWPsMap;
+    //std::map<std::string,bool> m_recoWPsMap;
+    //std::map<std::string,bool> m_isolWPsMap;
+    //std::map<std::string,bool> m_trigWPsMap;
+    
+    std::vector< std::string > m_recoWPs;
+    std::vector< std::string > m_isolWPs;
+    std::vector< std::string > m_trigWPs;
+    
     MuonInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~MuonInfoSwitch() {}
   protected:

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -259,9 +259,9 @@ namespace HelperClasses {
     bool m_trackhitcont;
     bool m_effSF;
     bool m_energyLoss;
-    std::map<std::string,bool> m_recoWPs;
-    std::map<std::string,bool> m_isolWPs;
-    std::map<std::string,bool> m_triggers;
+    std::map<std::string,bool> m_recoWPsMap;
+    std::map<std::string,bool> m_isolWPsMap;
+    std::map<std::string,bool> m_trigWPsMap;
     MuonInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~MuonInfoSwitch() {}
   protected:

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -259,6 +259,9 @@ namespace HelperClasses {
     bool m_trackhitcont;
     bool m_effSF;
     bool m_energyLoss;
+    std::map<std::string,bool> m_recoWPs;
+    std::map<std::string,bool> m_isolWPs;
+    std::map<std::string,bool> m_triggers;
     MuonInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~MuonInfoSwitch() {}
   protected:

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -46,35 +46,11 @@ namespace xAH {
     
     // scale factors w/ sys
     // per object
-    std::vector< float >  RecoEff_SF_Loose;
-    std::vector< float >  RecoEff_SF_Medium;
-    
-    //std::vector< float >  TrigEff_SF_Loose_Loose;
-    //std::vector< float >  TrigEff_SF_Loose_FixedCutTightTrackOnly;
-    //std::vector< float >  TrigEff_SF_Loose_Gradient;
-    //std::vector< float >  TrigEff_SF_Loose_GradientLoose;
-    //std::vector< float >  TrigEff_SF_Medium_FixedCutTightTrackOnly;
-    //std::vector< float >  TrigEff_SF_Medium_Gradient;
-    //std::vector< float >  TrigEff_SF_Medium_GradientLoose;
-    
-    //std::vector< float >  TrigMCEff_Loose_Loose;
-    //std::vector< float >  TrigMCEff_Loose_FixedCutTightTrackOnly;
-    //std::vector< float >  TrigMCEff_Loose_Gradient;
-    //std::vector< float >  TrigMCEff_Loose_GradientLoose;
-    //std::vector< float >  TrigMCEff_Medium_FixedCutTightTrackOnly;
-    //std::vector< float >  TrigMCEff_Medium_Gradient;
-    //std::vector< float >  TrigMCEff_Medium_GradientLoose;
-    
+    std::map< std::string, std::vector< float > > RecoEff_SF;
+    std::map< std::string, std::vector< float > > IsoEff_SF;
     std::map< std::string, std::vector< float > > TrigEff_SF;
     std::map< std::string, std::vector< float > > TrigMCEff;
     
-    std::vector< float >  IsoEff_SF_LooseTrackOnly;
-    std::vector< float >  IsoEff_SF_Loose;
-    std::vector< float >  IsoEff_SF_Tight;
-    std::vector< float >  IsoEff_SF_Gradient;
-    std::vector< float >  IsoEff_SF_GradientLoose;
-    std::vector< float >  IsoEff_SF_FixedCutLoose;
-    std::vector< float >  IsoEff_SF_FixedCutTightTrackOnly;
     std::vector< float >  TTVAEff_SF;
     
     // track parameters

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -49,21 +49,24 @@ namespace xAH {
     std::vector< float >  RecoEff_SF_Loose;
     std::vector< float >  RecoEff_SF_Medium;
     
-    std::vector< float >  TrigEff_SF_Loose_Loose;
-    std::vector< float >  TrigEff_SF_Loose_FixedCutTightTrackOnly;
-    std::vector< float >  TrigEff_SF_Loose_Gradient;
-    std::vector< float >  TrigEff_SF_Loose_GradientLoose;
-    std::vector< float >  TrigEff_SF_Medium_FixedCutTightTrackOnly;
-    std::vector< float >  TrigEff_SF_Medium_Gradient;
-    std::vector< float >  TrigEff_SF_Medium_GradientLoose;
+    //std::vector< float >  TrigEff_SF_Loose_Loose;
+    //std::vector< float >  TrigEff_SF_Loose_FixedCutTightTrackOnly;
+    //std::vector< float >  TrigEff_SF_Loose_Gradient;
+    //std::vector< float >  TrigEff_SF_Loose_GradientLoose;
+    //std::vector< float >  TrigEff_SF_Medium_FixedCutTightTrackOnly;
+    //std::vector< float >  TrigEff_SF_Medium_Gradient;
+    //std::vector< float >  TrigEff_SF_Medium_GradientLoose;
     
-    std::vector< float >  TrigMCEff_Loose_Loose;
-    std::vector< float >  TrigMCEff_Loose_FixedCutTightTrackOnly;
-    std::vector< float >  TrigMCEff_Loose_Gradient;
-    std::vector< float >  TrigMCEff_Loose_GradientLoose;
-    std::vector< float >  TrigMCEff_Medium_FixedCutTightTrackOnly;
-    std::vector< float >  TrigMCEff_Medium_Gradient;
-    std::vector< float >  TrigMCEff_Medium_GradientLoose;
+    //std::vector< float >  TrigMCEff_Loose_Loose;
+    //std::vector< float >  TrigMCEff_Loose_FixedCutTightTrackOnly;
+    //std::vector< float >  TrigMCEff_Loose_Gradient;
+    //std::vector< float >  TrigMCEff_Loose_GradientLoose;
+    //std::vector< float >  TrigMCEff_Medium_FixedCutTightTrackOnly;
+    //std::vector< float >  TrigMCEff_Medium_Gradient;
+    //std::vector< float >  TrigMCEff_Medium_GradientLoose;
+    
+    std::map< std::string, std::vector< float > > TrigEff_SF;
+    std::map< std::string, std::vector< float > > TrigMCEff;
     
     std::vector< float >  IsoEff_SF_LooseTrackOnly;
     std::vector< float >  IsoEff_SF_Loose;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -14,6 +14,8 @@
 #include <xAODAnaHelpers/Muon.h>
 #include <xAODAnaHelpers/ParticleContainer.h>
 
+typedef SG::AuxElement::Accessor< std::vector< float > > floatAccessor ;
+
 namespace xAH {
 
   class MuonContainer : public ParticleContainer<Muon,HelperClasses::MuonInfoSwitch>
@@ -70,21 +72,60 @@ namespace xAH {
       std::vector< std::vector< float > > *m_RecoEff_SF_Loose;
       std::vector< std::vector< float > > *m_RecoEff_SF_Medium;
       
-      std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Loose;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Loose_FixedCutTightTrackOnly;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Gradient;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Loose_GradientLoose;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Medium_FixedCutTightTrackOnly;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Medium_Gradient;
-      std::vector< std::vector< float > > *m_TrigEff_SF_Medium_GradientLoose;
+      std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
+      std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
+      std::vector< std::string > m_triggers = {
+                                                "HLT_mu10",
+                                                "HLT_mu14",
+                                                "HLT_mu18",
+                                                "HLT_mu20",
+                                                "HLT_mu22",
+                                                "HLT_mu24",
+                                                "HLT_mu26",
+                                                "HLT_mu40", 
+                                                "HLT_mu50",
+                                                "HLT_mu8noL1", 
+                                                "HLT_mu20_iloose_L1MU15",
+                                                "HLT_mu24_iloose_L1MU15",
+                                                "HLT_mu24_imedium",
+                                                "HLT_mu26_imedium",
+                                                "HLT_mu20_iloose_L1MU15_OR_HLT_mu50",
+                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu50",
+                                                "HLT_mu24_imedium_OR_HLT_mu50",
+                                                "HLT_mu26_imedium_OR_HLT_mu50",
+                                                "HLT_mu20_iloose_L1MU15_OR_HLT_mu40",
+                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu40",
+                                                "HLT_mu24_imedium_OR_HLT_mu40",
+                                                "HLT_mu26_imedium_OR_HLT_mu40",
+                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose",
+                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40",
+                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50",
+                                                "HLT_mu24_ivarmedium",
+                                                "HLT_mu24_ivarmedium_OR_HLT_mu40",
+                                                "HLT_mu24_ivarmedium_OR_HLT_mu50",
+                                                "HLT_mu26_ivarmedium",
+                                                "HLT_mu26_ivarmedium_OR_HLT_mu40",
+                                                "HLT_mu26_ivarmedium_OR_HLT_mu50",
+                                                };
+
+      std::vector< std::string > m_recoWPs = {"Loose","Medium","Tight"};
+      std::vector< std::string > m_isolWPs = {"Loose","FixedCutTightTrackOnly","Gradient","GradientLoose"};
       
-      std::vector< std::vector< float > > *m_TrigMCEff_Loose_Loose;
-      std::vector< std::vector< float > > *m_TrigMCEff_Loose_FixedCutTightTrackOnly;
-      std::vector< std::vector< float > > *m_TrigMCEff_Loose_Gradient;
-      std::vector< std::vector< float > > *m_TrigMCEff_Loose_GradientLoose;
-      std::vector< std::vector< float > > *m_TrigMCEff_Medium_FixedCutTightTrackOnly;
-      std::vector< std::vector< float > > *m_TrigMCEff_Medium_Gradient;
-      std::vector< std::vector< float > > *m_TrigMCEff_Medium_GradientLoose;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Loose;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_FixedCutTightTrackOnly;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Gradient;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_GradientLoose;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_FixedCutTightTrackOnly;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_Gradient;
+      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_GradientLoose;
+      
+      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_Loose;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_FixedCutTightTrackOnly;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_Gradient;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_GradientLoose;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_FixedCutTightTrackOnly;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_Gradient;
+      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_GradientLoose;
       
       std::vector< std::vector< float > > *m_IsoEff_SF_LooseTrackOnly;
       std::vector< std::vector< float > > *m_IsoEff_SF_Loose;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -14,8 +14,6 @@
 #include <xAODAnaHelpers/Muon.h>
 #include <xAODAnaHelpers/ParticleContainer.h>
 
-typedef SG::AuxElement::Accessor< std::vector< float > > floatAccessor ;
-
 namespace xAH {
 
   class MuonContainer : public ParticleContainer<Muon,HelperClasses::MuonInfoSwitch>
@@ -76,47 +74,6 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
       
-      std::vector< std::string > m_triggers = {
-                                                "HLT_mu10",
-                                                "HLT_mu14",
-                                                "HLT_mu18",
-                                                "HLT_mu20",
-                                                "HLT_mu22",
-                                                "HLT_mu24",
-                                                "HLT_mu26",
-                                                "HLT_mu40", 
-                                                "HLT_mu50",
-                                                "HLT_mu8noL1", 
-                                                "HLT_mu20_iloose_L1MU15",
-                                                "HLT_mu24_iloose_L1MU15",
-                                                "HLT_mu24_imedium",
-                                                "HLT_mu26_imedium",
-                                                "HLT_mu20_iloose_L1MU15_OR_HLT_mu50",
-                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu50",
-                                                "HLT_mu24_imedium_OR_HLT_mu50",
-                                                "HLT_mu26_imedium_OR_HLT_mu50",
-                                                "HLT_mu20_iloose_L1MU15_OR_HLT_mu40",
-                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu40",
-                                                "HLT_mu24_imedium_OR_HLT_mu40",
-                                                "HLT_mu26_imedium_OR_HLT_mu40",
-                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose",
-                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu40",
-                                                "HLT_mu24_iloose_L1MU15_OR_HLT_mu24_iloose_OR_HLT_mu50",
-                                                "HLT_mu24_ivarmedium",
-                                                "HLT_mu24_ivarmedium_OR_HLT_mu40",
-                                                "HLT_mu24_ivarmedium_OR_HLT_mu50",
-                                                "HLT_mu26_ivarmedium",
-                                                "HLT_mu26_ivarmedium_OR_HLT_mu40",
-                                                "HLT_mu26_ivarmedium_OR_HLT_mu50",
-                                                };
-
-      std::vector< std::string > m_reco = {"RecoLoose","RecoMedium","RecoTight"};
-      std::vector< std::string > m_isol = {"IsoLoose","IsoFixedCutTightTrackOnly","IsoGradient","IsoGradientLoose"};
-      
-      std::vector< std::string > m_recoWPs;
-      std::vector< std::string > m_isolWPs;
-      std::vector< std::string > m_trigWPs;
-  
       // track parameters
       std::vector<float> *m_trkd0;
       std::vector<float> *m_trkd0sig;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -69,11 +69,13 @@ namespace xAH {
     
       // scale factors w/ sys
       // per object
-      std::vector< std::vector< float > > *m_RecoEff_SF_Loose;
-      std::vector< std::vector< float > > *m_RecoEff_SF_Medium;
-      
+      std::vector< std::vector< float > > *m_TTVAEff_SF;
+    
+      std::map< std::string, std::vector< std::vector< float > > >* m_RecoEff_SF;
+      std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
+      
       std::vector< std::string > m_triggers = {
                                                 "HLT_mu10",
                                                 "HLT_mu14",
@@ -108,34 +110,13 @@ namespace xAH {
                                                 "HLT_mu26_ivarmedium_OR_HLT_mu50",
                                                 };
 
-      std::vector< std::string > m_recoWPs = {"Loose","Medium","Tight"};
-      std::vector< std::string > m_isolWPs = {"Loose","FixedCutTightTrackOnly","Gradient","GradientLoose"};
+      std::vector< std::string > m_reco = {"RecoLoose","RecoMedium","RecoTight"};
+      std::vector< std::string > m_isol = {"IsoLoose","IsoFixedCutTightTrackOnly","IsoGradient","IsoGradientLoose"};
       
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Loose;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_FixedCutTightTrackOnly;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_Gradient;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Loose_GradientLoose;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_FixedCutTightTrackOnly;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_Gradient;
-      //std::vector< std::vector< float > > *m_TrigEff_SF_Medium_GradientLoose;
-      
-      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_Loose;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_FixedCutTightTrackOnly;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_Gradient;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Loose_GradientLoose;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_FixedCutTightTrackOnly;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_Gradient;
-      //std::vector< std::vector< float > > *m_TrigMCEff_Medium_GradientLoose;
-      
-      std::vector< std::vector< float > > *m_IsoEff_SF_LooseTrackOnly;
-      std::vector< std::vector< float > > *m_IsoEff_SF_Loose;
-      std::vector< std::vector< float > > *m_IsoEff_SF_Tight;
-      std::vector< std::vector< float > > *m_IsoEff_SF_Gradient;
-      std::vector< std::vector< float > > *m_IsoEff_SF_GradientLoose;
-      std::vector< std::vector< float > > *m_IsoEff_SF_FixedCutLoose;
-      std::vector< std::vector< float > > *m_IsoEff_SF_FixedCutTightTrackOnly;
-      std::vector< std::vector< float > > *m_TTVAEff_SF;
-    
+      std::vector< std::string > m_recoWPs;
+      std::vector< std::string > m_isolWPs;
+      std::vector< std::string > m_trigWPs;
+  
       // track parameters
       std::vector<float> *m_trkd0;
       std::vector<float> *m_trkd0sig;

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -54,6 +54,7 @@ public:
   std::string   m_MCCampaign;
   std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
   std::string   m_DiMuTrig;          // this can be either a dimuon trigger chain, or an OR of ( N single muon trigger chains, dimuon chain )
+  std::string   m_SingleMuTrigList;  // list of comma-separated single-mu trigger corrections. Individual legs of di-mu menus can be parsed
 
   // TTVA efficiency SF
   std::string   m_WorkingPointTTVA;
@@ -101,6 +102,7 @@ private:
   std::vector<std::string> m_YearsList;                                    //!
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool;                         //!
   std::string m_TTVAEffSF_tool_name;                                       //!
+  std::vector<std::string> m_SingleMuTriggers;                             //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -52,9 +52,7 @@ public:
   std::string   m_WorkingPointIsoTrig;
   std::string   m_Years;
   std::string   m_MCCampaign;
-  std::string   m_SingleMuTrig;      // this can be either a single muon trigger chain, or an OR of ( 2 single muon chains )
-  std::string   m_DiMuTrig;          // this can be either a dimuon trigger chain, or an OR of ( N single muon trigger chains, dimuon chain )
-  std::string   m_SingleMuTrigList;  // list of comma-separated single-mu trigger corrections. Individual legs of di-mu menus can be parsed
+  std::string   m_MuTrigLegs;  // list of comma-separated single-mu trigger corrections. Individual legs of di-mu menus can be parsed
 
   // TTVA efficiency SF
   std::string   m_WorkingPointTTVA;


### PR DESCRIPTION
This pull request addresses #730. An update of HelperClasses.cxx/h MuonEfficiencyCorrection.cxx/h Muon.h and MuonContainer.cxx/h were necessary. Hard-coded lists of triggers, with isolation and reconstrucion working points were necessary in HelperClasses.h and MuonContainer.h