### PR TITLE
Updates to options in the container classes.

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -7,7 +7,7 @@ using std::vector;
 using std::string;
 
 ElectronContainer::ElectronContainer(const std::string& name, const std::string& detailStr, float units, bool mc)
-  : ParticleContainer(name, detailStr, units, mc, true, false)
+  : ParticleContainer(name, detailStr, units, mc, true)
 {
 
   if ( m_infoSwitch.m_kinematic ) {

--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -9,7 +9,7 @@ using std::vector;  using std::endl;  using std::cout;
 
 FatJetContainer::FatJetContainer(const std::string& name, const std::string& detailStr, const std::string& suffix, 
 				 float units, bool mc)
-  : ParticleContainer(name,detailStr,units,mc, false, false, suffix), 
+  : ParticleContainer(name,detailStr,units,mc, false, suffix), 
     m_trackJetPtCut(10e3),
     m_trackJetEtaCut(2.5)
 {

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -119,6 +119,8 @@ namespace HelperClasses{
 	    break;
 	  }
       }
+
+    m_useTheS   = has_exact("useTheS");
   }
 
   void MuonInfoSwitch::initialize(){
@@ -319,7 +321,6 @@ namespace HelperClasses{
   }
 
   void TruthInfoSwitch::initialize(){
-    m_kinematic     = has_exact("kinematic");
     m_type          = has_exact("type");
     m_bVtx          = has_exact("bVtx");
     m_parents       = has_exact("parents");
@@ -331,6 +332,7 @@ namespace HelperClasses{
     m_fitpars	    = has_exact("fitpars");
     m_numbers	    = has_exact("numbers");
     m_vertex	    = has_exact("vertex");
+    m_useTheS       = has_exact("useTheS");
   }
 
   void TauInfoSwitch::initialize(){

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -7,7 +7,7 @@ using std::vector;
 using std::string;
 
 MuonContainer::MuonContainer(const std::string& name, const std::string& detailStr, float units, bool mc)
-  : ParticleContainer(name, detailStr, units, mc, true, false)
+  : ParticleContainer(name, detailStr, units, mc, true)
 {
 
   // trigger

--- a/Root/PhotonContainer.cxx
+++ b/Root/PhotonContainer.cxx
@@ -7,7 +7,7 @@ using std::vector;
 using std::string;
 
 PhotonContainer::PhotonContainer(const std::string& name, const std::string& detailStr, float units, bool mc)
-  : ParticleContainer(name, detailStr, units, mc, true, false)
+  : ParticleContainer(name, detailStr, units, mc, true)
 {
 
 

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -7,7 +7,7 @@ using std::vector;
 using std::string;
 
 TauContainer::TauContainer(const std::string& name, const std::string& detailStr, float units, bool mc)
-  : ParticleContainer(name, detailStr, units, mc, true, false)
+  : ParticleContainer(name, detailStr, units, mc, true)
 {
 
   if( m_infoSwitch.m_kinematic) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -210,6 +210,7 @@ namespace HelperClasses {
         ============== ============ =======
         m_kinematic    kinematic    exact
         m_numLeading   NLeading     partial
+	m_useTheS      useTheS      exact
         ============== ============ =======
 
         .. note::
@@ -227,6 +228,7 @@ namespace HelperClasses {
   public:
     bool m_kinematic;
     int  m_numLeading;
+    bool m_useTheS;
     IParticleInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); }
     virtual ~IParticleInfoSwitch() {}
   protected:
@@ -484,14 +486,13 @@ namespace HelperClasses {
 
     @endrst
    */
-  class TruthInfoSwitch : public InfoSwitch {
+  class TruthInfoSwitch : public IParticleInfoSwitch {
   public:
-    bool m_kinematic;
     bool m_type;
     bool m_bVtx;
     bool m_parents;
     bool m_children;
-    TruthInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
+    TruthInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();
   };
@@ -508,6 +509,7 @@ namespace HelperClasses {
         m_fitpars        fitpars        exact
         m_numbers        numbers        exact
         m_vertex         vertex         exact
+	m_useTheS        useTheS        exact
         ================ ============== =======
 	
     @endrst
@@ -518,6 +520,7 @@ namespace HelperClasses {
     bool m_fitpars;
     bool m_numbers;
     bool m_vertex;
+    bool m_useTheS;
   TrackInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();


### PR DESCRIPTION
* Implement `ParticleContainer::m_useTheS` as an InfoSwitch option
* The default branch name for particle count is `nparticle` (singular)
* `ParticleContainer` now determines `m_useMass` automatically when connecting a `TTree`

The reason for the last point is to be able to change particle classes when reading the ntuple. A use case is saving truth (`xAOD::TruthParticle`) and reco (`xAOD::Photon`) photons. Currently the ntuples are made with `m_useMass=true` for `xAH::PhotonContainer` (reco) and `false` for `xAH::TruthContainer` (truth) when making the ntuple. However when I process the ntuples, I want to treat them abstractly as a `xAH::Photon` with the necessary info switches set.