### PR TITLE
Update PhotonCalibrator

### DIFF
--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -87,6 +87,16 @@ PhotonCalibrator :: PhotonCalibrator (std::string className) :
   m_isMC                    = false;
   m_useAFII                 = false;
 
+  m_conEffCalibPath ="PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2016.13TeV.rel20.7.25ns.con.v00.root";
+  m_uncEffCalibPath ="PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2016.13TeV.rel20.7.25ns.unc.v00.root";
+
+  m_conEffAFIICalibPath ="PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.con.v01.root";
+  m_uncEffAFIICalibPath ="PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.unc.v01.root";
+
+  m_tightIDConfigPath  = "ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMTightSelectorCutDefs.conf";
+  m_mediumIDConfigPath = "ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMMediumSelectorCutDefs.conf";
+  m_looseIDConfigPath  = "ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMLooseSelectorCutDefs.conf";
+
   m_toolInitializationAtTheFirstEventDone = false;
 
   // Systematics stuff
@@ -255,13 +265,13 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   //set the configuration file
   // todo : monitor the config files!
   RETURN_CHECK("PhotonHandler::initializeTools()",
-	       m_photonTightIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMTightSelectorCutDefs.conf"),
+	       m_photonTightIsEMSelector->setProperty("ConfigFile", m_tightIDConfigPath),
 	       "failed in setting property");
   RETURN_CHECK("PhotonHandler::initializeTools()",
-	       m_photonMediumIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMMediumSelectorCutDefs.conf"),
+	       m_photonMediumIsEMSelector->setProperty("ConfigFile",m_mediumIDConfigPath),
 	       "failed in setting property");
   RETURN_CHECK("PhotonHandler::initializeTools()",
-	       m_photonLooseIsEMSelector->setProperty("ConfigFile","ElectronPhotonSelectorTools/offline/mc15_20150712/PhotonIsEMLooseSelectorCutDefs.conf"),
+	       m_photonLooseIsEMSelector->setProperty("ConfigFile", m_looseIDConfigPath),
 	       "failed in setting property");
 
 
@@ -665,21 +675,19 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
     }
     m_photonLooseEffTool->msg().setLevel( msgLevel );
 
-    // todo : Set input files ** not yet available for 13 TeV ** Date : 13 May
-    // recommended files here: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommended_input_files
-    std::string file_unc = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.unc.v02.root");
-    std::string file_con = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.con.v02.root");
+    std::string conEffCalibPath  = PathResolverFindCalibFile(m_conEffCalibPath );
+    std::string uncEffCalibPath  = PathResolverFindCalibFile(m_uncEffCalibPath );
     if(m_useAFII){
-      file_unc = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.unc.v01.root");
-      file_con = PathResolverFindCalibFile("PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2015.13TeV.rel20.AFII.con.v01.root");
+      conEffCalibPath  = PathResolverFindCalibFile(m_conEffAFIICalibPath );
+      uncEffCalibPath  = PathResolverFindCalibFile(m_uncEffAFIICalibPath );
     }
 
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool->setProperty("CorrectionFileNameConv",file_con), "failed in setting property");
-    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool->setProperty("CorrectionFileNameUnconv",file_unc), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameConv"  ,conEffCalibPath), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonMediumEffTool->setProperty("CorrectionFileNameUnconv",uncEffCalibPath), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath), "failed in setting property");
+    RETURN_CHECK("PhotonHandler::initializeTools()", m_photonLooseEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath), "failed in setting property");
 
     // set data type
     RETURN_CHECK("PhotonHandler::initializeTools()", m_photonTightEffTool->setProperty("ForceDataType", dataType), "failed in setting property");

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -32,6 +32,19 @@ public:
   std::string m_inContainerName;
   std::string m_outContainerName;
 
+  // Calibration information
+  // recommended files here: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommended_input_files
+  std::string m_conEffCalibPath;
+  std::string m_uncEffCalibPath;
+  std::string m_conEffAFIICalibPath;
+  std::string m_uncEffAFIICalibPath;
+
+  // ID information
+  // recommended files here: ElectronLikelihoodLooseOfflineConfig2016_Smooth.conf
+  std::string m_tightIDConfigPath;
+  std::string m_mediumIDConfigPath;
+  std::string m_looseIDConfigPath;
+
   // sort after calibration
   bool    m_sort;
 

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -34,8 +34,6 @@ public:
 
   // sort after calibration
   bool    m_sort;
-  bool    m_toolInitializationAtTheFirstEventDone; //!
-  bool    m_isMC; //!
 
   // systematics
   std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
@@ -50,8 +48,8 @@ public:
   std::string m_decorrelationModel;
 
 private:
-  int m_numEvent;         //!
-  int m_numObject;        //!
+  bool    m_toolInitializationAtTheFirstEventDone; //!
+  bool    m_isMC; //!
 
   std::string m_outAuxContainerName;
   std::string m_outSCContainerName;


### PR DESCRIPTION
Updated the PhotonCalibrator to the latest recommendations. The list of changes is:

* Scale factors are now derived down to 10 GeV - [reference](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Photon_selection)
* Updated scale factors to latest recommendations - [reference](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommendations_for_full_2015_an)
* IsolationCorrectionTool no longer has the isMC property and uses applyCorrection to decorate photon - [reference](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/IsolationLeakageCorrections)
 
It is now also possible to set the recommendation files via attributes.
