### PR TITLE
Trees of Tracks

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -94,6 +94,11 @@ HelpTreeBase::~HelpTreeBase() {
     //truth
     for (auto truth: m_truth)
       delete truth.second;
+    
+    //track
+    for (auto track: m_tracks)
+      delete track.second;
+
 }
 
 
@@ -586,6 +591,60 @@ void HelpTreeBase::ClearTruth(const std::string truthName) {
 
 }
 
+/*********************
+ *
+ *   TRACKS
+ *
+ ********************/
+
+void HelpTreeBase::AddTrackParts(const std::string trackName, const std::string detailStr)
+{
+  if(m_debug) Info("AddTrackParts()", "Adding track particle %s with variables: %s", trackName.c_str(), detailStr.c_str());
+  m_tracks[trackName] = new xAH::TrackContainer(trackName, detailStr, m_units);
+
+  xAH::TrackContainer* thisTrack = m_tracks[trackName];
+  thisTrack->setBranches(m_tree);
+  this->AddTracksUser(trackName);
+}
+
+void HelpTreeBase::FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* trackParts ) {
+
+  this->ClearTracks(trackName);
+
+  // We need some basic cuts here to avoid many PseudoRapiditity warnings being thrown ...
+  // float trackparticle_ptmin  = 1.0;
+  // float trackparticle_etamax = 8.0;
+
+  for( auto track_itr : *trackParts ) {
+
+    // if((track_itr->pt() / m_units < trackparticle_ptmin) || (fabs(track_itr->eta()) > trackparticle_etamax) ){
+    //  continue;
+    // }
+
+    this->FillTrack(track_itr, trackName);
+  }
+
+}
+
+void HelpTreeBase::FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName )
+{
+  xAH::TrackContainer* thisTrack = m_tracks[trackName];
+
+  thisTrack->FillTrack(trackPart);
+
+  this->FillTracksUser(trackName, trackPart);
+
+  return;
+}
+
+void HelpTreeBase::ClearTracks(const std::string trackName) {
+
+  xAH::TrackContainer* thisTrack = m_tracks[trackName];
+  thisTrack->clear();
+
+  this->ClearTracksUser(trackName);
+
+}
 
 /*********************
  *

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -325,6 +325,12 @@ namespace HelperClasses{
     m_children      = has_exact("children");
   }
 
+  void TrackInfoSwitch::initialize(){
+    m_kinematic     = has_exact("kinematic");
+    m_fitpars	    = has_exact("fitpars");
+    m_numbers	    = has_exact("numbers");
+    m_vertex	    = has_exact("vertex");
+  }
 
   void TauInfoSwitch::initialize(){
     m_trackparams   = has_exact("trackparams");

--- a/Root/TrackContainer.cxx
+++ b/Root/TrackContainer.cxx
@@ -1,0 +1,338 @@
+#include "xAODAnaHelpers/TrackContainer.h"
+#include <xAODAnaHelpers/HelperFunctions.h>
+#include <iostream>
+#include <xAODTracking/TrackParticle.h>
+
+using namespace xAH;
+using std::vector; using std::endl; using std::cout;
+
+TrackContainer::TrackContainer(const std::string& name, const std::string& detailStr, float units) : ParticleContainer(name,detailStr,units,true)
+
+{
+  if(m_infoSwitch.m_fitpars){
+    m_chiSquared = new vector<float >;
+    m_d0 = new vector<float >;
+    m_definingParametersCovMatrix = new vector<std::vector<float> >;
+    m_expectInnermostPixelLayerHit = new vector<unsigned char >;
+    m_expectNextToInnermostPixelLayerHit = new vector<unsigned char >;
+    m_numberDoF = new vector<float >;
+  }
+
+  if(m_infoSwitch.m_numbers){
+    m_numberOfInnermostPixelLayerHits = new vector<unsigned char >;
+    m_numberOfNextToInnermostPixelLayerHits = new vector<unsigned char >;
+    m_numberOfPhiHoleLayers = new vector<unsigned char >;
+    m_numberOfPhiLayers = new vector<unsigned char >;
+    m_numberOfPixelDeadSensors = new vector<unsigned char >;
+    m_numberOfPixelHits = new vector<unsigned char >;
+    m_numberOfPixelHoles = new vector<unsigned char >;
+    m_numberOfPixelSharedHits = new vector<unsigned char >;
+    m_numberOfPrecisionHoleLayers = new vector<unsigned char >;
+    m_numberOfPrecisionLayers = new vector<unsigned char >;
+    m_numberOfSCTDeadSensors = new vector<unsigned char >;
+    m_numberOfSCTHits = new vector<unsigned char >;
+    m_numberOfSCTHoles = new vector<unsigned char >;
+    m_numberOfSCTSharedHits = new vector<unsigned char >;
+    m_numberOfTRTHits = new vector<unsigned char >;
+    m_numberOfTRTOutliers = new vector<unsigned char >;
+  }
+
+  m_phi = new vector<float >;
+  m_qOverP = new vector<float >;
+  m_theta = new vector<float >;
+
+  if(m_infoSwitch.m_vertex){
+    m_vertexLink = new vector<Int_t >;
+    m_vertexLink_persIndex = new vector<UInt_t >;
+    m_vertexLink_persKey = new vector<UInt_t >;
+    m_vz = new vector<float >;
+    m_z0 = new vector<float >;
+  }
+}
+
+TrackContainer::~TrackContainer()
+{
+  if(m_debug) std::cout << " Deleting TrackContainer "<< std::endl;
+
+  if(m_infoSwitch.m_fitpars){
+    delete m_chiSquared;
+    delete m_d0;
+    delete m_definingParametersCovMatrix;
+    delete m_expectInnermostPixelLayerHit;
+    delete m_expectNextToInnermostPixelLayerHit;
+    delete m_numberDoF;
+  }
+ 
+  if(m_infoSwitch.m_numbers){
+    delete m_numberOfInnermostPixelLayerHits;
+    delete m_numberOfNextToInnermostPixelLayerHits;
+    delete m_numberOfPhiHoleLayers;
+    delete m_numberOfPhiLayers;
+    delete m_numberOfPixelDeadSensors;
+    delete m_numberOfPixelHits;
+    delete m_numberOfPixelHoles;
+    delete m_numberOfPixelSharedHits;
+    delete m_numberOfPrecisionHoleLayers;
+    delete m_numberOfPrecisionLayers;
+    delete m_numberOfSCTDeadSensors;
+    delete m_numberOfSCTHits;
+    delete m_numberOfSCTHoles;
+    delete m_numberOfSCTSharedHits;
+    delete m_numberOfTRTHits;
+    delete m_numberOfTRTOutliers;
+  }
+
+  delete m_phi;
+  delete m_qOverP;
+  delete m_theta;
+
+  if(m_infoSwitch.m_vertex){
+    delete m_vertexLink;
+    delete m_vertexLink_persIndex;
+    delete m_vertexLink_persKey;
+    delete m_vz;
+    delete m_z0;
+  }
+}
+
+void TrackContainer::setTree(TTree *tree)
+{
+  ParticleContainer::setTree(tree);
+
+  if(m_infoSwitch.m_fitpars){
+    connectBranch<float>(tree, "chiSquared", &m_chiSquared);
+    connectBranch<float>(tree, "d0", &m_d0);
+    connectBranch<std::vector<float> >(tree, "definingParametersCovMatrix", &m_definingParametersCovMatrix);
+    connectBranch<unsigned char>(tree, "expectInnermostPixelLayerHit", &m_expectInnermostPixelLayerHit);
+    connectBranch<unsigned char>(tree, "expectNextToInnermostPixelLayerHit", &m_expectNextToInnermostPixelLayerHit);
+    connectBranch<float>(tree, "numberDoF", &m_numberDoF);
+  }
+
+  if(m_infoSwitch.m_numbers){
+    connectBranch<unsigned char>(tree, "numberOfInnermostPixelLayerHits", &m_numberOfInnermostPixelLayerHits);
+    connectBranch<unsigned char>(tree, "numberOfNextToInnermostPixelLayerHits", &m_numberOfNextToInnermostPixelLayerHits);
+    connectBranch<unsigned char>(tree, "numberOfPhiHoleLayers", &m_numberOfPhiHoleLayers);
+    connectBranch<unsigned char>(tree, "numberOfPhiLayers", &m_numberOfPhiLayers);
+    connectBranch<unsigned char>(tree, "numberOfPixelDeadSensors", &m_numberOfPixelDeadSensors);
+    connectBranch<unsigned char>(tree, "numberOfPixelHits", &m_numberOfPixelHits);
+    connectBranch<unsigned char>(tree, "numberOfPixelHoles", &m_numberOfPixelHoles);
+    connectBranch<unsigned char>(tree, "numberOfPixelSharedHits", &m_numberOfPixelSharedHits);
+    connectBranch<unsigned char>(tree, "numberOfPrecisionHoleLayers", &m_numberOfPrecisionHoleLayers);
+    connectBranch<unsigned char>(tree, "numberOfPrecisionLayers", &m_numberOfPrecisionLayers);
+    connectBranch<unsigned char>(tree, "numberOfSCTDeadSensors", &m_numberOfSCTDeadSensors);
+    connectBranch<unsigned char>(tree, "numberOfSCTHits", &m_numberOfSCTHits);
+    connectBranch<unsigned char>(tree, "numberOfSCTHoles", &m_numberOfSCTHoles);
+    connectBranch<unsigned char>(tree, "numberOfSCTSharedHits", &m_numberOfSCTSharedHits);
+    connectBranch<unsigned char>(tree, "numberOfTRTHits", &m_numberOfTRTHits);
+    connectBranch<unsigned char>(tree, "numberOfTRTOutliers", &m_numberOfTRTOutliers);
+  }    
+  
+  connectBranch<float>(tree, "phi", &m_phi);
+  connectBranch<float>(tree, "qOverP", &m_qOverP);
+  connectBranch<float>(tree, "theta", &m_theta);
+  
+  if(m_infoSwitch.m_vertex){
+    connectBranch<Int_t>(tree, "vertexLink", &m_vertexLink);
+    connectBranch<UInt_t>(tree, "vertexLink_persIndex", &m_vertexLink_persIndex);
+    connectBranch<UInt_t>(tree, "vertexLink_persKey", &m_vertexLink_persKey);
+    connectBranch<float>(tree, "vz", &m_vz);
+    connectBranch<float>(tree, "z0", &m_z0);
+  }
+}
+
+void TrackContainer::updateParticle(uint idx, TrackPart& track)
+{
+  if(m_debug) std::cout << "in TrackContainer::updateParticle" << std::endl;
+  ParticleContainer::updateParticle(idx, track);
+
+  if(m_infoSwitch.m_fitpars){
+    track.chiSquared = m_chiSquared->at(idx);
+    track.d0 = m_d0->at(idx);
+    track.definingParametersCovMatrix = m_definingParametersCovMatrix->at(idx);
+    track.expectInnermostPixelLayerHit = m_expectInnermostPixelLayerHit->at(idx);
+    track.expectNextToInnermostPixelLayerHit = m_expectNextToInnermostPixelLayerHit->at(idx);
+  }
+
+  if(m_infoSwitch.m_numbers){
+    track.numberDoF = m_numberDoF->at(idx);
+    track.numberOfInnermostPixelLayerHits = m_numberOfInnermostPixelLayerHits->at(idx);
+    track.numberOfNextToInnermostPixelLayerHits = m_numberOfNextToInnermostPixelLayerHits->at(idx);
+    track.numberOfPhiHoleLayers = m_numberOfPhiHoleLayers->at(idx);
+    track.numberOfPhiLayers = m_numberOfPhiLayers->at(idx);
+    track.numberOfPixelDeadSensors = m_numberOfPixelDeadSensors->at(idx);
+    track.numberOfPixelHits = m_numberOfPixelHits->at(idx);
+    track.numberOfPixelHoles = m_numberOfPixelHoles->at(idx);
+    track.numberOfPixelSharedHits = m_numberOfPixelSharedHits->at(idx);
+    track.numberOfPrecisionHoleLayers = m_numberOfPrecisionHoleLayers->at(idx);
+    track.numberOfPrecisionLayers = m_numberOfPrecisionLayers->at(idx);
+    track.numberOfSCTDeadSensors = m_numberOfSCTDeadSensors->at(idx);
+    track.numberOfSCTHits = m_numberOfSCTHits->at(idx);
+    track.numberOfSCTHoles = m_numberOfSCTHoles->at(idx);
+    track.numberOfSCTSharedHits = m_numberOfSCTSharedHits->at(idx);
+    track.numberOfTRTHits = m_numberOfTRTHits->at(idx);
+    track.numberOfTRTOutliers = m_numberOfTRTOutliers->at(idx);
+  }  
+
+  track.phi = m_phi->at(idx);
+  track.qOverP = m_qOverP->at(idx);
+  track.theta = m_theta->at(idx);
+
+  if(m_infoSwitch.m_vertex){
+    track.vertexLink = m_vertexLink->at(idx);
+    track.vertexLink_persIndex = m_vertexLink_persIndex->at(idx);
+    track.vertexLink_persKey = m_vertexLink_persKey->at(idx);
+    track.vz = m_vz->at(idx);
+    track.z0 = m_z0->at(idx);
+  }  
+
+  if(m_debug) std::cout << "leaving TrackContainer::updateParticle" << std::endl;
+  return;
+}
+
+void TrackContainer::setBranches(TTree *tree)
+{
+  ParticleContainer::setBranches(tree);
+
+  if(m_infoSwitch.m_fitpars){
+  setBranch<float>(tree, "chiSquared", m_chiSquared);
+  setBranch<float>(tree, "d0", m_d0);
+  setBranch<vector<float>>(tree, "definingParametersCovMatrix", m_definingParametersCovMatrix);
+  setBranch<unsigned char>(tree, "expectInnermostPixelLayerHit", m_expectInnermostPixelLayerHit);
+  setBranch<unsigned char>(tree, "expectNextToInnermostPixelLayerHit", m_expectNextToInnermostPixelLayerHit);
+  setBranch<float>(tree, "numberDoF", m_numberDoF);
+  }
+
+  if(m_infoSwitch.m_numbers){
+    setBranch<unsigned char>(tree, "numberOfInnermostPixelLayerHits", m_numberOfInnermostPixelLayerHits);
+    setBranch<unsigned char>(tree, "numberOfNextToInnermostPixelLayerHits", m_numberOfNextToInnermostPixelLayerHits);
+    setBranch<unsigned char>(tree, "numberOfPhiHoleLayers", m_numberOfPhiHoleLayers);
+    setBranch<unsigned char>(tree, "numberOfPhiLayers", m_numberOfPhiLayers);
+    setBranch<unsigned char>(tree, "numberOfPixelDeadSensors", m_numberOfPixelDeadSensors);
+    setBranch<unsigned char>(tree, "numberOfPixelHits", m_numberOfPixelHits);
+    setBranch<unsigned char>(tree, "numberOfPixelHoles", m_numberOfPixelHoles);
+    setBranch<unsigned char>(tree, "numberOfPixelSharedHits", m_numberOfPixelSharedHits);
+    setBranch<unsigned char>(tree, "numberOfPrecisionHoleLayers", m_numberOfPrecisionHoleLayers);
+    setBranch<unsigned char>(tree, "numberOfPrecisionLayers", m_numberOfPrecisionLayers);
+    setBranch<unsigned char>(tree, "numberOfSCTDeadSensors", m_numberOfSCTDeadSensors);
+    setBranch<unsigned char>(tree, "numberOfSCTHits", m_numberOfSCTHits);
+    setBranch<unsigned char>(tree, "numberOfSCTHoles", m_numberOfSCTHoles);
+    setBranch<unsigned char>(tree, "numberOfSCTSharedHits", m_numberOfSCTSharedHits);
+    setBranch<unsigned char>(tree, "numberOfTRTHits", m_numberOfTRTHits);
+    setBranch<unsigned char>(tree, "numberOfTRTOutliers", m_numberOfTRTOutliers);
+  }
+
+  setBranch<float>(tree, "phi", m_phi);
+  setBranch<float>(tree, "qOverP", m_qOverP);
+  setBranch<float>(tree, "theta", m_theta);
+
+  if(m_infoSwitch.m_vertex){
+    setBranch<Int_t>(tree, "vertexLink", m_vertexLink);
+    setBranch<UInt_t>(tree, "vertexLink_persIndex", m_vertexLink_persIndex);
+    setBranch<UInt_t>(tree, "vertexLink_persKey", m_vertexLink_persKey);
+    setBranch<float>(tree, "vz", m_vz);
+    setBranch<float>(tree, "z0", m_z0);
+  }
+}
+
+void TrackContainer::clear()
+{
+  ParticleContainer::clear();
+
+  if(m_infoSwitch.m_fitpars){
+    m_chiSquared->clear();
+    m_d0->clear();
+    m_definingParametersCovMatrix->clear();
+    m_expectInnermostPixelLayerHit->clear();
+    m_expectNextToInnermostPixelLayerHit->clear();
+    m_numberDoF->clear();
+  }
+
+  if(m_infoSwitch.m_numbers){
+    m_numberOfInnermostPixelLayerHits->clear();
+    m_numberOfNextToInnermostPixelLayerHits->clear();
+    m_numberOfPhiHoleLayers->clear();
+    m_numberOfPhiLayers->clear();
+    m_numberOfPixelDeadSensors->clear();
+    m_numberOfPixelHits->clear();
+    m_numberOfPixelHoles->clear();
+    m_numberOfPixelSharedHits->clear();
+    m_numberOfPrecisionHoleLayers->clear();
+    m_numberOfPrecisionLayers->clear();
+    m_numberOfSCTDeadSensors->clear();
+    m_numberOfSCTHits->clear();
+    m_numberOfSCTHoles->clear();
+    m_numberOfSCTSharedHits->clear();
+    m_numberOfTRTHits->clear();
+    m_numberOfTRTOutliers->clear();
+  }
+
+  m_phi->clear();
+  m_qOverP->clear();
+  m_theta->clear();
+
+  if(m_infoSwitch.m_vertex){
+    m_vertexLink->clear();
+    m_vertexLink_persIndex->clear();
+    m_vertexLink_persKey->clear();
+    m_vz->clear();
+    m_z0->clear();
+  }
+}
+
+void TrackContainer::FillTrack( const xAOD::TrackParticle* track ){
+  return FillTrack(static_cast<const xAOD::IParticle*>(track));
+}
+
+void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
+  if(m_debug) std::cout << "In Fill Track" << std::endl;
+  ParticleContainer::FillParticle(particle);
+
+  const xAOD::TrackParticle* track=dynamic_cast<const xAOD::TrackParticle*>(particle);
+  if(m_debug) std::cout << "Got TrackParticle" << std::endl;
+  
+  if(m_infoSwitch.m_fitpars){
+    if(m_debug) std::cout << "Filling fitpars" << std::endl;
+    m_chiSquared->push_back( track->chiSquared() );
+    m_d0->push_back( track->d0() );
+    m_numberDoF->push_back( track->numberDoF() );
+    m_definingParametersCovMatrix ->push_back(track->definingParametersCovMatrix() );
+    m_expectInnermostPixelLayerHit->push_back(track->expectInnermostPixelLayerHit() );
+    m_expectNextToInnermostPixelLayerHit->push_back(track->expectNextToInnermostPixelLayerHit() );
+  }
+
+  if(m_infoSwitch.m_numbers){
+    if(m_debug) std::cout << "Filling numbers" << std::endl;
+    m_numberOfInnermostPixelLayerHits->push_back(track->numberOfInnermostPixelLayerHits() );
+    m_numberOfNextToInnermostPixelLayerHits->push_back(track->numberOfNextToInnermostPixelLayerHits() );
+    m_numberOfPhiHoleLayers->push_back(track->numberOfPhiHoleLayers() );
+    m_numberOfPhiLayers->push_back(track->numberOfPhiLayers() );
+    m_numberOfPixelDeadSensors->push_back(track->numberOfPixelDeadSensors() );
+    m_numberOfPixelHits->push_back(track->numberOfPixelHits() );
+    m_numberOfPixelHoles->push_back(track->numberOfPixelHoles() );
+    m_numberOfPixelSharedHits->push_back(track->numberOfPixelSharedHits() );
+    m_numberOfPrecisionHoleLayers->push_back(track->numberOfPrecisionHoleLayers() );
+    m_numberOfPrecisionLayers->push_back(track->numberOfPrecisionLayers() );
+    m_numberOfSCTDeadSensors->push_back(track->numberOfSCTDeadSensors() );
+    m_numberOfSCTHits->push_back(track->numberOfSCTHits() );
+    m_numberOfSCTHoles->push_back(track->numberOfSCTHoles() );
+    m_numberOfSCTSharedHits->push_back(track->numberOfSCTSharedHits() );
+    m_numberOfTRTHits->push_back(track->numberOfTRTHits() );
+    m_numberOfTRTOutliers->push_back(track->numberOfTRTOutliers() );
+  }
+
+  m_phi->push_back(track->phi() );
+  m_qOverP->push_back(track->qOverP() );
+  m_theta->push_back(track->theta() );
+  
+  if(m_infoSwitch.m_vertex){
+    if(m_debug) std::cout << "Filling vertex" << std::endl;
+    m_vertexLink->push_back(track->vertexLink() );
+    m_vertexLink_persIndex->push_back(track->vertexLink.m_persIndex() );
+    m_vertexLink_persKey->push_back(track->vertexLink.m_persKey() );
+    m_vz->push_back(track->vz() );
+    m_z0->push_back(track->z0() );
+  }
+
+  if(m_debug) std::cout << "Leave Fill Track" << std::endl;
+  return;
+}

--- a/Root/TrackContainer.cxx
+++ b/Root/TrackContainer.cxx
@@ -42,9 +42,11 @@ TrackContainer::TrackContainer(const std::string& name, const std::string& detai
   m_theta = new vector<float >;
 
   if(m_infoSwitch.m_vertex){
-    m_vertexLink = new vector<Int_t >;
-    m_vertexLink_persIndex = new vector<UInt_t >;
-    m_vertexLink_persKey = new vector<UInt_t >;
+    /*
+      m_vertexLink = new vector<Int_t >;
+      m_vertexLink_persIndex = new vector<UInt_t >;
+      m_vertexLink_persKey = new vector<UInt_t >;
+    */
     m_vz = new vector<float >;
     m_z0 = new vector<float >;
   }
@@ -87,9 +89,11 @@ TrackContainer::~TrackContainer()
   delete m_theta;
 
   if(m_infoSwitch.m_vertex){
-    delete m_vertexLink;
-    delete m_vertexLink_persIndex;
-    delete m_vertexLink_persKey;
+    /*
+      delete m_vertexLink;
+      delete m_vertexLink_persIndex;
+      delete m_vertexLink_persKey;
+    */
     delete m_vz;
     delete m_z0;
   }
@@ -132,9 +136,11 @@ void TrackContainer::setTree(TTree *tree)
   connectBranch<float>(tree, "theta", &m_theta);
   
   if(m_infoSwitch.m_vertex){
-    connectBranch<Int_t>(tree, "vertexLink", &m_vertexLink);
-    connectBranch<UInt_t>(tree, "vertexLink_persIndex", &m_vertexLink_persIndex);
-    connectBranch<UInt_t>(tree, "vertexLink_persKey", &m_vertexLink_persKey);
+    /*
+      connectBranch<Int_t>(tree, "vertexLink", &m_vertexLink);
+      connectBranch<UInt_t>(tree, "vertexLink_persIndex", &m_vertexLink_persIndex);
+      connectBranch<UInt_t>(tree, "vertexLink_persKey", &m_vertexLink_persKey);
+    */
     connectBranch<float>(tree, "vz", &m_vz);
     connectBranch<float>(tree, "z0", &m_z0);
   }
@@ -178,9 +184,11 @@ void TrackContainer::updateParticle(uint idx, TrackPart& track)
   track.theta = m_theta->at(idx);
 
   if(m_infoSwitch.m_vertex){
-    track.vertexLink = m_vertexLink->at(idx);
-    track.vertexLink_persIndex = m_vertexLink_persIndex->at(idx);
-    track.vertexLink_persKey = m_vertexLink_persKey->at(idx);
+    /*
+      track.vertexLink = m_vertexLink->at(idx);
+      track.vertexLink_persIndex = m_vertexLink_persIndex->at(idx);
+      track.vertexLink_persKey = m_vertexLink_persKey->at(idx);
+    */
     track.vz = m_vz->at(idx);
     track.z0 = m_z0->at(idx);
   }  
@@ -226,9 +234,11 @@ void TrackContainer::setBranches(TTree *tree)
   setBranch<float>(tree, "theta", m_theta);
 
   if(m_infoSwitch.m_vertex){
-    setBranch<Int_t>(tree, "vertexLink", m_vertexLink);
-    setBranch<UInt_t>(tree, "vertexLink_persIndex", m_vertexLink_persIndex);
-    setBranch<UInt_t>(tree, "vertexLink_persKey", m_vertexLink_persKey);
+    /*
+      setBranch<Int_t>(tree, "vertexLink", m_vertexLink);
+      setBranch<UInt_t>(tree, "vertexLink_persIndex", m_vertexLink_persIndex);
+      setBranch<UInt_t>(tree, "vertexLink_persKey", m_vertexLink_persKey);
+    */
     setBranch<float>(tree, "vz", m_vz);
     setBranch<float>(tree, "z0", m_z0);
   }
@@ -271,9 +281,11 @@ void TrackContainer::clear()
   m_theta->clear();
 
   if(m_infoSwitch.m_vertex){
-    m_vertexLink->clear();
-    m_vertexLink_persIndex->clear();
-    m_vertexLink_persKey->clear();
+    /*
+      m_vertexLink->clear();
+      m_vertexLink_persIndex->clear();
+      m_vertexLink_persKey->clear();
+    */
     m_vz->clear();
     m_z0->clear();
   }
@@ -292,32 +304,71 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
   
   if(m_infoSwitch.m_fitpars){
     if(m_debug) std::cout << "Filling fitpars" << std::endl;
+
     m_chiSquared->push_back( track->chiSquared() );
     m_d0->push_back( track->d0() );
     m_numberDoF->push_back( track->numberDoF() );
-    m_definingParametersCovMatrix ->push_back(track->definingParametersCovMatrix() );
-    m_expectInnermostPixelLayerHit->push_back(track->expectInnermostPixelLayerHit() );
-    m_expectNextToInnermostPixelLayerHit->push_back(track->expectNextToInnermostPixelLayerHit() );
+    //m_definingParametersCovMatrix ->push_back(track->definingParametersCovMatrix() ); // fix this too
+
+    static SG::AuxElement::ConstAccessor<char> expectInnermostPixelLayerHit("expectInnermostPixelLayerHit");
+    //safeFill<char, int, xAOD::TrackParticle>(track, expectInnermostPixelLayerHit, m_expectInnermostPixelLayerHit, -999);    
+    m_expectInnermostPixelLayerHit->push_back(expectInnermostPixelLayerHit(*track));
+
+    //m_expectNextToInnermostPixelLayerHit->push_back(track->expectNextToInnermostPixelLayerHit() );
+    static SG::AuxElement::ConstAccessor<char> expectNextToInnermostPixelLayerHit("expectNextToInnermostPixelLayerHit");
+    m_expectNextToInnermostPixelLayerHit->push_back(expectNextToInnermostPixelLayerHit(*track));
   }
 
   if(m_infoSwitch.m_numbers){
     if(m_debug) std::cout << "Filling numbers" << std::endl;
-    m_numberOfInnermostPixelLayerHits->push_back(track->numberOfInnermostPixelLayerHits() );
-    m_numberOfNextToInnermostPixelLayerHits->push_back(track->numberOfNextToInnermostPixelLayerHits() );
-    m_numberOfPhiHoleLayers->push_back(track->numberOfPhiHoleLayers() );
-    m_numberOfPhiLayers->push_back(track->numberOfPhiLayers() );
-    m_numberOfPixelDeadSensors->push_back(track->numberOfPixelDeadSensors() );
-    m_numberOfPixelHits->push_back(track->numberOfPixelHits() );
-    m_numberOfPixelHoles->push_back(track->numberOfPixelHoles() );
-    m_numberOfPixelSharedHits->push_back(track->numberOfPixelSharedHits() );
-    m_numberOfPrecisionHoleLayers->push_back(track->numberOfPrecisionHoleLayers() );
-    m_numberOfPrecisionLayers->push_back(track->numberOfPrecisionLayers() );
-    m_numberOfSCTDeadSensors->push_back(track->numberOfSCTDeadSensors() );
-    m_numberOfSCTHits->push_back(track->numberOfSCTHits() );
-    m_numberOfSCTHoles->push_back(track->numberOfSCTHoles() );
-    m_numberOfSCTSharedHits->push_back(track->numberOfSCTSharedHits() );
-    m_numberOfTRTHits->push_back(track->numberOfTRTHits() );
-    m_numberOfTRTOutliers->push_back(track->numberOfTRTOutliers() );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfInnermostPixelLayerHits("numberOfInnermostPixelLayerHits");
+    m_numberOfInnermostPixelLayerHits->push_back(numberOfInnermostPixelLayerHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfNextToInnermostPixelLayerHits("numberOfNextToInnermostPixelLayerHits");
+    m_numberOfNextToInnermostPixelLayerHits->push_back(numberOfNextToInnermostPixelLayerHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPhiHoleLayers("numberOfPhiHoleLayers");
+    m_numberOfPhiHoleLayers->push_back(numberOfPhiHoleLayers(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPhiLayers("numberOfPhiLayers");
+    m_numberOfPhiLayers->push_back(numberOfPhiLayers(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPixelDeadSensors("numberOfPixelDeadSensors");
+    m_numberOfPixelDeadSensors->push_back(numberOfPixelDeadSensors(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPixelHits("numberOfPixelHits");
+    m_numberOfPixelHits->push_back(numberOfPixelHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPixelHoles("numberOfPixelHoles");
+    m_numberOfPixelHoles->push_back(numberOfPixelHoles(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPixelSharedHits("numberOfPixelSharedHits");
+    m_numberOfPixelSharedHits->push_back(numberOfPixelSharedHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPrecisionHoleLayers("numberOfPrecisionHoleLayers");
+    m_numberOfPrecisionHoleLayers->push_back(numberOfPrecisionHoleLayers(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfPrecisionLayers("numberOfPrecisionLayers");
+    m_numberOfPrecisionLayers->push_back(numberOfPrecisionLayers(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfSCTDeadSensors("numberOfSCTDeadSensors");
+    m_numberOfSCTDeadSensors->push_back(numberOfSCTDeadSensors(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfSCTHits("numberOfSCTHits");
+    m_numberOfSCTHits->push_back(numberOfSCTHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfSCTHoles("numberOfSCTHoles");
+    m_numberOfSCTHoles->push_back(numberOfSCTHoles(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfSCTSharedHits("numberOfSCTSharedHits");
+    m_numberOfSCTSharedHits->push_back(numberOfSCTSharedHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfTRTHits("numberOfTRTHits");
+    m_numberOfTRTHits->push_back(numberOfTRTHits(*track) );
+
+    static SG::AuxElement::ConstAccessor<unsigned char> numberOfTRTOutliers("numberOfTRTOutliers");
+    m_numberOfTRTOutliers->push_back(numberOfTRTOutliers(*track) );
   }
 
   m_phi->push_back(track->phi() );
@@ -326,9 +377,15 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
   
   if(m_infoSwitch.m_vertex){
     if(m_debug) std::cout << "Filling vertex" << std::endl;
-    m_vertexLink->push_back(track->vertexLink() );
-    m_vertexLink_persIndex->push_back(track->vertexLink.m_persIndex() );
-    m_vertexLink_persKey->push_back(track->vertexLink.m_persKey() );
+
+    //static SG::AuxElement::ConstAccessor<int> vertexLink("vertexLink");
+    /*
+      m_vertexLink->push_back(vertexLink(*track) );
+      //m_vertexLink_persIndex->push_back(track->vertexLink.m_persIndex() );
+      //m_vertexLink_persKey->push_back(track->vertexLink.m_persKey() );
+      m_vertexLink_persIndex->push_back( -999 );
+      m_vertexLink_persKey->push_back( -999 );
+    */    
     m_vz->push_back(track->vz() );
     m_z0->push_back(track->z0() );
   }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -37,6 +37,7 @@ TreeAlgo :: TreeAlgo (std::string className) :
   m_METDetailStr                = "";
   m_photonDetailStr             = "";
   m_truthParticlesDetailStr     = "";
+  m_trackParticlesDetailStr     = "";
 
   m_debug                       = false;
 
@@ -54,6 +55,7 @@ TreeAlgo :: TreeAlgo (std::string className) :
   m_METContainerName            = "";
   m_photonContainerName         = "";
   m_truthParticlesContainerName = "";
+  m_trackParticlesContainerName = "";
   m_l1JetContainerName          = "";
 
   m_muSystsVec                  = "";
@@ -263,6 +265,7 @@ EL::StatusCode TreeAlgo :: execute ()
     if (!m_METContainerName.empty() )           { helpTree->AddMET(m_METDetailStr);                                }
     if (!m_photonContainerName.empty() )        { helpTree->AddPhotons(m_photonDetailStr);                         }
     if (!m_truthParticlesContainerName.empty()) { helpTree->AddTruthParts("xAH_truth", m_truthParticlesDetailStr); }
+    if (!m_trackParticlesContainerName.empty()) { helpTree->AddTrackParts(m_trackParticlesContainerName, m_trackParticlesDetailStr); }
   }
 
   /* THIS IS WHERE WE START PROCESSING THE EVENT AND PLOTTING THINGS */
@@ -381,6 +384,12 @@ EL::StatusCode TreeAlgo :: execute ()
       RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthParticles, m_truthParticlesContainerName, m_event, m_store, m_verbose), "");
       helpTree->FillTruth("xAH_truth", inTruthParticles);
     }
+    if ( !m_trackParticlesContainerName.empty() ) {
+      const xAOD::TrackParticleContainer* inTrackParticles(nullptr);
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrackParticles, m_trackParticlesContainerName, m_event, m_store, m_verbose), "");
+      helpTree->FillTracks(m_trackParticlesContainerName, inTrackParticles);
+    }
+
 
     // fill the tree
     helpTree->Fill();

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -136,7 +136,7 @@ public:
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
 
-  void FillTracks( const std::string trackName, const xAOD::TruthParticleContainer* tracks);
+  void FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* tracks);
   void FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName );
 
   /**

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -26,6 +26,7 @@
 #include "xAODTruth/TruthParticleContainer.h"
 #include "xAODTau/TauJetContainer.h"
 #include "xAODMissingET/MissingETContainer.h"
+#include "xAODTracking/TrackParticleContainer.h"
 
 #include "xAODAnaHelpers/HelperClasses.h"
 #include "xAODAnaHelpers/EventInfo.h"
@@ -35,6 +36,7 @@
 #include "xAODAnaHelpers/PhotonContainer.h"
 #include "xAODAnaHelpers/FatJetContainer.h"
 #include "xAODAnaHelpers/TruthContainer.h"
+#include "xAODAnaHelpers/TrackContainer.h"
 #include "xAODAnaHelpers/MuonContainer.h"
 #include "xAODAnaHelpers/TauContainer.h"
 #include "xAODRootAccess/TEvent.h"
@@ -74,6 +76,7 @@ public:
   void AddJets        (const std::string detailStr = "", const std::string jetName = "jet");
   void AddL1Jets      ();
   void AddTruthParts  (const std::string truthName,      const std::string detailStr = "");
+  void AddTrackParts  (const std::string trackName,	 const std::string detailStr = "");
 
   /**
    *  @brief  Declare a new collection of fatjets to be written to the output tree.
@@ -133,6 +136,9 @@ public:
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
 
+  void FillTracks( const std::string trackName, const xAOD::TruthParticleContainer* tracks);
+  void FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName );
+
   /**
    *  @brief  Write a container of jets to the specified container name (and optionally suffix). The
    *          container name and suffix should be declared beforehand using `AddFatJets()`.
@@ -162,6 +168,7 @@ public:
   void ClearJets        (const std::string jetName = "jet");
   void ClearL1Jets      ();
   void ClearTruth       (const std::string truthName);
+  void ClearTracks	(const std::string trackName);
   void ClearFatJets     (const std::string fatjetName, const std::string suffix="");
   void ClearTruthFatJets(const std::string truthFatJetName = "truth_fatjet");
   void ClearTaus        (const std::string tauName = "tau" );
@@ -209,6 +216,11 @@ public:
     return;
   };
 
+  virtual void AddTracksUser(const std::string trackName, const std::string detailStr = "")       {
+    if(m_debug) Info("AddTracksUser","Empty function called from HelpTreeBase %s %s",trackName.c_str(), detailStr.c_str());
+    return;
+  };
+
   /**
    *  @brief  Declare a new fat jet collection. Automatically called once per call to `AddFatJets()`;
    *          override this if you want to provide your own additional branches for fatjets.
@@ -242,6 +254,7 @@ public:
   virtual void ClearElectronsUser   (const std::string /*elecName = "el"*/) { return; };
   virtual void ClearPhotonsUser     (const std::string /*photonName = "ph"*/) { return; };
   virtual void ClearTruthUser       (const std::string /*truthName*/) 	    { return; };
+  virtual void ClearTracksUser       (const std::string /*trackName*/)       { return; };
   virtual void ClearJetsUser        (const std::string /*jetName = "jet"*/ ) 	    { return; };
   virtual void ClearFatJetsUser     (const std::string /*fatjetName = "fatjet"*/, const std::string /*suffix = ""*/)   { return; };
   virtual void ClearTruthFatJetsUser(const std::string /*truthFatJetName = "truth_fatjet"*/)   { return; };
@@ -254,6 +267,7 @@ public:
   virtual void FillPhotonsUser  ( const xAOD::Photon*,   const std::string /*photonName = "ph"*/ )     { return; };
   virtual void FillJetsUser     ( const xAOD::Jet*,      const std::string /*jetName = "jet"*/  )               { return; };
   virtual void FillTruthUser    ( const std::string /*truthName*/, const xAOD::TruthParticle*  )               { return; };
+  virtual void FillTracksUser   ( const std::string /*trackName*/, const xAOD::TrackParticle*  )               { return; };
   /**
    *  @brief  Called once per call to `FillFatJets()`.Ooverride this if you want to any additional
    *          information to your jet collection.
@@ -325,6 +339,11 @@ protected:
   // Truth
   //
   std::map<std::string, xAH::TruthContainer*> m_truth;
+
+  //
+  // Tracks
+  //
+  std::map<std::string, xAH::TrackContainer*> m_tracks;
 
   //
   // fat jets

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -500,10 +500,10 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
-        m_kinematic      kinematic      exact
-        m_fitpars        fitpars        exact
+	m_kinematic      kinematic      exact
+	m_fitpars        fitpars        exact
 	m_numbers        numbers        exact
-        m_vertex         vertex         exact
+	m_vertex         vertex         exact
         ================ ============== =======
 
     @endrst

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -495,17 +495,18 @@ namespace HelperClasses {
 
   /**
     @rst
+    
         The :cpp:class:`HelperClasses::InfoSwitch` struct for Track Information.
 
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
-	m_kinematic      kinematic      exact
-	m_fitpars        fitpars        exact
-	m_numbers        numbers        exact
-	m_vertex         vertex         exact
+        m_kinematic      kinematic      exact
+        m_fitpars        fitpars        exact
+        m_numbers        numbers        exact
+        m_vertex         vertex         exact
         ================ ============== =======
-
+	
     @endrst
   */
   class TrackInfoSwitch : public InfoSwitch {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -495,6 +495,32 @@ namespace HelperClasses {
 
   /**
     @rst
+        The :cpp:class:`HelperClasses::InfoSwitch` struct for Track Information.
+
+        ================ ============== =======
+        Parameter        Pattern        Match
+        ================ ============== =======
+        m_kinematic      kinematic      exact
+        m_fitpars        fitpars        exact
+	m_numbers        numbers        exact
+        m_vertex         vertex         exact
+        ================ ============== =======
+
+    @endrst
+  */
+  class TrackInfoSwitch : public InfoSwitch {
+  public:
+    bool m_kinematic;
+    bool m_fitpars;
+    bool m_numbers;
+    bool m_vertex;
+  TrackInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
+  protected:
+    void initialize();
+  };
+
+  /**
+    @rst
         The :cpp:class:`HelperClasses::IParticleInfoSwitch` struct for Tau Information.
 
         ================ ============== =======

--- a/xAODAnaHelpers/TrackContainer.h
+++ b/xAODAnaHelpers/TrackContainer.h
@@ -1,0 +1,75 @@
+#ifndef xAODAnaHelpers_TrackContainer_H
+#define xAODAnaHelpers_TrackContainer_H
+
+#include <TTree.h>
+#include <TLorentzVector.h>
+
+#include <vector>
+#include <string>
+
+#include "xAODTracking/TrackParticle.h"
+
+#include <xAODAnaHelpers/HelperClasses.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+
+#include <xAODAnaHelpers/TrackPart.h>
+#include <xAODAnaHelpers/ParticleContainer.h>
+
+namespace xAH {
+
+  class TrackContainer : public ParticleContainer<TrackPart, HelperClasses::TrackInfoSwitch>
+    {
+    public:
+      TrackContainer(const std::string& name = "track", const std::string& detailStr="", float units = 1e3);
+      virtual ~TrackContainer();
+
+      virtual void setTree    (TTree *tree);
+      virtual void setBranches(TTree *tree);
+      virtual void clear();
+      virtual void FillTrack( const xAOD::TrackParticle* track );
+      virtual void FillTrack( const xAOD::IParticle* particle );
+      using ParticleContainer::setTree; // make other overloaded version of execute() to show up in subclass
+
+    protected:
+      
+      virtual void updateParticle(uint idx, TrackPart& track);
+
+    private:
+      // 
+      // Vector branches
+      //
+
+      std::vector<float>* m_chiSquared;
+      std::vector<float>* m_d0;
+      std::vector<std::vector<float> >* m_definingParametersCovMatrix;
+      std::vector<unsigned char>* m_expectInnermostPixelLayerHit;
+      std::vector<unsigned char>* m_expectNextToInnermostPixelLayerHit;
+      std::vector<float>* m_numberDoF;
+      std::vector<unsigned char>* m_numberOfInnermostPixelLayerHits;
+      std::vector<unsigned char>* m_numberOfNextToInnermostPixelLayerHits;
+      std::vector<unsigned char>* m_numberOfPhiHoleLayers;
+      std::vector<unsigned char>* m_numberOfPhiLayers;
+      std::vector<unsigned char>* m_numberOfPixelDeadSensors;
+      std::vector<unsigned char>* m_numberOfPixelHits;
+      std::vector<unsigned char>* m_numberOfPixelHoles;
+      std::vector<unsigned char>* m_numberOfPixelSharedHits;
+      std::vector<unsigned char>* m_numberOfPrecisionHoleLayers;
+      std::vector<unsigned char>* m_numberOfPrecisionLayers;
+      std::vector<unsigned char>* m_numberOfSCTDeadSensors;
+      std::vector<unsigned char>* m_numberOfSCTHits;
+      std::vector<unsigned char>* m_numberOfSCTHoles;
+      std::vector<unsigned char>* m_numberOfSCTSharedHits;
+      std::vector<unsigned char>* m_numberOfTRTHits;
+      std::vector<unsigned char>* m_numberOfTRTOutliers;
+      std::vector<float>* m_phi;
+      std::vector<float>* m_qOverP;
+      std::vector<float>* m_theta;
+      std::vector<Int_t>* m_vertexLink;
+      std::vector<UInt_t>* m_vertexLink_persIndex;
+      std::vector<UInt_t>* m_vertexLink_persKey;
+      std::vector<float>* m_vz;
+      std::vector<float>* m_z0;
+    };
+}
+
+#endif // xAODAnaHelpers_TrackContainer_H

--- a/xAODAnaHelpers/TrackPart.h
+++ b/xAODAnaHelpers/TrackPart.h
@@ -1,0 +1,54 @@
+#ifndef xAODAnaHelpers_TrackPart_H
+#define xAODAnaHelpers_TrackPart_H
+
+#include "xAODAnaHelpers/Particle.h"
+
+namespace xAH {
+  class TrackPart : public Particle
+  {
+  public:
+    // TrackPart() { };
+    // virtual ~TrackPart();
+    
+    float chiSquared;
+    float d0;
+    
+    std::vector<float> definingParametersCovMatrix;
+    unsigned char expectInnermostPixelLayerHit;
+    unsigned char expectNextToInnermostPixelLayerHit;
+
+    float numberDoF;
+
+    unsigned char numberOfInnermostPixelLayerHits;
+    unsigned char numberOfNextToInnermostPixelLayerHits;
+    unsigned char numberOfPhiHoleLayers;
+    unsigned char numberOfPhiLayers;
+    unsigned char numberOfPixelDeadSensors;
+    unsigned char numberOfPixelHits;
+    unsigned char numberOfPixelHoles;
+    unsigned char numberOfPixelSharedHits;
+    unsigned char numberOfPrecisionHoleLayers;
+    unsigned char numberOfPrecisionLayers;
+    unsigned char numberOfSCTDeadSensors;
+    unsigned char numberOfSCTHits;
+    unsigned char numberOfSCTHoles;
+    unsigned char numberOfSCTSharedHits;
+    unsigned char numberOfTRTHits;
+    unsigned char numberOfTRTOutliers;
+
+    float phi;
+    float qOverP;
+    float theta;
+
+    Int_t vertexLink;
+    UInt_t vertexLink_persIndex;
+    UInt_t vertexLink_persKey;
+
+    float vz;
+    float z0;
+
+  };
+} //xAH
+
+#endif // xAODAnaHelpers_TrackPart_H
+

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -31,6 +31,7 @@ public:
   std::string m_METDetailStr;
   std::string m_photonDetailStr;
   std::string m_truthParticlesDetailStr;
+  std::string m_trackParticlesDetailStr;
 
   std::string m_evtContainerName;
   std::string m_muContainerName;
@@ -50,6 +51,7 @@ public:
   std::string m_METContainerName;
   std::string m_photonContainerName;
   std::string m_truthParticlesContainerName;
+  std::string m_trackParticlesContainerName;
   std::string m_l1JetContainerName;
 
   // if these are set, assume systematics are being processed over


### PR DESCRIPTION
Adding functionality to get `InDetTrackParticles` from the `TreeAlgo`. This required adding the necessary container, etc.

Available `detailStr` options are currently `kinematic trackpars numbers vertex` ... these might not be the most optimal choices, but they cover the content that is available in the derivation I'm looking at, and should be easily expandable if others want to do that in the future.

🍻 