### PR TITLE
Updates/muon sf uncertainties

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -287,6 +287,40 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
 
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
+  m_muonInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr ); 
+  
+  //std::string tname = m_tree->GetName();
+  
+  //if ( tname == "nominal" ) {
+     
+     if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+       for (auto& reco : m_muonInfoSwitch->m_recoWPs) {
+         std::string recoEffSF_sysNames = "muon_RecoEff_SF_" + reco + "_sysNames";
+         m_tree->Branch( recoEffSF_sysNames.c_str() , & (m_RecoEff_SF_sysNames)[ reco ] );
+       }
+     }
+     
+     if ( m_muonInfoSwitch->m_isoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+       for (auto& isol : m_muonInfoSwitch->m_isolWPs) {
+         std::string isolEffSF_sysNames = "muon_IsoEff_SF_" + isol + "_sysNames";
+         m_tree->Branch( isolEffSF_sysNames.c_str() , & (m_IsoEff_SF_sysNames)[ isol ] );
+       }
+     }
+     
+     if ( m_muonInfoSwitch->m_trigEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+       for (auto& trig : m_muonInfoSwitch->m_trigWPs) {
+         std::string trigEffSF_sysNames = "muon_TrigEff_SF_" + trig + "_sysNames";
+         m_tree->Branch( trigEffSF_sysNames.c_str() , & (m_TrigEff_SF_sysNames)[ trig ] );
+       }
+     }
+     
+     if ( m_muonInfoSwitch->m_ttvaEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+       std::string ttvaEffSF_sysNames = "muon_TTVAEff_SF_sysNames";
+       m_tree->Branch( ttvaEffSF_sysNames.c_str() , &m_TTVAEff_SF_sysNames );
+     }
+  
+  //}
+
   m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC);
 
   xAH::MuonContainer* thisMuon = m_muons[muonName];
@@ -298,7 +332,47 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
 void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string muonName ) {
 
   this->ClearMuons(muonName);
+  
+  //std::string tname = m_tree->GetName();
+  
+  //if ( tname == "nominal" ) {
+  
+    if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& reco : m_muonInfoSwitch->m_recoWPs ) {
+        std::vector< std::string >* tmp_reco_sys = new std::vector< std::string >;   
+        if ( m_store->retrieve(tmp_reco_sys, "MuonEfficiencyCorrector_RecoSyst_" + reco).isSuccess() ) { 
+          (m_RecoEff_SF_sysNames)[ reco ] = *tmp_reco_sys;
+        }
+      } 
+    }
+    
+    if ( m_muonInfoSwitch->m_isoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& isol : m_muonInfoSwitch->m_isolWPs ) {
+        std::vector< std::string >* tmp_iso_sys = new std::vector< std::string >;   
+        if ( m_store->retrieve(tmp_iso_sys, "MuonEfficiencyCorrector_IsoSyst_" + isol).isSuccess() ) { 
+          (m_IsoEff_SF_sysNames)[ isol ] = *tmp_iso_sys;
+        }
+      } 
+    }
+  
+    if ( m_muonInfoSwitch->m_trigEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& trig : m_muonInfoSwitch->m_trigWPs ) {
+        std::vector< std::string >* tmp_trig_sys = new std::vector< std::string >;
+        if ( m_store->retrieve(tmp_trig_sys, "MuonEfficiencyCorrector_TrigSyst_" + trig).isSuccess() ) { 
+          (m_TrigEff_SF_sysNames)[ trig ] = *tmp_trig_sys;
+        }
+      }
+    }
+  
+    if ( m_muonInfoSwitch->m_ttvaEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      std::vector< std::string >* tmp_ttva_sys = new std::vector< std::string >;   
+      if ( m_store->retrieve(tmp_ttva_sys, "MuonEfficiencyCorrector_TTVASyst_TTVA").isSuccess() ) { 
+        m_TTVAEff_SF_sysNames = *tmp_ttva_sys;
+      }
+    }
 
+  //}
+  
   for( auto muon_itr : *muons ) {
     this->FillMuon(muon_itr, primaryVertex, muonName);
   }
@@ -318,6 +392,34 @@ void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primary
 
 void HelpTreeBase::ClearMuons(const std::string muonName) {
 
+  //std::string tname = m_tree->GetName();
+  
+  //if ( tname == "nominal" ) {
+  
+    if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& reco : m_muonInfoSwitch->m_recoWPs ) {
+          (m_RecoEff_SF_sysNames)[ reco ].clear();
+        }
+    }
+    
+    if ( m_muonInfoSwitch->m_isoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& isol : m_muonInfoSwitch->m_isolWPs ) {
+          (m_IsoEff_SF_sysNames)[ isol ].clear();
+        }
+    }
+    
+    if ( m_muonInfoSwitch->m_trigEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+      for ( auto& trig : m_muonInfoSwitch->m_trigWPs ) {
+          (m_TrigEff_SF_sysNames)[ trig ].clear();
+        }
+    }
+    
+    if ( m_muonInfoSwitch->m_ttvaEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
+       m_TTVAEff_SF_sysNames.clear();
+    }
+
+  //}
+  
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   thisMuon->clear();
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -143,10 +143,11 @@ namespace HelperClasses{
       if ( token.compare( 0, trig_prfx.length(), trig_prfx ) == 0 ) { m_trigWPs.push_back(token); }
     }  
     
-    //for (const auto& isol : isolWPs) { m_isolWPsMap[isol] = has_exact(isol); }                        
-    //for (const auto& reco : recoWPs) { m_recoWPsMap[reco] = has_exact(reco); }                        
-    //for (const auto& trig : trigWPs) { m_trigWPsMap[trig] = has_exact(trig); }                        
-
+    m_recoEff_sysNames = has_exact("recoEff_sysNames");
+    m_isoEff_sysNames  = has_exact("isoEff_sysNames");
+    m_trigEff_sysNames = has_exact("trigEff_sysNames"); 
+    m_ttvaEff_sysNames = has_exact("ttvaEff_sysNames"); 
+    
   }
 
   void ElectronInfoSwitch::initialize(){

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -62,7 +62,7 @@ MuonCalibrator :: MuonCalibrator (std::string className) :
   // list of comma-separated years
   m_Years                   = "Data16,Data15"; 
   
-  m_do_sagittaCorr          = false;
+  m_do_sagittaCorr          = true;
   m_sagittaRelease          = "sagittaBiasDataAll_06_02_17";
   m_do_sagittaMCDistortion  = false;
 
@@ -211,18 +211,21 @@ EL::StatusCode MuonCalibrator :: initialize ()
     } else {
       m_muonCalibrationAndSmearingTools[yr] = new CP::MuonCalibrationAndSmearingTool( m_muonCalibrationAndSmearingTool_names[yr]);
       m_muonCalibrationAndSmearingTools[yr]->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-      if ( !m_release.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release),"Failed to set property Release"); }
-      if ( !yr.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ),"Failed to set Year property of MuonCalibrationAndSmearingTool"); }
+      
       if ( yr == "Data16") { 
-
-        
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07"),"Failed to set property Release");
         RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
         RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
         RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ),"Failed to set SagittaRelease property of MuonCalibrationAndSmearingTool"); 
-      } else {
+      } else if (yr == "Data15") {
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_08_07"),"Failed to set property Release");
         RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ),"Failed to set SagittaCorr property of MuonCalibrationAndSmearingTool"); 
         RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ),"Failed to set doSagittaMCDistortion property of MuonCalibrationAndSmearingTool"); 
+      } else if ( !yr.empty() ) {
+        RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ),"Failed to set Year property of MuonCalibrationAndSmearingTool"); 
       }
+      
+      if ( !m_release.empty() ) { RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release),"Failed to set property Release"); }
 
       RETURN_CHECK("MuonCalibrator::initialize()", m_muonCalibrationAndSmearingTools[yr]->initialize(), "Failed to properly initialize the MuonCalibrationAndSmearingTool.");
 

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -764,7 +764,6 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
     
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accRecoSF;
-    static std::map< std::string, SG::AuxElement::Accessor< std::vector< std::string > > > accRecoSF_sysNames;
     
     for (auto& reco : m_infoSwitch.m_recoWPs) {
             

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -148,6 +148,7 @@ MuonContainer::~MuonContainer()
     delete m_TrigMCEff  ;
     
     delete m_TTVAEff_SF ;
+
   }
       // track parameters
   if ( m_infoSwitch.m_trackparams ) {
@@ -430,7 +431,6 @@ void MuonContainer::setBranches(TTree *tree)
     for (auto& reco : m_infoSwitch.m_recoWPs) {
       std::string recoEffSF = "muon_RecoEff_SF_" + reco;
       tree->Branch( recoEffSF.c_str() , & (*m_RecoEff_SF)[ reco ] );
-
     }
     
     for (auto& isol : m_infoSwitch.m_isolWPs) {
@@ -764,6 +764,7 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
     
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accRecoSF;
+    static std::map< std::string, SG::AuxElement::Accessor< std::vector< std::string > > > accRecoSF_sysNames;
     
     for (auto& reco : m_infoSwitch.m_recoWPs) {
             
@@ -774,6 +775,7 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
       }else { 
         m_RecoEff_SF->at( reco  ).push_back( junkSF ); 
       }
+    
     }
     
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accIsoSF;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -657,12 +657,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with reco efficiency (useful at all?), and the corresponding SF
     	 //
-    	 //if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
-    	 //}
-    	 //if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
-    	 //}
+    	 if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
+    	 }
+    	 if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
+    	 }
 
     	 // b)
     	 // obtain reco efficiency SF as a float (to be stored away separately)
@@ -694,7 +694,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Reco efficiency:");
-    	   Info( "executeSF()", "\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "Efficiency" ) );
+    	   Info( "executeSF()", "\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
     	   Info( "executeSF()", "and its SF:");
     	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", recoEffSF );
@@ -761,12 +761,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with iso efficiency (useful at all?), and the corresponding SF
     	 //
-    	 //if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
-    	 //}
-    	 //if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
-    	 //}
+    	 if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
+    	 }
+    	 if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
+    	 }
 
     	 // b)
     	 // obtain iso efficiency SF as a float (to be stored away separately)
@@ -797,8 +797,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
-//    	   Info( "executeSF()", "Iso efficiency:");
-//    	   Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOEfficiency" ) );
+           Info( "executeSF()", "Iso efficiency:");
+           Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
     	   Info( "executeSF()", "and its SF:");
     	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", IsoEffSF );
@@ -1109,12 +1109,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with TTVA efficiency (useful at all?), and the corresponding SF
     	 //
-    	 //if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
-    	 //}
-    	 //if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
-    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
-    	 //}
+    	 if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	   Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
+    	 }
+    	 if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
+    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
+    	 }
 
     	 // b)
     	 // obtain TTVA efficiency SF as a float (to be stored away separately)
@@ -1145,9 +1145,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
-    	   Info( "executeSF()", "TTVA efficiency SF:");
+           Info( "executeSF()", "TTVA efficiency:");
+           Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
+    	   Info( "executeSF()", "and its SF:");
+    	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", TTVAEffSF );
-    	   Info( "executeSF()", "--------------------------------------");
+           Info( "executeSF()", "--------------------------------------");
     	 }
 
     	 ++idx;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -610,10 +610,6 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   //
   // These vector<string> are eventually stored in TStore
   //
-  std::vector< std::string >* sysVariationNamesReco  = new std::vector< std::string >;
-  std::vector< std::string >* sysVariationNamesIso   = new std::vector< std::string >;
-  std::vector< std::string >* sysVariationNamesTrig  = new std::vector< std::string >;
-  std::vector< std::string >* sysVariationNamesTTVA  = new std::vector< std::string >;
 
   // 1.
   // Reco efficiency SFs - this is a per-MUON weight
@@ -622,6 +618,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
+  std::vector< std::string >* sysVariationNamesReco  = new std::vector< std::string >;
+  
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_recoEffSF_tool_name) ) {
@@ -657,12 +655,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with reco efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
-    	 }
-    	 if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
-    	 }
+    	 //if ( m_muRecoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Reco");
+    	 //}
+    	 //if ( m_muRecoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Reco");
+    	 //}
 
     	 // b)
     	 // obtain reco efficiency SF as a float (to be stored away separately)
@@ -683,6 +681,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // Add it to decoration vector
     	 //
     	 sfVecReco( *mu_itr ).push_back( recoEffSF );
+         
+         // reco sys names are saved in a vector. Entries positions are preserved!
+         //
+    	 SG::AuxElement::Decorator< std::vector<std::string> > sfVecReco_sysNames( m_outputSystNamesReco + "_sysNames" );
+    	 if ( !sfVecReco_sysNames.isAvailable( *mu_itr ) ) {
+  	   sfVecReco_sysNames( *mu_itr ) = std::vector<std::string>();
+         }
+    	 sfVecReco_sysNames( *mu_itr ).push_back( syst_it.name().c_str() );
 
     	 if ( m_debug ) {
     	   Info( "executeSF()", "===>>>");
@@ -693,10 +699,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
-    	   Info( "executeSF()", "Reco efficiency:");
-    	   Info( "executeSF()", "\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
+    	   //Info( "executeSF()", "Reco efficiency:");
+    	   //Info( "executeSF()", "\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
     	   Info( "executeSF()", "and its SF:");
-    	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
+    	   //Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", recoEffSF );
     	   Info( "executeSF()", "--------------------------------------");
     	 }
@@ -726,6 +732,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
+  std::vector< std::string >* sysVariationNamesIso   = new std::vector< std::string >;
+  
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_isoEffSF_tool_name) ) {
@@ -761,12 +769,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with iso efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
-    	 }
-    	 if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
-    	 }
+    	 //if ( m_muIsoSF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for Iso");
+    	 //}
+    	 //if ( m_muIsoSF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for Iso");
+    	 //}
 
     	 // b)
     	 // obtain iso efficiency SF as a float (to be stored away separately)
@@ -797,10 +805,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
-           Info( "executeSF()", "Iso efficiency:");
-           Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
+           //Info( "executeSF()", "Iso efficiency:");
+           //Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
     	   Info( "executeSF()", "and its SF:");
-    	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
+    	   //Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", IsoEffSF );
     	   Info( "executeSF()", "--------------------------------------");
     	 }
@@ -834,6 +842,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   //
   // NB: calculation of the event SF is up to the analyzer
 
+  
   // Do it only if a tool with *this* name hasn't already been used
   //
   
@@ -921,13 +930,41 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     
   if ( !isToolAlreadyUsed(m_trigEffSF_tool_names[randYear]) ) {
 
-    for ( const auto& syst_it : m_systListTrig ) {
-      for ( const auto& trig_it : m_SingleMuTriggers ) {
-
+    for ( const auto& trig_it : m_SingleMuTriggers ) {
+      
+      std::vector< std::string >* sysVariationNamesTrig  = new std::vector< std::string >;
+      // this is used to put the list of sys strings in the store.
+      // The original string needs to be updated with the name of 
+      // the trigger for every item in the trigger loop. 
+      //
+      //std::string m_fullname_outputSystNamesTrig;
+      
+      std::string eff_string = m_outputSystNamesTrigMCEff;
+      std::string ineffstr   = "MuonEfficiencyCorrector_TrigMCEff_";
+      std::string outeffstr  = "MuonEfficiencyCorrector_TrigMCEff_" + trig_it + "_";
+      
+      for(std::string::size_type i = 0; (i = eff_string.find(ineffstr, i)) != std::string::npos;) {
+        eff_string.replace(i, ineffstr.length(), outeffstr);
+        i += outeffstr.length();
+      } 
+      
+      std::string sf_string = m_outputSystNamesTrig;
+      std::string insfstr   = "MuonEfficiencyCorrector_TrigSyst_";
+      std::string outsfstr  = "MuonEfficiencyCorrector_TrigSyst_" + trig_it + "_";
+      
+      for(std::string::size_type i = 0; (i = sf_string.find(insfstr, i)) != std::string::npos;) {
+        sf_string.replace(i, insfstr.length(), outsfstr);
+        i += outsfstr.length();
+      } 
+      //if (idx == 0) { m_fullname_outputSystNamesTrig = sf_string; }
+      //std::cout << "This is the new string: " << m_fullname_outputSystNamesTrig << std::endl;
+      
+      for ( const auto& syst_it : m_systListTrig ) {
+        
         // Create the name of the SF weight to be recorded
         //   template:  SYSNAME_MuTrigEff_SF
         //
-        std::string sfName = "MuTrigEff_SF_" + trig_it + "_" + m_WorkingPointRecoTrig + "_" + m_WorkingPointIsoTrig;
+        std::string sfName = "MuTrigEff_SF_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
         if ( !syst_it.name().empty() ) {
            std::string prepend = syst_it.name() + "_";
            sfName.insert( 0, prepend );
@@ -958,25 +995,6 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
         
            //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
            //
-           
-           std::string eff_string = m_outputSystNamesTrigMCEff ;
-           std::string ineffstr  = "MuonEfficiencyCorrector_TrigMCEff_";
-           std::string outeffstr = "MuonEfficiencyCorrector_TrigMCEff_" + trig_it + "_";
-           
-           for(std::string::size_type i = 0; (i = eff_string.find(ineffstr, i)) != std::string::npos;) {
-             eff_string.replace(i, ineffstr.length(), outeffstr);
-             i += outeffstr.length();
-           } 
-           
-           std::string sf_string = m_outputSystNamesTrig;
-           std::string insfstr  = "MuonEfficiencyCorrector_TrigSyst_";
-           std::string outsfstr = "MuonEfficiencyCorrector_TrigSyst_" + trig_it + "_";
-           
-           for(std::string::size_type i = 0; (i = sf_string.find(insfstr, i)) != std::string::npos;) {
-             sf_string.replace(i, insfstr.length(), outsfstr);
-             i += outsfstr.length();
-           } 
-           
            SG::AuxElement::Decorator< std::vector<float> > effMC( eff_string );
            if ( !effMC.isAvailable( *mu_itr ) ) {
              effMC( *mu_itr ) = std::vector<float>();
@@ -1048,8 +1066,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            ++idx;
         
         } // close muon loop
-      } // close  trigger loop
-    }  // close loop on trigger efficiency SF systematics
+      }  // close loop on trigger efficiency SF systematics
+    
+      if ( countSyst == 0 ) { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesTrig, sf_string), "Failed to record vector of systematic names for muon trigger efficiency  SF" ); }
+    
+    } // close  trigger loop
 
     // Add list of systematics names to TStore
     //
@@ -1059,7 +1080,6 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     //
     // Use the counter defined in execute() to check this is done only once per event
     //
-    if ( countSyst == 0 ) { RETURN_CHECK( "MuonEfficiencyCorrector::executeSF()", m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig), "Failed to record vector of systematic names for muon trigger efficiency  SF" ); }
 
   }
 
@@ -1070,6 +1090,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
+  std::vector< std::string >* sysVariationNamesTTVA  = new std::vector< std::string >;
+  
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_TTVAEffSF_tool_name) ) {
@@ -1109,12 +1131,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 // a)
     	 // decorate directly the muon with TTVA efficiency (useful at all?), and the corresponding SF
     	 //
-    	 if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
-    	   Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
-    	 }
-    	 if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
-    	   Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
-    	 }
+    	 //if ( m_muTTVASF_tool->applyMCEfficiency( *mu_itr ) != CP::CorrectionCode::Ok ) {
+    	 //  Warning( "executeSF()", "Problem in applyMCEfficiency for TTVA");
+    	 //}
+    	 //if ( m_muTTVASF_tool->applyEfficiencyScaleFactor( *mu_itr ) != CP::CorrectionCode::Ok ) {	 
+    	 //  Warning( "executeSF()", "Problem in applyEfficiencyScaleFactor for TTVA");
+    	 //}
 
     	 // b)
     	 // obtain TTVA efficiency SF as a float (to be stored away separately)
@@ -1145,10 +1167,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   Info( "executeSF()", " ");
     	   Info( "executeSF()", "Systematic: %s", syst_it.name().c_str() );
     	   Info( "executeSF()", " ");
-           Info( "executeSF()", "TTVA efficiency:");
-           Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
+           //Info( "executeSF()", "TTVA efficiency:");
+           //Info( "executeSF()", "\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
     	   Info( "executeSF()", "and its SF:");
-    	   Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
+    	   //Info( "executeSF()", "\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
     	   Info( "executeSF()", "\t %f (from getEfficiencyScaleFactor())", TTVAEffSF );
            Info( "executeSF()", "--------------------------------------");
     	 }

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -110,6 +110,7 @@ public:
   // control which branches are filled
   HelperClasses::TriggerInfoSwitch*    m_trigInfoSwitch;
   HelperClasses::JetTriggerInfoSwitch* m_jetTrigInfoSwitch;
+  HelperClasses::MuonInfoSwitch*       m_muonInfoSwitch;
 
   std::string                  m_triggerSelection;
   TrigConf::xAODConfigTool*    m_trigConfTool;
@@ -359,7 +360,11 @@ protected:
   // muons
   //
   std::map<std::string, xAH::MuonContainer*> m_muons;
-
+  std::map<std::string, std::vector<std::string> > m_RecoEff_SF_sysNames;
+  std::map<std::string, std::vector<std::string> > m_IsoEff_SF_sysNames;
+  std::map<std::string, std::vector<std::string> > m_TrigEff_SF_sysNames;
+  std::vector<std::string>  m_TTVAEff_SF_sysNames;
+  
   //
   // electrons
   //

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -260,14 +260,17 @@ namespace HelperClasses {
     bool m_trackhitcont;
     bool m_effSF;
     bool m_energyLoss;
-    //std::map<std::string,bool> m_recoWPsMap;
-    //std::map<std::string,bool> m_isolWPsMap;
-    //std::map<std::string,bool> m_trigWPsMap;
     
     std::vector< std::string > m_recoWPs;
     std::vector< std::string > m_isolWPs;
     std::vector< std::string > m_trigWPs;
     
+    bool m_recoEff_sysNames;
+    bool m_isoEff_sysNames;
+    bool m_trigEff_sysNames;
+    bool m_ttvaEff_sysNames;
+
+
     MuonInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~MuonInfoSwitch() {}
   protected:

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -53,9 +53,6 @@ namespace xAH {
     
     std::vector< float >  TTVAEff_SF;
 
-    std::map< std::string, std::vector< std::string > > RecoEff_SF_sysNames;
-
-
     // track parameters
     float trkd0;
     float trkd0sig;

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -52,7 +52,10 @@ namespace xAH {
     std::map< std::string, std::vector< float > > TrigMCEff;
     
     std::vector< float >  TTVAEff_SF;
-    
+
+    std::map< std::string, std::vector< std::string > > RecoEff_SF_sysNames;
+
+
     // track parameters
     float trkd0;
     float trkd0sig;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -68,7 +68,7 @@ namespace xAH {
       // scale factors w/ sys
       // per object
       std::vector< std::vector< float > > *m_TTVAEff_SF;
-    
+      
       std::map< std::string, std::vector< std::vector< float > > >* m_RecoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;


### PR DESCRIPTION
The possibility is provided to include a vector of strings in the tree with the name of the nominal and systematically altered entries of the muon efficiency corrections. A correspondence is made b/w the name in this vector and the entries in the SF branch. In the TreeAlgo, the user with specify for what kind of correction this string will be included e.g. reco, iso, trigger etc. Several branches might have been included by the user for each correction corresponding to different working point, however, when the option is selected in the TreeAlgo configuration, strings will be included for all working points. If no sys is configured for a specific working point in this case, the vector will only contain the nominal string.  In addition to this, this pull request addresses some configuration updates for the muon calibrator. This pull request would close #815 

 