### PR TITLE
Disable muon efficiency decorations

### DIFF
--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -649,12 +649,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with reco efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
-    	 }
-    	 if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
-    	 }
+    	 //if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
+    	 //}
+    	 //if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
+    	 //}
 
     	 // b)
     	 // obtain reco efficiency SF as a float (to be stored away separately)
@@ -753,12 +753,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with iso efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
-    	 }
-    	 if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
-    	 }
+    	 //if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
+    	 //}
+    	 //if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
+    	 //}
 
     	 // b)
     	 // obtain iso efficiency SF as a float (to be stored away separately)
@@ -1101,12 +1101,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with TTVA efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
-    	 }
-    	 if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
-    	 }
+    	 //if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
+    	 //}
+    	 //if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
+    	 //}
 
     	 // b)
     	 // obtain TTVA efficiency SF as a float (to be stored away separately)


### PR DESCRIPTION
Direct decoration of muons with its efficiencies has been commented as the following error message appeared with AB 2.4.26:

`EfficiencyScaleFactor     WARNING Could not find histogram for variation central and muon with pt=26832.0957, eta=-1.74 and phi=2.31, returning 1.0
MuonEfficiencyCorrecto... WARNING Problem in applyMCEfficiency for Iso`

This only happens for the isolation, but direct decorations of reco and TTVA efficiencies have been commented as well for consistency. Notice that this will not change the content of the output ntuple
and said decoration was not used previously. 