### PR TITLE
Update/object sf decor for sys

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -522,13 +522,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
 
   if ( m_inputAlgoSystNames.empty() ) {
 
-      RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    // I might not want to decorate sys altered electrons but for some events the nominal container might not exist 
+    // if electrons are only allowed in systematic instances, hence, we have to check for the existence of the nominal container
+    //
+    if ( m_store->contains<xAOD::ElectronContainer>( m_inContainerName )  ) {
+       RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
 
-      if ( m_debug ) { Info( "execute", "Number of electrons: %i", static_cast<int>(inputElectrons->size()) ); }
+       if ( m_debug ) { Info( "execute", "Number of electrons: %i", static_cast<int>(inputElectrons->size()) ); }
 
-      // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
-      //
-      this->executeSF( inputElectrons, countInputCont );
+       // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
+       //
+       this->executeSF( inputElectrons, countInputCont );
+    }
 
   } else {
   // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo.

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -292,9 +292,9 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
 
   m_muonInfoSwitch = new HelperClasses::MuonInfoSwitch( detailStr );
 
-  //std::string tname = m_tree->GetName();
+  std::string tname = m_tree->GetName();
 
-  //if ( tname == "nominal" ) {
+  if ( tname == "nominal" ) {
 
      if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
        for (auto& reco : m_muonInfoSwitch->m_recoWPs) {
@@ -322,7 +322,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
        m_tree->Branch( ttvaEffSF_sysNames.c_str() , &m_TTVAEff_SF_sysNames );
      }
 
-  //}
+  }
 
   m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC);
 
@@ -336,9 +336,9 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
   this->ClearMuons(muonName);
 
-  //std::string tname = m_tree->GetName();
+  std::string tname = m_tree->GetName();
 
-  //if ( tname == "nominal" ) {
+  if ( tname == "nominal" ) {
 
     if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
       for ( auto& reco : m_muonInfoSwitch->m_recoWPs ) {
@@ -374,7 +374,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
       }
     }
 
-  //}
+  }
 
   for( auto muon_itr : *muons ) {
     this->FillMuon(muon_itr, primaryVertex, muonName);
@@ -395,9 +395,9 @@ void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primary
 
 void HelpTreeBase::ClearMuons(const std::string muonName) {
 
-  //std::string tname = m_tree->GetName();
+  std::string tname = m_tree->GetName();
 
-  //if ( tname == "nominal" ) {
+  if ( tname == "nominal" ) {
 
     if ( m_muonInfoSwitch->m_recoEff_sysNames && m_muonInfoSwitch->m_effSF && m_isMC ) {
       for ( auto& reco : m_muonInfoSwitch->m_recoWPs ) {
@@ -421,7 +421,7 @@ void HelpTreeBase::ClearMuons(const std::string muonName) {
        m_TTVAEff_SF_sysNames.clear();
     }
 
-  //}
+  }
 
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   thisMuon->clear();

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -105,6 +105,8 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   m_outputSystNamesTrigMCEff   = "MuonEfficiencyCorrector_TrigMCEff";
   m_outputSystNamesTTVA        = "MuonEfficiencyCorrector_TTVASyst";
 
+  m_decorateWithNomOnInputSys  = true;
+
 }
 
 
@@ -504,7 +506,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
        
        // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
        //
-       this->executeSF( eventInfo, inputMuons, countInputCont );
+       this->executeSF( eventInfo, inputMuons, countInputCont, true );
     }
 
   } else {
@@ -519,6 +521,8 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
     	// loop over systematic sets available
 	//
     	for ( auto systName : *systNames ) {
+           
+           bool isNomMuonSelection = systName.empty();
 
            RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
 
@@ -534,7 +538,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
 	   // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
 	   //
-           this->executeSF( eventInfo, inputMuons, countInputCont );
+           this->executeSF( eventInfo, inputMuons, countInputCont, isNomMuonSelection );
 
 	   // increment counter
 	   //
@@ -602,7 +606,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst  )
+EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst, bool isNomSel )
 {
 
   //
@@ -632,6 +636,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     if(countSyst == 0) sysVariationNamesReco  = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListReco ) {
+      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue; 
 
       // Create the name of the SF weight to be recorded
       //   template:  SYSNAME_MuRecoEff_SF
@@ -748,6 +753,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     if(countSyst == 0) sysVariationNamesIso   = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListIso ) {
+      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue; 
 
       // Create the name of the SF weight to be recorded
       //   template:  SYSNAME_MuIsoEff_SF_WP
@@ -970,6 +976,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
       //std::cout << "This is the new string: " << m_fullname_outputSystNamesTrig << std::endl;
 
       for ( const auto& syst_it : m_systListTrig ) {
+        if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue; 
 
         // Create the name of the SF weight to be recorded
         //   template:  SYSNAME_MuTrigEff_SF
@@ -1109,6 +1116,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     if(countSyst == 0) sysVariationNamesTTVA  = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListTTVA ) {
+      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue; 
 
       // Create the name of the SF weight to be recorded
       //   template:  SYSNAME_MuTTVAEff_SF_WP

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -493,14 +493,19 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   unsigned int countInputCont(0);
 
   if ( m_inputAlgoSystNames.empty() ) {
-
-    RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
-
-   if ( m_debug ) { Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); }
-
-    // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
+    
+    // I might not want to decorate sys altered muons but for some events the nominal container might not exist 
+    // if muons are only allowed in systematic instances, hence, we have to check for the existence of the nominal container
     //
-    this->executeSF( eventInfo, inputMuons, countInputCont );
+    if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName )  ) {
+       RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+       
+       if ( m_debug ) { Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) ); }
+       
+       // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
+       //
+       this->executeSF( eventInfo, inputMuons, countInputCont );
+    }
 
   } else {
   // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo. This is the case of calibrators: one different SC

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -76,6 +76,8 @@ public:
   std::string   m_outputSystNamesTrig;
   std::string   m_outputSystNamesTrigMCEff;
   std::string   m_outputSystNamesTTVA;
+  
+  bool          m_decorateWithNomOnInputSys; // will consider efficiency decorations only for the nominal run
 
 private:
 
@@ -129,7 +131,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual EL::StatusCode executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst  );
+  virtual EL::StatusCode executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst, bool isNomSel );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers


### PR DESCRIPTION
Systematics for Muon efficiency SFs are only considered for the nominal tree. All other trees, e.g. associated with different muon calibrations will only contain the nominal values of the SF.
This would partially resolve #824. Notice, that the option of saving eff systematics also for calibration trees is still supported.