### PR TITLE
Update muon calibration configuration

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -217,12 +217,12 @@ EL::StatusCode MuonCalibrator :: initialize ()
         // The following properties are supported in MuonMomentumCorrections-01-00-58
         // not in AB 2.4.26. Remember to uncomment them for future releases!
         //
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonTriggerScaleFactors"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonTriggerScaleFactors"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonTriggerScaleFactors"); 
+        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
+        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
+        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
       } else {
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonTriggerScaleFactors"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonTriggerScaleFactors"); 
+        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
+        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
       }
 
       RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->initialize(), "Failed to properly initialize the MuonCalibrationAndSmearingTool.");

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -6,6 +6,10 @@
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
 
+// external tools include(s):
+#include "AsgTools/AnaToolHandle.h"
+#include "PileupReweighting/PileupReweightingTool.h"
+
 class MuonCalibrator : public xAH::Algorithm
 {
   // put your configuration variables here as public variables.
@@ -17,9 +21,14 @@ public:
   std::string m_outContainerName;
 
   std::string m_release;
+  std::string m_Years;
 
   // sort after calibration
   bool    m_sort;
+  
+  bool         m_do_sagittaCorr;
+  std::string  m_sagittaRelease;
+  bool         m_do_sagittaMCDistortion;
 
   // systematics
   std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
@@ -55,8 +64,13 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  CP::MuonCalibrationAndSmearingTool *m_muonCalibrationAndSmearingTool; //!
+  //CP::MuonCalibrationAndSmearingTool *m_muonCalibrationAndSmearingTool; //!
 
+  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                            //!
+  std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;  //!   
+  std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                      //!
+  std::vector<std::string> m_YearsList;                                                           //!
+  
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker
   // node (done by the //!)


### PR DESCRIPTION
This resolves #790. A year dependent configuration of the MuonCalibration is introduced. As illustrated in [this twiki](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/MCPAnalysisGuidelinesMC15#Muon_momentum_scale_and_resoluti) some of the features of the tool can only be configured from 2016 on. For MC the decision is taken using a random run number from the PRW tool. Notice that this updated configuration is only available for MuonMomentumCorrections-01-00-58 not in AB 2.4.26. So the actual setting of the tool properties
is commented out for now but it has already been prepared!  