### PR TITLE
allow jet container to be decorated without removing jets that fail fJVT

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -104,6 +104,7 @@ JetSelector :: JetSelector (std::string className) :
   m_JVFCut                  = 0.5;
   m_doJVT                   = false;
   m_dofJVT                  = false;
+  m_dofJVTVeto              = true;
 
   m_pt_max_JVT              = 60e3;
   m_eta_max_JVT             = 2.4;
@@ -848,12 +849,12 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   } // m_doJVF
 
   if(m_dofJVT){
-    if(!jet->auxdata<char>("passFJVT")=='1'){
+    if(jet->auxdata<char>("passFJVT")!=1){
       if(m_debug) {
 	Info("passCuts()","jet pt = %.1f,eta = %.1f,phi = %.1f",jet->pt(),jet->eta(),jet->phi());
         Info("PassCuts()","Failed forward JVT");
       }
-      return 0;
+      if(m_dofJVTVeto)return 0;
     }
     else if (m_debug && TMath::Abs(jet->eta()>2.5) ) {
       Info("passCuts()","jet pt = %.1f,eta = %.1f,phi = %.1f",jet->pt(),jet->eta(),jet->phi());

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -72,6 +72,7 @@ public:
   float m_JVFCut;                 // cut value
   bool m_doJVT;                   // check JVT
   bool m_dofJVT;                  // check forward JVT 
+  bool m_dofJVTVeto;              // Remove jets that fail fJVT. Like JVT, the default is to clean the collection
   float m_pt_max_JVT;             // max pT (JVT is a pileup cut)
   float m_eta_max_JVT;            // detector eta cut
 


### PR DESCRIPTION
Not quite ready to remove all jets that fail fJVT! Best to study in more detail. Now allowing container to be decorated but not remove  jets. Default is still like JVT, where jets are removed though.