### PR TITLE
Additional features for b-jet trigger studies

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -262,6 +262,7 @@ namespace HelperClasses{
     m_etaPhiMap           = has_exact("etaPhiMap");
     m_byAverageMu         = has_exact("byAverageMu");
     m_vsLumiBlock         = has_exact("vsLumiBlock");
+    m_lumiB_runN          = has_exact("lumiB_runN");
 
     m_sfFTagFix.clear();
     if( has_match( "sfFTagFix" ) ) {

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -213,7 +213,6 @@ StatusCode JetHists::initialize() {
     
     if(m_infoSwitch->m_vsLumiBlock){
 
-
       m_frac_MV2c2040_vs_lBlock  = book(m_name, "frac_MV2c2040_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c2040", 0, 1);
       m_frac_MV2c2050_vs_lBlock  = book(m_name, "frac_MV2c2050_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c2050", 0, 1);
       m_frac_MV2c2060_vs_lBlock  = book(m_name, "frac_MV2c2060_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c2060", 0, 1);
@@ -366,7 +365,7 @@ StatusCode JetHists::initialize() {
     m_vtx_online_x0                  = book(m_name, "vtx_online_x0",  "vtx_online_x0",   100,  -0.2,  0.2);
     m_vtx_online_y0                  = book(m_name, "vtx_online_y0",  "vtx_online_y0",   100,  -0.2,  0.2);
     m_vtx_online_z0                  = book(m_name, "vtx_online_z0",  "vtx_online_z0",   100, -200, 200);
-    m_vtx_online_z0_s                = book(m_name, "vtx_online_z0_s",  "vtx_online_z0_s",   100, -10, 10);
+    m_vtx_online_z0_s                = book(m_name, "vtx_online_z0_s","vtx_online_z0_s",   100, -10, 10);
 
     m_vtx_online_x0_raw              = book(m_name, "vtx_online_x0_raw",  "vtx_online_x0_raw",   100,  -0.2,  0.2);
     m_vtx_online_y0_raw              = book(m_name, "vtx_online_y0_raw",  "vtx_online_y0_raw",   100,  -0.2,  0.2);
@@ -384,11 +383,12 @@ StatusCode JetHists::initialize() {
     m_vtxDiffz0                      = book(m_name, "vtx_diff_z0",   "vtx_diff_z0",   100, -100, 100);
     m_vtxDiffz0_m                    = book(m_name, "vtx_diff_z0_m", "vtx_diff_z0_m", 100,  -20,  20);
     m_vtxDiffz0_s                    = book(m_name, "vtx_diff_z0_s", "vtx_diff_z0_s", 100,  -5,  5);
-    m_vtxHadDummy                    = book(m_name, "vtx_hadDummy",  "vtx_hadDummy",  3, -0.5, 2.5);
+    m_vtxClass                       = book(m_name, "vtxClass",      "vtxClass",        3, -0.5, 2.5);
     
-    m_bs_online_vz                  = book(m_name, "bs_online_vz",  "bs_online_vz",   200, -5, 5);
-    m_bs_online_vy                  = book(m_name, "bs_online_vy",  "bs_online_vy",   200, -2, 2);
-    m_bs_online_vx                  = book(m_name, "bs_online_vx",  "bs_online_vx",   200, -2, 2);
+    m_bs_online_vz                  = book(m_name, "bs_online_vz",  "bs_online_vz",   200,   -5,   5);
+    m_bs_online_vz_l                = book(m_name, "bs_online_vz_l","bs_online_vz_l", 200, -100, 100);
+    m_bs_online_vy                  = book(m_name, "bs_online_vy",  "bs_online_vy",   200,   -2,   2);
+    m_bs_online_vx                  = book(m_name, "bs_online_vx",  "bs_online_vx",   200,   -2,   2);
 
     m_vtxDiffz0_vs_vtx_offline_z0     = book(m_name, "vtxDiffz0_vs_vtx_offline_z0",
 					     "vtx_offline_z0",  100, -200, 200,
@@ -406,9 +406,9 @@ StatusCode JetHists::initialize() {
 					       "vtx_diff_y0",   100,  -0.1,  0.1,
 					       "vtx_diff_z0",   100, -10, 10);
 
-    m_vtxHadDummy_vs_jetPt            = book(m_name, "vtxHadDummy_vs_jetPt",
+    m_vtxClass_vs_jetPt            = book(m_name, "vtxClass_vs_jetPt",
 					     "jetPt",  100, 0, 1000,
-					     "hadDummy", -0.1, 2.1);
+					     "vtxClass", 4, -1.1, 3.1);
 
     m_vtx_online_y0_vs_vtx_online_z0  = book(m_name, "vtx_online_y0_vs_vtx_online_z0",					  
 					     "vtx_online_z0", 100, -50, 50,					     
@@ -423,7 +423,7 @@ StatusCode JetHists::initialize() {
       m_vtxDiffx0_vs_lBlock      = book(m_name, "vtxDiffx0_vs_lBlock",    "LumiBlock",  200, 0, 2000, "vtx_diff_x0",    -0.1, 0.1);
       m_vtxDiffy0_vs_lBlock      = book(m_name, "vtxDiffy0_vs_lBlock",    "LumiBlock",  200, 0, 2000, "vtx_diff_y0",    -0.1, 0.1);
       m_vtxDiffz0_vs_lBlock      = book(m_name, "vtxDiffz0_vs_lBlock",    "LumiBlock",  200, 0, 2000, "vtx_diff_z0",    -5, 5);
-      m_vtxHadDummy_vs_lBlock    = book(m_name, "vtxHadDummy_vs_lBlock",  "LumiBlock",  200, 0, 2000, "hadDummy", -0.1, 1.1);
+      m_vtxClass_vs_lBlock    = book(m_name, "vtxClass_vs_lBlock",  "LumiBlock",  200, 0, 2000, "vtxClass", -0.1, 1.1);
       m_vtxEff1_vs_lBlock        = book(m_name, "vtxEff1_vs_lBlock",      "LumiBlock",  200, 0, 2000, "vtx eff (1mm)", -0.1, 1.1);
       m_vtxEff10_vs_lBlock       = book(m_name, "vtxEff10_vs_lBlock",     "LumiBlock",  200, 0, 2000, "vtx eff (10mm)", -0.1, 1.1);
       m_vtxEff1_raw_vs_lBlock    = book(m_name, "vtxEff1_raw_vs_lBlock",  "LumiBlock",  200, 0, 2000, "vtx eff (1mm)", -0.1, 1.1);
@@ -432,6 +432,7 @@ StatusCode JetHists::initialize() {
       m_vtxEff10_noDummy_vs_lBlock   = book(m_name, "vtxEff10_noDummy_vs_lBlock", "LumiBlock",  200, 0, 2000, "vtx eff (10mm)", -0.1, 1.1);
 
     }
+     
 
   }
 
@@ -1388,27 +1389,30 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
     if(offline_pvx) m_vtxOfflineValid->Fill(1.0, eventWeight);
     else            m_vtxOfflineValid->Fill(0.0, eventWeight);
 
-    char hadDummyPV = jet->auxdata< char >("hadDummyPV");
-    if( hadDummyPV == '0')  m_vtxHadDummy -> Fill(0.0, eventWeight);
-    if( hadDummyPV == '1')  m_vtxHadDummy -> Fill(1.0, eventWeight);
-    if( hadDummyPV == '2')  m_vtxHadDummy -> Fill(2.0, eventWeight);
+    // Use of vtxClass is new, hadDummyPV is old but need backward compatibility.
+    char vtxClass = jet->auxdata< char >("hadDummyPV");
+    if( vtxClass == '0')  m_vtxClass -> Fill(0.0, eventWeight); 
+    if( vtxClass == '1')  m_vtxClass -> Fill(1.0, eventWeight);
+    if( vtxClass == '2')  m_vtxClass -> Fill(2.0, eventWeight);
 
+    
     float bs_online_vx = jet->auxdata< float >("bs_online_vx");
     m_bs_online_vx -> Fill( bs_online_vx , eventWeight);
     float bs_online_vy = jet->auxdata< float >("bs_online_vy");
     m_bs_online_vy -> Fill( bs_online_vy , eventWeight);
     float bs_online_vz = jet->auxdata< float >("bs_online_vz");
-    m_bs_online_vz -> Fill( bs_online_vz , eventWeight);
+    m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
+    m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
 
-    //if(hadDummyPV)  m_vtxHadDummy ->Fill(1.0, eventWeight);
-    //else            m_vtxHadDummy ->Fill(0.0, eventWeight);
+    //if(hadDummyPV)  m_vtxClass ->Fill(1.0, eventWeight);
+    //else            m_vtxClass ->Fill(0.0, eventWeight);
 
     if(offline_pvx && online_pvx){
 
       float online_x0_raw = online_pvx->x();
       float online_y0_raw = online_pvx->y();
       float online_z0_raw = online_pvx->z();
-      if(hadDummyPV){
+      if(vtxClass!='0'){
 	online_x0_raw = 0;
 	online_y0_raw = 0;
 	online_z0_raw = 0;
@@ -1442,7 +1446,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       m_vtxDiffz0_s_vs_vtxDiffx0      ->Fill(vtxDiffx0, vtxDiffz0, eventWeight);
       m_vtxDiffz0_s_vs_vtxDiffy0      ->Fill(vtxDiffy0, vtxDiffz0, eventWeight);
 
-      m_vtxHadDummy_vs_jetPt        ->Fill(jet->pt()/1e3, bool(hadDummyPV), eventWeight);
+      m_vtxClass_vs_jetPt        ->Fill(jet->pt()/1e3, bool(vtxClass), eventWeight);
 
       m_vtx_online_y0_vs_vtx_online_z0 -> Fill(online_pvx->z(), online_pvx->y(), eventWeight);
       m_vtx_online_x0_vs_vtx_online_z0 -> Fill(online_pvx->z(), online_pvx->x(), eventWeight);
@@ -1454,14 +1458,14 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
 	m_vtxDiffx0_vs_lBlock     ->Fill(lumiBlock, vtxDiffx0          , eventWeight);
 	m_vtxDiffy0_vs_lBlock     ->Fill(lumiBlock, vtxDiffy0          , eventWeight);
 	m_vtxDiffz0_vs_lBlock     ->Fill(lumiBlock, vtxDiffz0          , eventWeight);
-	m_vtxHadDummy_vs_lBlock   ->Fill(lumiBlock, bool(hadDummyPV),    eventWeight);
+	m_vtxClass_vs_lBlock   ->Fill(lumiBlock, bool(vtxClass),    eventWeight);
 
 	bool correctVtx1 = (fabs(vtxDiffz0) < 1);
 	bool correctVtx10 = (fabs(vtxDiffz0) < 10);
 	m_vtxEff1_vs_lBlock   ->Fill(lumiBlock, correctVtx1,    eventWeight);
 	m_vtxEff10_vs_lBlock  ->Fill(lumiBlock, correctVtx10,    eventWeight);
 
-	if(!hadDummyPV){
+	if(!vtxClass){
 	  m_vtxEff1_noDummy_vs_lBlock   ->Fill(lumiBlock, correctVtx1,    eventWeight);
 	  m_vtxEff10_noDummy_vs_lBlock  ->Fill(lumiBlock, correctVtx10,    eventWeight);
 	}
@@ -1622,24 +1626,28 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 	std::cout << "non-valid online vtx: ";
 	m_vtxOnlineValid ->Fill(0.0, eventWeight);
 	}*/
+
+      // vtxHadDummy is an old var. I am moving to a new variable name here.
+      float vtxClass=jet->vtxHadDummy;
       
       float online_x0_raw = jet->vtx_online_x0;
       float online_y0_raw = jet->vtx_online_y0;
       float online_z0_raw = jet->vtx_online_z0;
-      if(jet->vtxHadDummy){
+      if(vtxClass){
 	online_x0_raw = 0;
 	online_y0_raw = 0;
 	online_z0_raw = 0;
       }
       
-      m_vtxHadDummy               ->Fill(jet->vtxHadDummy          , eventWeight);
+      m_vtxClass               ->Fill(vtxClass          , eventWeight);
 
       float bs_online_vx = jet->bs_online_vx;
       m_bs_online_vx -> Fill( bs_online_vx , eventWeight);
       float bs_online_vy = jet->bs_online_vy;
       m_bs_online_vy -> Fill( bs_online_vy , eventWeight);
       float bs_online_vz = jet->bs_online_vz;
-      m_bs_online_vz -> Fill( bs_online_vz , eventWeight);
+      m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
+      m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
       
       float vtxDiffx0      = jet->vtx_online_x0 - jet->vtx_offline_x0;
 
@@ -1674,7 +1682,7 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       m_vtxDiffz0_s_vs_vtxDiffx0      ->Fill(vtxDiffx0, vtxDiffz0, eventWeight);
       m_vtxDiffz0_s_vs_vtxDiffy0      ->Fill(vtxDiffy0, vtxDiffz0, eventWeight);
       
-      m_vtxHadDummy_vs_jetPt   ->Fill(jet->p4.Pt(), bool(jet->vtxHadDummy),    eventWeight);
+      m_vtxClass_vs_jetPt   ->Fill(jet->p4.Pt(), bool(vtxClass),    eventWeight);
 
       m_vtx_online_y0_vs_vtx_online_z0 ->Fill(jet->vtx_online_z0, jet->vtx_online_y0, eventWeight);
       m_vtx_online_x0_vs_vtx_online_z0 ->Fill(jet->vtx_online_z0, jet->vtx_online_x0, eventWeight);
@@ -1685,14 +1693,14 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 	m_vtxDiffx0_vs_lBlock     ->Fill(lumiBlock, vtxDiffx0          , eventWeight);
 	m_vtxDiffy0_vs_lBlock     ->Fill(lumiBlock, vtxDiffy0          , eventWeight);
 	m_vtxDiffz0_vs_lBlock     ->Fill(lumiBlock, vtxDiffz0          , eventWeight);
-	m_vtxHadDummy_vs_lBlock   ->Fill(lumiBlock, bool(jet->vtxHadDummy),    eventWeight);
+	m_vtxClass_vs_lBlock   ->Fill(lumiBlock, bool(vtxClass),    eventWeight);
 
 	bool correctVtx1  = (fabs(vtxDiffz0) < 1);
 	bool correctVtx10 = (fabs(vtxDiffz0) < 10);
 	m_vtxEff1_vs_lBlock   ->Fill(lumiBlock, correctVtx1,    eventWeight);
 	m_vtxEff10_vs_lBlock  ->Fill(lumiBlock, correctVtx10,    eventWeight);
 
-	if(!jet->vtxHadDummy){
+	if(!vtxClass){
 	  m_vtxEff1_noDummy_vs_lBlock   ->Fill(lumiBlock, correctVtx1,    eventWeight);
 	  m_vtxEff10_noDummy_vs_lBlock  ->Fill(lumiBlock, correctVtx10,    eventWeight);
 	}

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -1413,10 +1413,8 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
     m_bs_online_vy -> Fill( bs_online_vy , eventWeight);
     float bs_online_vz = jet->auxdata< float >("bs_online_vz");
 
-    if( fabs(bs_online_vy) > 0.1 ){  
-        m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
-    	m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
-    }
+    m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
+    m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
   
 
 
@@ -1684,10 +1682,8 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       m_bs_online_vy -> Fill( bs_online_vy , eventWeight);
       float bs_online_vz = jet->bs_online_vz;
 
-      if( fabs(bs_online_vy) > 0.1 ){  
-	m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
-	m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
-      }
+      m_bs_online_vz   -> Fill( bs_online_vz , eventWeight);
+      m_bs_online_vz_l -> Fill( bs_online_vz , eventWeight);
       
       //if( fabs(bs_online_vy) < 0.1 ){
       //   std::cout << " -> bs_online_vx" << bs_online_vx << "bs_online_vy" << bs_online_vy << "bs_online_vz" << bs_online_vz << std::endl;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -397,6 +397,7 @@ namespace HelperClasses {
         m_hltVtxComp     hltVtxComp     exact
         m_charge         charge         exact
         m_vsLumiBlock    vsLumiBlock    exact
+        m_lumiB_runN    lumiB_runN    exact
         m_byAverageMu    byAverageMu    exact
         m_etaPhiMap      etaPhiMap      exact
         ================ ============== =======
@@ -443,6 +444,7 @@ namespace HelperClasses {
     bool m_charge;
     bool m_etaPhiMap;
     bool m_vsLumiBlock;
+    bool m_lumiB_runN;
     bool m_byAverageMu;
     bool m_area;
     bool m_JVC;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -72,12 +72,12 @@ namespace xAH {
       float MV2;
       int  HadronConeExclTruthLabelID;
 
-      float vtxOnlineValid=-1;
+      float vtxOnlineValid;
       float vtxHadDummy;
       
-      float bs_online_vx=999;
-      float bs_online_vy=999;
-      float bs_online_vz=999;
+      float bs_online_vx;
+      float bs_online_vy;
+      float bs_online_vz;
 
       float vtx_offline_x0;
       float vtx_offline_y0;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -72,12 +72,12 @@ namespace xAH {
       float MV2;
       int  HadronConeExclTruthLabelID;
 
-      float vtxOnlineValid;
+      float vtxOnlineValid=-1;
       float vtxHadDummy;
       
-      float bs_online_vx;
-      float bs_online_vy;
-      float bs_online_vz;
+      float bs_online_vx=999;
+      float bs_online_vy=999;
+      float bs_online_vz=999;
 
       float vtx_offline_x0;
       float vtx_offline_y0;

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -158,7 +158,7 @@ class JetHists : public IParticleHists
 
     
     
-    TProfile* m_vtxHadDummy_vs_lBlock; //!
+    TProfile* m_vtxClass_vs_lBlock; //!
     TProfile* m_vtxEff10_vs_lBlock; //!
     TProfile* m_vtxEff1_vs_lBlock; //!
     TProfile* m_vtxEff10_raw_vs_lBlock; //!
@@ -306,8 +306,9 @@ class JetHists : public IParticleHists
     TH1F* m_bs_online_vx; //!
     TH1F* m_bs_online_vy; //!
     TH1F* m_bs_online_vz; //!
+    TH1F* m_bs_online_vz_l; //!
 
-    TH1F* m_vtxHadDummy; //!
+    TH1F* m_vtxClass; //!
     TProfile*   m_vtxDiffx0_vs_lBlock    ; //!
     TProfile*   m_vtxDiffy0_vs_lBlock    ; //!
     TProfile*   m_vtxDiffz0_vs_lBlock    ; //!
@@ -349,7 +350,7 @@ class JetHists : public IParticleHists
     TH2F* m_vtxDiffz0_s_vs_vtxDiffy0;
 
     // TProfile in prep for showing it is flat
-    TProfile*  m_vtxHadDummy_vs_jetPt;
+    TH2F*  m_vtxClass_vs_jetPt;
 
 
 };

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -313,6 +313,13 @@ class JetHists : public IParticleHists
     TProfile*   m_vtxDiffy0_vs_lBlock    ; //!
     TProfile*   m_vtxDiffz0_vs_lBlock    ; //!
 
+    TH2F* m_lumiB_runN;
+    TH2F* m_lumiB_runN_vtxClass     ;
+    TH2F* m_lumiB_runN_vtxDiffz0    ;
+    TH2F* m_lumiB_runN_lumiB        ;
+    TH2F* m_lumiB_runN_bs_online_vz ;
+    TH2F* m_lumiB_runN_bs_den       ;
+
     TProfile*   m_vtx_online_x0_vs_vtx_online_z0;
     TProfile*   m_vtx_online_y0_vs_vtx_online_z0;
     


### PR DESCRIPTION
* Fill online beamspot information before main jet loop to reduce number of times beamspot is not found due to not finding matching HLT jet tracks.
* Adding run# vs lumi block 2D histogram feature
* Rename hadDummy to vertexClass in histograming code.