### PR TITLE
Updated JVT tool in JetSelector:

### DIFF
--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -98,6 +98,17 @@ public:
         @endrst
         */
   std::string m_WorkingPointJVT;
+
+  /**
+     @brief Configuration containting JVT scale factors.
+     
+     @rst
+     The configuration file with the scale factors calculated by the ``CP::IJetJvtEfficiency``.
+
+     See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration for latest recommendation.
+     @endrst
+  */ 
+  std::string m_SFFileJVT;
   std::string m_outputSystNamesJVT;
 
   float         m_systValJVT;


### PR DESCRIPTION
 * Add m_SFFileJVT option to select file with SFs (Moriond 2017 is default)
 * Use `ASG_MAKE_ANA_TOOL` to initialize `CP::JetJvtEfficiency` tool (gets rid of depricated warnings)
 * Jet pt/eta definitions for JVT are now decided by the tool (manual cut still uses m_pt_max_JVT and m_peta_max_JVT)

More information on the SF configurations:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration#JetJvtEfficiency_Tool_Usage