### PR TITLE
Fix in HelpTreeBase to save L1 jets in >2.4.22

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -439,18 +439,18 @@ void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets ) {
   this->ClearL1Jets();
 
   for( auto jet_itr : *jets ) {
-    m_l1Jet_et8x8->push_back ( jet_itr->et8x8() / m_units );
-    m_l1Jet_eta->push_back( jet_itr->eta() );
-    m_l1Jet_phi->push_back( jet_itr->phi() );
+    m_l1Jet_et8x8.push_back ( jet_itr->et8x8() / m_units );
+    m_l1Jet_eta.push_back( jet_itr->eta() );
+    m_l1Jet_phi.push_back( jet_itr->phi() );
     m_nL1Jet++;
   }
 }
 
 void HelpTreeBase::ClearL1Jets() {
   m_nL1Jet = 0;
-  m_l1Jet_et8x8->clear();
-  m_l1Jet_eta->clear();
-  m_l1Jet_phi->clear();
+  m_l1Jet_et8x8.clear();
+  m_l1Jet_eta.clear();
+  m_l1Jet_phi.clear();
 }
 
 

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -317,9 +317,9 @@ protected:
   // L1 Jets
   //
   int m_nL1Jet;
-  std::vector<float> *m_l1Jet_et8x8;
-  std::vector<float> *m_l1Jet_eta;
-  std::vector<float> *m_l1Jet_phi;
+  std::vector<float> m_l1Jet_et8x8;
+  std::vector<float> m_l1Jet_eta;
+  std::vector<float> m_l1Jet_phi;
 
   //
   // Truth


### PR DESCRIPTION
This only changes the implementation of the storing of L1 jets in HelpTreeBase to make it work in AB >2.4.22.