### PR TITLE
adds a configurable member for AFII on/off for the electron eff corr

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -54,6 +54,8 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string classNam
   m_inContainerName         = "";
   m_outContainerName        = "";
 
+  m_setAFII                 = false;
+
   // Systematics stuff
   //
   m_inputAlgoSystNames      = "";
@@ -170,11 +172,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   int sim_flav(1); // default for FullSim
   if ( m_isMC ) {
     const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
-    if ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) {
+    if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ) {
       Info("initialize()", "Setting simulation flavour to AFII");
       sim_flav = 3;
     }
-    else if ( stringMeta.empty() ) {
+    else if ( !m_setAFII && stringMeta.empty() ) {
       Warning("initialize()", "No meta-data string found. Simulation flavour will be set to FullSim. Care if you are running on Fast-Sim MC.");
     }
   }

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -39,6 +39,9 @@ public:
   std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
                                        // the downstream algos. We need that as we deepcopy the input containers
 
+  /** @brief Force AFII flag in calibration, in case metadata is broken */
+  bool m_setAFII;
+
   float m_systValPID;
   float m_systValIso;
   float m_systValReco;


### PR DESCRIPTION
This adds a configurable m_setAFII member. The same is already implemented in the electron calibrator: 

https://github.com/UCATLAS/xAODAnaHelpers/blob/master/Root/ElectronCalibrator.cxx#L202