### PR TITLE
added trigger option for electron scale-factors

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -388,10 +388,12 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
 
     for (auto& PID : m_infoSwitch.m_PIDWPs) {
       for (auto& iso : m_infoSwitch.m_isolWPs) {
-        elec.TrigEff_SF[ PID+iso ] = (*m_TrigEff_SF)[ PID+iso ].at(idx);
-        elec.TrigMCEff [ PID+iso ] = (*m_TrigMCEff )[ PID+iso ].at(idx);
-        if(iso.empty()) continue;
-        elec.IsoEff_SF[ PID+iso ] =  (*m_IsoEff_SF) [ PID+iso ].at(idx);
+        if(!iso.empty())
+          elec.IsoEff_SF[ PID+iso ] =  (*m_IsoEff_SF) [ PID+iso ].at(idx);
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+          elec.TrigEff_SF[ trig+PID+iso ] = (*m_TrigEff_SF)[ trig+PID+iso ].at(idx);
+          elec.TrigMCEff [ trig+PID+iso ] = (*m_TrigMCEff )[ trig+PID+iso ].at(idx);
+        }
       }
     }
 
@@ -868,7 +870,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       for (auto& isol : m_infoSwitch.m_isolWPs) {
 
         if(!isol.empty()) {
-          std::string IsoSF = "EleEffCorr_IsoSyst_" + PID + isol;
+          std::string IsoSF = "EleEffCorr_IsoSyst_" + PID + "_" + isol;
           accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( PID+isol , SG::AuxElement::Accessor< std::vector< float > >( IsoSF ) ) );
           if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) { 
             m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) ); 

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -107,20 +107,20 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    auto PID_it = std::begin(m_PIDWPs);
-    auto iso_it = std::begin(m_isolWPs);
-    while ( PID_it != std::end(m_PIDWPs) ) {
-      if (!m_infoSwitch.m_PIDWPs[ *PID_it ]) PID_it = m_PIDWPs.erase( PID_it );
-      else PID_it++;
-    }
-    while ( iso_it != std::end(m_isolWPs) ) {
-      if (!m_infoSwitch.m_isolWPs[ *iso_it ]) iso_it = m_isolWPs.erase( iso_it );
-      else iso_it++;
-    }
-    if (m_debug) {
-      for (auto& PID : m_PIDWPs) {
-        for (auto& isol : m_isolWPs) {
-          Info("ElectronConainer()", "Used working points: %s%s", PID.c_str(), isol.c_str() );
+
+    // default PID working points if no user input
+    if ( !m_infoSwitch.m_PIDWPs.size() ) m_infoSwitch.m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
+
+    // default isolation working points if no user input
+    if ( !m_infoSwitch.m_isolWPs.size() ) m_infoSwitch.m_isolWPs = {"","isolGradient","isolLoose","isolTight"};
+
+    // default trigger working points if no user input
+    if ( !m_infoSwitch.m_trigWPs.size() ) m_infoSwitch.m_trigWPs = {"SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0"};
+
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      for (auto& isol : m_infoSwitch.m_isolWPs) {
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+          Info("ElectronConainer()", "Used working points: %s_%s_%s", trig.c_str(), PID.c_str(), isol.c_str() );
         }
       }
     }
@@ -282,16 +282,19 @@ void ElectronContainer::setTree(TTree *tree)
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    for (auto& PID : m_PIDWPs) {
-      for (auto& isol : m_isolWPs) {
-        tree->SetBranchStatus ( (m_name+"_TrigEff_SF_" + PID + isol).c_str() , 1 );
-        tree->SetBranchAddress( (m_name+"_TrigEff_SF_" + PID + isol).c_str() , & (*m_TrigEff_SF)[ PID+isol ] );
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      for (auto& isol : m_infoSwitch.m_isolWPs) {
+        if(!isol.empty()) {
+          tree->SetBranchStatus ( (m_name+"_IsoEff_SF_" + PID + "_" + isol).c_str() , 1);
+          tree->SetBranchAddress( (m_name+"_IsoEff_SF_" + PID + "_" + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+        }
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+          tree->SetBranchStatus ( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , 1 );
+          tree->SetBranchAddress( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
 
-        tree->SetBranchStatus ( (m_name+"_TrigMCEff_"  + PID + isol).c_str() , 1 );
-        tree->SetBranchAddress( (m_name+"_TrigMCEff_"  + PID + isol).c_str() , & (*m_TrigMCEff) [ PID+isol ] );
-        if(isol.empty()) continue;
-        tree->SetBranchStatus ( (m_name+"_IsoEff_SF_" + PID + isol).c_str() , 1);
-        tree->SetBranchAddress( (m_name+"_IsoEff_SF_" + PID + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+          tree->SetBranchStatus ( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , 1 );
+          tree->SetBranchAddress( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
+        }
       }
     }
     
@@ -383,8 +386,8 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
   // per object
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    for (auto& PID : m_PIDWPs) {
-      for (auto& iso : m_isolWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      for (auto& iso : m_infoSwitch.m_isolWPs) {
         elec.TrigEff_SF[ PID+iso ] = (*m_TrigEff_SF)[ PID+iso ].at(idx);
         elec.TrigMCEff [ PID+iso ] = (*m_TrigMCEff )[ PID+iso ].at(idx);
         if(iso.empty()) continue;
@@ -491,12 +494,14 @@ void ElectronContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    for (auto& PID : m_PIDWPs) {
-      for (auto& isol : m_isolWPs) {
-        tree->Branch( (m_name+"_TrigEff_SF_" + PID + isol).c_str() , & (*m_TrigEff_SF)[ PID+isol ] );
-        tree->Branch( (m_name+"_TrigMCEff_"  + PID + isol).c_str() , & (*m_TrigMCEff) [ PID+isol ] );
-        if(isol.empty()) continue;
-        tree->Branch( (m_name+"_IsoEff_SF_" + PID + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      for (auto& isol : m_infoSwitch.m_isolWPs) {
+        if(!isol.empty())
+          tree->Branch( (m_name+"_IsoEff_SF_"  + PID + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+          tree->Branch( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
+          tree->Branch( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
+        }
       }
     }
     
@@ -601,12 +606,14 @@ void ElectronContainer::clear()
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
     
-    for (auto& PID : m_PIDWPs) {
-      for (auto& isol : m_isolWPs) {
-        (*m_TrigEff_SF)[ PID+isol ].clear();
-        (*m_TrigMCEff)[ PID+isol ].clear();
-        if(isol.empty()) continue;
-        (*m_IsoEff_SF)[ PID+isol ].clear();
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      for (auto& isol : m_infoSwitch.m_isolWPs) {
+        if(!isol.empty())
+          (*m_IsoEff_SF)[ PID+isol ].clear();
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+          (*m_TrigEff_SF)[ trig+PID+isol ].clear();
+          (*m_TrigMCEff)[ trig+PID+isol ].clear();
+        }
       }
     }
 
@@ -852,37 +859,46 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
     std::vector<float> junkSF(1,1.0);
     std::vector<float> junkEff(1,0.0);
 
-    static std::map< std::string, floatAccessor > accIsoSF;
-    static std::map< std::string, floatAccessor > accTrigSF;
-    static std::map< std::string, floatAccessor > accTrigEFF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accIsoSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigEFF;
 
-    for (auto& PID : m_PIDWPs) {
-      
-      for (auto& isol : m_isolWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
 
-       accTrigSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_TrigSyst_" + PID + isol ) ) );
-       if( (accTrigSF.at( PID+isol )).isAvailable( *elec ) ) { 
-         m_TrigEff_SF->at( PID+isol ).push_back( (accTrigSF.at( PID+isol ))( *elec ) ); 
-       }else { 
-         m_TrigEff_SF->at( PID+isol ).push_back( junkSF ); 
-       }
+      for (auto& isol : m_infoSwitch.m_isolWPs) {
 
-       accTrigEFF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_TrigMCEffSyst_" + PID + isol ) ) );
-       if( (accTrigEFF.at( PID+isol )).isAvailable( *elec ) ) { 
-         m_TrigMCEff->at( PID+isol ).push_back( (accTrigEFF.at( PID+isol ))( *elec ) ); 
-       } else { 
-         m_TrigMCEff->at( PID+isol ).push_back( junkEff ); 
-       }
+        if(!isol.empty()) {
+          std::string IsoSF = "EleEffCorr_IsoSyst_" + PID + isol;
+          accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( PID+isol , SG::AuxElement::Accessor< std::vector< float > >( IsoSF ) ) );
+          if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) { 
+            m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) ); 
+          } else { 
+            m_IsoEff_SF->at( PID+isol ).push_back( junkSF ); 
+          }
+        }
 
-       if(isol.empty()) continue;
-       accIsoSF.insert( std::pair<std::string, floatAccessor > ( PID+isol , floatAccessor( "EleEffCorr_IsoSyst_" + PID + isol ) ) );
-       if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) { 
-         m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) ); 
-       } else { 
-         m_IsoEff_SF->at( PID+isol ).push_back( junkSF ); 
-       }
-     }
-   }
+        for (auto& trig : m_infoSwitch.m_trigWPs) {
+
+          std::string TrigSF = "EleEffCorr_TrigSyst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
+          accTrigSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigSF ) ) );
+          if( (accTrigSF.at( trig+PID+isol )).isAvailable( *elec ) ) { 
+            m_TrigEff_SF->at( trig+PID+isol ).push_back( (accTrigSF.at( trig+PID+isol ))( *elec ) ); 
+          }else { 
+            m_TrigEff_SF->at( trig+PID+isol ).push_back( junkSF ); 
+          }
+
+          std::string TrigEFF = "EleEffCorr_TrigMCEffSyst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
+          accTrigEFF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigEFF ) ) );
+          if( (accTrigEFF.at( trig+PID+isol )).isAvailable( *elec ) ) { 
+            m_TrigMCEff->at( trig+PID+isol ).push_back( (accTrigEFF.at( trig+PID+isol ))( *elec ) ); 
+          } else { 
+            m_TrigMCEff->at( trig+PID+isol ).push_back( junkEff ); 
+          }
+
+        }
+
+      }
+    }
 
    static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("EleEffCorr_RecoSyst");
    static SG::AuxElement::Accessor< std::vector< float > > accPIDSF_LHLooseAndBLayer("EleEffCorr_PIDSyst_LooseAndBLayerLLH");

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -170,6 +170,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       Info("initialize()", "Setting simulation flavour to AFII");
       sim_flav = 3;
     }
+    else if ( stringMeta.empty() ) {
+      Warning("initialize()", "No meta-data string found. Simulation flavour will be set to FullSim. Care if you are running on Fast-Sim MC.");
+    }
   }
 
   // 1.
@@ -315,7 +318,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       m_asgElEffCorrTool_elSF_Reco->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
       std::vector<std::string> inputFilesReco{ m_corrFileNameReco } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("CorrectionFileNameList",inputFilesReco),"Failed to set property CorrectionFileNameList");
-      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("ForceDataType",1),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Reco");
     }
 
@@ -353,6 +356,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
     m_WorkingPointIsoTrig = HelperFunctions::parse_wp( "ISO", m_corrFileNameTrig );
     m_WorkingPointIDTrig  = HelperFunctions::parse_wp( "ID", m_corrFileNameTrig );
+    m_WorkingPointTrigTrig = HelperFunctions::parse_wp( "TRIG", m_corrFileNameTrigMCEff );
 
     if ( m_WorkingPointIDTrig.empty() ) {
       Error("initialize()", "ID working point for trigger SF not found in config file! This should not happen. Exiting." );
@@ -361,7 +365,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
     std::cout << "\n\n Trigger ISOLATION wp: " << m_WorkingPointIsoTrig << "\n Trigger ID wp: " << m_WorkingPointIDTrig << "\n\n" << std::endl;
 
-    m_TrigEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_Trig_" + m_WorkingPointIDTrig;
+    m_TrigEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_Trig_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
     if ( !m_WorkingPointIsoTrig.empty() ) {
       m_TrigEffSF_tool_name += ( "_isol" + m_WorkingPointIsoTrig );
     }
@@ -375,7 +379,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       m_asgElEffCorrTool_elSF_Trig->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
       std::vector<std::string> inputFilesTrig{ m_corrFileNameTrig } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("CorrectionFileNameList",inputFilesTrig),"Failed to set property CorrectionFileNameList");
-      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("ForceDataType",1),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Trig");
     }
 
@@ -407,7 +411,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
     //
-    m_outputSystNamesTrig = m_outputSystNamesTrig + "_" + m_WorkingPointIDTrig;
+    m_outputSystNamesTrig = m_outputSystNamesTrig + "_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
     if ( !m_WorkingPointIsoTrig.empty() ) {
       m_outputSystNamesTrig += ( "_isol" + m_WorkingPointIsoTrig );
     }
@@ -419,7 +423,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   if ( !m_corrFileNameTrigMCEff.empty() ) {
 
-    m_TrigMCEff_tool_name = "ElectronEfficiencyCorrectionTool_effSF_TrigMCEff_" + m_WorkingPointIDTrig;
+    m_TrigMCEff_tool_name = "ElectronEfficiencyCorrectionTool_effSF_TrigMCEff_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
     if ( !m_WorkingPointIsoTrig.empty() ) {
       m_TrigMCEff_tool_name += ( "_isol" + m_WorkingPointIsoTrig );
     }    
@@ -433,7 +437,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       m_asgElEffCorrTool_elSF_TrigMCEff->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
       std::vector<std::string> inputFilesTrigMCEff{ m_corrFileNameTrigMCEff } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("CorrectionFileNameList",inputFilesTrigMCEff),"Failed to set property CorrectionFileNameList");
-      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("ForceDataType",1),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool TrigMCEff");
     }
 
@@ -465,7 +469,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
     //
-    m_outputSystNamesTrigMCEff = m_outputSystNamesTrigMCEff + "_" + m_WorkingPointIDTrig;;
+    m_outputSystNamesTrigMCEff = m_outputSystNamesTrigMCEff + "_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;;
     if ( !m_WorkingPointIsoTrig.empty() ) {
       m_outputSystNamesTrigMCEff += ( "_isol" + m_WorkingPointIsoTrig );
     }

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -169,6 +169,25 @@ namespace HelperClasses{
     m_isolWPs["_isolLooseTrackOnly"]           = has_exact("isolLooseTrackOnly");
     m_isolWPs["_isolTight"]                    = has_exact("isolTight");
     m_isolWPs[""]                              = has_exact("isolNoRequirement");
+    m_trigWPs["DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_"]       = has_exact("DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH");
+    m_trigWPs["DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_"]                = has_exact("DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0");
+    m_trigWPs["DI_E_2015_e17_lhloose_2016_e17_lhloose_"]                               = has_exact("DI_E_2015_e17_lhloose_2016_e17_lhloose");
+    m_trigWPs["MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_"]                       = has_exact("MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0");
+    m_trigWPs["MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_"]                       = has_exact("MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0");
+    m_trigWPs["MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_"]                       = has_exact("MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0");
+    m_trigWPs["MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_"] = has_exact("MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI");
+    m_trigWPs["MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_"] = has_exact("MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI");
+    m_trigWPs["SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_"] = has_exact("SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0");
+    m_trigWPs["SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_"] = has_exact("SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0");
+    m_trigWPs["TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_"]                           = has_exact("TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0");
+    m_trigWPs["TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_"]                          = has_exact("TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0");
+    m_trigWPs["TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_"]                         = has_exact("TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0");
+    m_trigWPs["TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_"]                        = has_exact("TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0");
+    m_trigWPs["e17_lhloose_L1EM15_"]                                                   = has_exact("e17_lhloose_L1EM15");
+    m_trigWPs["e17_lhmedium_"]                                                         = has_exact("e17_lhmedium");
+    m_trigWPs["e17_lhmedium_nod0_"]                                                    = has_exact("e17_lhmedium_nod0");
+    m_trigWPs["e17_lhmedium_nod0_L1EM15HI_"]                                           = has_exact("e17_lhmedium_nod0_L1EM15HI");
+    m_trigWPs["e17_lhmedium_nod0_ivarloose_L1EM15HI_"]                                 = has_exact("e17_lhmedium_nod0_ivarloose_L1EM15HI");
   }
 
   void PhotonInfoSwitch::initialize(){

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -156,38 +156,28 @@ namespace HelperClasses{
     m_trackparams   = has_exact("trackparams");
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
-    // working points for scale-factors    
-    m_PIDWPs["LooseAndBLayerLLH"]  = has_exact("LooseAndBLayerLLH");
-    m_PIDWPs["MediumLLH"]          = has_exact("MediumLLH");
-    m_PIDWPs["TightLLH"]           = has_exact("TightLLH");
-    m_isolWPs["_isolFixedCutLoose"]            = has_exact("isolFixedCutLoose");
-    m_isolWPs["_isolFixedCutTight"]            = has_exact("isolFixedCutTight");
-    m_isolWPs["_isolFixedCutTightTrackOnly"]   = has_exact("isolFixedCutTightTrackOnly");
-    m_isolWPs["_isolGradient"]                 = has_exact("isolGradient");
-    m_isolWPs["_isolGradientLoose"]            = has_exact("isolGradientLoose");
-    m_isolWPs["_isolLoose"]                    = has_exact("isolLoose");
-    m_isolWPs["_isolLooseTrackOnly"]           = has_exact("isolLooseTrackOnly");
-    m_isolWPs["_isolTight"]                    = has_exact("isolTight");
-    m_isolWPs[""]                              = has_exact("isolNoRequirement");
-    m_trigWPs["DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_"]       = has_exact("DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH");
-    m_trigWPs["DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_"]                = has_exact("DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0");
-    m_trigWPs["DI_E_2015_e17_lhloose_2016_e17_lhloose_"]                               = has_exact("DI_E_2015_e17_lhloose_2016_e17_lhloose");
-    m_trigWPs["MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_"]                       = has_exact("MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0");
-    m_trigWPs["MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_"]                       = has_exact("MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0");
-    m_trigWPs["MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_"]                       = has_exact("MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0");
-    m_trigWPs["MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_"] = has_exact("MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI");
-    m_trigWPs["MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_"] = has_exact("MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI");
-    m_trigWPs["SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_"] = has_exact("SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0");
-    m_trigWPs["SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_"] = has_exact("SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0");
-    m_trigWPs["TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_"]                           = has_exact("TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0");
-    m_trigWPs["TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_"]                          = has_exact("TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0");
-    m_trigWPs["TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_"]                         = has_exact("TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0");
-    m_trigWPs["TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_"]                        = has_exact("TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0");
-    m_trigWPs["e17_lhloose_L1EM15_"]                                                   = has_exact("e17_lhloose_L1EM15");
-    m_trigWPs["e17_lhmedium_"]                                                         = has_exact("e17_lhmedium");
-    m_trigWPs["e17_lhmedium_nod0_"]                                                    = has_exact("e17_lhmedium_nod0");
-    m_trigWPs["e17_lhmedium_nod0_L1EM15HI_"]                                           = has_exact("e17_lhmedium_nod0_L1EM15HI");
-    m_trigWPs["e17_lhmedium_nod0_ivarloose_L1EM15HI_"]                                 = has_exact("e17_lhmedium_nod0_ivarloose_L1EM15HI");
+    // working points for scale-factors
+
+    // working points combinations for trigger corrections 
+    std::string token;
+    std::string PID_keyword = "LLH";
+    std::string isol_keyword = "isol";
+    std::string trig_keyword1 = "DI_E_";
+    std::string trig_keyword2 = "MULTI_L_";
+    std::string trig_keyword3 = "SINGLE_E_";
+    std::string trig_keyword4 = "TRI_E_";
+    
+    std::istringstream ss(m_configStr);
+    while ( std::getline(ss, token, ' ') ) {
+     if ( token.find(PID_keyword ) != std::string::npos )        { m_PIDWPs.push_back(token); }
+     if ( token.find(isol_keyword ) != std::string::npos )       { m_isolWPs.push_back(token); }
+     if ( token.find("isolNoRequirement") != std::string::npos ) { m_isolWPs.push_back(""); }
+     if ( (token.find(trig_keyword1 ) != std::string::npos) ||
+      (token.find(trig_keyword2 ) != std::string::npos) ||
+      (token.find(trig_keyword3 ) != std::string::npos) ||
+      (token.find(trig_keyword4 ) != std::string::npos)  )   { m_trigWPs.push_back(token); }
+   } 
+
   }
 
   void PhotonInfoSwitch::initialize(){

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -169,13 +169,15 @@ namespace HelperClasses{
     
     std::istringstream ss(m_configStr);
     while ( std::getline(ss, token, ' ') ) {
-     if ( token.find(PID_keyword ) != std::string::npos )        { m_PIDWPs.push_back(token); }
-     if ( token.find(isol_keyword ) != std::string::npos )       { m_isolWPs.push_back(token); }
+     if ( token.find(PID_keyword ) != std::string::npos ) { m_PIDWPs.push_back(token); }
      if ( token.find("isolNoRequirement") != std::string::npos ) { m_isolWPs.push_back(""); }
+     if ( (token.compare( 0, isol_keyword.length(), isol_keyword ) == 0) && 
+           token!="isolation" && 
+           token!="isolNoRequirement" ) { m_isolWPs.push_back(token); }
      if ( (token.find(trig_keyword1 ) != std::string::npos) ||
-      (token.find(trig_keyword2 ) != std::string::npos) ||
-      (token.find(trig_keyword3 ) != std::string::npos) ||
-      (token.find(trig_keyword4 ) != std::string::npos)  )   { m_trigWPs.push_back(token); }
+          (token.find(trig_keyword2 ) != std::string::npos) ||
+          (token.find(trig_keyword3 ) != std::string::npos) ||
+          (token.find(trig_keyword4 ) != std::string::npos)  ) { m_trigWPs.push_back(token); }
    } 
 
   }

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -489,6 +489,17 @@ std::string HelperFunctions::parse_wp( const std::string& type, const std::strin
     init = string_pos( config_name, '.', 2 );
     end  = found_ID;
     
+  } else if ( type.compare("TRIG") == 0 ) {
+ 
+    std::size_t found_trigger = config_name.find("trigger");
+    
+    // Return empty string if no LLH in config name
+    
+    if ( found_trigger == std::string::npos ) { return wp; }
+       
+    init = string_pos( config_name, '.', 3 );
+    end  = string_pos( config_name, '.', 2 ) - 1;
+    
   } else {
   
     Warning("HelperFunctions::parse_wp()","WP type can be either 'ISO' or 'ID'. Please check passed parameters of this function. Returning empty WP.");

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -14,8 +14,6 @@
 #include <xAODAnaHelpers/Electron.h>
 #include <xAODAnaHelpers/ParticleContainer.h>
 
-typedef SG::AuxElement::Accessor< std::vector< float > > floatAccessor ;
-
 namespace xAH {
 
   class ElectronContainer : public ParticleContainer<Electron,HelperClasses::ElectronInfoSwitch>
@@ -93,29 +91,6 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
-      std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
-      std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
-      std::vector< std::string > m_trigWPs = {
-          "DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_",
-          "DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_",
-          "DI_E_2015_e17_lhloose_2016_e17_lhloose_",
-          "MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_",
-          "MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_",
-          "MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_",
-          "MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_",
-          "MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_",
-          "SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_",
-          "SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_",
-          "TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_",
-          "TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_",
-          "TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_",
-          "TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_",
-          "e17_lhloose_L1EM15_",
-          "e17_lhmedium_",
-          "e17_lhmedium_nod0_",
-          "e17_lhmedium_nod0_L1EM15HI_",
-          "e17_lhmedium_nod0_ivarloose_L1EM15HI_"
-                                              };
       
       // track parameters
       std::vector<float>* m_trkd0;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -95,6 +95,27 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
       std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
       std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
+      std::vector< std::string > m_trigWPs = {
+          "DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_",
+          "DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_",
+          "DI_E_2015_e17_lhloose_2016_e17_lhloose_",
+          "MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_",
+          "MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_",
+          "MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_",
+          "MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_",
+          "MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_",
+          "SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_",
+          "SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_",
+          "TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_",
+          "TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_",
+          "TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_",
+          "TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_",
+          "e17_lhloose_L1EM15_",
+          "e17_lhmedium_",
+          "e17_lhmedium_nod0_",
+          "e17_lhmedium_nod0_L1EM15HI_",
+          "e17_lhmedium_nod0_ivarloose_L1EM15HI_"
+                                              };
       
       // track parameters
       std::vector<float>* m_trkd0;

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -68,6 +68,7 @@ private:
 
   std::string m_WorkingPointIDTrig;  //!
   std::string m_WorkingPointIsoTrig; //! 
+  std::string m_WorkingPointTrigTrig; //! 
 
   std::vector<CP::SystematicSet> m_systListPID;  //!
   std::vector<CP::SystematicSet> m_systListIso;  //!

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -291,35 +291,30 @@ namespace HelperClasses {
         m_PIDWPs["MediumLLH"]                    MediumLLH                   exact
         m_PIDWPs["TightLLH"]                     TightLLH                    exact
 
-        m_isolWPs["_isolFixedCutLoose"]          isolFixedCutLoose           exact
-        m_isolWPs["_isolFixedCutTight"]          isolFixedCutTight           exact
-        m_isolWPs["_isolFixedCutTightTrackOnly"] isolFixedCutTightTrackOnly  exact
-        m_isolWPs["_isolGradient"]               isolGradient                exact
-        m_isolWPs["_isolGradientLoose"]          isolGradientLoose           exact
-        m_isolWPs["_isolLoose"]                  isolLoose                   exact
-        m_isolWPs["_isolLooseTrackOnly"]         isolLooseTrackOnly          exact
-        m_isolWPs["_isolTight"]                  isolTight                   exact
-        m_isolWPs[""]                            isolNoRequirement           exact
+        m_isolWPs["isolFixedCutLoose"]          isolFixedCutLoose           exact
+        m_isolWPs["isolFixedCutTight"]          isolFixedCutTight           exact
+        m_isolWPs["isolFixedCutTightTrackOnly"] isolFixedCutTightTrackOnly  exact
+        m_isolWPs["isolGradient"]               isolGradient                exact
+        m_isolWPs["isolGradientLoose"]          isolGradientLoose           exact
+        m_isolWPs["isolLoose"]                  isolLoose                   exact
+        m_isolWPs["isolLooseTrackOnly"]         isolLooseTrackOnly          exact
+        m_isolWPs["isolTight"]                  isolTight                   exact
+        m_isolWPs[""]                           isolNoRequirement           exact
 
-        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_]      DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH   exact
-        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_]               DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0            exact
-        m_trigWPs[DI_E_2015_e17_lhloose_2016_e17_lhloose_]                              DI_E_2015_e17_lhloose_2016_e17_lhloose                           exact
-        m_trigWPs[MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_]                      MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0                   exact
-        m_trigWPs[MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_]                      MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0                   exact
-        m_trigWPs[MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_]                      MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0                   exact
-        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI        exact
-        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI        exact
-        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
-        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
-        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_]                          TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0                       exact
-        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_]                         TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0                      exact
-        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_]                        TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0                     exact
-        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_]                       TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0                    exact
-        m_trigWPs[e17_lhloose_L1EM15_]                                                  e17_lhloose_L1EM15                                               exact
-        m_trigWPs[e17_lhmedium_]                                                        e17_lhmedium                                                     exact
-        m_trigWPs[e17_lhmedium_nod0_]                                                   e17_lhmedium_nod0                                                exact
-        m_trigWPs[e17_lhmedium_nod0_L1EM15HI_]                                          e17_lhmedium_nod0_L1EM15HI                                       exact
-        m_trigWPs[e17_lhmedium_nod0_ivarloose_L1EM15HI_]                                e17_lhmedium_nod0_ivarloose_L1EM15HI                             exact
+        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH]      DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH   exact
+        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0]               DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0            exact
+        m_trigWPs[DI_E_2015_e17_lhloose_2016_e17_lhloose]                              DI_E_2015_e17_lhloose_2016_e17_lhloose                           exact
+        m_trigWPs[MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0]                      MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0]                      MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0]                      MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI        exact
+        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI        exact
+        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
+        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
+        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_                          TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0                       exact
+        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0]                         TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0                      exact
+        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0]                        TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0                     exact
+        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0]                       TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0                    exact
         ============== ============ =======
 
     @endrst
@@ -332,9 +327,9 @@ namespace HelperClasses {
     bool m_trackparams;
     bool m_trackhitcont;
     bool m_effSF;
-    std::map<std::string,bool> m_PIDWPs;
-    std::map<std::string,bool> m_isolWPs;
-    std::map<std::string,bool> m_trigWPs;
+    std::vector< std::string > m_PIDWPs;
+    std::vector< std::string > m_isolWPs;
+    std::vector< std::string > m_trigWPs;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -286,9 +286,11 @@ namespace HelperClasses {
         m_trackparams  trackparams  exact
         m_trackhitcont trackhitcont exact
         m_effSF        effSF        exact
+
         m_PIDWPs["LooseAndBLayerLLH"]            LooseAndBLayerLLH           exact
         m_PIDWPs["MediumLLH"]                    MediumLLH                   exact
         m_PIDWPs["TightLLH"]                     TightLLH                    exact
+
         m_isolWPs["_isolFixedCutLoose"]          isolFixedCutLoose           exact
         m_isolWPs["_isolFixedCutTight"]          isolFixedCutTight           exact
         m_isolWPs["_isolFixedCutTightTrackOnly"] isolFixedCutTightTrackOnly  exact
@@ -298,6 +300,26 @@ namespace HelperClasses {
         m_isolWPs["_isolLooseTrackOnly"]         isolLooseTrackOnly          exact
         m_isolWPs["_isolTight"]                  isolTight                   exact
         m_isolWPs[""]                            isolNoRequirement           exact
+
+        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH_]      DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH   exact
+        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0_]               DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0            exact
+        m_trigWPs[DI_E_2015_e17_lhloose_2016_e17_lhloose_]                              DI_E_2015_e17_lhloose_2016_e17_lhloose                           exact
+        m_trigWPs[MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0_]                      MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0_]                      MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0_]                      MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0                   exact
+        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI_]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI        exact
+        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI_]      MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI        exact
+        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
+        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_]   SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
+        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0_]                          TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0                       exact
+        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0_]                         TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0                      exact
+        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0_]                        TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0                     exact
+        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0_]                       TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0                    exact
+        m_trigWPs[e17_lhloose_L1EM15_]                                                  e17_lhloose_L1EM15                                               exact
+        m_trigWPs[e17_lhmedium_]                                                        e17_lhmedium                                                     exact
+        m_trigWPs[e17_lhmedium_nod0_]                                                   e17_lhmedium_nod0                                                exact
+        m_trigWPs[e17_lhmedium_nod0_L1EM15HI_]                                          e17_lhmedium_nod0_L1EM15HI                                       exact
+        m_trigWPs[e17_lhmedium_nod0_ivarloose_L1EM15HI_]                                e17_lhmedium_nod0_ivarloose_L1EM15HI                             exact
         ============== ============ =======
 
     @endrst
@@ -312,6 +334,7 @@ namespace HelperClasses {
     bool m_effSF;
     std::map<std::string,bool> m_PIDWPs;
     std::map<std::string,bool> m_isolWPs;
+    std::map<std::string,bool> m_trigWPs;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:


### PR DESCRIPTION
Added a possibility of having electron scale-factors for multiple triggers, similarly to isolation and PID. Very similar to the muon implementation: https://github.com/UCATLAS/xAODAnaHelpers/pull/731.

This should close the following issues: https://github.com/UCATLAS/xAODAnaHelpers/issues/728, https://github.com/UCATLAS/xAODAnaHelpers/issues/679

If no user input is given to the "m_elDetailStr" flag, default working points will be selected:

```
if ( !m_PIDWPs.size() ) m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
if ( !m_isolWPs.size() ) m_isolWPs = {"","_isolGradient","_isolLoose","_isolTight"};
if ( !m_trigWPs.size() ) m_trigWPs = {"SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0_"};
```

The output tree will look like this in this case:

![longtriggername](https://cloud.githubusercontent.com/assets/12948551/19684467/97090bce-9ab7-11e6-9038-a86bcc0c675d.png)

The names of the trigger SF are rather long, but this is the official trigger name.. The branches will be empty if the user doesn't configure an appropriate EffCorrection tool of course. The correct configuration in this case would be:

```
path_el_eff = "ElectronEfficiencyCorrection/2015_2016/rel20.7/ICHEP_June2016_v3/"
trigger_el_eff = "SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0"

"m_corrFileNameTrig"      : path_el_eff + "trigger/efficiencySF." + trigger_el_eff + ".LooseAndBLayerLLH_d0z0_v11.root",
"m_corrFileNameTrigMCEff" : path_el_eff + "trigger/efficiency." + trigger_el_eff + ".LooseAndBLayerLLH_d0z0_v11.root",
```

The output can then be modified by changing the "m_elDetailStr" flag. E.g.:

```
electronPIDWorkingPoints     = "LooseAndBLayerLLH MediumLLH TightLLH " # space at the end
electronIsolWorkingPoints    = "isolNoRequirement isolFixedCutLoose isolLooseTrackOnly isolGradient isolLoose isolTight " # space at the end
electronTrigWorkingPoints    = "DI_E_2015_e17_lhloose_2016_e17_lhloose " # space at the end
"m_elDetailStr"           : electronTrigWorkingPoints + electronPIDWorkingPoints + electronIsolWorkingPoints + "kinematic trigger isolation PID trackparams effSF",
```

In this case, the output is the following:

![dietrigger](https://cloud.githubusercontent.com/assets/12948551/19684509/da424ec8-9ab7-11e6-8c88-72b97d139dc6.png)

It is also possible to have multiple triggers:

![multitrig](https://cloud.githubusercontent.com/assets/12948551/19684661/c49932ca-9ab8-11e6-8c8a-9f9a29e87fd4.png)
