### PR TITLE
Syst updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV=2.4.27
+  - ABV=2.4.28
 
 before_install:
   - ls

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -57,6 +57,7 @@ BJetEfficiencyCorrector :: BJetEfficiencyCorrector (std::string className) :
   m_taggerName             = "MV2c10";
   m_useDevelopmentFile     = true;
   m_coneFlavourLabel       = true;
+  m_systematicsStrategy    = "SFEigen";
 
   // allowed operating points:
   // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#xAOD_interface
@@ -227,6 +228,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     m_BJetEffSFTool->msg().setLevel( MSG::INFO ); // DEBUG, VERBOSE, INFO, ERROR
 
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("TaggerName",          m_taggerName),"Failed to set property");
+    RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("SystematicsStrategy", m_systematicsStrategy ), "Failed to set property");
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("OperatingPoint",      m_operatingPtCDI),"Failed to set property");
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("JetAuthor",           m_jetAuthor),"Failed to set property");
     RETURN_CHECK( "BJetEfficiencyCorrector::initialize()", m_BJetEffSFTool->setProperty("ScaleFactorFileName", m_corrFileName),"Failed to set property");

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -210,7 +210,8 @@ EL::StatusCode ElectronCalibrator :: initialize ()
 
   // Get a list of recommended systematics for this tool
   //
-  const CP::SystematicSet recSyst = CP::SystematicSet();
+  //const CP::SystematicSet recSyst = CP::SystematicSet();
+  const CP::SystematicSet& recSyst = m_EgammaCalibrationAndSmearingTool->recommendedSystematics();
 
   Info("initialize()"," Initializing Electron Calibrator Systematics :");
   //

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -217,9 +217,9 @@ EL::StatusCode MuonCalibrator :: initialize ()
         // The following properties are supported in MuonMomentumCorrections-01-00-58
         // not in AB 2.4.26. Remember to uncomment them for future releases!
         //
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
-        //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
       } else {
         //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
         //RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
@@ -245,7 +245,8 @@ EL::StatusCode MuonCalibrator :: initialize ()
 
   // Get a list of recommended systematics for this tool
   //
-  const CP::SystematicSet recSyst = CP::SystematicSet();
+  //const CP::SystematicSet recSyst = CP::SystematicSet();
+  const CP::SystematicSet& recSyst = m_muonCalibrationAndSmearingTools[m_YearsList.at(0)]->recommendedSystematics();
 
   Info("initialize()"," Initializing Muon Calibrator Systematics :");
   //

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -33,6 +33,7 @@ public:
   std::string m_taggerName;
   bool        m_useDevelopmentFile;
   bool        m_coneFlavourLabel;
+  std::string m_systematicsStrategy;
 
   std::string m_operatingPt;      // Operating point.
   std::string m_operatingPtCDI;   // the one CDI will understand


### PR DESCRIPTION
Bump to 2.4.28, and updates for b-tagging efficiency systematics strategy.

@fscutti @kratsg Also included are a local change I had to ElectronCalibration and MuonCalibrator to let me access the recommended uncertainties.  How were you currently accessing "All" uncertainties?  If there's already a better way to do it, I'll remove those two updates.
