### PR TITLE
[skip ci] add here

### DIFF
--- a/docs/Installing.rst
+++ b/docs/Installing.rst
@@ -74,7 +74,7 @@ This step requires a little extra work, but compiles significantly faster. First
 
 .. parsed-literal::
 
-  asetup AnalysisBase,\ |ab_release_cm|\
+  asetup AnalysisBase,\ |ab_release_cm|\,here
 
 This also sets up a ``CMakeLists.txt`` file in this top-level directory that searches for all packages you've checked out inside it. Next, you will need a build directory that builds all your checked-out packages which is separate from your source code:
 


### PR DESCRIPTION
Docs are missing `asetup,...,here` which needs to be added for CMakeLists.txt to be generated automatically.