### PR TITLE
Migrate wiki fully to header documentation

### DIFF
--- a/docs/Algorithms.rst
+++ b/docs/Algorithms.rst
@@ -9,30 +9,7 @@ TStore will manage the memory for the user.
 Event Selection
 ---------------
 
-BasicEventSelection
-~~~~~~~~~~~~~~~~~~~
-
-This algorithm performs the very basic event selection. This should be
-the first algo in the algo chain. It can create weighted and unweighted
-cutflow objects to be picked up downstream by other xAH algos, and your
-own. The selection applied in **data** only is:
-
-1. GRL ( can be turned off )
-2. LAr Error
-3. Tile Error
-4. Core Flag
-
-For **MC** only, the pileup reweight can be applied.
-
-In **both** data and simulation the following cuts are applied 1. the
-highest sum pT^2 PV has 2 or more tracks 2. trigger requirements
-
-For derivations the MetaData can be accessed and added to the cutflow
-for normalization
-
-The parameters to control the trigger and all cuts in general are
-described in the header documentation:
-https://github.com/UCATLAS/xAODAnaHelpers/wiki/xAH\_BasicEventSelection.h
+(moved to BasicEventSelection.h)
 
 Jet Related
 -----------
@@ -179,19 +156,19 @@ MuonEfficiencyCorrector
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Produces a container of muons decorated with efficiencies and scale factors.
-This container is not simply the one in input, but is a deepCopy of that. 
+This container is not simply the one in input, but is a deepCopy of that.
 This allows flexibility in decorating muons of systematically altered containers.
 The output container has a configurable name and is only created for MC events.
-When working with systematic uncertainties, a list of systematics is passed 
-to this algorithm *m_inputAlgoSystNames*\. This algorithm supports comma 
-separated lists as inputs, which will be considered as a unique list. The 
-systematic names in this list will be looked for to retrieve the muon containers 
-to decorate. Systematic variations on the decorations themselves might be 
-unnecessary for all systematic muon containers and might only be considered 
-for the nominal container (need of deepCopy). This is the default configuration. 
-Otherwise the  option *m_decorateWithNomOnInputSys*\ can be set to false. 
+When working with systematic uncertainties, a list of systematics is passed
+to this algorithm *m_inputAlgoSystNames*\. This algorithm supports comma
+separated lists as inputs, which will be considered as a unique list. The
+systematic names in this list will be looked for to retrieve the muon containers
+to decorate. Systematic variations on the decorations themselves might be
+unnecessary for all systematic muon containers and might only be considered
+for the nominal container (need of deepCopy). This is the default configuration.
+Otherwise the  option *m_decorateWithNomOnInputSys*\ can be set to false.
 The algorithm features the option *m_sysNamesForParCont*\ which is a list of systematic
-names. For each of them, a copy of the nominal muon container is put in the 
+names. For each of them, a copy of the nominal muon container is put in the
 store carrying the name of the systematic. These containers are only decorated
 with the nominal efficiencies and scale factors. The use case of this are MET
 systematics for which one does not want systematic variations on efficiencies,

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -31,66 +31,111 @@ namespace Trig {
   class TrigDecisionTool;
 }
 
+/**
+  @rst
+    This algorithm performs the very basic event selection. This should be the first algo in the algo chain. It can create weighted and unweighted cutflow objects to be picked up downstream by other xAH algos, and your own. The selection applied in data only is:
+
+      - GRL (can be turned off)
+      - LAr Error
+      - Tile Error
+      - Core Flag
+
+    .. note:: For MC only, the pileup reweight can also be applied.
+
+    In both data and simulation (MC), the following cuts are applied
+
+      - the highest sum :math:`p_{T}^2` primary vertex has 2 or more tracks (see :cpp:member:`~BasicEventSelection::m_applyPrimaryVertexCut`)
+      - trigger requirements (see :cpp:member:`~BasicEventSelection::m_applyTriggerCut`)
+
+    For derivations, the metadata can be accessed and added to the cutflow for normalization. The parameters to control the trigger are described in this header file. If one wants to write out some of the trigger information into a tree using :cpp:class:`~HelpTreeBase`, flags must be set here.
+
+  @endrst
+*/
 class BasicEventSelection : public xAH::Algorithm
 {
-  // put your configuration variables here as public variables.
-  // that way they can be set directly from CINT and python.
   public:
-    // variables read in through configuration file
-
+    /// @brief Protection when running on truth xAOD
     bool m_truthLevelOnly;
 
-    // GRL
+  // GRL
+    /// @brief Apply GRL selection
     bool m_applyGRLCut;
+    /// @brief Path to GRL XML file
     std::string m_GRLxml;
+    /// @brief Run numbers to skip in GRL
     std::string m_GRLExcludeList;
 
-    // Clean Powheg huge weight
+  // Clean Powheg huge weight
     bool m_cleanPowheg;
 
-    // Reweight Sherpa 2.2 Samples
+  // Reweight Sherpa 2.2 Samples
     bool  m_reweightSherpa22;
 
-    //PU Reweighting
+  //PU Reweighting
+    /**
+      @rst
+        Reweight pile-up profile :math:`\mu`
+      @endrst
+    */
     bool m_doPUreweighting;
     bool m_doPUreweightingSys;
+    /// @brief Comma separated list of filenames
     std::string m_lumiCalcFileNames;
+    /// @brief Comma separated list of filenames
     std::string m_PRWFileNames;
 
     // Unprescaling data
     bool m_savePrescaleDataWeight;
 
-    // Primary Vertex
+  // Primary Vertex
+    /// @brief Name of vertex container
     std::string m_vertexContainerName;
+    /// @brief Enable to apply a primary vertex cut
     bool m_applyPrimaryVertexCut;
+    /// @brief Minimum number of tracks from **the** primary vertex (Harmonized Cut)
     int m_PVNTrack;
 
-    // Event Cleaning
+  // Event Cleaning
     bool m_applyEventCleaningCut;
     bool m_applyCoreFlagsCut;
 
     // Print Branch List
     bool m_printBranchList;
 
-    // Trigger
+  // Trigger
     /**
-       @brief Decisions of Triggers listed in m_triggerSelection are saved and cut on depending on m_applyTriggerCut
+      @rst
+        RegEx expression to choose triggers to consider to be cut on with :cpp:member:`~BasicEventSelection::m_applyTriggerCut`
+      @endrst
     */
     std::string m_triggerSelection;
 
-    /**
-       @brief Decisions of Triggers listed in m_extraTriggerSelection are saved but not cut on
-    */
+    /// @brief Decisions of triggers which are saved but not cut on
     std::string m_extraTriggerSelection;
 
+    /**
+      @rst
+        Skip events in which the trigger string :cpp:member:`~BasicEventSelection::m_triggerSelection` does not fire
+      @endrst
+    */
     bool m_applyTriggerCut;
+    /**
+      @rst
+        Save string of fired triggers matching :cpp:member:`~BasicEventSelection::m_triggerSelection`
+      @endrst
+    */
     bool m_storeTrigDecisions;
+    /// @brief Save if any L1 trigger fired, e.g. ``"L1_.*"``
     bool m_storePassL1;
+    /// @brief Save if any HLT trigger fired, e.g. ``"HLT_.*"``
     bool m_storePassHLT;
+    /// @brief Save master, L1, and HLT key
     bool m_storeTrigKeys;
 
-    // Metadata
+  // Metadata
+    /// @brief The name of the derivation
     std::string m_derivationName;
+    /// @brief Retrieve and save information on DAOD selection
     bool m_useMetaData;
 
     /* Output Stream Names */
@@ -158,7 +203,7 @@ class BasicEventSelection : public xAH::Algorithm
     TH1D* m_truth_cutflowHist_1; //!
 
     /** TTree for duplicates bookeeping */
-    
+
     TTree*   m_duplicatesTree;  //!
     int      m_duplRunNumber;
     long int m_duplEventNumber;

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -15,26 +15,52 @@
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
 
+/**
+  @rst
+    This is the algorithm class used to calibrate electrons.
+
+    In a nutshell, this algorithm performs the following actions:
+
+      - retrieves an ``xAOD::ElectronContainer`` from either ``TEvent`` or ``TStore``
+      - makes a shallow copy container and fills it with energy-and-direction calibrated electrons using the ``EgammaCalibrationAndSmearingTool`` in `Tools Used <ToolsUsed.html>`__
+      - saves the shallow copy container to ``TStore`` from where it can be retrieved by algorithms downstream via name lookup
+
+  @endrst
+*/
 class ElectronCalibrator : public xAH::Algorithm
 {
   // put your configuration variables here as public variables.
   // that way they can be set directly from CINT and python.
 public:
-  // configuration variables
+// configuration variables
+  /// @brief The name of the input container for this algorithm to read from ``TEvent`` or ``TStore``
   std::string m_inContainerName;
+  /**
+      @brief The name of the nominal output container written by the algorithm to ``TStore``
+
+      If the algorithm applies systematic variations, for each shallow copy saved to ``TStore``, the systematic name will be appended to this.
+  */
   std::string m_outContainerName;
 
-  // sort after calibration
+  /// Sort the processed container elements by transverse momentum
   bool    m_sort;
 
 
-  // systematics
-  std::string m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
-  			             // upstream algo (e.g., the SC containers with calibration systematics)
-  std::string m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers produced by THIS
-  				     // algo ( these will be the m_inputAlgoSystNames of the algo downstream
-  float       m_systVal;
-  std::string m_systName;
+// systematics
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers from the upstream algorithm, which will be processed by this algorithm.
+
+    This vector is retrieved from the ``TStore``. If left blank, it means there is no upstream algorithm which applies systematics. This is the case when processing straight from the original ``xAOD`` or ``DxAOD``.
+  */
+  std::string m_inputAlgoSystNames;
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers created by by this algorithm.
+
+    @rst
+      If :cpp:member:`~xAH::Algorithm::m_systName` is empty, the vector will contain only an empty string. When running on systematics, this is the string a downstream algorithm needs to process electrons.
+    @endrst
+  */
+  std::string m_outputAlgoSystNames;
 
   std::string m_esModel;
   std::string m_decorrelationModel;
@@ -59,7 +85,7 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool *m_EgammaCalibrationAndSmearingTool; //!
-  CP::IsolationCorrectionTool          *m_IsolationCorrectionTool;          //! /* apply leakage correction to calo based isolation variables for electrons */
+  CP::IsolationCorrectionTool          *m_IsolationCorrectionTool;          //! // apply leakage correction to calo based isolation variables for electrons
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -23,21 +23,50 @@
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
 
+/**
+  @rst
+    This is the algorithm class that applies generic corrections to electrons. At the moment, only data/MC efficiency correction is included (electron trigger SF and others will follow...).
+
+    In a nutshell, this algorithm performs the following actions:
+
+      - retrieves an ``xAOD::ElectronContainer`` from either ``TEvent`` or ``TStore``
+      - adds a scale factor (SF) decoration for each electron in the input container calculated via the ``AsgElectronEfficiencyCorrectionTool`` in `Tools Used <ToolsUsed.html>`__
+      - the nominal SF and all the systematically-varied ones are saved as a ``vector<double>`` decoration for each electron
+
+    .. note:: Bear in mind that this algorithm must be called after :cpp:class:`~ElectronSelector`. In fact, the configuration file(s) being used must have the same working point as the one chosen in the selector.
+
+  @endrst
+*/
 class ElectronEfficiencyCorrector : public xAH::Algorithm
 {
-  // put your configuration variables here as public variables.
-  // that way they can be set directly from CINT and python.
 public:
-  // configuration variables
+  /// @brief The name of the input container for this algorithm to read from ``TEvent`` or ``TStore``
   std::string  m_inContainerName;
+  /**
+      @brief The name of the nominal output container written by the algorithm to ``TStore``
+
+      If the algorithm applies systematic variations, for each shallow copy saved to ``TStore``, the systematic name will be appended to this.
+  */
   std::string  m_outContainerName;
 
-  // systematics
-  std::string   m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
-  			               // upstream algo (e.g., the SC containers with calibration systematics)
-  
-  std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
-                                       // the downstream algos. We need that as we deepcopy the input containers
+// systematics
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers from the upstream algorithm, which will be processed by this algorithm.
+
+    This vector is retrieved from the ``TStore``. If left blank, it means there is no upstream algorithm which applies systematics. This is the case when processing straight from the original ``xAOD`` or ``DxAOD``.
+  */
+  std::string m_inputAlgoSystNames;
+
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers created by by this algorithm.
+
+    @rst
+      If :cpp:member:`~xAH::Algorithm::m_systName` is empty, the vector will contain only an empty string. When running on systematics, this is the string a downstream algorithm needs to process electrons.
+
+      .. note:: We need this as we deep-copy the input containers.
+    @endrst
+  */
+  std::string   m_outputAlgoSystNames;
 
   /** @brief Force AFII flag in calibration, in case metadata is broken */
   bool m_setAFII;
@@ -75,8 +104,8 @@ private:
   std::string m_IsoPID_WP; //!
 
   std::string m_WorkingPointIDTrig;  //!
-  std::string m_WorkingPointIsoTrig; //! 
-  std::string m_WorkingPointTrigTrig; //! 
+  std::string m_WorkingPointIsoTrig; //!
+  std::string m_WorkingPointTrigTrig; //!
 
   std::vector<CP::SystematicSet> m_systListPID;  //!
   std::vector<CP::SystematicSet> m_systListIso;  //!

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -30,60 +30,118 @@ namespace Trig {
   class MatchingTool;
 }
 
+/**
+  @rst
+    This is the algorithm class that selects electrons according to user's choice.
+
+    In a nutshell, this algorithm performs the following actions:
+
+      - retrieves an ``xAOD::ElectronContainer`` from either ``TEvent`` or ``TStore``
+      - iterates over the input container, and if electron passes selection, copies it in a ``ConstDataVector(SG::VIEW_ELEMENTS)`` container. Otherwise, the electron is skipped
+      - saves the view container to ``TStore``, from where it can be retrieved by algorithms downstream via a name lookup
+
+  @endrst
+*/
 class ElectronSelector : public xAH::Algorithm
 {
-  /*
-  put your configuration variables here as public variables.
-  that way they can be set directly from CINT and python.
-
-  variables that don't get filled at submission time should be
-  protected from being send from the submission node to the worker
-  node (done by the //!)
-  */
-
 public:
 
   bool m_useCutFlow;
 
   /* configuration variables */
 
-  std::string    m_inContainerName;          /* input container name */
-  std::string    m_outContainerName;         /* output container name */
-  std::string    m_outAuxContainerName;      /* output auxiliary container name */
+  /// @brief The name of the input container for this algorithm read from ``TEvent`` or ``TStore``
+  std::string    m_inContainerName;
+  /// @brief The name of the nominal output container written by the algorithm to ``TStore``
+  std::string    m_outContainerName;
+
+// systematics
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers from the upstream algorithm, which will be processed by this algorithm.
+
+    This vector is retrieved from the ``TStore``. If left blank, it means there is no upstream algorithm which applies systematics. This is the case when processing straight from the original ``xAOD`` or ``DxAOD``.
+  */
   std::string    m_inputAlgoSystNames;
+  /**
+    @brief The name of the vector containing the names of the systematically-varied containers created by by this algorithm.
+
+    @rst
+      If :cpp:member:`~xAH::Algorithm::m_systName` is empty, the vector will contain only an empty string. When running on systematics, this is the string a downstream algorithm needs to process electrons.
+    @endrst
+  */
   std::string    m_outputAlgoSystNames;
-  bool       	 m_decorateSelectedObjects;  /* decorate selected objects - default "passSel" */
-  bool       	 m_createSelectedContainer;  /* fill using SG::VIEW_ELEMENTS to be light weight */
-  int        	 m_nToProcess;  	     /* look at n objects */
-  int        	 m_pass_min;		     /* minimum number of objects passing cuts */
-  int        	 m_pass_max;		     /* maximum number of objects passing cuts */
-  float      	 m_pT_max;		     /* require pT < pt_max */
-  float      	 m_pT_min;		     /* require pT > pt_min */
-  float      	 m_eta_max;		     /* require |eta| < eta_max */
-  bool	     	 m_vetoCrack;		     /* require |eta| outside crack region */
-  float      	 m_d0_max;		     /* require d0 < m_d0_max */
-  float      	 m_d0sig_max;		     /* require d0 significance (at BL) < m_d0sig_max */
-  float	     	 m_z0sintheta_max;	     /* require z0*sin(theta) (at BL - corrected with vertex info) < m_z0sintheta_max */
+
+  /// @brief Adds a ``passSel`` decoration for objects that pass selection
+  bool       	 m_decorateSelectedObjects;
+  /// @brief Fill using a read-only container (``SG::VIEW_ELEMENTS``) to ``TStore``
+  bool       	 m_createSelectedContainer;
+  /// @brief Number of objects to process, set ``n=-1`` to look at all
+  int        	 m_nToProcess;
+  /// @brief Require event to have minimum number of objects passing selection
+  int        	 m_pass_min;
+  /// @brief Require event to have maximum number of objects passing selection
+  int        	 m_pass_max;
+  /// @brief [MeV] Require objects to have maximum transverse momentum threshold
+  float      	 m_pT_max;
+  /// @brief [MeV] Require objects to have minimum transverse momentum threshold
+  float      	 m_pT_min;
+  /**
+    @rst
+      Require objects to have maximum :math:`|\eta|` value
+    @endrst
+  */
+  float      	 m_eta_max;
+  /**
+    @rst
+      Require objects to have :math:`|\eta|` outside the crack region using ``caloCluster->eta()``
+    @endrst
+  */
+  bool	     	 m_vetoCrack;
+  /**
+    @rst
+      Require objects to have a maximum :math:`d_{0}` [mm] (transverse impact parameter)
+    @endrst
+  */
+  float      	 m_d0_max;
+  /**
+    @rst
+      Require objects to have a maximum :math:`d_{0}` significance at BL
+    @endrst
+  */
+  float      	 m_d0sig_max;
+  /**
+    @rst
+      Require objects to have maximum :math:`z_{0}\sin(\theta)` [mm] (longitudinal impact paramter) at BL - corrected with vertex info
+    @endrst
+  */
+  float	     	 m_z0sintheta_max;
+  /// @brief Perform author kinematic cut
   bool           m_doAuthorCut;
+  /// @brief Perform object quality cut
   bool           m_doOQCut;
 
   ///// electron PID /////
 
   /** @brief To read electron PID decision from DAOD, rather than recalculate with tool */
   bool           m_readIDFlagsFromDerivation;
-  /** @brief Performs the Likelihood PID B-Layer cut locally.
-   * @note Occurs automatically only if :cpp:member:`xAH::ElectronSelector::m_LHOperatingPoint` is LooseBL and :cpp:member:`xAH::ElectronSelector::m_readIDFlagsFromDerivation`` is true */
+  /**
+    @brief Performs the Likelihood PID B-Layer cut locally.
+    @rst
+      .. note:: Occurs automatically only if :cpp:member:`~ElectronSelector::m_LHOperatingPoint` is ``LooseBL`` and :cpp:member:`~ElectronSelector::m_readIDFlagsFromDerivation` is ``true``
+
+    @endrst
+  */
   bool           m_doBLTrackQualityCut;
 
-  //// likelihood-based  ////
+//// likelihood-based  ////
   /** @brief Instantiate and perform the electron Likelihood PID */
   bool           m_doLHPID;
-  /** @brief Cut on electron Likelihood PID */
+  /** @brief Cut on electron Likelihood PID (recommended) */
   bool           m_doLHPIDcut;
   /** @brief Loosest Likelihood PID operating point to save */
   std::string    m_LHOperatingPoint;
 
-  //// cut-based ////
+//// cut-based ////
   /** @brief Instantiate and perform the electron cut-based PID */
   bool           m_doCutBasedPID;
   /** @brief Cut on electron cut-based PID */
@@ -91,17 +149,29 @@ public:
   /** @brief Loosest cut-based PID operating point to save */
   std::string    m_CutBasedOperatingPoint;
 
-  /* isolation */
+/* isolation */
+  /** @brief reject objects which do not pass this isolation cut - default = "" (no cut) */
+  std::string    m_MinIsoWPCut;
+  /** @brief decorate objects with ``isIsolated_*`` flag for each WP in this input list - default = all current ASG WPs */
+  std::string    m_IsoWPList;
+  /** @rst
+     to define a custom WP - make sure ``"UserDefined"`` is added in :cpp:member:`~ElectronSelector::m_IsoWPList`
+  @endrst */
+  std::string    m_CaloIsoEff;
+  /** @rst
+     to define a custom WP - make sure ``"UserDefined"`` is added in :cpp:member:`~ElectronSelector::m_IsoWPList`
+  @endrst */
+  std::string    m_TrackIsoEff;
+  /** @rst
+     to define a custom WP - make sure ``"UserDefined"`` is added in :cpp:member:`~ElectronSelector::m_IsoWPList`
+  @endrst */
+  std::string    m_CaloBasedIsoType;
+  /** @rst
+     to define a custom WP - make sure ``"UserDefined"`` is added in :cpp:member:`~ElectronSelector::m_IsoWPList`
+  @endrst */
+  std::string    m_TrackBasedIsoType;
 
-  std::string    m_MinIsoWPCut;              /* reject objects which do not pass this isolation cut - default = "" (no cut) */
-  std::string    m_IsoWPList;                /* decorate objects with 'isIsolated_*' flag for each WP in this input list - default = all current ASG WPs */
-  std::string    m_CaloIsoEff;               /* to define a custom WP - make sure "UserDefined" is added in the above input list! */
-  std::string    m_TrackIsoEff;              /* to define a custom WP - make sure "UserDefined" is added in the above input list! */
-  std::string    m_CaloBasedIsoType;         /* to define a custom WP - make sure "UserDefined" is added in the above input list! */
-  std::string    m_TrackBasedIsoType;        /* to define a custom WP - make sure "UserDefined" is added in the above input list! */
-
-  /* trigger matching */
-
+/* trigger matching */
   std::string    m_singleElTrigChains;   /* A comma-separated string w/ alll the HLT single electron trigger chains for which you want to perform the matching.
   			      	            This is passed by the user as input in configuration
 				            If left empty (as it is by default), no trigger matching will be attempted at all */
@@ -112,16 +182,31 @@ public:
 
 private:
 
+  /// @brief the name of the auxiliary store for the output container
+  std::string    m_outAuxContainerName;
+
+  /// @brief keep track of the total number of events processed
   int m_numEvent;           //!
+  /// @brief keep track of the total number of objects processed
   int m_numObject;          //!
+  /** @rst
+    keep track of the number of passed events, and fill the cutflow (relevant only if using the algo to skim events: see :cpp:member:`~ElectronSelector::m_pass_max` and :cpp:member:`~ElectronSelector::m_pass_min` above)
+  @endrst */
   int m_numEventPass;       //!
+  /** @rst
+    keep track of the number of weighted passed events, and fill the cutflow (relevant only if using the algo to skim events: see :cpp:member:`~ElectronSelector::m_pass_max` and :cpp:member:`~ElectronSelector::m_pass_min` above)
+  @endrst */
   int m_weightNumEventPass; //!
+  /// @brief keep track of the number of selected objects
   int m_numObjectPass;      //!
 
-  /* event-level cutflow */
+/* event-level cutflow */
 
+  /// @brief histogram for event cutflow
   TH1D* m_cutflowHist;      //!
+  /// @brief histgram for weighted event cutflow
   TH1D* m_cutflowHistW;     //!
+  /// @brief index of bin corresponding to this step of the full cutflow
   int   m_cutflow_bin;      //!
 
   bool  m_isUsedBefore;     //!
@@ -148,11 +233,14 @@ private:
 
   /* tools */
 
+  /// @brief MC15 ASG tool for isolation
   asg::AnaToolHandle<CP::IsolationSelectionTool> m_isolationSelectionTool_handle; //!
   std::string m_isolationSelectionTool_name;                                      //!
 
   /* PID manager(s) */
+  /// @brief class to manage LH PID selection/decorations - see ISSUE for explaination
   ElectronLHPIDManager*                    m_el_LH_PIDManager;        //!
+  /// @brief class to manage cut-based PID selection/decorations - see ISSUE for explaination
   ElectronCutBasedPIDManager*              m_el_CutBased_PIDManager;  //!
   Trig::TrigDecisionTool*                  m_trigDecTool;             //!
   asg::AnaToolHandle<Trig::MatchingTool>   m_trigElectronMatchTool_handle;  //!
@@ -161,8 +249,14 @@ private:
 
   /* other private members */
 
-  std::vector<std::string>            m_singleElTrigChainsList;  //!  /* contains all the HLT trigger chains tokens extracted from m_singleElTrigChains */
-  std::vector<std::string>            m_diElTrigChainsList;      //!  /* contains all the HLT trigger chains tokens extracted from m_diElTrigChains */
+  /** @rst
+    contains all the HLT trigger chains tokens extracted from :cpp:member:`~ElectronSelector::m_singleElTrigChains`
+  @endrst */
+  std::vector<std::string>            m_singleElTrigChainsList;  //!
+  /** @rst
+    contains all the HLT trigger chains tokens extracted from :cpp:member:`~ElectronSelector::m_diElTrigChains`
+  @endrst */
+  std::vector<std::string>            m_diElTrigChainsList;      //!
 
 public:
 

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -28,49 +28,93 @@
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
 
+/** @rst
+  A wrapper to a few JetETMiss packages. By setting the configuration parameters detailed in the header documentation, one can:
+
+    - calibrate a given jet collection
+    - apply systematic variations for JES
+    - apply systematic variations for JER
+    - decorate the jet with the decision of the Jet Cleaning tool
+
+  When considering systematics, a new ``xAOD::JetCollection`` is created for each systematic variation. The names are then saved in a vector for downstream algorithms to use.
+
+@endrst */
 class JetCalibrator : public xAH::Algorithm
 {
-  // put your configuration variables here as public variables.
-  // that way they can be set directly from CINT and python.
 public:
-  // configuration variables
+  /// @brief The name of the input container for this algorithm to read from ``TEvent`` or ``TStore``
   std::string m_inContainerName;
+  /**
+      @brief The name of the nominal output container written by the algorithm to ``TStore``
+
+      If the algorithm applies systematic variations, for each shallow copy saved to ``TStore``, the systematic name will be appended to this.
+  */
   std::string m_outContainerName;
 
+  /// @brief set to ``AntiKt4EMTopo`` for ``AntiKt4EMTopoJets``
   std::string m_jetAlgo;
+  /// @brief name of vector holding names of jet systematics given by the JetEtmiss Tools
   std::string m_outputAlgo;
+  /// @brief config for JetCalibrationTool for Data
   std::string m_calibConfigData;
+  /// @brief config for JetCalibrationTool for Full Sim MC
   std::string m_calibConfigFullSim;
+  /// @brief config for JetCalibrationTool for AFII MC
   std::string m_calibConfigAFII;
+  /// @brief config files actually passed to JetCalibrationTool chosen from the above depending on what information stored in the input file
   std::string m_calibConfig;
+  /// @brief List of calibration steps. "Insitu" added automatically if running on data
   std::string m_calibSequence;
+  /// @brief config for JES Uncertainty Tool
   std::string m_JESUncertConfig;
+  /// @brief JetUncertaintiesTool parameter
   std::string m_JESUncertMCType;
+  /** @rst
+    If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.
+
+    With SampleHandler, one can define sample metadata in job steering macro. You can do this with relevant samples doing something like:
+
+    .. code-block:: c++
+
+      // access a single sample
+      Sample *sample = sh.get ("mc14_13TeV.blahblahblah");
+      sample->setMetaString("SimulationFlavour", "AFII");
+
+  @endrst */
   bool m_setAFII;
   bool m_forceInsitu;
 
-  bool m_isTrigger; // whether the jet collection is trigger or not (soon: different calibrations)
+  /// @brief whether the jet collection is trigger or not (soon: different calibrations)
+  bool m_isTrigger;
 
+  // @brief Config for JER Uncert Tool. If not empty the tool will run
   std::string m_JERUncertConfig;
+  /// @brief Set systematic mode as Full (true) or Simple (false)
   bool m_JERFullSys;
+  /// @brief Apply nominal smearing
   bool m_JERApplyNominal;
 
-  /** @brief enable to apply jet cleaning decoration */
+  /// @brief enable to apply jet cleaning decoration
   bool m_doCleaning;
+  /// @brief Cut Level
   std::string m_jetCleanCutLevel;
+  /// @brief Save all cleaning decisions as decorators
   bool m_saveAllCleanDecisions;
+  /// @brief Do Ugly cleaning ( i.e. TileGap 3 )
   bool m_jetCleanUgly;
+  /// @brief Recalculate JVT using the calibrated jet pT
   bool m_redoJVT;
-  // sort after calibration
+  /// @brief Sort the processed container elements by transverse momentum
   bool    m_sort;
-  //Apply jet cleaning to parent jet
+  /// @brief Apply jet cleaning to parent jet
   bool    m_cleanParent;
   bool    m_applyFatJetPreSel;
 
-  // systematics
+// systematics
+  /// @brief set to true if systematics asked for and exist
   bool m_runSysts;
 
-  // jet tile correction
+  /// @brief jet tile correction
   bool m_doJetTileCorr;
 
 private:
@@ -99,13 +143,7 @@ private:
   asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle; //!
 
 
-  // variables that don't get filled at submission time should be
-  // protected from being send from the submission node to the worker
-  // node (done by the //!)
 public:
-  // Tree *myTree; //!
-  // TH1 *myHist; //!
-
 
   // this is a standard constructor
   JetCalibrator (std::string className = "JetCalibrator");


### PR DESCRIPTION
This fully closes #330 !

As this gets closed, the wiki will be disabled on the GitHub repo in favor of documentation available in the header files. For future documentation change/requests, issues should be labeled with `[docs]` appropriately.