### PR TITLE
bump from 2.4.26 to 2.4.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV=2.4.26
+  - ABV=2.4.27
 
 before_install:
   - ls


### PR DESCRIPTION
Bump AB to 2.4.27 to allow for use of latest recommendations for Moriond:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/AnalysisBaseReleaseNotes24#ReleaseNotes27