### PR TITLE
Update/muon selection type

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -214,15 +214,13 @@ EL::StatusCode MuonCalibrator :: initialize ()
       if ( !m_release.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release),"Failed to set property Release"); }
       if ( !yr.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ),"Failed to set Year property of MuonCalibrationAndSmearingTool"); }
       if ( yr == "Data16") { 
-        // The following properties are supported in MuonMomentumCorrections-01-00-58
-        // not in AB 2.4.26. Remember to uncomment them for future releases!
-        //
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
+        
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
       } else {
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
       }
 
       RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->initialize(), "Failed to properly initialize the MuonCalibrationAndSmearingTool.");
@@ -230,17 +228,6 @@ EL::StatusCode MuonCalibrator :: initialize ()
     }
   }
   
-  // Initialize the CP::MuonCalibrationAndSmearingTool
-  //
-  //if ( asg::ToolStore::contains<CP::MuonCalibrationAndSmearingTool>("MuonCalibrationAndSmearingTool") ) {
-  //  m_muonCalibrationAndSmearingTool = asg::ToolStore::get<CP::MuonCalibrationAndSmearingTool>("MuonCalibrationAndSmearingTool");
-  //} else {
-  //  m_muonCalibrationAndSmearingTool = new CP::MuonCalibrationAndSmearingTool("MuonCalibrationAndSmearingTool");
-  //}
-  //m_muonCalibrationAndSmearingTool->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-  //if ( !m_release.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTool->setProperty("Release", m_release),"Failed to set property Release"); }
-  //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTool->initialize(), "Failed to properly initialize the MuonCalibrationAndSmearingTool.");
-
   // ***********************************************************
 
   // Get a list of recommended systematics for this tool

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -276,13 +276,13 @@ EL::StatusCode MuonSelector :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-  std::set<std::string> muonTypeSet;
-  muonTypeSet.insert("");
-  muonTypeSet.insert("Combined");
-  muonTypeSet.insert("MuonStandAlone");
-  muonTypeSet.insert("SegmentTagged");
-  muonTypeSet.insert("CaloTagged");
-  muonTypeSet.insert("SiliconAssociatedForwardMuon");
+  //std::set<std::string> muonTypeSet;
+  //muonTypeSet.insert("");
+  //muonTypeSet.insert("Combined");
+  //muonTypeSet.insert("MuonStandAlone");
+  //muonTypeSet.insert("SegmentTagged");
+  //muonTypeSet.insert("CaloTagged");
+  //muonTypeSet.insert("SiliconAssociatedForwardMuon");
   //if ( muonTypeSet.find(m_muonType) == muonTypeSet.end() ) {
   //  Error("initialize()", "Unknown muon type requested: %s!",m_muonType.c_str());
   //  return EL::StatusCode::FAILURE;

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -89,7 +89,7 @@ MuonSelector :: MuonSelector (std::string className) :
   // configurable cuts
   //
   m_muonQualityStr          = "Medium";
-  m_muonType                = "";
+  //m_muonType                = "";
   m_pass_max                = -1;
   m_pass_min                = -1;
   m_pT_max                  = 1e8;
@@ -283,10 +283,10 @@ EL::StatusCode MuonSelector :: initialize ()
   muonTypeSet.insert("SegmentTagged");
   muonTypeSet.insert("CaloTagged");
   muonTypeSet.insert("SiliconAssociatedForwardMuon");
-  if ( muonTypeSet.find(m_muonType) == muonTypeSet.end() ) {
-    Error("initialize()", "Unknown muon type requested: %s!",m_muonType.c_str());
-    return EL::StatusCode::FAILURE;
-  }
+  //if ( muonTypeSet.find(m_muonType) == muonTypeSet.end() ) {
+  //  Error("initialize()", "Unknown muon type requested: %s!",m_muonType.c_str());
+  //  return EL::StatusCode::FAILURE;
+  //}
 
   // Parse input isolation WP list, split by comma, and put into a vector for later use
   // Make sure it's not empty!
@@ -897,15 +897,15 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   //
   // muon type cut
   //
-  HelperClasses::EnumParser<xAOD::Muon::MuonType> muTypeParser;
-  if ( !m_muonType.empty() ) {
-    if ( muon->muonType() != static_cast<int>(muTypeParser.parseEnum(m_muonType))) {
-      if ( m_debug ) { Info("PassCuts()", "Muon type: %d - required: %s . Failed", muon->muonType(), m_muonType.c_str()); }
-      return 0;
-    }
-  }
-  if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_type_cut, 1 );
-  if ( m_isUsedBefore && m_useCutFlow ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_type_cut, 1 ); }
+  //HelperClasses::EnumParser<xAOD::Muon::MuonType> muTypeParser;
+  //if ( !m_muonType.empty() ) {
+  //  if ( muon->muonType() != static_cast<int>(muTypeParser.parseEnum(m_muonType))) {
+  //    if ( m_debug ) { Info("PassCuts()", "Muon type: %d - required: %s . Failed", muon->muonType(), m_muonType.c_str()); }
+  //    return 0;
+  //  }
+  //}
+  //if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_type_cut, 1 );
+  //if ( m_isUsedBefore && m_useCutFlow ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_type_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
   //

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -64,8 +64,6 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  //CP::MuonCalibrationAndSmearingTool *m_muonCalibrationAndSmearingTool; //!
-
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                            //!
   std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;  //!   
   std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                      //!

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -57,7 +57,7 @@ public:
   float          m_pT_min;		     /* require pT > pt_min */
   int            m_muonQuality;	             /* require quality */
   std::string    m_muonQualityStr;           /* require type */
-  std::string    m_muonType;	             /* require type */
+  //std::string    m_muonType;	             /* require type */
   float          m_eta_max;		     /* require |eta| < eta_max */
   float          m_d0_max;                   /* require d0 < m_d0_max */
   float          m_d0sig_max; 	             /* require d0 significance (at BL) < m_d0sig_max */

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -125,7 +125,6 @@ private:
 
   // tools
 
-  //asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle;  //!
   asg::AnaToolHandle<CP::IsolationSelectionTool>  m_isolationSelectionTool_handle;  //!
   std::string m_isolationSelectionTool_name;                                         //!
   asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle;       //!


### PR DESCRIPTION
As explained in [this twiki](https://twiki.cern.ch/twiki/bin/view/Atlas/MuonSelectionTool#Quality_definition) the muon reconstruction working points are inclusive
wrt different reconstruction methods, e.g. combined, standalone etc. Therefore, the user should only specify the desired working point and any reference to the type of muon is redundant. This was already implemented in our code however m_Type was still present in the MuonSelector module and has been commented out to avoid confusion in the configuration of the tool.

In addition to this the configuration of the MuonCalibrator has been updated for AB >= 2.4.27