### PR TITLE
xAH_run returns non-zero (1) status code when the main code crashes.

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -612,3 +612,4 @@ if __name__ == "__main__":
   except Exception, e:
     # we crashed
     xAH_logger.exception("{0}\nAn exception was caught!".format("-"*20))
+    sys.exit(1)


### PR DESCRIPTION
Can be used by scripts running several xAH_run instances to check their status.