### PR TITLE
added the CorrelationModel configurable member

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -69,6 +69,7 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string classNam
   m_outputSystNamesReco     = "EleEffCorr_RecoSyst";
   m_outputSystNamesTrig     = "EleEffCorr_TrigSyst";
   m_outputSystNamesTrigMCEff = "EleEffCorr_TrigMCEffSyst";
+  m_correlationModel = "FULL";
 
   // file(s) containing corrections
   //
@@ -201,6 +202,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       std::vector<std::string> inputFilesPID{ m_corrFileNamePID } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->setProperty("CorrectionFileNameList",inputFilesPID),"Failed to set property CorrectionFileNameList");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->setProperty("CorrelationModel",m_correlationModel),"Failed to set property CorrelationModel");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool PID");
     }
 
@@ -267,6 +269,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       std::vector<std::string> inputFilesIso{ m_corrFileNameIso } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Iso->setProperty("CorrectionFileNameList",inputFilesIso),"Failed to set property CorrectionFileNameList");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Iso->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Iso->setProperty("CorrelationModel",m_correlationModel),"Failed to set property CorrelationModel");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Iso->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Iso");
     }
 
@@ -319,6 +322,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       std::vector<std::string> inputFilesReco{ m_corrFileNameReco } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("CorrectionFileNameList",inputFilesReco),"Failed to set property CorrectionFileNameList");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->setProperty("CorrelationModel",m_correlationModel),"Failed to set property CorrelationModel");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Reco");
     }
 
@@ -380,6 +384,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       std::vector<std::string> inputFilesTrig{ m_corrFileNameTrig } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("CorrectionFileNameList",inputFilesTrig),"Failed to set property CorrectionFileNameList");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->setProperty("CorrelationModel",m_correlationModel),"Failed to set property CorrelationModel");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Trig");
     }
 
@@ -438,6 +443,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       std::vector<std::string> inputFilesTrigMCEff{ m_corrFileNameTrigMCEff } ; // initialise vector w/ all the files containing corrections
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("CorrectionFileNameList",inputFilesTrigMCEff),"Failed to set property CorrectionFileNameList");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("ForceDataType",sim_flav),"Failed to set property ForceDataType");
+      RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("CorrelationModel",m_correlationModel),"Failed to set property CorrelationModel");
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool TrigMCEff");
     }
 

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -55,6 +55,7 @@ public:
   std::string m_corrFileNameReco;
   std::string m_corrFileNameTrig;
   std::string m_corrFileNameTrigMCEff;
+  std::string m_correlationModel;
 
 private:
   int m_numEvent;         //!


### PR DESCRIPTION
Made the "CorrelationModel" option in ElectronEffCorrectors configurable through user scripts. Should close https://github.com/UCATLAS/xAODAnaHelpers/issues/808.