### PR TITLE
Finalize the trigDecTool upon completion.

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1053,7 +1053,7 @@ EL::StatusCode BasicEventSelection :: finalize ()
   m_RunNr_VS_EvtNr.clear();
 
   if ( m_grl )          { delete m_grl; m_grl = nullptr; }
-  if ( m_trigDecTool )  { delete m_trigDecTool;  m_trigDecTool = nullptr; }
+  if ( m_trigDecTool )  { m_trigDecTool->finalize(); delete m_trigDecTool;  m_trigDecTool = nullptr; }
   if ( m_trigConfTool ) { delete m_trigConfTool;  m_trigConfTool = nullptr; }
 
   //after execution loop 


### PR DESCRIPTION
xAODAnaHelpers currently creates an instance at the beginning of a sample and then deletes the TrigDecisionTool at the end of every sample. The tool keeps an internal count of its instances. Thus the finalize function needs to be called before deleting the tool. Otherwise the following error occurs:

`virtual StatusCode Trig::TrigDecisionTool::initialize()): Will not 
accept multiple instances. If you really want to have some, use 
'AcceptMultipleInstance' property `

This was introduced (fixed?) recently in the tool. More information is available here:
https://groups.cern.ch/group/hn-atlas-PATHelp/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-PATHelp%2fLists%2fArchive%2fTriggerDecisionTool%20ERROR%20Will%20not%20accept%20multiple%20instances&FolderCTID=0x0120020084D7E80CB0C3394A8D54EF07C309B044