### PR TITLE
Different Variables for each Jet Coll - Store L1 Jets (TreeAlgo)

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -418,6 +418,44 @@ void HelpTreeBase::ClearPhotons(const std::string photonName) {
 
 /*********************
  *
+ *   L1 JETS
+ *
+ ********************/
+
+void HelpTreeBase::AddL1Jets()
+{
+
+  if(m_debug) Info("AddL1Jets()", "Adding kinematics jet variables");
+
+  m_tree->Branch("nL1Jets",     &m_nL1Jet,"nL1Jets/I");
+  m_tree->Branch("L1Jet_et8x8", &m_l1Jet_et8x8);
+  m_tree->Branch("L1Jet_eta",   &m_l1Jet_eta);
+  m_tree->Branch("L1Jet_phi",   &m_l1Jet_phi);
+
+}
+
+void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets ) {
+
+  this->ClearL1Jets();
+
+  for( auto jet_itr : *jets ) {
+    m_l1Jet_et8x8->push_back ( jet_itr->et8x8() / m_units );
+    m_l1Jet_eta->push_back( jet_itr->eta() );
+    m_l1Jet_phi->push_back( jet_itr->phi() );
+    m_nL1Jet++;
+  }
+}
+
+void HelpTreeBase::ClearL1Jets() {
+  m_nL1Jet = 0;
+  m_l1Jet_et8x8->clear();
+  m_l1Jet_eta->clear();
+  m_l1Jet_phi->clear();
+}
+
+
+/*********************
+ *
  *   JETS
  *
  ********************/

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -22,6 +22,7 @@
 #include "xAODEgamma/PhotonContainer.h"
 #include "xAODMuon/MuonContainer.h"
 #include "xAODJet/JetContainer.h"
+#include "xAODTrigger/JetRoIContainer.h"
 #include "xAODTruth/TruthParticleContainer.h"
 #include "xAODTau/TauJetContainer.h"
 #include "xAODMissingET/MissingETContainer.h"
@@ -71,6 +72,7 @@ public:
   void AddElectrons   (const std::string detailStr = "", const std::string elecName = "el");
   void AddPhotons     (const std::string detailStr = "", const std::string photonName = "ph");
   void AddJets        (const std::string detailStr = "", const std::string jetName = "jet");
+  void AddL1Jets      ();
   void AddTruthParts  (const std::string truthName,      const std::string detailStr = "");
 
   /**
@@ -126,6 +128,7 @@ public:
 
   void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string jetName = "jet" );
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
+  void FillL1Jets( const xAOD::JetRoIContainer* jets );
 
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
@@ -157,6 +160,7 @@ public:
   void ClearElectrons   (const std::string elecName = "el");
   void ClearPhotons     (const std::string photonName = "ph");
   void ClearJets        (const std::string jetName = "jet");
+  void ClearL1Jets      ();
   void ClearTruth       (const std::string truthName);
   void ClearFatJets     (const std::string fatjetName, const std::string suffix="");
   void ClearTruthFatJets(const std::string truthFatJetName = "truth_fatjet");
@@ -308,6 +312,14 @@ protected:
   //  Jets
   //
   std::map<std::string, xAH::JetContainer*> m_jets;
+
+  //
+  // L1 Jets
+  //
+  int m_nL1Jet;
+  std::vector<float> *m_l1Jet_et8x8;
+  std::vector<float> *m_l1Jet_eta;
+  std::vector<float> *m_l1Jet_phi;
 
   //
   // Truth

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -23,6 +23,7 @@ public:
   std::string m_muDetailStr;
   std::string m_elDetailStr;
   std::string m_jetDetailStr;
+  std::vector<std::string> m_jetDetails;
   std::string m_truthJetDetailStr;
   std::string m_fatJetDetailStr;
   std::string m_truthFatJetDetailStr;
@@ -49,6 +50,7 @@ public:
   std::string m_METContainerName;
   std::string m_photonContainerName;
   std::string m_truthParticlesContainerName;
+  std::string m_l1JetContainerName;
 
   // if these are set, assume systematics are being processed over
   std::string m_muSystsVec;


### PR DESCRIPTION
These changes extend the functionalities of TreeAlgo. Now it's possible to store different set of variables for each jet collection through "m_jetDetailStr". The set for each jet collection is distinguished by "|". Example:

"m_jetDetailStr": "kinematic rapidity clean scales trackPV|kinematic rapidity"

Please note it shouldn't be any " " (black/space) between the strings and "|". This is to maintain the backward compatibility. 

It's possible to use the same strings for all the jet collections (by simply not using "|", so using only one set of strings), for instance:

"m_jetDetailStr": "kinematic rapidity clean scales trackPV"

It was also added the possibility of storing L1 jets in trees by setting "m_l1JetContainerName". Basic kinematics are stored (et8x8, eta and phi). This would allow to perform the emulation of triggers. 