### PR TITLE
Update/met constructor sys

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -588,7 +588,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
       
         } // close loop on systematic sets available from upstream algo
         
-        if ( !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
+        if ( !m_outputAlgoSystNames.empty() && !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
           RETURN_CHECK( "ElectronEfficiencyCorrector::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names."); 
         }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -567,10 +567,8 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
              
              if ( m_debug ){
                  Info( "execute", "Number of electrons: %i", static_cast<int>(outputElectrons->size()) );
-                 //Info( "execute", "Number of electrons: %i", static_cast<int>(inputElectrons->size()) );
 	         Info( "execute", "Input syst: %s", systName.c_str() );
                  unsigned int idx(0);
-                 //for ( auto el : *(inputElectrons) ) {
                  for ( auto el : *(outputElectrons) ) {
                      Info( "execute", "Input electron %i, pt = %.2f GeV ", idx, (el->pt() * 1e-3) );
                      ++idx;
@@ -579,7 +577,6 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
              
              // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
 	     //
-             //this->executeSF( inputElectrons, countInputCont );
              this->executeSF( outputElectrons, countInputCont );
              
              vecOutContainerNames->push_back( systName ); 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -66,50 +66,46 @@ METConstructor :: METConstructor (std::string className) :
     Algorithm(className)
 {
 
-  m_debug           = false;
+  m_debug                 = false;
 
   m_referenceMETContainer = "MET_Reference_AntiKt4LCTopo";
   m_mapName               = "METAssoc_AntiKt4LCTopo";
   m_coreName              = "MET_Core_AntiKt4LCTopo";
   m_outputContainer       = "NewRefFinal";
 
-  m_inputJets       = "";
-  m_inputElectrons  = "";
-  m_inputPhotons    = "";
-  m_inputTaus       = "";
-  m_inputMuons      = "";
-
-  m_doElectronCuts  = false;
-  m_doPhotonCuts    = false;
-  m_doTauCuts       = false;
-  m_doMuonCuts      = false;
-
-  m_doMuonEloss     = false;
-  m_doIsolMuonEloss = false;
-  m_doJVTCut        = false;
-
-  m_useCaloJetTerm  = true;
-  m_useTrackJetTerm = false;
-
+  m_inputJets             = "";
+  m_inputElectrons        = "";
+  m_inputPhotons          = "";
+  m_inputTaus             = "";
+  m_inputMuons            = "";
+                          
+  m_doElectronCuts        = false;
+  m_doPhotonCuts          = false;
+  m_doTauCuts             = false;
+  m_doMuonCuts            = false;
+                          
+  m_doMuonEloss           = false;
+  m_doIsolMuonEloss       = false;
+  m_doJVTCut              = false;
+                          
+  m_useCaloJetTerm        = true;
+  m_useTrackJetTerm       = false;
 
   // used for systematics 
-  m_runNominal         = true; // set to false if you want to run met systematics
-  m_systName = "All";// do not change it, not useful
-  m_systVal = 1;
+  m_runNominal             = true; // set to false if you want to run met systematics
+  m_systName               = "All";// do not change it, not useful
+  m_systVal                = 1;
   m_SoftTermSystConfigFile = "TrackSoftTerms.config";
-
-    m_inputAlgoJets = "";
-  m_inputAlgoSystMuons = "";
-  m_inputAlgoSystEle = "";
-  m_inputAlgoPhotons = "";
-
+  
   // add for met syst tool
-  m_jetSystematics  = "jets_Syst";
-  m_eleSystematics  = "ele_Syst";
-  m_muonSystematics = "muons_Syst";
-  m_phoSystematics  = "photons_Syst";
-
-  }
+  m_jetSystematics         = "";
+  m_eleSystematics         = "";
+  m_muonSystematics        = "";
+  m_phoSystematics         = "";
+  
+  m_outputAlgoSystNames    = "";
+  
+}
 
 EL::StatusCode METConstructor :: setupJob (EL::Job& job)
 {
@@ -128,9 +124,9 @@ EL::StatusCode METConstructor :: setupJob (EL::Job& job)
 
    // to validate and check:
    //enable status code failures
-    //CP::CorrectionCode::enableFailure();
-    //CP::SystematicCode::enableFailure();
-    //StatusCode::enableFailure();// do not decomment this, maybe an unchecked status code gives a crash...
+   //CP::CorrectionCode::enableFailure();
+   //CP::SystematicCode::enableFailure();
+   //StatusCode::enableFailure();// do not decomment this, maybe an unchecked status code gives a crash...
 
 
   return EL::StatusCode::SUCCESS;
@@ -190,35 +186,10 @@ EL::StatusCode METConstructor :: initialize ()
   m_metmaker_handle.setName("METMaker");
   m_metmaker_handle.retrieve();
  
-//  m_metmaker_handle = new met::METMaker("METMaker");
-//  if(m_metmaker_handle->initialize().isFailure()){
-//    Error("initialize()", "Failed to properly initialize MET maker. Exiting." );
-//    return EL::StatusCode::FAILURE;
-//  }
-
-
   ///////////// IMETSystematicsTool ///////////////////
   ASG_SET_ANA_TOOL_TYPE(m_metSyst_handle, met::METSystematicsTool);
   m_metSyst_handle.setName("METSyst");
   m_metSyst_handle.retrieve();
-
-//  // METSystematicsTool initialization
-//  // creation and set properties of the tools:
-//  m_metSyst_handle = new met::METSystematicsTool("METSystematicsTool");
-//  //this is needed to do jet track systematics (here not useful):
-//  //RETURN_CHECK( "METConstructor::initialize()", m_metSyst_handle->setProperty( "ConfigJetTrkFile", "METTrack_2012.config"), "");
-//  //RETURN_CHECK( "METConstructor::initialize()", m_metSyst_handle->setProperty(  "ConfigSoftCaloFile", "METRefFinal_Obsolete2012_V2.config"), "");//NO CST syst provided at the moment
-//  RETURN_CHECK( "METConstructor::initialize()", m_metSyst_handle->setProperty(  "ConfigSoftTrkFile", m_SoftTermSystConfigFile), "");
-//  RETURN_CHECK( "METConstructor::initialize()", m_metSyst_handle->setProperty( "JetColl", m_inputJets.Data() ), "");//this should be the same type as you give to rebuildJetMet
-//  //m_metSyst_handle->msg().setLevel(MSG::WARNING);  //to have more messages :  VERBOSE, INFO, DEBUG, WARNING
-//
-//  if( ( m_metSyst_handle->initialize().isFailure() )){
-//   Error("Initialize()", "initialization of the met Syst tools failed.  Exiting");
-//   return EL::StatusCode::FAILURE;
-//  }
-
-//  RETURN_CHECK( "METConstructor::initialize()", m_m_metSyst_handle->setProperty( "DoMuonEloss", m_doMuonEloss), "");
-//  RETURN_CHECK( "METConstructor::initialize()", m_m_metSyst_handle->setProperty( "DoIsolMuonEloss", m_doIsolMuonEloss), "");
 
   m_tauSelTool = new TauAnalysisTools::TauSelectionTool( "TauSelectionTool" );
   if (m_tauSelTool->initialize().isFailure()) {
@@ -226,87 +197,33 @@ EL::StatusCode METConstructor :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-
   Info("initialize()", "METConstructor Interface %s succesfully initialized!", m_name.c_str());
 
   //use the helper function getlistofsystematics:
 
- // run syst
+  // run syst
   if(!m_runNominal && !m_systName.empty()) { //  m_systName is set by default to m_systName= "All", do not change it
+      // get the syst from met syst tool
+      const CP::SystematicSet recSyst = m_metSyst_handle->recommendedSystematics();
+      sysList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
 
-// get the syst from met syst tool
-const CP::SystematicSet recSyst = m_metSyst_handle->recommendedSystematics();
-sysList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
-
-
- //add the syst for jets 
- if(!m_inputAlgoJets.empty()){
-   std::vector<std::string>* sysJetsNames(nullptr);
-   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysJetsNames, m_jetSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
-
-   for ( auto systName : *sysJetsNames ) {
-     if (systName != "")sysList.push_back(CP::SystematicSet(systName));// do not store twice the nominal case!!
-   //cout<< "jet syst added is = "<< systName<< endl;
-   }
- }
-
-  //add the syst for electrons
- if(!m_inputAlgoSystEle.empty()){
-   std::vector<std::string>* sysElectronsNames(nullptr);
-   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysElectronsNames, m_eleSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
-
-   for ( auto systName : *sysElectronsNames ) {
-     if (systName != "")sysList.push_back(CP::SystematicSet(systName));// do not store twice the nominal case!! the empty string is already in syslist
-   //cout<< "ele syst added is = "<< systName<< endl;
-   }
- }
-
-  //add the syst for muons
- if(!m_inputAlgoSystMuons.empty()){
-   std::vector<std::string>* sysMuonsNames(nullptr);
-   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysMuonsNames, m_muonSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
-
-   for ( auto systName : *sysMuonsNames ) {
-     if (systName != "")sysList.push_back(CP::SystematicSet(systName));// do not store twice the nominal case!! the empty string is already in syslist
-   //cout<< "muon syst added is = "<< systName<< endl;
-   }
- }
-
-   //add the syst for photons
- if(!m_inputAlgoPhotons.empty()){
-   std::vector<std::string>* sysPhotonsNames(nullptr);
-   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysPhotonsNames, m_phoSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
-
-   for ( auto systName : *sysPhotonsNames ) {
-     if (systName != "")sysList.push_back(CP::SystematicSet(systName));// do not store twice the nominal case!! the empty string is already in syslist
-   //cout<< "photon syst added is = "<< systName<< endl;
-   }
- }
-
-
-}else { //run nominal
-  sysList.push_back(CP::SystematicSet()); // add empty systematic (Nominal case)
-      }
-
-
- for ( const auto& syst_it : sysList ) {
-    if (m_debug) cout<<"syst_it = "<<syst_it.name()<<endl;
-
-    Info("initialize()","\t %s", (syst_it.name()).c_str());
+  } else { //run nominal
+    sysList.push_back(CP::SystematicSet()); // add empty systematic (Nominal case) 
   }
 
+  for ( const auto& syst_it : sysList ) {
+    if (m_debug) cout<<"syst_it = "<<syst_it.name()<<endl;
+    Info("METConstructor::initialize()","\t %s", (syst_it.name()).c_str());
+  }
 
-  m_numEvent = 0;//just as a check
-
+  m_numEvent = 0; //just as a check
 
   // define m_isMC
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
 
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
-  if ( m_debug ) { Info("initialize()", "Is MC? %i", static_cast<int>(m_isMC) ); }
-
-
+  if ( m_debug ) { Info("METConstructor::initialize()", "Is MC? %i", static_cast<int>(m_isMC) ); }
 
 
   return EL::StatusCode::SUCCESS;
@@ -315,324 +232,338 @@ sysList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal,
 
 EL::StatusCode METConstructor :: execute ()
 {
-  // Here you do everything that needs to be done on every single
-  // events, e.g. read input variables, apply cuts, and fill
-  // histograms and trees.  This is where most of your actual analysis
-  // code will go.
-
-  if(m_debug) Info("execute()", "Performing MET reconstruction...");
-
-  m_numEvent ++ ;
-  //if (m_debug) cout<< "number of processed events now is : "<< m_numEvent <<endl;
-
-    
-  const xAOD::MissingETContainer* coreMet(0);
-  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Core.");
-
-  const xAOD::MissingETAssociationMap* metMap = 0;
-  RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(metMap,  m_mapName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Map.");
-
-  std::vector<CP::SystematicSet>::const_iterator sysListItr;
-  std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-
-  //
-  // get vector of string giving the Systematic names:
-  //
-
-  // JETS
-  std::vector<std::string>* systNamesJets(nullptr);
-  if (!m_runNominal && !m_inputAlgoJets.empty()) {
-    RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(systNamesJets, m_inputAlgoJets, 0, m_store, m_debug) ,"");
-    if (m_debug) cout<<"  the inputAlgoJets is = "<<m_inputAlgoJets<<endl;
-  }
-
-  // MUONS
-  std::vector<std::string>* systNames_mu(nullptr);
-  if (!m_runNominal && !m_inputAlgoSystMuons.empty()) {
-    RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(systNames_mu, m_inputAlgoSystMuons, 0, m_store, m_debug) ,"");
-  } else if (m_debug) cout<<"muon systematics are not available "<< endl ;
-
-
-  // ELECTRONS
- std::vector<std::string>* systNames_ele(nullptr);
- if (!m_runNominal && !m_inputAlgoSystEle.empty()) {
-   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(systNames_ele, m_inputAlgoSystEle, 0, m_store, m_debug) ,"");
- } else if (m_debug) cout<<"electron systematics are not available "<< endl ;
-
-
- // at the moment for photons and taus syst we consider only the list of syst already in SystematicSet (from SystematicRegistry)
- // since we do not have stored systematics for taus and ph...
-
- // PHOTONS
- std::vector<std::string>* systNames_ph(nullptr);
- if (!m_runNominal && !m_inputAlgoPhotons.empty()) {
-   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(systNames_ph, m_inputAlgoPhotons, 0, m_store, m_debug) ,"");
- } else if (m_debug) cout<<"photon systematics are not available "<< endl ;
-
- // TAUS
- // (...)
-
-
- // now start the loop over systematics
- for (sysListItr = sysList.begin(); sysListItr != sysList.end(); ++sysListItr){// loop over systematics
-
-   //this is kind of annoying, but applySystematicVariation only takes a SystematicSet, but *sysListItr is a SystematicVariation.
-   //We use the SystematicSet constructor which just takes a SystematicVariation
-   //CP::SystematicSet iSysSet( (*sysListItr).name());
-   //tell the tool that we are using this SystematicSet (of one SystematicVariation for now)
-   //after this call, when we use applyCorrection, the given met term will be adjusted with this systematic applied
-   //assert(    m_metSyst_handle->applySystematicVariation(sysList) );
+   // Here you do everything that needs to be done on every single
+   // events, e.g. read input variables, apply cuts, and fill
+   // histograms and trees.  This is where most of your actual analysis
+   // code will go.
+   
+   if(m_debug) Info("execute()", "Performing MET reconstruction...");
+   
+   m_numEvent ++ ;
+   //if (m_debug) cout<< "number of processed events now is : "<< m_numEvent <<endl;
+   
+     
+   const xAOD::MissingETContainer* coreMet(0);
+   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Core.");
+   
+   const xAOD::MissingETAssociationMap* metMap = 0;
+   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(metMap,  m_mapName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Map.");
+   
+   std::vector<CP::SystematicSet>::const_iterator sysListItr;
+   std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
+   
    //
-   // info from https://svnweb.cern.ch/trac/atlasoff/browser/Reconstruction/MET/METUtilities/trunk/util/example_METMaker_METSystematicsTool.cxx
-
-   CP::SystematicSet iSysSet( (*sysListItr).name()); // to pass from SystematicVariation to SystematicSet
+   // get vector of string giving the Systematic names:
    //
-   std::string sysListItrString;// just for convenience, to retrieve the containers
-   sysListItrString= (*sysListItr).name();
-
-	
-   if (m_debug) cout<<" loop over systematic = "<<sysListItr->name() <<endl;
-   vecOutContainerNames->push_back( sysListItr->name() );
-	
-   //create a met container, one for each syst
-   xAOD::MissingETContainer* newMet = new xAOD::MissingETContainer();
-   xAOD::MissingETAuxContainer* metAuxCont = new xAOD::MissingETAuxContainer();
-   newMet->setStore(metAuxCont);
-
-   metMap->resetObjSelectionFlags();
-
-   // now retrieve the object containers and build the met
-   // if the syst varied container exists take it, otherwise take the nominal one
-
-   ///////////////////////
-   ////// ELECTRONS  /////
-   ///////////////////////
-
- if( m_inputElectrons.Length() > 0 ) {
-   const xAOD::ElectronContainer* eleCont(0);
-   if ( m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString ) ) {
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving electron cont.");
-     if (m_debug) cout<< "retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met "<< endl;
-   }else{
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
-   }
-
-   if (m_doElectronCuts) {
-     ConstDataVector<xAOD::ElectronContainer> metElectrons(SG::VIEW_ELEMENTS);
-     for (const auto& el : *eleCont) if (CutsMETMaker::accept(el)) metElectrons.push_back(el);
-     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefEle", xAOD::Type::Electron, newMet, metElectrons.asDataVector(), metMap), "Failed rebuilding electron component.");
-   } else {
-     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefEle", xAOD::Type::Electron, newMet, eleCont, metMap), "Failed rebuilding electron component.");
-   }
-  }// close "if( m_inputElectrons.Length() > 0 )"
-
-
-
-  //////////////////////
-  //////  PHOTONS  /////
-  //////////////////////
-
-  if( m_inputPhotons.Length() > 0 ) {
-   const xAOD::PhotonContainer* phoCont(0);
-   if ( m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString ) ) {
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
-     if (m_debug) cout<< "retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met "<< endl;
-   }else{
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
-   }
-
-    if (m_doPhotonCuts) {
-      ConstDataVector<xAOD::PhotonContainer> metPhotons(SG::VIEW_ELEMENTS);
-      for (const auto& ph : *phoCont) {
-
-        bool testPID = 0;
-        ph->passSelection(testPID, "Tight");
-        if( !testPID ) continue;
-
-        //ATH_MSG_VERBOSE("Photon author = " << ph->author() << " test " << (ph->author()&20));
-        if (!(ph->author() & 20)) continue;
-
-        if (ph->pt() < 25e3) continue;
-
-        float feta = fabs(ph->eta());
-        if (feta > 2.37 || (1.37 < feta && feta < 1.52)) continue;
-
-        metPhotons.push_back(ph);
-      }
-      RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, metPhotons.asDataVector(), metMap), "Failed rebuilding photon component.");
-    } else {
-      RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, phoCont, metMap), "Failed rebuilding photon component.");
-    }
-  }
-
-
-  ///////////////////
-  //////  TAUS  /////
-  ///////////////////
-
-  // NOTE: for taus we are not applying systematics! since "m_inputTaus.Data()+sysListItrString" is not in Tstore!
-
-  if( m_inputTaus.Length() > 0 ) {
-    const xAOD::TauJetContainer* tauCont(0);
-   if ( m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
-
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
-     if (m_debug) cout<< "retrieving tau container "<<    m_inputTaus.Data() +sysListItrString << " to be added to the met "<< endl;
-   }else{
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
-   }
-
-    if (m_doTauCuts) {
-      ConstDataVector<xAOD::TauJetContainer> metTaus(SG::VIEW_ELEMENTS);
-      for (const auto& tau : *tauCont) {
-
-        if (tau->pt() < 20e3) continue;
-        if (fabs(tau->eta()) > 2.37) continue;
-        if (!m_tauSelTool->accept(tau)) continue;
-
-        metTaus.push_back(tau);
-      }
-      RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefTau", xAOD::Type::Tau, newMet, metTaus.asDataVector(), metMap), "Failed rebuilding tau component.");
-    } else {
-      RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefTau", xAOD::Type::Tau, newMet, tauCont, metMap), "Failed rebuilding tau component.");
-    }
-  }
-
-   ////////////////////
-   //////  MUONS  /////
-   ////////////////////
-
- bool done_METMuons(false);
- if( m_inputMuons.Length() > 0  && m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
-   std::string m_inputMuons_Syst =  m_inputMuons.Data() +sysListItrString;
-   const xAOD::MuonContainer* muonCont(0);
-   if ( m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving muon cont.");
-   }
-   else{
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data(), m_event, m_store, m_debug), "Failed retrieving electronmuon cont.");
-   }
-   if (m_doMuonCuts) {
-     ConstDataVector<xAOD::MuonContainer> metMuons(SG::VIEW_ELEMENTS);
-     for (const auto& mu : *muonCont) if (CutsMETMaker::accept(mu)) metMuons.push_back(mu);
-     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("Muons", xAOD::Type::Muon, newMet, metMuons.asDataVector(), metMap), "Failed rebuilding muon component.");
-     done_METMuons = true;
-   } else {
-     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("Muons", xAOD::Type::Muon, newMet, muonCont, metMap), "Failed rebuilding muon component.");
-     done_METMuons = true;
-   }
- }
-
-   ////////////////////
-   //////  Jets  /////
-   ////////////////////
-   const xAOD::JetContainer* jetCont(0);
-   std::string m_inputJets_Syst =  m_inputJets.Data() +sysListItrString;// just for convenience
-   if (m_debug) cout<<" the jet container name is : "<<m_inputJets_Syst<< endl;
-
-   if ( m_store->contains<xAOD::JetContainer>(m_inputJets.Data()+sysListItrString ) ) {
-     if (m_debug) cout << "syst is = "<<sysListItrString <<endl;
-     //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont,m_inputJets_Syst  ), "");// is this necessary?
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
-   }
-   else {
-   if (m_debug) cout<<" not found this jet container : "<< m_inputJets.Data()+sysListItrString<< endl;
-     //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont, m_inputJets.Data() ), "");// is this necessary?
-     RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
-   }
-
-   // the jet term and soft term(s) are built simultaneously using METMaker::rebuildJetMET(...) or METMaker::rebuildTrackMET(...)
-   // to build MET using a calorimeter or track based jet term, respectively.
-   // pass to rebuildJetMET calibrated jets (full container)
-   //
-
-   // NOTE: you have to set m_doJVTCut correctly when running! 
-
-  if ( m_useCaloJetTerm ) {
-    RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut), "Failed to build cluster-based jet/MET.");
-  } else if ( m_useTrackJetTerm ) {
-    RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildTrackMET("RefJetTrk", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut), "Failed to build track-based jet/MET.");
-  } else {
-    Error("execute()", "Both m_useCaloJetTerm and m_useTrackJetTerm appear to be set to 'false'. This should not happen. Please check your MET configuration file");
-    return EL::StatusCode::FAILURE;
-  }
-
-   //now tell the m_metSyst_handle that we are using this SystematicSet (of one SystematicVariation for now)
-   //after this call, when we use applyCorrection, the given met term will be adjusted with this systematic applied
-   // assert(   m_metSyst_handle->applySystematicVariation(iSysSet) );
+   // load each object systematic. This is done at the execution level
+   // as systematic containers have to exist. To avoid adding several 
+   // times the same systematic a check has to be performed on sysList
    //
    
-  if (m_isMC) {
-    if( m_metSyst_handle->applySystematicVariation(iSysSet) != CP::SystematicCode::Ok) {
-      cout<<"Error !!! not able to applySystematicVariation "<< endl;
-    }
-   }
-
-   //get the soft cluster term, and applyCorrection
-   xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
-   //assert( softClusMet != 0); //check we retrieved the clust term
-   if( m_isMC && m_metSyst_handle->applyCorrection(*softClusMet) != CP::CorrectionCode::Ok) {
-     Error("METConstructor::execute()", "Could not apply correction to soft clus met !!!! ");
-   }
-   if (m_debug) std::cout << "Soft cluster met term met : " << softClusMet->met() << std::endl;
-
-   //get the track soft term, and applyCorrection
-   xAOD::MissingET * softTrkMet = (*newMet)["PVSoftTrk"];
-   if( m_isMC && m_metSyst_handle->applyCorrection(*softTrkMet) != CP::CorrectionCode::Ok) {
-     Error("METConstructor::execute()", "Could not apply correction to soft track met !!!! ");
-   }
-   if (m_debug) std::cout << "track met soft term : " << softTrkMet->met() << std::endl;
-
-   //only for track jets
-   /*xAOD::MissingET * jetMet = (*newMet)["RefJet"];
-     if( (*jetMet)->applyCorrection(iSysSet) != CP::CorrectionCode::Ok) {
-     Error("METConstructor::execute()", "Could not apply correction to jet met !!!! ");
-     };
-     std::cout << "Jet met term met " << jetMet->met() << std::endl;*/
-
-   // build met:
-   RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->buildMETSum("FinalClus", newMet, MissingETBase::Source::LCTopo), "Failed to build FinalClus MET.");
-   RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->buildMETSum("FinalTrk",  newMet, MissingETBase::Source::Track),  "Failed to build FinalTrk MET.");
-
-   RETURN_CHECK("METConstructor::execute()", m_store->record(newMet, (m_outputContainer+ sysListItr->name()).Data() ), "Failed to store MET output container.");
-   RETURN_CHECK("METConstructor::execute()", m_store->record(metAuxCont, (m_outputContainer+  sysListItr->name() + "Aux.").Data()), "Failed to store MET output container.");
-
-   if (m_debug) std::cout << " FinalClus met, for syst  = "<< sysListItr->name() <<"is = " << (*newMet->find("FinalClus"))->met() << std::endl;
-    if (m_debug) std::cout << " FinalTrk met, for syst  = "<< sysListItr->name() <<"is = " << (*newMet->find("FinalTrk"))->met() << std::endl;
-   if (m_debug) cout<< "storing met container :  "<< (m_outputContainer+ sysListItr->name()).Data() << endl;
-   if (m_debug) cout<< "storing  Aux met container :  "<< (m_outputContainer+ sysListItr->name() + "Aux.").Data() << endl;
-
-	
-  if ( m_debug ) {
-    const xAOD::MissingETContainer* oldMet(0);
-    RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(oldMet, m_referenceMETContainer.Data(), m_event, m_store, m_verbose) ,"");
-    //xAOD::MissingETContainer::const_iterator final(oldMet->find("FinalClus"));
-    //xAOD::MissingETContainer::const_iterator newfinal(newMet->find("FinalClus"));
-    Info("execute()", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-    if( m_inputElectrons.Length() > 0 ) Info("execute()", "RefEle:     old=%8.f  new=%8.f", (*oldMet->find("RefEle"))->met(), (*newMet->find("RefEle"))->met());
-    if( m_inputPhotons.Length() > 0 )   Info("execute()", "RefPhoton:  old=%8.f  new=%8.f", (*oldMet->find("RefGamma"))->met(), (*newMet->find("RefGamma"))->met());
-    if( m_inputTaus.Length() > 0 )      Info("execute()", "RefTau:     old=%8.f  new=%8.f", (*oldMet->find("RefTau"))->met(), (*newMet->find("RefTau"))->met());
-    if( m_inputMuons.Length() > 0 && done_METMuons )     Info("execute()", "RefMuon:    old=%8.f  new=%8.f", (*oldMet->find("Muons"))->met(), (*newMet->find("Muons"))->met());
-    Info("execute()", "RefJet:       old=%8.f  new=%8.f", (*oldMet->find("RefJet"))->met(), (*newMet->find("RefJet"))->met());
-    Info("execute()", "SoftClus:     old=%8.f  new=%8.f", (*oldMet->find("SoftClus"))->met(), (*newMet->find("SoftClus"))->met());
-    Info("execute()", "PVSoftTrk:    old=%8.f  new=%8.f", (*oldMet->find("PVSoftTrk"))->met(), (*newMet->find("PVSoftTrk"))->met());
-    Info("execute()", "  ");
-    Info("execute()", "FinalClus:    old=%8.f  new=%8.f", (*oldMet->find("FinalClus"))->met(), (*newMet->find("FinalClus"))->met());
-    Info("execute()", "       >>>>> R=%.3f",          (*oldMet->find("FinalClus"))->met()/ (*newMet->find("FinalClus"))->met());
-   // Info("execute()", "FinalTrk:     old=%8.f  new=%8.f", (*oldMet->find("FinalTrk"))->met(), (*newMet->find("FinalTrk"))->met());
-   // Info("execute()", "       >>>>> R=%.3f",          (*oldMet->find("FinalTrk"))->met()/ (*newMet->find("FinalTrk"))->met());
-  }
-
- }//end loop over systematics
-
-
-
- // add vector of systematic names to TStore
-   RETURN_CHECK("METConstructor::execute()",m_store->record(vecOutContainerNames, (m_outputContainer+"_Syst").Data() ), "Failed to record vector of output container names.");
-
+   //add the syst for jets 
+   if(!m_runNominal && !m_jetSystematics.empty()){
+     std::vector<std::string>* sysJetsNames(nullptr);
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysJetsNames, m_jetSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
    
-  //if (m_debug) m_store->print();// print TStore content
-  if (m_debug) cout<< "vecOutContainerNames in tstore :  "<<  (m_outputContainer+"_Syst").Data() << endl; 
+     for ( auto systName : *sysJetsNames ) {
+       if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
+     if ( m_debug ) cout<< "jet syst added is = "<< systName<< endl;
+     }
+   }
+   
+   //add the syst for electrons
+   if(!m_runNominal && !m_eleSystematics.empty()){
+     std::vector<std::string>* sysElectronsNames(nullptr);
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysElectronsNames, m_eleSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+   
+     for ( auto systName : *sysElectronsNames ) {
+       if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())  ) sysList.push_back(CP::SystematicSet(systName));
+     if ( m_debug ) cout<< "ele syst added is = "<< systName<< endl;
+     }
+   }
+   
+   //add the syst for muons
+   if(!m_runNominal && !m_muonSystematics.empty()){
+     std::vector<std::string>* sysMuonsNames(nullptr);
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysMuonsNames, m_muonSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+   
+     for ( auto systName : *sysMuonsNames ) {
+       if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
+     if ( m_debug ) cout<< "muon syst added is = "<< systName<< endl;
+     }
+   }
+   
+   //add the syst for photons
+   if(!m_runNominal && !m_phoSystematics.empty()){
+     std::vector<std::string>* sysPhotonsNames(nullptr);
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysPhotonsNames, m_phoSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+   
+     for ( auto systName : *sysPhotonsNames ) {
+       if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
+     if ( m_debug ) cout<< "photon syst added is = "<< systName<< endl;
+     }
+   }
+
+   // now start the loop over systematics
+   for (sysListItr = sysList.begin(); sysListItr != sysList.end(); ++sysListItr) {  // loop over systematics
+
+      //this is kind of annoying, but applySystematicVariation only takes a SystematicSet, but *sysListItr is a SystematicVariation.
+      //We use the SystematicSet constructor which just takes a SystematicVariation
+      //CP::SystematicSet iSysSet( (*sysListItr).name());
+      //tell the tool that we are using this SystematicSet (of one SystematicVariation for now)
+      //after this call, when we use applyCorrection, the given met term will be adjusted with this systematic applied
+      //assert(    m_metSyst_handle->applySystematicVariation(sysList) );
+      //
+      // info from https://svnweb.cern.ch/trac/atlasoff/browser/Reconstruction/MET/METUtilities/trunk/util/example_METMaker_METSystematicsTool.cxx
+      
+      CP::SystematicSet iSysSet( (*sysListItr).name()); // to pass from SystematicVariation to SystematicSet
+      //
+      std::string sysListItrString;// just for convenience, to retrieve the containers
+      sysListItrString= (*sysListItr).name();
+      
+      if (m_debug) cout<<" loop over systematic = "<<sysListItr->name() <<endl;
+      
+      vecOutContainerNames->push_back( sysListItr->name() );
+ 
+      //create a met container, one for each syst
+      xAOD::MissingETContainer* newMet = new xAOD::MissingETContainer();
+      xAOD::MissingETAuxContainer* metAuxCont = new xAOD::MissingETAuxContainer();
+      newMet->setStore(metAuxCont);
+      
+      metMap->resetObjSelectionFlags();
+      
+      // now retrieve the object containers and build the met
+      // if the syst varied container exists take it, otherwise take the nominal one
+      
+      ///////////////////////
+      ////// ELECTRONS  /////
+      ///////////////////////
+      
+      if( m_inputElectrons.Length() > 0  && m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString )) {
+         const xAOD::ElectronContainer* eleCont(0);
+         if ( m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString ) ) {
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving electron cont.");
+           if (m_debug) cout<< "retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met "<< endl;
+         }else{
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+         }
+         
+         if (m_doElectronCuts) {
+           ConstDataVector<xAOD::ElectronContainer> metElectrons(SG::VIEW_ELEMENTS);
+           for (const auto& el : *eleCont) if (CutsMETMaker::accept(el)) metElectrons.push_back(el);
+           RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefEle", xAOD::Type::Electron, newMet, metElectrons.asDataVector(), metMap), "Failed rebuilding electron component.");
+         } else {
+           RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefEle", xAOD::Type::Electron, newMet, eleCont, metMap), "Failed rebuilding electron component.");
+         }
+      } // close "if( m_inputElectrons.Length() > 0 )"
+      
+      
+      /////////////////////////
+      /////////  PHOTONS  /////
+      /////////////////////////
+       
+      if( m_inputPhotons.Length() > 0  && m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString )) {
+         const xAOD::PhotonContainer* phoCont(0);
+         if ( m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString ) ) {
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
+           if (m_debug) cout<< "retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met "<< endl;
+         } else {
+         RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+      }
+      
+      if (m_doPhotonCuts) {
+        ConstDataVector<xAOD::PhotonContainer> metPhotons(SG::VIEW_ELEMENTS);
+        for (const auto& ph : *phoCont) {
+          
+          bool testPID = 0;
+          ph->passSelection(testPID, "Tight");
+          if( !testPID ) continue;
+      
+          //ATH_MSG_VERBOSE("Photon author = " << ph->author() << " test " << (ph->author()&20));
+          if (!(ph->author() & 20)) continue;
+      
+          if (ph->pt() < 25e3) continue;
+      
+          float feta = fabs(ph->eta());
+          if (feta > 2.37 || (1.37 < feta && feta < 1.52)) continue;
+      
+          metPhotons.push_back(ph);
+        }
+        
+        RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, metPhotons.asDataVector(), metMap), "Failed rebuilding photon component.");
+      
+      } else {
+        RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefGamma", xAOD::Type::Photon, newMet, phoCont, metMap), "Failed rebuilding photon component.");
+       }
+     }
+      
+     //////////////////////
+     /////////  TAUS  /////
+     //////////////////////
+         
+     ///// NOTE: for taus we are not applying systematics! since "m_inputTaus.Data()+sysListItrString" is not in Tstore!
+      
+     if( m_inputTaus.Length() > 0  && m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
+        const xAOD::TauJetContainer* tauCont(0);
+        if ( m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
+           
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
+          if (m_debug) cout<< "retrieving tau container "<< m_inputTaus.Data()+sysListItrString << " to be added to the met "<< endl;
+       
+        } else {
+        RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+      }
+      
+       if (m_doTauCuts) {
+         ConstDataVector<xAOD::TauJetContainer> metTaus(SG::VIEW_ELEMENTS);
+         for (const auto& tau : *tauCont) {
+      
+           if (tau->pt() < 20e3) continue;
+           if (fabs(tau->eta()) > 2.37) continue;
+           if (!m_tauSelTool->accept(tau)) continue;
+      
+           metTaus.push_back(tau);
+         }
+         RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefTau", xAOD::Type::Tau, newMet, metTaus.asDataVector(), metMap), "Failed rebuilding tau component.");
+       } else {
+         RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("RefTau", xAOD::Type::Tau, newMet, tauCont, metMap), "Failed rebuilding tau component.");
+       }
+     }
+      
+     ////////////////////
+     //////  MUONS  /////
+     ////////////////////
+      
+     if( m_inputMuons.Length() > 0  && m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
+       std::string m_inputMuons_Syst =  m_inputMuons.Data() +sysListItrString;
+        const xAOD::MuonContainer* muonCont(0);
+        if ( m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving muon cont.");
+        } else {
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data(), m_event, m_store, m_debug), "Failed retrieving electronmuon cont.");
+        }
+        if (m_doMuonCuts) {
+          ConstDataVector<xAOD::MuonContainer> metMuons(SG::VIEW_ELEMENTS);
+          for (const auto& mu : *muonCont) if (CutsMETMaker::accept(mu)) metMuons.push_back(mu);
+          RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("Muons", xAOD::Type::Muon, newMet, metMuons.asDataVector(), metMap), "Failed rebuilding muon component.");
+        } else {
+          RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildMET("Muons", xAOD::Type::Muon, newMet, muonCont, metMap), "Failed rebuilding muon component.");
+        }
+     }
+      
+     ////////////////////
+     //////  Jets  /////
+     ////////////////////
+     
+     const xAOD::JetContainer* jetCont(0);
+     std::string m_inputJets_Syst =  m_inputJets.Data() +sysListItrString;// just for convenience
+     if (m_debug) cout<<" the jet container name is : "<<m_inputJets_Syst<< endl;
+     
+     if ( m_store->contains<xAOD::JetContainer>(m_inputJets.Data()+sysListItrString ) ) {
+       if (m_debug) cout << "syst is = "<<sysListItrString <<endl;
+       //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont,m_inputJets_Syst  ), "");// is this necessary?
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
+     } else {
+       if (m_debug) cout<<" not found this jet container : "<< m_inputJets.Data()+sysListItrString<< endl;
+       //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont, m_inputJets.Data() ), "");// is this necessary?
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
+     }
+     
+     // the jet term and soft term(s) are built simultaneously using METMaker::rebuildJetMET(...) or METMaker::rebuildTrackMET(...)
+     // to build MET using a calorimeter or track based jet term, respectively.
+     // pass to rebuildJetMET calibrated jets (full container)
+     //
+     
+     // NOTE: you have to set m_doJVTCut correctly when running! 
+      
+     if ( m_useCaloJetTerm ) {
+       RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut), "Failed to build cluster-based jet/MET.");
+     } else if ( m_useTrackJetTerm ) {
+       RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->rebuildTrackMET("RefJetTrk", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut), "Failed to build track-based jet/MET.");
+     } else {
+       Error("execute()", "Both m_useCaloJetTerm and m_useTrackJetTerm appear to be set to 'false'. This should not happen. Please check your MET configuration file");
+       return EL::StatusCode::FAILURE;
+     }
+      
+     //now tell the m_metSyst_handle that we are using this SystematicSet (of one SystematicVariation for now)
+     //after this call, when we use applyCorrection, the given met term will be adjusted with this systematic applied
+     // assert(   m_metSyst_handle->applySystematicVariation(iSysSet) );
+     //
+      
+     if (m_isMC) {
+       if( m_metSyst_handle->applySystematicVariation(iSysSet) != CP::SystematicCode::Ok) {
+         cout<<"Error !!! not able to applySystematicVariation "<< endl;
+       }
+     }
+      
+     //get the soft cluster term, and applyCorrection
+     xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
+     //assert( softClusMet != 0); //check we retrieved the clust term
+     if( m_isMC && m_metSyst_handle->applyCorrection(*softClusMet) != CP::CorrectionCode::Ok) {
+       Error("METConstructor::execute()", "Could not apply correction to soft clus met !!!! ");
+     }
+     if (m_debug) std::cout << "Soft cluster met term met : " << softClusMet->met() << std::endl;
+     
+     //get the track soft term, and applyCorrection
+     xAOD::MissingET * softTrkMet = (*newMet)["PVSoftTrk"];
+     if( m_isMC && m_metSyst_handle->applyCorrection(*softTrkMet) != CP::CorrectionCode::Ok) {
+       Error("METConstructor::execute()", "Could not apply correction to soft track met !!!! ");
+     }
+     if (m_debug) std::cout << "track met soft term : " << softTrkMet->met() << std::endl;
+     
+     //only for track jets
+     /*xAOD::MissingET * jetMet = (*newMet)["RefJet"];
+       if( (*jetMet)->applyCorrection(iSysSet) != CP::CorrectionCode::Ok) {
+       Error("METConstructor::execute()", "Could not apply correction to jet met !!!! ");
+       };
+       std::cout << "Jet met term met " << jetMet->met() << std::endl;*/
+     
+     // build met:
+
+     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->buildMETSum("FinalClus", newMet, MissingETBase::Source::LCTopo), "Failed to build FinalClus MET.");
+     RETURN_CHECK("METConstructor::execute()", m_metmaker_handle->buildMETSum("FinalTrk",  newMet, MissingETBase::Source::Track),  "Failed to build FinalTrk MET.");
+     
+     RETURN_CHECK("METConstructor::execute()", m_store->record(newMet, (m_outputContainer+sysListItr->name()).Data() ), "Failed to store MET output container.");
+     RETURN_CHECK("METConstructor::execute()", m_store->record(metAuxCont, (m_outputContainer+sysListItr->name() + "Aux.").Data()), "Failed to store MET output container.");
+     
+     if (m_debug) std::cout << " FinalClus met, for syst  = "<< sysListItr->name() << " is = " << (*newMet->find("FinalClus"))->met() << std::endl;
+     if (m_debug) std::cout << " FinalTrk met, for syst  = "<< sysListItr->name() << " is = " << (*newMet->find("FinalTrk"))->met() << std::endl;
+     if (m_debug) cout<< "storing met container :  "<< (m_outputContainer+ sysListItr->name()).Data() << endl;
+     if (m_debug) cout<< "storing  Aux met container :  "<< (m_outputContainer+ sysListItr->name() + "Aux.").Data() << endl;
+     
+     
+     /* something causes a crash down here     
+     if ( m_debug ) {
+       const xAOD::MissingETContainer* oldMet(0);
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(oldMet, m_referenceMETContainer.Data(), m_event, m_store, m_verbose) ,"");
+       //xAOD::MissingETContainer::const_iterator final(oldMet->find("FinalClus"));
+       //xAOD::MissingETContainer::const_iterator newfinal(newMet->find("FinalClus"));
+       Info("execute()", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+       if( m_inputElectrons.Length() > 0 ) Info("execute()", "RefEle:     old=%8.f  new=%8.f", (*oldMet->find("RefEle"))->met(), (*newMet->find("RefEle"))->met());
+       if( m_inputPhotons.Length() > 0 )   Info("execute()", "RefPhoton:  old=%8.f  new=%8.f", (*oldMet->find("RefGamma"))->met(), (*newMet->find("RefGamma"))->met());
+       if( m_inputTaus.Length() > 0 )      Info("execute()", "RefTau:     old=%8.f  new=%8.f", (*oldMet->find("RefTau"))->met(), (*newMet->find("RefTau"))->met());
+       if( m_inputMuons.Length() > 0 )     Info("execute()", "RefMuon:    old=%8.f  new=%8.f", (*oldMet->find("Muons"))->met(), (*newMet->find("Muons"))->met());
+       Info("execute()", "RefJet:       old=%8.f  new=%8.f", (*oldMet->find("RefJet"))->met(), (*newMet->find("RefJet"))->met());
+       Info("execute()", "SoftClus:     old=%8.f  new=%8.f", (*oldMet->find("SoftClus"))->met(), (*newMet->find("SoftClus"))->met());
+       Info("execute()", "PVSoftTrk:    old=%8.f  new=%8.f", (*oldMet->find("PVSoftTrk"))->met(), (*newMet->find("PVSoftTrk"))->met());
+       Info("execute()", "  ");
+       Info("execute()", "FinalClus:    old=%8.f  new=%8.f", (*oldMet->find("FinalClus"))->met(), (*newMet->find("FinalClus"))->met());
+       Info("execute()", "       >>>>> R=%.3f",          (*oldMet->find("FinalClus"))->met()/ (*newMet->find("FinalClus"))->met());
+       // Info("execute()", "FinalTrk:     old=%8.f  new=%8.f", (*oldMet->find("FinalTrk"))->met(), (*newMet->find("FinalTrk"))->met());
+       // Info("execute()", "       >>>>> R=%.3f",          (*oldMet->find("FinalTrk"))->met()/ (*newMet->find("FinalTrk"))->met());
+     }
+     */
+
+
+   } //end loop over systematics
+
+   // might have already been stored by another execution of this algo 
+   // or by a previous iteration of the same
+   if ( !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { 
+      RETURN_CHECK( "METConstructor::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names.");
+   }
+   
+   if ( m_verbose ) m_store->print();// print TStore content
  
   return EL::StatusCode::SUCCESS;
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -526,9 +526,9 @@ EL::StatusCode METConstructor :: execute ()
      RETURN_CHECK("METConstructor::execute()", m_store->record(newMet, (m_outputContainer+sysListItr->name()).Data() ), "Failed to store MET output container.");
      RETURN_CHECK("METConstructor::execute()", m_store->record(metAuxCont, (m_outputContainer+sysListItr->name() + "Aux.").Data()), "Failed to store MET output container.");
      
-     if (m_debug) std::cout << " FinalClus met, for syst  = "<< sysListItr->name() << " is = " << (*newMet->find("FinalClus"))->met() << std::endl;
-     if (m_debug) std::cout << " FinalTrk met, for syst  = "<< sysListItr->name() << " is = " << (*newMet->find("FinalTrk"))->met() << std::endl;
-     if (m_debug) cout<< "storing met container :  "<< (m_outputContainer+ sysListItr->name()).Data() << endl;
+     if (m_debug) std::cout << " FinalClus met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalClus"))->met() << std::endl;
+     if (m_debug) std::cout << " FinalTrk met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalTrk"))->met() << std::endl;
+     if (m_debug) cout<< "storing met container :  " << (m_outputContainer+ sysListItr->name()).Data() << endl;
      if (m_debug) cout<< "storing  Aux met container :  "<< (m_outputContainer+ sysListItr->name() + "Aux.").Data() << endl;
      
      

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -609,7 +609,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
            } // check existence of container
     	} // close loop on systematic sets available from upstream algo
        
-        if ( !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
+        if ( !m_outputAlgoSystNames.empty() && !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
           RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names."); 
         }
    }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -94,6 +94,9 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   //
   m_inputAlgoSystNames         = "";
   m_outputAlgoSystNames        = "";
+  
+  m_sysNamesForParCont         = "";
+
   m_systValReco 	       = 0.0;
   m_systValIso 	               = 0.0;
   m_systValTrig 	       = 0.0;
@@ -196,15 +199,24 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   m_numObject     = 0;
 
 
-    //asg::AnaToolHandle<CP::IPileupReweightingTool>   m_pileup_tool_handle; //!
-
-//  RETURN_CHECK("MuonEfficiencyCorrector::initialize()", checkToolStore<CP::PileupReweightingTool>("Pileup"), "Failed to check whether tool already exists in asg::ToolStore" );
-//  if ( m_isMC && !isToolAlreadyUsed("Pileup") ) {
-//    Error("initialize()","A configured CP::PileupReweightingTool must already exist in the asg::ToolStore! Are you creating one in xAH::BasicEventSelector?" );
-//    return EL::StatusCode::FAILURE;
-//  }
-
   // *******************************************************
+  
+  // several lists of systematics could be configured
+  // this is the case when MET sys should be added 
+  // to the OR ones
+  std::string tmp_sysNames = m_inputAlgoSystNames;
+  
+  while ( tmp_sysNames.size() > 0) {
+    size_t pos = tmp_sysNames.find_first_of(',');
+    if ( pos == std::string::npos ) {
+      pos = tmp_sysNames.size();
+      m_sysNames.push_back(tmp_sysNames.substr(0, pos));
+      tmp_sysNames.erase(0, pos);
+    } else {
+      m_sysNames.push_back(tmp_sysNames.substr(0, pos));
+      tmp_sysNames.erase(0, pos+1);
+    }
+  } 
 
   // Create a ToolHandle of the PRW tool which is passed to the MuonEfficiencyScaleFactors class later
   //
@@ -518,20 +530,55 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
 	// get vector of string giving the syst names of the upstream algo m_inputAlgo (rememeber: 1st element is a blank string: nominal case!)
 	//
-        std::vector<std::string>* systNames(nullptr);
-        RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+        std::vector<std::string> systNames;
+        
+        // add each vector of systematics names to the full list 
+        //
+        for ( auto sysInput : m_sysNames ) {
+          std::vector<std::string>* it_systNames(nullptr);
+          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(it_systNames, sysInput, 0, m_store, m_verbose) ,"");
+          systNames.insert( systNames.end(), it_systNames->begin(), it_systNames->end() );
+        }
+        // and now remove eventual duplicates
+        //
+        HelperFunctions::remove_duplicates(systNames);
 
-    	// loop over systematic sets available
+        // create parallel container of muons for met systematics.
+        // this does not get decorated and contains the same elements
+        // of the nominal container. It will be used by the TreeAlgo
+        // as we don't want sys variations for eff in MET sys trees. 
+        //
+        if ( !m_sysNamesForParCont.empty() )  {
+          std::vector<std::string>* par_systNames(nullptr);
+
+          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(par_systNames, m_sysNamesForParCont, 0, m_store, m_verbose) ,"");
+          
+          for ( auto sys : *par_systNames ) {
+             if ( !sys.empty() && !m_store->contains<xAOD::MuonContainer>( m_inContainerName+sys ) ) {
+               const xAOD::MuonContainer* tmpMuons(nullptr);
+
+               if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName ) ) {
+                  
+                  RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(tmpMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+                  RETURN_CHECK("MuonEfficiencyCorrector::execute()", (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_inContainerName+sys, tmpMuons)), "");
+               
+               } // the nominal container is copied therefore it has to exist!
+             
+             } // skip the nominal case or if the container already exists
+          } // consider all "parallel" systematics specified by the user
+        
+        } // do this thing only if required
+
+        // loop over systematic sets available
 	//
         std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
 
-        for ( auto systName : *systNames ) {
+        for ( auto systName : systNames ) {
            
            const xAOD::MuonContainer* outputMuons(nullptr);
            bool isNomMuonSelection = systName.empty();
            
            if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName+systName )  ) {
-
               RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
               
               if ( !m_store->contains<xAOD::MuonContainer>( m_outContainerName+systName ) ) {

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -13,6 +13,7 @@
 // EDM include(s):
 #include "xAODEventInfo/EventInfo.h"
 #include "xAODMuon/MuonContainer.h"
+#include "xAODMuon/MuonAuxContainer.h"
 #include "xAODMuon/Muon.h"
 #include "xAODBase/IParticleHelpers.h"
 #include "xAODBase/IParticleContainer.h"
@@ -56,6 +57,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   // Input container to be read from TEvent or TStore
   //
   m_inContainerName            = "";
+  m_outContainerName           = "";
 
   m_calibRelease               = "Data15_allPeriods_241115";
 
@@ -91,6 +93,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   // Systematics stuff
   //
   m_inputAlgoSystNames         = "";
+  m_outputAlgoSystNames        = "";
   m_systValReco 	       = 0.0;
   m_systValIso 	               = 0.0;
   m_systValTrig 	       = 0.0;
@@ -520,19 +523,30 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
     	// loop over systematic sets available
 	//
-    	for ( auto systName : *systNames ) {
-           
-           bool isNomMuonSelection = systName.empty();
+        std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
 
+        for ( auto systName : *systNames ) {
+           
+           const xAOD::MuonContainer* outputMuons(nullptr);
+           bool isNomMuonSelection = systName.empty();
+           
            if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName+systName )  ) {
 
               RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
               
+              if ( !m_store->contains<xAOD::MuonContainer>( m_outContainerName+systName ) ) {
+                 RETURN_CHECK("MuonEfficiencyCorrector::execute()", (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_outContainerName+systName, inputMuons)), "");
+              } 
+              
+              RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, m_verbose) ,"");
+
     	      if ( m_debug ){
-	        Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) );
+	        //Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) );
+	        Info( "execute", "Number of muons: %i", static_cast<int>(outputMuons->size()) );
 	        Info( "execute", "Input syst: %s", systName.c_str() );
 	        unsigned int idx(0);
-    	        for ( auto mu : *(inputMuons) ) {
+    	        //for ( auto mu : *(inputMuons) ) {
+    	        for ( auto mu : *(outputMuons) ) {
     	          Info( "execute", "Input muon %i, pt = %.2f GeV ", idx, (mu->pt() * 1e-3) );
     	          ++idx;
     	        }
@@ -540,15 +554,20 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
               
 	      // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
 	      //
-              this->executeSF( eventInfo, inputMuons, countInputCont, isNomMuonSelection );
-              
-	      // increment counter
+              //this->executeSF( eventInfo, inputMuons, countInputCont, isNomMuonSelection );
+              this->executeSF( eventInfo, outputMuons, countInputCont, isNomMuonSelection );
+	     
+              vecOutContainerNames->push_back( systName ); 
+              // increment counter
 	      //
 	      ++countInputCont;
         
            } // check existence of container
     	} // close loop on systematic sets available from upstream algo
-
+       
+        if ( !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
+          RETURN_CHECK( "MuonEfficiencyCorrector::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names."); 
+        }
    }
 
   // look what we have in TStore
@@ -682,10 +701,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //
     	 //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
     	 //
+
     	 SG::AuxElement::Decorator< std::vector<float> > sfVecReco( m_outputSystNamesReco );
     	 if ( !sfVecReco.isAvailable( *mu_itr ) ) {
   	   sfVecReco( *mu_itr ) = std::vector<float>();
-    	 }
+    	 } 
 
     	 float recoEffSF(1.0);
     	 if ( m_muRecoSF_tool->getEfficiencyScaleFactor( *mu_itr, recoEffSF ) != CP::CorrectionCode::Ok ) {
@@ -702,9 +722,9 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 SG::AuxElement::Decorator< std::vector<std::string> > sfVecReco_sysNames( m_outputSystNamesReco + "_sysNames" );
     	 if ( !sfVecReco_sysNames.isAvailable( *mu_itr ) ) {
   	   sfVecReco_sysNames( *mu_itr ) = std::vector<std::string>();
-         }
+         } 
     	 sfVecReco_sysNames( *mu_itr ).push_back( syst_it.name().c_str() );
-
+         
     	 if ( m_debug ) {
     	   Info( "executeSF()", "===>>>");
     	   Info( "executeSF()", " ");

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -541,11 +541,9 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
               RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, m_verbose) ,"");
 
     	      if ( m_debug ){
-	        //Info( "execute", "Number of muons: %i", static_cast<int>(inputMuons->size()) );
 	        Info( "execute", "Number of muons: %i", static_cast<int>(outputMuons->size()) );
 	        Info( "execute", "Input syst: %s", systName.c_str() );
 	        unsigned int idx(0);
-    	        //for ( auto mu : *(inputMuons) ) {
     	        for ( auto mu : *(outputMuons) ) {
     	          Info( "execute", "Input muon %i, pt = %.2f GeV ", idx, (mu->pt() * 1e-3) );
     	          ++idx;
@@ -554,7 +552,6 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
               
 	      // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
 	      //
-              //this->executeSF( eventInfo, inputMuons, countInputCont, isNomMuonSelection );
               this->executeSF( eventInfo, outputMuons, countInputCont, isNomMuonSelection );
 	     
               vecOutContainerNames->push_back( systName ); 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -70,7 +70,7 @@ OverlapRemover :: OverlapRemover (std::string className) :
   m_useCutFlow    = true;
 
   // input container(s) to be read from TEvent or TStore
-  m_outputAlgo                  = "OR_Algo";                   // name of vector<string> of combined syst pushed in TStore. 
+  m_outputAlgoSystNames         = "ORAlgo_Syst";                   // name of vector<string> of combined syst pushed in TStore. 
 
   /* Muons */
   m_inContainerName_Muons       = "";
@@ -367,7 +367,7 @@ EL::StatusCode OverlapRemover :: execute ()
   }
 
   // save list of systs that should be considered down stream
-  RETURN_CHECK( "OverlapRemover::execute()", m_store->record( m_vecOutContainerNames, m_outputAlgo), "Failed to record vector of output container names.");
+  RETURN_CHECK( "OverlapRemover::execute()", m_store->record( m_vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names.");
 
   // look what do we have in TStore
   if ( m_verbose ) { m_store->print(); }

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -29,11 +29,15 @@ class ElectronEfficiencyCorrector : public xAH::Algorithm
   // that way they can be set directly from CINT and python.
 public:
   // configuration variables
-  std::string m_inContainerName;
+  std::string  m_inContainerName;
+  std::string  m_outContainerName;
 
   // systematics
-  std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
-  			             // upstream algo (e.g., the SC containers with calibration systematics)
+  std::string   m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
+  			               // upstream algo (e.g., the SC containers with calibration systematics)
+  
+  std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
+                                       // the downstream algos. We need that as we deepcopy the input containers
 
   float m_systValPID;
   float m_systValIso;

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -503,6 +503,14 @@ namespace HelperFunctions {
       tree->SetBranchAddress ((name+"_"+branch).c_str()  , variable);
     }
 
+  // function to remove duplicates from a vector. Thank you, oh internet!
+  // http://stackoverflow.com/questions/9237216/removing-duplicates-in-a-vector-of-strings
+  template <typename T>
+  void remove_duplicates(std::vector<T>& vec)
+  {
+    std::sort(vec.begin(), vec.end());
+    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+  }
 
 } // close namespace HelperFunctions
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -41,10 +41,10 @@ public:
   TString m_inputMuons;
 
 
-  std::string  m_inputAlgoJets;  // name of vector<string> of syst retrieved from TStore
-  std::string  m_inputAlgoSystMuons;  // name of vector<string> of syst retrieved from TStore
-  std::string  m_inputAlgoSystEle;  // name of vector<string> of syst retrieved from TStore
-  std::string m_inputAlgoPhotons; // name of vector<string> of syst retrieved from TStore
+  //std::string  m_inputAlgoJets;  // name of vector<string> of syst retrieved from TStore
+  //std::string  m_inputAlgoSystMuons;  // name of vector<string> of syst retrieved from TStore
+  //std::string  m_inputAlgoSystEle;  // name of vector<string> of syst retrieved from TStore
+  //std::string m_inputAlgoPhotons; // name of vector<string> of syst retrieved from TStore
 
   bool    m_doElectronCuts;
   bool    m_doPhotonCuts;
@@ -89,7 +89,7 @@ public:
    */
   std::string m_phoSystematics;
 
-
+  std::string m_outputAlgoSystNames;
   
 
 private:

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -36,6 +36,7 @@ public:
 
   // configuration variables
   std::string   m_inContainerName;
+  std::string   m_outContainerName;
 
   std::string   m_calibRelease;
 
@@ -62,7 +63,9 @@ public:
   // systematics
   std::string   m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
   			               // upstream algo (e.g., the SC containers with calibration systematics)
-
+  
+  std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
+                                       // the downstream algos. We need that as we deepcopy the input containers
   float         m_systValReco;
   float         m_systValIso;
   float         m_systValTrig;

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -66,6 +66,11 @@ public:
   
   std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
                                        // the downstream algos. We need that as we deepcopy the input containers
+
+  std::string   m_sysNamesForParCont;  // this is the name of the vector of names for the systematics to be used for the creation of
+                                       // a parallel container. This will be just a copy of the nominal one with the sys name appended.
+                                       // Use cases: MET-specific systematics. 
+  
   float         m_systValReco;
   float         m_systValIso;
   float         m_systValTrig;
@@ -96,6 +101,8 @@ private:
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
   std::vector<CP::SystematicSet> m_systListTTVA; //!
+
+  std::vector<std::string> m_sysNames; //!
 
   // tools
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;     //!

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -108,7 +108,7 @@ class OverlapRemover : public xAH::Algorithm
   bool m_doEleEleOR;
 
   /** @brief Output systematics list container name */
-  std::string  m_outputAlgo;
+  std::string  m_outputAlgoSystNames;
 
   /** @brief Input container name */
   std::string  m_inContainerName_Electrons;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -60,6 +60,7 @@ public:
   std::string m_jetSystsVec;
   std::string m_photonSystsVec;
   std::string m_fatJetSystsVec;
+  std::string m_metSystsVec;
 
   bool m_DC14;
   float m_units;


### PR DESCRIPTION
O bit of restyle for the handling of vectors holding sys unc names for the MET. Nothing major, just eliminating 
useless code. In addition to this, the MuonEfficiencyCorrector module now supports the possibility of creating a "parallel" systematic container for a specified set of systematic uncertainties. This is just a deep copy of the nominal container but is not decorated with all the systematic unc. of the scale factors. This feature is necessary when writing out sys trees related to the MET which should include the nominal list of muons for which eff sys decorations are unnecessary. The same option does not exist (yet) for electrons as all eff sys uncertainties are taken into account also for sys trees. This is still tolerable with a small set of such systematics like we use atm.