### PR TITLE
Save multiple jet collections with TreeAlgo

### DIFF
--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -35,7 +35,13 @@ public:
   std::string m_muContainerName;
   std::string m_elContainerName;
   std::string m_jetContainerName;
+  std::vector<std::string> m_jetContainers;
+  std::string m_jetBranchName;
+  std::vector<std::string> m_jetBranches;
   std::string m_truthJetContainerName;
+  std::vector<std::string> m_truthJetContainers;
+  std::string m_truthJetBranchName;
+  std::vector<std::string> m_truthJetBranches;
   std::string m_trigJetContainerName;
   std::string m_fatJetContainerName;
   std::string m_truthFatJetContainerName;


### PR DESCRIPTION
These changes allows to store more than one jet (reco or truth) collection with TreeAlgo. The backwards compatibility is maintained. 

Usage example:
      "m_jetContainerName": "AntiKt4EMTopoJets_Signal AntiKt2LCTopoJets_Signal",
      "m_jetBranchName": "RefJet 2LCJet",
      "m_truthJetContainerName": "AntiKt4TruthJets_Signal AntiKt2TruthJets_Signal",
      "m_truthJetBranchName": "Truth4Jet Truth2Jet",

When saving only one jet colletion there is no need to specify "m_jetBranchName" and "m_truthJetBranchName" and the standard names will be used ("jet" and "truthJet"). These variables are used to set the name of the branches for each one of the jet collections.

When running systematics, it's assumed that only the first jet collection is the one which needs to be variated.

These changes are crucial for the JetEtmiss R-scan team.