### PR TITLE
Make random run number optional in PhotonCalibrator.

### DIFF
--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -109,6 +109,8 @@ PhotonCalibrator :: PhotonCalibrator (std::string className) :
   m_esModel                 = "es2016data_mc15c";
   m_decorrelationModel      = "";
 
+  m_randomRunNumber         = -1;
+
 }
 
 
@@ -204,7 +206,7 @@ EL::StatusCode PhotonCalibrator :: initialize ()
 
   RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("ESModel", m_esModel),"Failed to set property ESModel");
   RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("decorrelationModel", m_decorrelationModel),"Failed to set property decorrelationModel");
-  RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("randomRunNumber", EgammaCalibPeriodRunNumbersExample::run_2016), "Failed to set property decorrelationModel");
+  if(m_randomRunNumber>0) RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("randomRunNumber", m_randomRunNumber), "Failed to set property randomRunNumber");
   if (m_useAFII) {
     RETURN_CHECK( "PhotonCalibrator::initialize()", m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", 1), "Failed to set property useAFII");
   }

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -59,6 +59,7 @@ public:
 
   std::string m_esModel;
   std::string m_decorrelationModel;
+  int m_randomRunNumber;
 
 private:
   bool    m_toolInitializationAtTheFirstEventDone; //!


### PR DESCRIPTION
The photon calibration now requires pile-up reweighing to be run. It is necessary for the ZEESTAT systeamtic. Previously this was by-passed by assigning a random run number to the tool. This patch makes default the recommended behavior (PRW tool).

https://twiki.cern.ch/twiki/bin/view/AtlasProtected/ElectronPhotonFourMomentumCorrection#Recommendations_for_data15_data1