### PR TITLE
Migrate algorithms to empty constructors and use ATH_MSG_XXX

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -22,7 +22,8 @@ xAH::Algorithm::Algorithm(std::string className) :
   m_isMC(-1),
   m_event(nullptr),
   m_store(nullptr),
-  m_className(className)
+  m_className(className),
+  m_registered(false)
 {
 }
 
@@ -31,6 +32,7 @@ xAH::Algorithm::~Algorithm()
 }
 
 StatusCode xAH::Algorithm::algInitialize(){
+    // register an instance of the the class
     registerInstance();
     return StatusCode::SUCCESS;
 }
@@ -40,10 +42,11 @@ StatusCode xAH::Algorithm::algFinalize(){
     return StatusCode::SUCCESS;
 }
 
-xAH::Algorithm* xAH::Algorithm::setName(std::string name){
+xAH::Algorithm* xAH::Algorithm::SetName(std::string name){
   m_name = name;
   // call the TNamed
-  this->SetName(name.c_str());
+  //EL::Algorithm::SetName((m_className+"."+name).c_str());
+  EL::Algorithm::SetName(name.c_str());
   return this;
 }
 
@@ -89,7 +92,9 @@ int xAH::Algorithm::isMC(){
 }
 
 void xAH::Algorithm::registerInstance(){
+    if(m_registered) return;
     m_instanceRegistry[m_className]++;
+    m_registered = true;
 }
 
 int xAH::Algorithm::numInstances(){

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -13,6 +13,7 @@ std::map<std::string, int> xAH::Algorithm::m_instanceRegistry = {};
 ClassImp(xAH::Algorithm)
 
 xAH::Algorithm::Algorithm(std::string className) :
+  m_debugLevel(MSG::INFO),
   m_debug(false),
   m_verbose(false),
   m_systName(""),
@@ -33,7 +34,8 @@ xAH::Algorithm::~Algorithm()
 StatusCode xAH::Algorithm::algInitialize(){
     // register an instance of the the class
     registerInstance();
-    if(!m_name.empty()) SetName(m_name.c_str());
+    SetName(m_name.c_str());
+    msg().setLevel(m_debugLevel);
     return StatusCode::SUCCESS;
 }
 

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -15,7 +15,6 @@ ClassImp(xAH::Algorithm)
 xAH::Algorithm::Algorithm(std::string className) :
   m_debugLevel(MSG::INFO),
   m_debug(false),
-  m_verbose(false),
   m_systName(""),
   m_systVal(0),
   m_eventInfoContainerName("EventInfo"),
@@ -46,7 +45,6 @@ StatusCode xAH::Algorithm::algFinalize(){
 
 xAH::Algorithm* xAH::Algorithm::setLevel(int level){
   m_debug = level & 1;
-  m_verbose = (level >> 1)&1;
   return this;
 }
 

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -14,7 +14,6 @@ ClassImp(xAH::Algorithm)
 
 xAH::Algorithm::Algorithm(std::string className) :
   m_debugLevel(MSG::INFO),
-  m_debug(false),
   m_systName(""),
   m_systVal(0),
   m_eventInfoContainerName("EventInfo"),
@@ -43,11 +42,6 @@ StatusCode xAH::Algorithm::algFinalize(){
     return StatusCode::SUCCESS;
 }
 
-xAH::Algorithm* xAH::Algorithm::setLevel(int level){
-  m_debug = level & 1;
-  return this;
-}
-
 StatusCode xAH::Algorithm::parseSystValVector(){
 
     std::stringstream ss(m_systValVectorString);
@@ -69,13 +63,13 @@ int xAH::Algorithm::isMC(){
   const xAOD::EventInfo* ei(nullptr);
   // couldn't retrieve it
   if(!HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store, msg()).isSuccess()){
-    if(m_debug) ATH_MSG_WARNING( "Could not retrieve eventInfo container: " << m_eventInfoContainerName);
+    ATH_MSG_DEBUG( "Could not retrieve eventInfo container: " << m_eventInfoContainerName);
     return -1;
   }
 
   static SG::AuxElement::ConstAccessor<uint32_t> eventType("eventTypeBitmask");
   if(!eventType.isAvailable(*ei)){
-    if(m_debug) ATH_MSG_WARNING( "eventType is not available.");
+    ATH_MSG_DEBUG( "eventType is not available.");
     return -1;
   }
 

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -34,6 +34,7 @@ StatusCode xAH::Algorithm::algInitialize(){
     registerInstance();
     SetName(m_name.c_str());
     msg().setLevel(m_debugLevel);
+    m_debug = msg().msgLevel(MSG::DEBUG);
     return StatusCode::SUCCESS;
 }
 

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -73,7 +73,7 @@ int xAH::Algorithm::isMC(){
 
   const xAOD::EventInfo* ei(nullptr);
   // couldn't retrieve it
-  if(!HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store).isSuccess()){
+  if(!HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store, msg()).isSuccess()){
     if(m_debug) ATH_MSG_WARNING( "Could not retrieve eventInfo container: " << m_eventInfoContainerName);
     return -1;
   }

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -13,16 +13,15 @@ std::map<std::string, int> xAH::Algorithm::m_instanceRegistry = {};
 ClassImp(xAH::Algorithm)
 
 xAH::Algorithm::Algorithm(std::string className) :
-  m_name(""),
   m_debug(false),
   m_verbose(false),
   m_systName(""),
   m_systVal(0),
   m_eventInfoContainerName("EventInfo"),
   m_isMC(-1),
+  m_className(className),
   m_event(nullptr),
   m_store(nullptr),
-  m_className(className),
   m_registered(false)
 {
 }
@@ -34,20 +33,13 @@ xAH::Algorithm::~Algorithm()
 StatusCode xAH::Algorithm::algInitialize(){
     // register an instance of the the class
     registerInstance();
+    if(!m_name.empty()) SetName(m_name.c_str());
     return StatusCode::SUCCESS;
 }
 
 StatusCode xAH::Algorithm::algFinalize(){
     unregisterInstance();
     return StatusCode::SUCCESS;
-}
-
-xAH::Algorithm* xAH::Algorithm::SetName(std::string name){
-  m_name = name;
-  // call the TNamed
-  //EL::Algorithm::SetName((m_className+"."+name).c_str());
-  EL::Algorithm::SetName(name.c_str());
-  return this;
 }
 
 xAH::Algorithm* xAH::Algorithm::setLevel(int level){
@@ -99,7 +91,7 @@ void xAH::Algorithm::registerInstance(){
 
 int xAH::Algorithm::numInstances(){
     if(m_instanceRegistry.find(m_className) == m_instanceRegistry.end()){
-        printf("numInstances: we seem to have recorded zero instances of %s. This should not happen.", m_className.c_str());
+        msg() << MSG::ERROR << "numInstances: we seem to have recorded zero instances of " << m_className << ". This should not happen." << endmsg;
         return 0;
     }
     return m_instanceRegistry.at(m_className);
@@ -107,7 +99,7 @@ int xAH::Algorithm::numInstances(){
 
 void xAH::Algorithm::unregisterInstance(){
     if(m_instanceRegistry.find(m_className) == m_instanceRegistry.end()){
-        printf("unregisterInstance: we seem to have recorded zero instances of %s. This should not happen.", m_className.c_str());
+        msg() << MSG::ERROR << "unregisterInstance: we seem to have recorded zero instances of " << m_className << ". This should not happen." << endmsg;
     }
     m_instanceRegistry[m_className]--;
 }

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -123,7 +123,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   m_store = wk()->xaodStore();
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("BJetEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("BJetEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
   ATH_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
@@ -320,7 +320,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
   // retrieve event
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   if ( m_debug ) ATH_MSG_INFO( "\n\n eventNumber: " << eventInfo->eventNumber() << std::endl );
 
   //
@@ -335,7 +335,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
   if ( m_inputAlgo.empty() ) {
 
     // this will be the collection processed - no matter what!!
-    RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, msg()) ,"");
 
     executeEfficiencyCorrection( inJets, eventInfo, true);
 
@@ -349,7 +349,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
     // get vector of string giving the names
     //
     std::vector<std::string>* systNames(nullptr);
-    RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, msg()) ,"");
 
     //
     // loop over systematics
@@ -358,7 +358,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
 
       bool doNominal = (systName == "");
 
-      RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName+systName, m_event, m_store, msg()) ,"");
 
       executeEfficiencyCorrection( inJets, eventInfo, doNominal );
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -45,7 +45,6 @@ BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
   //ATH_MSG_INFO( "Calling constructor");
 
   // read flags set from .config file
-  m_debug                   = false;
   m_inContainerName         = "";
   m_inputAlgo               = "";
   m_systName                = "";      // default: no syst
@@ -251,16 +250,15 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   //
   // Print out
   //
-  if( !m_systName.empty() && m_debug && m_getScaleFactors ) {
-    std::cout << "-----------------------------------------------------" << std::endl;
+  if( !m_systName.empty() && m_getScaleFactors ) {
+    ATH_MSG_DEBUG("-----------------------------------------------------");
     const std::map<CP::SystematicVariation, std::vector<std::string> > allowed_variations = m_BJetEffSFTool->listSystematics();
-    std::cout << "Allowed systematics variations for tool " << m_BJetEffSFTool->name() << ":" << std::endl;
+    ATH_MSG_DEBUG("Allowed systematics variations for tool " << m_BJetEffSFTool->name() << ":");
     for (auto var : allowed_variations) {
-      std::cout << std::setw(40) << std::left << var.first.name() << ":";
-      for (auto flv : var.second) std::cout << " " << flv;
-      std::cout << std::endl;
+      ATH_MSG_DEBUG(std::setw(40) << std::left << var.first.name() << ":");
+      for (auto flv : var.second) ATH_MSG_DEBUG("\t" << flv);
     }
-    std::cout << "-----------------------------------------------------" << std::endl;
+    ATH_MSG_DEBUG("-----------------------------------------------------");
   }
 
 
@@ -269,9 +267,9 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     CP::SystematicSet affectSysts = m_BJetEffSFTool->affectingSystematics();
     // Convert into a simple list
     std::vector<CP::SystematicSet> affectSystList = CP::make_systematics_vector(affectSysts);
-    if( !m_systName.empty() && m_debug ) {
+    if( !m_systName.empty() ) {
       for ( const auto& syst_it : affectSystList ){
-        ATH_MSG_INFO(" tool can be affected by systematic: " << syst_it.name());
+        ATH_MSG_DEBUG(" tool can be affected by systematic: " << syst_it.name());
       }
     }
 
@@ -280,10 +278,8 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     // Convert into a simple list -- nominal is included already here!!
     m_systList = CP::make_systematics_vector(recSysts);
     if( !m_systName.empty() ) {
-      if(m_debug){
-        for ( const auto& syst_it : m_systList ){
-          ATH_MSG_INFO(" available recommended systematic: " << syst_it.name());
-        }
+      for ( const auto& syst_it : m_systList ){
+        ATH_MSG_DEBUG(" available recommended systematic: " << syst_it.name());
       }
     } else { // remove all but the nominal
       std::vector<CP::SystematicSet>::iterator syst_it = m_systList.begin();
@@ -314,14 +310,14 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 
 EL::StatusCode BJetEfficiencyCorrector :: execute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Applying BJet Efficency Corrector... "); }
+  ATH_MSG_DEBUG( "Applying BJet Efficency Corrector... ");
 
   //
   // retrieve event
   //
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("BJetEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
-  if ( m_debug ) ATH_MSG_INFO( "\n\n eventNumber: " << eventInfo->eventNumber() << std::endl );
+  ATH_MSG_DEBUG("\n\n eventNumber: " << eventInfo->eventNumber() << std::endl );
 
   //
   //  input jets
@@ -366,7 +362,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
 
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Leave Efficency Selection... "); }
+  ATH_MSG_DEBUG( "Leave Efficency Selection... ");
 
   return EL::StatusCode::SUCCESS;
 
@@ -379,7 +375,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 								      const xAOD::EventInfo* eventInfo,
 								      bool doNominal)
 {
-  if(m_debug) ATH_MSG_INFO( "Applying BJet Cuts and Efficiency Correction (when applicable...) ");
+  ATH_MSG_DEBUG("Applying BJet Cuts and Efficiency Correction (when applicable...) ");
 
   //
   // Create Scale Factor aux for all jets
@@ -412,7 +408,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     //
     if ( !doNominal ) {
       if( syst_it.name() != "" ) {
-        if ( m_debug ) ATH_MSG_INFO("Not running B-tag systematics when doing JES systematics");
+        ATH_MSG_DEBUG("Not running B-tag systematics when doing JES systematics");
         continue;
       }
     }
@@ -423,7 +419,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     //
     if ( !m_runAllSyst ) {
       if( syst_it.name() != m_systName ) {
-        if ( m_debug ) ATH_MSG_INFO("Not running systematics only apply nominal SF");
+        ATH_MSG_DEBUG("Not running systematics only apply nominal SF");
         continue;
       }
     }
@@ -432,7 +428,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     // Create the name of the weight
     //   template:  SYSNAME
     //
-    if ( m_debug ) ATH_MSG_INFO( "systematic variation name is: " << syst_it.name());
+    ATH_MSG_DEBUG("systematic variation name is: " << syst_it.name());
     sysVariationNames->push_back(syst_it.name());
 
     //
@@ -444,7 +440,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
         ATH_MSG_ERROR( "Failed to configure BJetEfficiencyCorrections for systematic " << syst_it.name());
         return EL::StatusCode::FAILURE;
       }
-      if(m_debug) ATH_MSG_INFO( "Successfully applied systematic: " << syst_it.name());
+      ATH_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());
     }
 
     bool tagged(false);
@@ -494,7 +490,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
       if(doNominal) SF_GLOBAL *= SF;
 
       /*
-      if( m_getScaleFactors && m_debug){
+      if( m_getScaleFactors){
         //
         // directly obtain reco efficiency
         //
@@ -508,30 +504,26 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
       }
       */
 
-      if ( m_debug ) {
-         ATH_MSG_INFO( "===>>>");
-         ATH_MSG_INFO( " ");
-	 ATH_MSG_INFO( "Jet " << idx << " pt = " << jet_itr->pt()*1e-3 << " GeV , eta = " << jet_itr->eta() );
-	 ATH_MSG_INFO( " ");
-	 ATH_MSG_INFO( "BTag SF decoration: " << m_decorSF );
-	 ATH_MSG_INFO( " ");
-         ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-         ATH_MSG_INFO( " ");
-         ATH_MSG_INFO( "BTag SF:");
-         ATH_MSG_INFO( "\t from tool = " << SF << ", from object = " << sfVec(*jet_itr).back());
-         ATH_MSG_INFO( "--------------------------------------");
-       }
+       ATH_MSG_DEBUG( "===>>>");
+       ATH_MSG_DEBUG( " ");
+       ATH_MSG_DEBUG( "Jet " << idx << " pt = " << jet_itr->pt()*1e-3 << " GeV , eta = " << jet_itr->eta() );
+       ATH_MSG_DEBUG( " ");
+       ATH_MSG_DEBUG( "BTag SF decoration: " << m_decorSF );
+       ATH_MSG_DEBUG( " ");
+       ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+       ATH_MSG_DEBUG( " ");
+       ATH_MSG_DEBUG( "BTag SF:");
+       ATH_MSG_DEBUG( "\t from tool = " << SF << ", from object = " << sfVec(*jet_itr).back());
+       ATH_MSG_DEBUG( "--------------------------------------");
       ++idx;
 
     } // close jet loop
 
     // For *this* systematic, store the global SF weight for the event
-    if ( m_debug ) {
-       ATH_MSG_INFO( "--------------------------------------");
-       ATH_MSG_INFO( "GLOBAL BTag SF for event:");
-       ATH_MSG_INFO( "\t " << SF_GLOBAL );
-       ATH_MSG_INFO( "--------------------------------------");
-    }
+    ATH_MSG_DEBUG( "--------------------------------------");
+    ATH_MSG_DEBUG( "GLOBAL BTag SF for event:");
+    ATH_MSG_DEBUG( "\t " << SF_GLOBAL );
+    ATH_MSG_DEBUG( "--------------------------------------");
 
     //
     //  Add the SF only if doing nominal Jets
@@ -547,10 +539,8 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   if(doNominal){
     RETURN_CHECK( "BJetEfficiencyCorrector::execute()", m_store->record( sysVariationNames, m_outputSystName), "Failed to record vector of systematic names.");
 
-    if(m_debug){
-      std::cout << "Size is " << sysVariationNames->size() << std::endl;
-      for(auto sysName : *sysVariationNames) std::cout << sysName << std::endl;
-    }
+    ATH_MSG_DEBUG("Size is " << sysVariationNames->size());
+    for(auto sysName : *sysVariationNames) ATH_MSG_DEBUG(sysName);
   }
 
   return EL::StatusCode::SUCCESS;
@@ -559,7 +549,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
 EL::StatusCode BJetEfficiencyCorrector :: postExecute ()
 {
-  if(m_debug) ATH_MSG_INFO( "Calling postExecute");
+  ATH_MSG_DEBUG("Calling postExecute");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -30,8 +30,8 @@ using HelperClasses::ToolName;
 ClassImp(BJetEfficiencyCorrector)
 
 
-BJetEfficiencyCorrector :: BJetEfficiencyCorrector (std::string className) :
-    Algorithm(className),
+BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
+    Algorithm("BJetEfficiencyCorrector"),
     m_BJetSelectTool(nullptr),
     m_BJetEffSFTool(nullptr)
 {
@@ -42,7 +42,7 @@ BJetEfficiencyCorrector :: BJetEfficiencyCorrector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   // read flags set from .config file
   m_debug                   = false;

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -61,7 +61,6 @@ BasicEventSelection :: BasicEventSelection () :
   //ATH_MSG_INFO( "Calling constructor");
 
   // basics
-  m_debug = false;
   m_truthLevelOnly = false;
 
   // override derivation name

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -373,7 +373,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
   RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
-  if ( m_debug ) { ATH_MSG_INFO( "Is MC? " << static_cast<int>(m_isMC) ); }
+  ATH_MSG_DEBUG( "Is MC? " << static_cast<int>(m_isMC) );
 
   //Protection in case GRL does not apply to this run
   //
@@ -660,17 +660,15 @@ EL::StatusCode BasicEventSelection :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if( m_debug ) { ATH_MSG_INFO( "Basic Event Selection"); }
+  ATH_MSG_DEBUG( "Basic Event Selection");
 
   // Print every 1000 entries, so we know where we are:
   //
   if ( (m_eventCounter % 1000) == 0 ) {
     ATH_MSG_INFO( "Entry number = " << m_eventCounter);
-    if ( m_verbose ) {
-      ATH_MSG_INFO( "Store Content:");
-      m_store->print();
-      ATH_MSG_INFO( "End Content");
-    }
+    ATH_MSG_VERBOSE( "Store Content:");
+    ATH_EXEC_VERBOSE(m_store->print());
+    ATH_MSG_VERBOSE( "End Content");
   }
 
   //-----------------------------------------
@@ -788,7 +786,7 @@ EL::StatusCode BasicEventSelection :: execute ()
       float weight_Sherpa22 = -999.;
       weight_Sherpa22 = m_reweightSherpa22_tool_handle->getWeight();
       weight_Sherpa22Decor( *eventInfo ) = weight_Sherpa22;
-      if( m_debug)  ATH_MSG_INFO("Setting Sherpa 2.2 reweight to " << weight_Sherpa22);
+      ATH_MSG_DEBUG("Setting Sherpa 2.2 reweight to " << weight_Sherpa22);
 
     } // If not already decorated
   } // if m_reweightSherpa22
@@ -822,7 +820,7 @@ EL::StatusCode BasicEventSelection :: execute ()
 
     if ( m_RunNr_VS_EvtNr.find(thispair) != m_RunNr_VS_EvtNr.end() ) {
 
-      if ( m_debug ) { ATH_MSG_WARNING("Found duplicated event! runNumber = " << static_cast<uint32_t>(eventInfo->runNumber()) << ", eventNumber = " << static_cast<uint32_t>(eventInfo->eventNumber()) << ". Skipping this event"); }
+      ATH_MSG_WARNING("Found duplicated event! runNumber = " << static_cast<uint32_t>(eventInfo->runNumber()) << ", eventNumber = " << static_cast<uint32_t>(eventInfo->eventNumber()) << ". Skipping this event");
 
       // Bookkeep info in duplicates TTree
       //
@@ -868,15 +866,11 @@ EL::StatusCode BasicEventSelection :: execute ()
   //------------------------------------------------------
   if ( !m_isMC ) {
 
-    if ( m_debug ) {
+    // Get the streams that the event was put in
+    const std::vector<  xAOD::EventInfo::StreamTag > streams = eventInfo->streamTags();
 
-      // Get the streams that the event was put in
-      const std::vector<  xAOD::EventInfo::StreamTag > streams = eventInfo->streamTags();
-
-      for ( auto& it : streams ) {
-	 const std::string stream_name = it.name();
-	 ATH_MSG_INFO( "event has fired stream: " << stream_name );
-      }
+    for ( auto& stream : streams ) {
+      ATH_MSG_DEBUG( "event has fired stream: " << stream.name() );
     }
 
     // GRL

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -30,8 +30,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(BasicEventSelection)
 
-BasicEventSelection :: BasicEventSelection (std::string className) :
-    Algorithm(className),
+BasicEventSelection :: BasicEventSelection () :
+    Algorithm("BasicEventSelection"),
     m_grl(nullptr),
     m_pileup_tool_handle("CP::PileupReweightingTool/Pileup"),
     m_trigConfTool(nullptr),
@@ -58,7 +58,7 @@ BasicEventSelection :: BasicEventSelection (std::string className) :
   // called on both the submission and the worker node.  Most of your
   // initialization code will go into histInitialize() and
   // initialize().
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   // basics
   m_debug = false;

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -370,7 +370,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
   }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
   if ( m_debug ) { ATH_MSG_INFO( "Is MC? " << static_cast<int>(m_isMC) ); }
@@ -712,7 +712,7 @@ EL::StatusCode BasicEventSelection :: execute ()
   // Grab event
   //------------------
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("BasicEventSelection::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("BasicEventSelection::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   //------------------------------------------------------------------------------------------
   // Declare an 'eventInfo' decorator with the MC event weight
@@ -931,7 +931,7 @@ EL::StatusCode BasicEventSelection :: execute ()
 
   const xAOD::VertexContainer* vertices(nullptr);
   if ( !m_truthLevelOnly && m_applyPrimaryVertexCut ) {
-    RETURN_CHECK("BasicEventSelection::execute()", HelperFunctions::retrieve(vertices, m_vertexContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("BasicEventSelection::execute()", HelperFunctions::retrieve(vertices, m_vertexContainerName, m_event, m_store, msg()) ,"");
 
     if ( !HelperFunctions::passPrimaryVertexSelection( vertices, m_PVNTrack ) ) {
       wk()->skipEvent();

--- a/Root/ClusterHistsAlgo.cxx
+++ b/Root/ClusterHistsAlgo.cxx
@@ -18,7 +18,6 @@ ClusterHistsAlgo :: ClusterHistsAlgo () :
 {
   m_inContainerName         = "";
   m_detailStr               = "";
-  m_debug                   = false;
 
 }
 

--- a/Root/ClusterHistsAlgo.cxx
+++ b/Root/ClusterHistsAlgo.cxx
@@ -66,7 +66,7 @@ EL::StatusCode ClusterHistsAlgo :: initialize ()
 EL::StatusCode ClusterHistsAlgo :: execute ()
 {
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ClusterHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ClusterHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
 
   float eventWeight(1);
@@ -75,7 +75,7 @@ EL::StatusCode ClusterHistsAlgo :: execute ()
   }
 
   const xAOD::CaloClusterContainer* ccls(nullptr);
-  RETURN_CHECK("ClusterHistsAlgo::execute()", HelperFunctions::retrieve(ccls, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ClusterHistsAlgo::execute()", HelperFunctions::retrieve(ccls, m_inContainerName, m_event, m_store, msg()) ,"");
 
   RETURN_CHECK("ClusterHistsAlgo::execute()", m_plots->execute( ccls, eventWeight ), "");
 

--- a/Root/ClusterHistsAlgo.cxx
+++ b/Root/ClusterHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ClusterHistsAlgo)
 
-ClusterHistsAlgo :: ClusterHistsAlgo (std::string className) :
-    Algorithm(className),
+ClusterHistsAlgo :: ClusterHistsAlgo () :
+    Algorithm("ClusterHistsAlgo"),
     m_plots(nullptr)
 {
   m_inContainerName         = "";

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -96,8 +96,6 @@ EL::StatusCode DebugTool :: initialize ()
 
 EL::StatusCode DebugTool :: execute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( " "); }
-
   ATH_MSG_INFO( m_name);
 
   //
@@ -114,7 +112,7 @@ EL::StatusCode DebugTool :: execute ()
 
 EL::StatusCode DebugTool :: postExecute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG("Calling postExecute");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/DebugTool.cxx
+++ b/Root/DebugTool.cxx
@@ -37,11 +37,11 @@
 ClassImp(DebugTool)
 
 
-DebugTool :: DebugTool (std::string className) :
-    Algorithm(className),
+DebugTool :: DebugTool () :
+    Algorithm("DebugTool"),
     m_printStore(false)
 {
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 }
 
 EL::StatusCode DebugTool :: setupJob (EL::Job& job)

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -373,7 +373,7 @@ EL::StatusCode ElectronCalibrator :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -58,8 +58,6 @@ ElectronCalibrator :: ElectronCalibrator () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
-
   // input container to be read from TEvent or TStore
   //
   m_inContainerName         = "";
@@ -218,7 +216,7 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
-  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
+  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, msg() );
 
   ATH_MSG_INFO("Will be using EgammaCalibrationAndSmearingTool systematic:");
   std::vector< std::string >* SystElectronsNames = new std::vector< std::string >;
@@ -262,7 +260,7 @@ EL::StatusCode ElectronCalibrator :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Electron Calibration ... "); }
+  ATH_MSG_DEBUG("Applying Electron Calibration ... ");
 
   m_numEvent++;
 
@@ -320,11 +318,9 @@ EL::StatusCode ElectronCalibrator :: execute ()
       // set smearing seeding if needed - no need for this after Base,2.1.26
       // m_EgammaCalibrationAndSmearingTool->setRandomSeed(eventInfo->eventNumber() + 100 * idx);
       //
-      if ( m_debug ) {
-	ATH_MSG_INFO("Checking electron "<<idx<<", raw pt = "<<elSC_itr->pt()*1e-3<<" GeV ");
-	if ( elSC_itr->pt() > 7e3 && !(elSC_itr->caloCluster()) ){
-	  ATH_MSG_WARNING( "electron " << idx << ", raw pt = " << elSC_itr->pt() * 1e-3 << " GeV, does not have caloCluster()! " );
-	}
+      ATH_MSG_DEBUG("Checking electron "<<idx<<", raw pt = "<<elSC_itr->pt()*1e-3<<" GeV ");
+      if ( elSC_itr->pt() > 7e3 && !(elSC_itr->caloCluster()) ){
+        ATH_MSG_DEBUG( "electron " << idx << ", raw pt = " << elSC_itr->pt() * 1e-3 << " GeV, does not have caloCluster()! " );
       }
 
       // apply calibration (w/ syst) and leakage correction to calo based iso vars
@@ -338,7 +334,7 @@ EL::StatusCode ElectronCalibrator :: execute ()
 	}
       }
 
-      if ( m_debug ) { ATH_MSG_INFO( "Calibrated pt with systematic: " << syst_it.name() <<" , pt = " << elSC_itr->pt() * 1e-3 << " GeV"); }
+      ATH_MSG_DEBUG( "Calibrated pt with systematic: " << syst_it.name() <<" , pt = " << elSC_itr->pt() * 1e-3 << " GeV");
 
       ++idx;
 
@@ -384,7 +380,7 @@ EL::StatusCode ElectronCalibrator :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG("Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -44,8 +44,8 @@ using HelperClasses::ToolName;
 ClassImp(ElectronCalibrator)
 
 
-ElectronCalibrator :: ElectronCalibrator (std::string className) :
-    Algorithm(className),
+ElectronCalibrator :: ElectronCalibrator () :
+    Algorithm("ElectronCalibrator"),
     m_EgammaCalibrationAndSmearingTool(nullptr),
     m_IsolationCorrectionTool(nullptr)
 {
@@ -56,7 +56,7 @@ ElectronCalibrator :: ElectronCalibrator (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -167,7 +167,7 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   // Check if is MC
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_debug) ,"");
+  RETURN_CHECK("ElectronCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
 
   m_numEvent      = 0;
@@ -269,9 +269,9 @@ EL::StatusCode ElectronCalibrator :: execute ()
   // get the collection from TEvent or TStore
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   const xAOD::ElectronContainer* inElectrons(nullptr);
-  RETURN_CHECK("ElectronCalibrator::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronCalibrator::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName, m_event, m_store, msg()) ,"");
 
   // loop over available systematics - remember syst == EMPTY_STRING --> baseline
   // prepare a vector of the names of CDV containers

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -350,7 +350,7 @@ EL::StatusCode ElectronCalibrator :: execute ()
 
     // save pointers in ConstDataVector with same order
     //
-    RETURN_CHECK( "ElectronCalibrator::execute()", HelperFunctions::makeSubsetCont(calibElectronsSC.first, calibElectronsCDV), "");
+    RETURN_CHECK( "ElectronCalibrator::execute()", HelperFunctions::makeSubsetCont(calibElectronsSC.first, calibElectronsCDV, msg()), "");
 
     // Sort after copying to CDV.
     if ( m_sort ) {

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -53,7 +53,7 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
 
     m_n_LHMedium = 0;
     m_LHMedium = new std::vector<int>   ();
-    
+
     m_n_LHTight = 0;
     m_LHTight = new std::vector<int>   ();
 
@@ -69,17 +69,17 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    
+
     m_TrigEff_SF = new std::map< std::string, std::vector< std::vector< float > > >();
     m_TrigMCEff  = new std::map< std::string, std::vector< std::vector< float > > >();
     m_IsoEff_SF  = new std::map< std::string, std::vector< std::vector< float > > >();
-    
+
     m_RecoEff_SF                  = new std::vector< std::vector< float > > ();
     m_PIDEff_SF_LHLooseAndBLayer  = new std::vector< std::vector< float > > ();
     m_PIDEff_SF_LHLoose           = new std::vector< std::vector< float > > ();
     m_PIDEff_SF_LHMedium          = new std::vector< std::vector< float > > ();
     m_PIDEff_SF_LHTight           = new std::vector< std::vector< float > > ();
-    
+
   }
 
   if ( m_infoSwitch.m_trackparams ) {
@@ -117,14 +117,14 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     // default trigger working points if no user input
     if ( !m_infoSwitch.m_trigWPs.size() ) m_infoSwitch.m_trigWPs = {"SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0"};
 
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
-      for (auto& isol : m_infoSwitch.m_isolWPs) {
-        for (auto& trig : m_infoSwitch.m_trigWPs) {
-          Info("ElectronConainer()", "Used working points: %s_%s_%s", trig.c_str(), PID.c_str(), isol.c_str() );
-        }
-      }
-    }
-  }   
+    //for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    //  for (auto& isol : m_infoSwitch.m_isolWPs) {
+    //    for (auto& trig : m_infoSwitch.m_trigWPs) {
+    //      Info("ElectronConainer()", "Used working points: %s_%s_%s", trig.c_str(), PID.c_str(), isol.c_str() );
+    //    }
+    //  }
+    //}
+  }
 
 
 }
@@ -297,7 +297,7 @@ void ElectronContainer::setTree(TTree *tree)
         }
       }
     }
-    
+
     connectBranch<std::vector<float> >(tree, "RecoEff_SF"  ,                &m_RecoEff_SF  );
     connectBranch<std::vector<float> >(tree, "PIDEff_SF_LHLooseAndBLayer",  &m_PIDEff_SF_LHLooseAndBLayer);
     connectBranch<std::vector<float> >(tree, "PIDEff_SF_LHLoose",           &m_PIDEff_SF_LHLoose);
@@ -334,7 +334,7 @@ void ElectronContainer::setTree(TTree *tree)
 
 void ElectronContainer::updateParticle(uint idx, Electron& elec)
 {
-  ParticleContainer::updateParticle(idx,elec);  
+  ParticleContainer::updateParticle(idx,elec);
 
   if ( m_infoSwitch.m_kinematic ) {
     elec.caloCluster_eta = m_caloCluster_eta -> at(idx);
@@ -346,7 +346,7 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
     elec.isTrigMatchedToChain  =     m_isTrigMatchedToChain  ->at(idx);
     elec.listTrigChains        =     m_listTrigChains        ->at(idx);
   }
-    
+
   // isolation
   if ( m_infoSwitch.m_isolation ) {
     elec.isIsolated_LooseTrackOnly                =     m_isIsolated_LooseTrackOnly                  ->at(idx);
@@ -370,18 +370,18 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
     elec.topoetcone30                             =     m_topoetcone30                               ->at(idx);
     elec.topoetcone40                             =     m_topoetcone40                               ->at(idx);
   }
-  
+
   // quality
   if ( m_infoSwitch.m_PID ) {
-    elec.LHLoose       = m_LHLoose    ->at(idx);   
-    elec.LHLooseBL     = m_LHLooseBL  ->at(idx);   
-    elec.LHMedium      = m_LHMedium   ->at(idx);   
-    elec.LHTight       = m_LHTight    ->at(idx);   
-    elec.IsEMLoose     = m_IsEMLoose  ->at(idx);   
-    elec.IsEMMedium    = m_IsEMMedium ->at(idx);   
-    elec.IsEMTight     = m_IsEMTight  ->at(idx);   
+    elec.LHLoose       = m_LHLoose    ->at(idx);
+    elec.LHLooseBL     = m_LHLooseBL  ->at(idx);
+    elec.LHMedium      = m_LHMedium   ->at(idx);
+    elec.LHTight       = m_LHTight    ->at(idx);
+    elec.IsEMLoose     = m_IsEMLoose  ->at(idx);
+    elec.IsEMMedium    = m_IsEMMedium ->at(idx);
+    elec.IsEMTight     = m_IsEMTight  ->at(idx);
   }
-  
+
   // scale factors w/ sys
   // per object
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -506,7 +506,7 @@ void ElectronContainer::setBranches(TTree *tree)
         }
       }
     }
-    
+
     setBranch<vector<float> >(tree, "RecoEff_SF"  ,                m_RecoEff_SF  );
     setBranch<vector<float> >(tree, "PIDEff_SF_LHLooseAndBLayer",  m_PIDEff_SF_LHLooseAndBLayer);
     setBranch<vector<float> >(tree, "PIDEff_SF_LHLoose",           m_PIDEff_SF_LHLoose);
@@ -545,7 +545,7 @@ void ElectronContainer::setBranches(TTree *tree)
 
 void ElectronContainer::clear()
 {
-  
+
   ParticleContainer::clear();
 
   if ( m_infoSwitch.m_kinematic ) {
@@ -591,7 +591,7 @@ void ElectronContainer::clear()
 
     m_n_LHMedium = 0;
     m_LHMedium   -> clear();
-    
+
     m_n_LHTight = 0;
     m_LHTight   -> clear();
 
@@ -607,7 +607,7 @@ void ElectronContainer::clear()
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    
+
     for (auto& PID : m_infoSwitch.m_PIDWPs) {
       for (auto& isol : m_infoSwitch.m_isolWPs) {
         if(!isol.empty())
@@ -624,7 +624,7 @@ void ElectronContainer::clear()
     m_PIDEff_SF_LHLoose           -> clear();
     m_PIDEff_SF_LHMedium          -> clear();
     m_PIDEff_SF_LHTight           -> clear();
-    
+
   }
 
   if ( m_infoSwitch.m_trackparams ) {
@@ -658,7 +658,7 @@ void ElectronContainer::FillElectron( const xAOD::Electron* elec, const xAOD::Ve
   return FillElectron(static_cast<const xAOD::IParticle*>(elec), primaryVertex);
 }
 
-void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAOD::Vertex* primaryVertex ) 
+void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAOD::Vertex* primaryVertex )
 {
 
   ParticleContainer::FillParticle(particle);
@@ -693,7 +693,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
     }
 
     m_isTrigMatchedToChain->push_back(matches);
-    
+
     // if at least one match among the chains is found, say this electron is trigger matched
     if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_isTrigMatched->push_back(1); }
     else { m_isTrigMatched->push_back(0); }
@@ -793,7 +793,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
   if ( m_infoSwitch.m_trackparams ) {
     if ( trk ) {
-    
+
       //
       // NB.:
       // All track parameters are calculated at the perigee, i.e., the point of closest approach to the origin of some r.f. (which in RunII is NOT the ATLAS detector r.f!).
@@ -802,15 +802,15 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       // The coordinates of this r.f. wrt. the ATLAS system origin are returned by means of vx(), vy(), vz()
       //
       m_trkd0->push_back( trk->d0() );
-      
+
       static SG::AuxElement::Accessor<float> d0SigAcc ("d0sig");
       float d0_significance =  ( d0SigAcc.isAvailable( *elec ) ) ? fabs( d0SigAcc( *elec ) ) : -1.0;
       m_trkd0sig->push_back( d0_significance );
       m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
-      
+
       static SG::AuxElement::Accessor<float> z0sinthetaAcc("z0sintheta");
       float z0sintheta =  ( z0sinthetaAcc.isAvailable( *elec ) ) ? z0sinthetaAcc( *elec ) : -999.0;
-    
+
       m_trkz0sintheta->push_back( z0sintheta );
       m_trkphi0->push_back( trk->phi0() );
       m_trktheta->push_back( trk->theta() );
@@ -818,7 +818,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       m_trkqOverP->push_back( trk->qOverP() );
 
     } else {
-        
+
       m_trkd0->push_back( -999.0 );
       m_trkd0sig->push_back( -1.0 );
       m_trkz0->push_back( -999.0 );
@@ -872,10 +872,10 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
         if(!isol.empty()) {
           std::string IsoSF = "EleEffCorr_IsoSyst_" + PID + "_" + isol;
           accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( PID+isol , SG::AuxElement::Accessor< std::vector< float > >( IsoSF ) ) );
-          if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) { 
-            m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) ); 
-          } else { 
-            m_IsoEff_SF->at( PID+isol ).push_back( junkSF ); 
+          if( (accIsoSF.at( PID+isol )).isAvailable( *elec ) ) {
+            m_IsoEff_SF->at( PID+isol ).push_back( (accIsoSF.at( PID+isol ))( *elec ) );
+          } else {
+            m_IsoEff_SF->at( PID+isol ).push_back( junkSF );
           }
         }
 
@@ -883,18 +883,18 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
           std::string TrigSF = "EleEffCorr_TrigSyst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
           accTrigSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigSF ) ) );
-          if( (accTrigSF.at( trig+PID+isol )).isAvailable( *elec ) ) { 
-            m_TrigEff_SF->at( trig+PID+isol ).push_back( (accTrigSF.at( trig+PID+isol ))( *elec ) ); 
-          }else { 
-            m_TrigEff_SF->at( trig+PID+isol ).push_back( junkSF ); 
+          if( (accTrigSF.at( trig+PID+isol )).isAvailable( *elec ) ) {
+            m_TrigEff_SF->at( trig+PID+isol ).push_back( (accTrigSF.at( trig+PID+isol ))( *elec ) );
+          }else {
+            m_TrigEff_SF->at( trig+PID+isol ).push_back( junkSF );
           }
 
           std::string TrigEFF = "EleEffCorr_TrigMCEffSyst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
           accTrigEFF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigEFF ) ) );
-          if( (accTrigEFF.at( trig+PID+isol )).isAvailable( *elec ) ) { 
-            m_TrigMCEff->at( trig+PID+isol ).push_back( (accTrigEFF.at( trig+PID+isol ))( *elec ) ); 
-          } else { 
-            m_TrigMCEff->at( trig+PID+isol ).push_back( junkEff ); 
+          if( (accTrigEFF.at( trig+PID+isol )).isAvailable( *elec ) ) {
+            m_TrigMCEff->at( trig+PID+isol ).push_back( (accTrigEFF.at( trig+PID+isol ))( *elec ) );
+          } else {
+            m_TrigMCEff->at( trig+PID+isol ).push_back( junkEff );
           }
 
         }

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -30,8 +30,8 @@ using HelperClasses::ToolName;
 ClassImp(ElectronEfficiencyCorrector)
 
 
-ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string className) :
-    Algorithm(className),
+ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
+    Algorithm("ElectronEfficiencyCorrector"),
     m_asgElEffCorrTool_elSF_PID(nullptr),
     m_asgElEffCorrTool_elSF_Iso(nullptr),
     m_asgElEffCorrTool_elSF_Reco(nullptr),
@@ -45,7 +45,7 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector (std::string classNam
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -162,7 +162,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
   m_numEvent      = 0;
@@ -511,7 +511,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
 
   if ( m_debug ) { ATH_MSG_INFO( "Applying Electron Efficiency Correction... "); }
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // initialise containers
   //
@@ -531,7 +531,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
     // if electrons are only allowed in systematic instances, hence, we have to check for the existence of the nominal container
     //
     if ( m_store->contains<xAOD::ElectronContainer>( m_inContainerName )  ) {
-       RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+       RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, msg()) ,"");
 
        if ( m_debug ) { ATH_MSG_INFO( "Number of electrons: " << static_cast<int>(inputElectrons->size()) ); }
 
@@ -547,7 +547,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
       // get vector of string giving the syst names of the upstream algo m_inputAlgo (rememeber: 1st element is a blank string: nominal case!)
       //
       std::vector<std::string>* systNames(nullptr);
-      RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+      RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) ,"");
 
     	// loop over systematic sets available
 	//
@@ -559,13 +559,13 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
 
           if ( m_store->contains<xAOD::ElectronContainer>( m_inContainerName+systName )  ) {
 
-             RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
+             RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName+systName, m_event, m_store, msg()) ,"");
 
              if ( !m_store->contains<xAOD::ElectronContainer>( m_outContainerName+systName ) ) {
                RETURN_CHECK("ElectronEfficiencyCorrector::execute()", (HelperFunctions::makeDeepCopy<xAOD::ElectronContainer, xAOD::ElectronAuxContainer, xAOD::Electron>(m_store, m_outContainerName+systName, inputElectrons)), "");
              }
 
-             RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputElectrons, m_outContainerName+systName, m_event, m_store, m_verbose) ,"");
+             RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputElectrons, m_outContainerName+systName, m_event, m_store, msg()) ,"");
 
              if ( m_debug ){
                  ATH_MSG_INFO( "Number of electrons: " << static_cast<int>(outputElectrons->size()) );

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -47,8 +47,6 @@ ElectronEfficiencyCorrector :: ElectronEfficiencyCorrector () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
-
   // input container to be read from TEvent or TStore
   //
   m_inContainerName         = "";
@@ -186,7 +184,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   if ( !m_corrFileNamePID.empty() ) {
 
-    m_PID_WP = HelperFunctions::parse_wp( "ID", m_corrFileNamePID );
+    m_PID_WP = HelperFunctions::parse_wp( "ID", m_corrFileNamePID, msg() );
 
     if ( m_PID_WP.empty() ) {
       ATH_MSG_ERROR( "ID working point for electronID SF not found in config file! This should not happen. Exiting." );
@@ -211,22 +209,20 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_PID->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool PID");
     }
 
-    if ( m_debug ) {
+    // Get a list of affecting systematics
+   //
+    CP::SystematicSet affectSystsPID = m_asgElEffCorrTool_elSF_PID->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsPID ) { ATH_MSG_DEBUG("AsgElectronEfficiencyCorrectionTool can be affected by PID efficiency systematic: " << syst_it.name()); }
 
-      // Get a list of affecting systematics
-     //
-      CP::SystematicSet affectSystsPID = m_asgElEffCorrTool_elSF_PID->affectingSystematics();
-      //
-      // Convert into a simple list
-      //
-      for ( const auto& syst_it : affectSystsPID ) { ATH_MSG_INFO("AsgElectronEfficiencyCorrectionTool can be affected by PID efficiency systematic: " << syst_it.name()); }
-    }
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsPID = m_asgElEffCorrTool_elSF_PID->recommendedSystematics();
-    m_systListPID = HelperFunctions::getListofSystematics( recSystsPID, m_systNamePID, m_systValPID, m_debug );
+    m_systListPID = HelperFunctions::getListofSystematics( recSystsPID, m_systNamePID, m_systValPID, msg() );
 
     ATH_MSG_INFO("Will be using AsgElectronEfficiencyCorrectionTool PID efficiency systematic:");
     for ( const auto& syst_it : m_systListPID ) {
@@ -248,8 +244,8 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   if ( !m_corrFileNameIso.empty() ) {
 
-    m_Iso_WP    = HelperFunctions::parse_wp( "ISO", m_corrFileNameIso );
-    m_IsoPID_WP = HelperFunctions::parse_wp( "ID", m_corrFileNameIso );
+    m_Iso_WP    = HelperFunctions::parse_wp( "ISO", m_corrFileNameIso, msg() );
+    m_IsoPID_WP = HelperFunctions::parse_wp( "ID", m_corrFileNameIso, msg() );
 
     if ( m_Iso_WP.empty() ) {
       ATH_MSG_ERROR("ISO working point for isolation SF not found in config file! This should not happen. Exiting." );
@@ -278,22 +274,21 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Iso->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Iso");
     }
 
-    if ( m_debug ) {
 
-      // Get a list of affecting systematics
-     //
-      CP::SystematicSet affectSystsIso = m_asgElEffCorrTool_elSF_Iso->affectingSystematics();
-      //
-      // Convert into a simple list
-      //
-      for ( const auto& syst_it : affectSystsIso ) { ATH_MSG_INFO("AsgElectronEfficiencyCorrectionTool can be affected by Iso efficiency systematic: " << syst_it.name()); }
-    }
+    // Get a list of affecting systematics
+   //
+    CP::SystematicSet affectSystsIso = m_asgElEffCorrTool_elSF_Iso->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsIso ) { ATH_MSG_DEBUG("AsgElectronEfficiencyCorrectionTool can be affected by Iso efficiency systematic: " << syst_it.name()); }
+
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsIso = m_asgElEffCorrTool_elSF_Iso->recommendedSystematics();
-    m_systListIso = HelperFunctions::getListofSystematics( recSystsIso, m_systNameIso, m_systValIso, m_debug );
+    m_systListIso = HelperFunctions::getListofSystematics( recSystsIso, m_systNameIso, m_systValIso, msg() );
 
     ATH_MSG_INFO("Will be using AsgElectronEfficiencyCorrectionTool Iso efficiency systematic:");
     for ( const auto& syst_it : m_systListIso ) {
@@ -331,22 +326,21 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Reco->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Reco");
     }
 
-    if ( m_debug ) {
 
-      // Get a list of affecting systematics
-      //
-      CP::SystematicSet affectSystsReco = m_asgElEffCorrTool_elSF_Reco->affectingSystematics();
-      //
-      // Convert into a simple list
-      //
-      for ( const auto& syst_it : affectSystsReco ) { ATH_MSG_INFO("AsgElectronEfficiencyCorrectionTool can be affected by reco efficiency systematic: " << syst_it.name()); }
-    }
+    // Get a list of affecting systematics
+    //
+    CP::SystematicSet affectSystsReco = m_asgElEffCorrTool_elSF_Reco->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsReco ) { ATH_MSG_DEBUG("AsgElectronEfficiencyCorrectionTool can be affected by reco efficiency systematic: " << syst_it.name()); }
+
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsReco = m_asgElEffCorrTool_elSF_Reco->recommendedSystematics();
-    m_systListReco = HelperFunctions::getListofSystematics( recSystsReco, m_systNameReco, m_systValReco, m_debug );
+    m_systListReco = HelperFunctions::getListofSystematics( recSystsReco, m_systNameReco, m_systValReco, msg() );
 
     ATH_MSG_INFO("Will be using AsgElectronEfficiencyCorrectionTool reco efficiency systematic:");
     for ( const auto& syst_it : m_systListReco ) {
@@ -363,9 +357,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   if ( !m_corrFileNameTrig.empty() ) {
 
-    m_WorkingPointIsoTrig = HelperFunctions::parse_wp( "ISO", m_corrFileNameTrig );
-    m_WorkingPointIDTrig  = HelperFunctions::parse_wp( "ID", m_corrFileNameTrig );
-    m_WorkingPointTrigTrig = HelperFunctions::parse_wp( "TRIG", m_corrFileNameTrigMCEff );
+    m_WorkingPointIsoTrig = HelperFunctions::parse_wp( "ISO", m_corrFileNameTrig, msg() );
+    m_WorkingPointIDTrig  = HelperFunctions::parse_wp( "ID", m_corrFileNameTrig, msg() );
+    m_WorkingPointTrigTrig = HelperFunctions::parse_wp( "TRIG", m_corrFileNameTrigMCEff, msg() );
 
     if ( m_WorkingPointIDTrig.empty() ) {
       ATH_MSG_ERROR( "ID working point for trigger SF not found in config file! This should not happen. Exiting." );
@@ -393,22 +387,21 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_Trig->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool Trig");
     }
 
-    if ( m_debug ) {
 
-      // Get a list of affecting systematics
-     //
-      CP::SystematicSet affectSystsTrig = m_asgElEffCorrTool_elSF_Trig->affectingSystematics();
-      //
-      // Convert into a simple list
-      //
-      for ( const auto& syst_it : affectSystsTrig ) { ATH_MSG_INFO("AsgElectronEfficiencyCorrectionTool can be affected by Trig efficiency SF systematic: " << syst_it.name()); }
-    }
+    // Get a list of affecting systematics
+   //
+    CP::SystematicSet affectSystsTrig = m_asgElEffCorrTool_elSF_Trig->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsTrig ) { ATH_MSG_DEBUG("AsgElectronEfficiencyCorrectionTool can be affected by Trig efficiency SF systematic: " << syst_it.name()); }
+
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsTrig = m_asgElEffCorrTool_elSF_Trig->recommendedSystematics();
-    m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, m_debug );
+    m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, msg() );
 
     ATH_MSG_INFO("Will be using AsgElectronEfficiencyCorrectionTool Trig efficiency SF systematic:");
     for ( const auto& syst_it : m_systListTrig ) {
@@ -452,22 +445,21 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       RETURN_CHECK( "ElectronEfficiencyCorrector::initialize()", m_asgElEffCorrTool_elSF_TrigMCEff->initialize(), "Failed to properly initialize the AsgElectronEfficiencyCorrectionTool TrigMCEff");
     }
 
-    if ( m_debug ) {
 
-      // Get a list of affecting systematics
-     //
-      CP::SystematicSet affectSystsTrigMCEff = m_asgElEffCorrTool_elSF_TrigMCEff->affectingSystematics();
-      //
-      // Convert into a simple list
-      //
-      for ( const auto& syst_it : affectSystsTrigMCEff ) { ATH_MSG_INFO("AsgElectronEfficiencyCorrectionTool can be affected by TrigMCEff efficiency systematic: " << syst_it.name()); }
-    }
+    // Get a list of affecting systematics
+   //
+    CP::SystematicSet affectSystsTrigMCEff = m_asgElEffCorrTool_elSF_TrigMCEff->affectingSystematics();
+    //
+    // Convert into a simple list
+    //
+    for ( const auto& syst_it : affectSystsTrigMCEff ) { ATH_MSG_DEBUG("AsgElectronEfficiencyCorrectionTool can be affected by TrigMCEff efficiency systematic: " << syst_it.name()); }
+
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsTrigMCEff = m_asgElEffCorrTool_elSF_TrigMCEff->recommendedSystematics();
-    m_systListTrigMCEff = HelperFunctions::getListofSystematics( recSystsTrigMCEff, m_systNameTrigMCEff, m_systValTrigMCEff, m_debug );
+    m_systListTrigMCEff = HelperFunctions::getListofSystematics( recSystsTrigMCEff, m_systNameTrigMCEff, m_systValTrigMCEff, msg() );
 
     ATH_MSG_INFO("Will be using AsgElectronEfficiencyCorrectionTool TrigMCEff efficiency systematic:");
     for ( const auto& syst_it : m_systListTrigMCEff ) {
@@ -509,7 +501,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
     return EL::StatusCode::SUCCESS;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Electron Efficiency Correction... "); }
+  ATH_MSG_DEBUG( "Applying Electron Efficiency Correction... ");
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
@@ -533,7 +525,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
     if ( m_store->contains<xAOD::ElectronContainer>( m_inContainerName )  ) {
        RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputElectrons, m_inContainerName, m_event, m_store, msg()) ,"");
 
-       if ( m_debug ) { ATH_MSG_INFO( "Number of electrons: " << static_cast<int>(inputElectrons->size()) ); }
+       ATH_MSG_DEBUG( "Number of electrons: " << static_cast<int>(inputElectrons->size()) );
 
        // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
        //
@@ -567,14 +559,12 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
 
              RETURN_CHECK("ElectronEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputElectrons, m_outContainerName+systName, m_event, m_store, msg()) ,"");
 
-             if ( m_debug ){
-                 ATH_MSG_INFO( "Number of electrons: " << static_cast<int>(outputElectrons->size()) );
-	         ATH_MSG_INFO( "Input syst: " << systName );
-                 unsigned int idx(0);
-                 for ( auto el : *(outputElectrons) ) {
-                     ATH_MSG_INFO( "Input electron " << idx << ", pt = " << el->pt() * 1e-3 << " GeV " );
-                     ++idx;
-                 }
+             ATH_MSG_DEBUG( "Number of electrons: " << static_cast<int>(outputElectrons->size()) );
+             ATH_MSG_DEBUG( "Input syst: " << systName );
+             unsigned int idx(0);
+             for ( auto el : *(outputElectrons) ) {
+               ATH_MSG_DEBUG( "Input electron " << idx << ", pt = " << el->pt() * 1e-3 << " GeV " );
+               ++idx;
              }
 
              // decorate electrons w/ SF - there will be a decoration w/ different name for each syst!
@@ -610,7 +600,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -696,7 +686,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) ATH_MSG_INFO( "Electron PID efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ATH_MSG_DEBUG("Electron PID efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesPID->push_back(sfName);
 
       // apply syst
@@ -705,14 +695,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	ATH_MSG_ERROR("Failed to configure AsgElectronEfficiencyCorrectionTool_PID for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_PID->appliedSystematics().name() ); }
+      ATH_MSG_DEBUG( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_PID->appliedSystematics().name() );
 
       // and now apply PID efficiency SF!
       //
       unsigned int idx(0);
       for ( auto el_itr : *(inputElectrons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying PID efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying PID efficiency SF" );
 
     	 bool isBadElectron(false);
 
@@ -729,18 +719,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
     	 //
     	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
     	   isBadElectron = true;
     	 }
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
     	 if ( el_itr->pt() < 15e3 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
     	   isBadElectron = true;
     	 }
     	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
     	   isBadElectron = true;
     	 }
 
@@ -757,19 +747,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 sfVecPID( *el_itr ).push_back( pidEffSF );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Electron " << idx << ", pt = " << el_itr->pt()*1e-3 << " GeV ");
-  	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "PID SF decoration: " << m_outputSystNamesPID );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "PID efficiency SF:");
-    	   ATH_MSG_INFO( "\t " << pidEffSF << " (from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Electron " << idx << ", pt = " << el_itr->pt()*1e-3 << " GeV ");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "PID SF decoration: " << m_outputSystNamesPID );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "PID efficiency SF:");
+         ATH_MSG_DEBUG( "\t " << pidEffSF << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -813,7 +801,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) ATH_MSG_INFO( "Electron Iso efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ATH_MSG_DEBUG("Electron Iso efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesIso->push_back(sfName);
 
       // apply syst
@@ -822,14 +810,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	ATH_MSG_ERROR("Failed to configure AsgElectronEfficiencyCorrectionTool_Iso for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Iso->appliedSystematics().name() ); }
+      ATH_MSG_DEBUG( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Iso->appliedSystematics().name() );
 
       // and now apply Iso efficiency SF!
       //
       unsigned int idx(0);
       for ( auto el_itr : *(inputElectrons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying Iso efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying Iso efficiency SF" );
 
     	 bool isBadElectron(false);
 
@@ -846,18 +834,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
     	 //
     	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
     	   isBadElectron = true;
     	 }
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
     	 if ( el_itr->pt() < 15e3 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
     	   isBadElectron = true;
     	 }
     	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
     	   isBadElectron = true;
     	 }
 
@@ -874,19 +862,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 sfVecIso( *el_itr ).push_back( IsoEffSF );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
-  	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Iso SF decoration: " << m_outputSystNamesIso );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Iso efficiency SF:");
-    	   ATH_MSG_INFO( "\t " << IsoEffSF << " (from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Iso SF decoration: " << m_outputSystNamesIso );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Iso efficiency SF:");
+         ATH_MSG_DEBUG( "\t " << IsoEffSF << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -930,7 +916,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) ATH_MSG_INFO( "Electron Reco efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ATH_MSG_DEBUG("Electron Reco efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesReco->push_back(sfName);
 
       // apply syst
@@ -939,14 +925,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	ATH_MSG_ERROR("Failed to configure AsgElectronEfficiencyCorrectionTool_Reco for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Reco->appliedSystematics().name() ); }
+      ATH_MSG_DEBUG( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Reco->appliedSystematics().name() );
 
       // and now apply Reco efficiency SF!
       //
       unsigned int idx(0);
       for ( auto el_itr : *(inputElectrons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying Reco efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying Reco efficiency SF" );
 
     	 bool isBadElectron(false);
 
@@ -963,18 +949,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
     	 //
     	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
   	   isBadElectron = true;
     	 }
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
     	 if ( el_itr->pt() < 15e3 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
   	   isBadElectron = true;
     	 }
     	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
   	   isBadElectron = true;
     	 }
 
@@ -991,19 +977,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 sfVecReco( *el_itr ).push_back( recoEffSF );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Reco SF decoration: " << m_outputSystNamesReco );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Reco efficiency SF:");
-    	   ATH_MSG_INFO( "\t " << recoEffSF << " (from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Reco SF decoration: " << m_outputSystNamesReco );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Reco efficiency SF:");
+         ATH_MSG_DEBUG( "\t " << recoEffSF << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -1053,7 +1037,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) ATH_MSG_INFO( "Electron Trig efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ATH_MSG_DEBUG("Electron Trig efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesTrig->push_back(sfName);
 
       // apply syst
@@ -1062,14 +1046,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	ATH_MSG_ERROR("Failed to configure AsgElectronEfficiencyCorrectionTool_Trig for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Trig->appliedSystematics().name() ); }
+      ATH_MSG_DEBUG( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_Trig->appliedSystematics().name() );
 
       // and now apply trigger efficiency SF!
       //
       unsigned int idx(0);
       for ( auto el_itr : *(inputElectrons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying Trigger efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying Trigger efficiency SF" );
 
     	 bool isBadElectron(false);
 
@@ -1086,18 +1070,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
     	 //
     	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
   	   isBadElectron = true;
     	 }
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
     	 if ( el_itr->pt() < 15e3 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
   	   isBadElectron = true;
     	 }
     	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
   	   isBadElectron = true;
     	 }
 
@@ -1115,19 +1099,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 sfVecTrig( *el_itr ).push_back( trigEffSF );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Trigger efficiency SF decoration: " << m_outputSystNamesTrig );
-	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Trigger efficiency SF:");
-    	   ATH_MSG_INFO( "\t " << trigEffSF << "(from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Trigger efficiency SF decoration: " << m_outputSystNamesTrig );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Trigger efficiency SF:");
+         ATH_MSG_DEBUG( "\t " << trigEffSF << "(from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -1174,7 +1156,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) ATH_MSG_INFO( "Electron Trig MC efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ATH_MSG_DEBUG("Electron Trig MC efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesTrigMCEff->push_back(sfName);
 
       // apply syst
@@ -1183,14 +1165,14 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	ATH_MSG_ERROR("Failed to configure AsgElectronEfficiencyCorrectionTool_TrigMCEff for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_TrigMCEff->appliedSystematics().name() ); }
+      ATH_MSG_DEBUG( "Successfully applied systematics: " << m_asgElEffCorrTool_elSF_TrigMCEff->appliedSystematics().name() );
 
       // and now apply trigger MC efficiency!
       //
       unsigned int idx(0);
       for ( auto el_itr : *(inputElectrons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying Trigger MC efficiency" ); }
+    	 ATH_MSG_DEBUG( "Applying Trigger MC efficiency" );
 
     	 bool isBadElectron(false);
 
@@ -1207,18 +1189,18 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
     	 //
     	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
   	   isBadElectron = true;
     	 }
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
     	 if ( el_itr->pt() < 15e3 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
   	   isBadElectron = true;
     	 }
     	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   if ( m_debug ) { ATH_MSG_INFO( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance"); }
+    	   ATH_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
   	   isBadElectron = true;
     	 }
 
@@ -1236,19 +1218,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 sfVecTrigMCEff( *el_itr ).push_back( trigMCEff );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Trigger efficiency decoration: " << m_outputSystNamesTrigMCEff );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Trigger MC efficiency:");
-    	   ATH_MSG_INFO( "\t " << trigMCEff << " (from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Electron " << idx << ", pt = " << el_itr->pt() * 1e-3 << " GeV" );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Trigger efficiency decoration: " << m_outputSystNamesTrigMCEff );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Trigger MC efficiency:");
+         ATH_MSG_DEBUG( "\t " << trigMCEff << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -598,7 +598,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ElectronHists.cxx
+++ b/Root/ElectronHists.cxx
@@ -20,7 +20,7 @@ StatusCode ElectronHists::initialize() {
   if( m_infoSwitch->m_isolation ) {
     if(m_debug) Info("ElectronHists::initialize()", "adding isolation plots");
 
-    
+
     m_isIsolated_LooseTrackOnly           = book(m_name, "isIsolated_LooseTrackOnly"       ,   "isIsolated_LooseTrackOnly", 3, -1.5, 1.5);
     m_isIsolated_Loose                    = book(m_name, "isIsolated_Loose"            ,       "isIsolated_Loose", 3, -1.5, 1.5);
     m_isIsolated_Tight                    = book(m_name, "isIsolated_Tight"             ,      "isIsolated_Tight", 3, -1.5, 1.5);
@@ -52,7 +52,7 @@ StatusCode ElectronHists::initialize() {
     m_topoetcone30_rel = book(m_name, "topoetcone30_rel", "topoetcone30_rel", 110, -0.2, 2);
     m_topoetcone40_rel = book(m_name, "topoetcone40_rel", "topoetcone40_rel", 110, -0.2, 2);
   }
- 
+
   // quality
   if(m_infoSwitch->m_quality){
     //m_LHVeryLoose = book(m_name, "LHVeryLoose", "LHVeryLoose", 3, -1.5, 1.5);
@@ -60,7 +60,7 @@ StatusCode ElectronHists::initialize() {
     m_LHMedium    = book(m_name, "LHMedium"   , "LHMedium"   , 3, -1.5, 1.5);
     m_LHTight     = book(m_name, "LHTight"    , "LHTight"    , 3, -1.5, 1.5);
   }
-  
+
   return StatusCode::SUCCESS;
 }
 
@@ -82,7 +82,7 @@ StatusCode ElectronHists::execute( const xAOD::IParticle* particle, float eventW
 
   // isolation
   if ( m_infoSwitch->m_isolation ) {
-    
+
     static SG::AuxElement::Accessor<char> isIsoLooseTrackOnlyAcc ("isIsolated_LooseTrackOnly");
     static SG::AuxElement::Accessor<char> isIsoLooseAcc ("isIsolated_Loose");
     static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
@@ -114,7 +114,7 @@ StatusCode ElectronHists::execute( const xAOD::IParticle* particle, float eventW
     m_topoetcone20->Fill( electron->isolation( xAOD::Iso::topoetcone20) / 1e3, eventWeight );
     m_topoetcone30->Fill( electron->isolation( xAOD::Iso::topoetcone30) / 1e3, eventWeight );
     m_topoetcone40->Fill( electron->isolation( xAOD::Iso::topoetcone40) / 1e3, eventWeight );
-    
+
     float electronPt = electron->pt();
     m_ptcone20_rel     ->Fill( electron->isolation( xAOD::Iso::ptcone20 )     / electronPt,  eventWeight );
     m_ptcone30_rel     ->Fill( electron->isolation( xAOD::Iso::ptcone30 )     / electronPt,  eventWeight );
@@ -151,20 +151,20 @@ StatusCode ElectronHists::execute( const xAH::Particle* particle, float eventWei
     }
 
   m_isIsolated_LooseTrackOnly           ->Fill( elec->isIsolated_LooseTrackOnly ,  eventWeight );
-  m_isIsolated_Loose                    ->Fill( elec->isIsolated_Loose ,  eventWeight ); 
-  m_isIsolated_Tight                    ->Fill( elec->isIsolated_Tight ,  eventWeight ); 
+  m_isIsolated_Loose                    ->Fill( elec->isIsolated_Loose ,  eventWeight );
+  m_isIsolated_Tight                    ->Fill( elec->isIsolated_Tight ,  eventWeight );
   m_isIsolated_Gradient                 ->Fill( elec->isIsolated_Gradient ,  eventWeight );
   m_isIsolated_GradientLoose            ->Fill( elec->isIsolated_GradientLoose ,  eventWeight );
-  //m_isIsolated_GradientT1               ->Fill( elec->isIsolated_GradientLoose ,  eventWeight ); 
-  //m_isIsolated_GradientT2               ->Fill( elec->isIsoGradientT2Acc ,  eventWeight ); 
-  //m_isIsolated_MU0p06                   ->Fill( elec->isIsoMU0p06Acc ,  eventWeight ); 
-  m_isIsolated_FixedCutLoose            ->Fill( elec->isIsolated_FixedCutLoose ,  eventWeight ); 
-  //m_isIsolated_FixedCutTight            ->Fill( elec->isIsolated_FixedCutTight ,  eventWeight ); 
-  m_isIsolated_FixedCutTightTrackOnly   ->Fill( elec->isIsolated_FixedCutTightTrackOnly ,  eventWeight ); 
-  m_isIsolated_UserDefinedFixEfficiency ->Fill( elec->isIsolated_UserDefinedFixEfficiency ,  eventWeight ); 
-  m_isIsolated_UserDefinedCut           ->Fill( elec->isIsolated_UserDefinedCut ,  eventWeight ); 
+  //m_isIsolated_GradientT1               ->Fill( elec->isIsolated_GradientLoose ,  eventWeight );
+  //m_isIsolated_GradientT2               ->Fill( elec->isIsoGradientT2Acc ,  eventWeight );
+  //m_isIsolated_MU0p06                   ->Fill( elec->isIsoMU0p06Acc ,  eventWeight );
+  m_isIsolated_FixedCutLoose            ->Fill( elec->isIsolated_FixedCutLoose ,  eventWeight );
+  //m_isIsolated_FixedCutTight            ->Fill( elec->isIsolated_FixedCutTight ,  eventWeight );
+  m_isIsolated_FixedCutTightTrackOnly   ->Fill( elec->isIsolated_FixedCutTightTrackOnly ,  eventWeight );
+  m_isIsolated_UserDefinedFixEfficiency ->Fill( elec->isIsolated_UserDefinedFixEfficiency ,  eventWeight );
+  m_isIsolated_UserDefinedCut           ->Fill( elec->isIsolated_UserDefinedCut ,  eventWeight );
 
-  
+
   // isolation
   if ( m_infoSwitch->m_isolation ) {
     m_ptcone20    ->Fill( elec->ptcone20    , eventWeight );
@@ -190,13 +190,13 @@ StatusCode ElectronHists::execute( const xAH::Particle* particle, float eventWei
     m_topoetcone40_rel ->Fill( elec->topoetcone40/elecPt    ,  eventWeight );
   }
 
-  
+
   if ( m_infoSwitch->m_quality ) {
 
-    //m_isVeryLoose->Fill( elec->  isVeryLoose,  eventWeight ); 
-    m_LHLoose    ->Fill( elec->  LHLoose    ,  eventWeight ); 
-    m_LHMedium   ->Fill( elec->  LHMedium   ,  eventWeight ); 
-    m_LHTight    ->Fill( elec->  LHTight    ,  eventWeight );  
+    //m_isVeryLoose->Fill( elec->  isVeryLoose,  eventWeight );
+    m_LHLoose    ->Fill( elec->  LHLoose    ,  eventWeight );
+    m_LHMedium   ->Fill( elec->  LHMedium   ,  eventWeight );
+    m_LHTight    ->Fill( elec->  LHTight    ,  eventWeight );
 
   }
 

--- a/Root/ElectronHistsAlgo.cxx
+++ b/Root/ElectronHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ElectronHistsAlgo)
 
-ElectronHistsAlgo :: ElectronHistsAlgo (std::string className) :
-IParticleHistsAlgo(className)
+ElectronHistsAlgo :: ElectronHistsAlgo () :
+IParticleHistsAlgo("ElectronHistsAlgo")
 { }
 
 EL::StatusCode ElectronHistsAlgo :: setupJob (EL::Job& job)

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -35,8 +35,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ElectronSelector)
 
-ElectronSelector :: ElectronSelector (std::string className) :
-    Algorithm(className),
+ElectronSelector :: ElectronSelector () :
+    Algorithm("ElectronSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_el_cutflowHist_1(nullptr),
@@ -54,7 +54,7 @@ ElectronSelector :: ElectronSelector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
   m_useCutFlow              = true;

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -627,7 +627,7 @@ EL::StatusCode ElectronSelector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if( !eventPass ) {
     wk()->skipEvent();

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -484,7 +484,7 @@ EL::StatusCode ElectronSelector :: execute ()
   if ( m_debug ) { ATH_MSG_INFO( "Applying Electron Selection... "); }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // MC event weight
   //
@@ -541,7 +541,7 @@ EL::StatusCode ElectronSelector :: execute ()
 
     // this will be the collection processed - no matter what!!
     //
-    RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName, m_event, m_store, msg()) ,"");
 
     // create output container (if requested)
     ConstDataVector<xAOD::ElectronContainer>* selectedElectrons(nullptr);
@@ -566,7 +566,7 @@ EL::StatusCode ElectronSelector :: execute ()
     // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
     //
     std::vector< std::string >* systNames(nullptr);
-    RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) ,"");
 
     // prepare a vector of the names of CDV containers for usage by downstream algos
     // must be a pointer to be recorded in TStore
@@ -581,7 +581,7 @@ EL::StatusCode ElectronSelector :: execute ()
 
       if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
 
-      RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName + systName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName + systName, m_event, m_store, msg()) ,"");
 
       // create output container (if requested) - one for each systematic
       //
@@ -643,7 +643,7 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
 {
 
   const xAOD::VertexContainer* vertices(nullptr);
-  RETURN_CHECK("ElectronSelector::executeSelection()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronSelector::executeSelection()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
 
   int nPass(0); int nObj(0);
@@ -758,7 +758,7 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
       if ( m_debug ) { ATH_MSG_INFO( "Doing di-electron trigger matching..."); }
 
       const xAOD::EventInfo* eventInfo(nullptr);
-      RETURN_CHECK("ElectronSelector::executeSelection()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("ElectronSelector::executeSelection()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
       typedef std::pair< std::pair<unsigned int,unsigned int>, char>     dielectron_trigmatch_pair;
       typedef std::multimap< std::string, dielectron_trigmatch_pair >    dielectron_trigmatch_pair_map;
@@ -964,7 +964,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("ElectronSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
 

--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -16,7 +16,7 @@ EventInfo::EventInfo(const std::string& detailStr, float units, bool mc)
 
 EventInfo::~EventInfo()
 {
-  if(m_debug) cout << " Deleting EventInfo "  << endl;  
+  if(m_debug) cout << " Deleting EventInfo "  << endl;
 }
 
 void EventInfo::setTree(TTree *tree)
@@ -25,41 +25,41 @@ void EventInfo::setTree(TTree *tree)
   connectBranch<int>     (tree, "runNumber",   &m_runNumber);
   connectBranch<Long64_t>(tree, "eventNumber", &m_eventNumber);
   connectBranch<int>     (tree, "lumiBlock",   &m_lumiBlock);
-  connectBranch<uint32_t>(tree, "coreFlags",   &m_coreFlags);           
+  connectBranch<uint32_t>(tree, "coreFlags",   &m_coreFlags);
 
   if(m_mc){
-    connectBranch<int     >(tree, "mcEventNumber",              &m_mcEventNumber);       
-    connectBranch<int     >(tree, "mcChannelNumber",            &m_mcChannelNumber);    
-    connectBranch<float   >(tree, "mcEventWeight",              &m_mcEventWeight);       
+    connectBranch<int     >(tree, "mcEventNumber",              &m_mcEventNumber);
+    connectBranch<int     >(tree, "mcChannelNumber",            &m_mcChannelNumber);
+    connectBranch<float   >(tree, "mcEventWeight",              &m_mcEventWeight);
   } else {
-    connectBranch<int     >(tree, "bcid",                       &m_bcid);                 
-    connectBranch<float   >(tree, "prescale_DataWeight",               &m_prescale_DataWeight);       
+    connectBranch<int     >(tree, "bcid",                       &m_bcid);
+    connectBranch<float   >(tree, "prescale_DataWeight",               &m_prescale_DataWeight);
   }
 
   if ( m_infoSwitch.m_eventCleaning ) {
-    connectBranch<uint32_t>(tree, "timeStamp",                  &m_timeStamp);           
-    connectBranch<uint32_t>(tree, "timeStampNSOffset",          &m_timeStampNSOffset);  
-    connectBranch<bool    >(tree, "TileError",                  &m_TileError);           
-    connectBranch<bool    >(tree, "SCTError",                   &m_SCTError);            
-    connectBranch<bool    >(tree, "LArError",                   &m_LArError);            
-    connectBranch<uint32_t>(tree, "TileFlags",                  &m_TileFlags);           
-    connectBranch<uint32_t>(tree, "SCTFlags",                   &m_SCTFlags);            
-    connectBranch<uint32_t>(tree, "LArFlags",                   &m_LArFlags);            
+    connectBranch<uint32_t>(tree, "timeStamp",                  &m_timeStamp);
+    connectBranch<uint32_t>(tree, "timeStampNSOffset",          &m_timeStampNSOffset);
+    connectBranch<bool    >(tree, "TileError",                  &m_TileError);
+    connectBranch<bool    >(tree, "SCTError",                   &m_SCTError);
+    connectBranch<bool    >(tree, "LArError",                   &m_LArError);
+    connectBranch<uint32_t>(tree, "TileFlags",                  &m_TileFlags);
+    connectBranch<uint32_t>(tree, "SCTFlags",                   &m_SCTFlags);
+    connectBranch<uint32_t>(tree, "LArFlags",                   &m_LArFlags);
   }
 
   if ( m_infoSwitch.m_pileup ) {
     connectBranch<int  >(tree, "NPV",                              &m_npv);
     connectBranch<float>(tree, "actualInteractionsPerCrossing",    &m_actualMu);
     connectBranch<float>(tree, "averageInteractionsPerCrossing",   &m_averageMu);
-    connectBranch<float>(tree, "weight_pileup",                    &m_weight_pileup);       
+    connectBranch<float>(tree, "weight_pileup",                    &m_weight_pileup);
     if ( m_infoSwitch.m_pileupsys ) {
       connectBranch<float>(tree, "weight_pileup_up",               &m_weight_pileup_up);
       connectBranch<float>(tree, "weight_pileup_down",             &m_weight_pileup_down);
     }
     if(m_mc){
-      connectBranch<float>(tree, "correct_mu",                 &m_correct_mu);          
-      connectBranch<int  >(tree, "rand_run_nr",                &m_rand_run_nr);         
-      connectBranch<int  >(tree, "rand_lumiblock_nr",          &m_rand_lumiblock_nr);  
+      connectBranch<float>(tree, "correct_mu",                 &m_correct_mu);
+      connectBranch<int  >(tree, "rand_run_nr",                &m_rand_run_nr);
+      connectBranch<int  >(tree, "rand_lumiblock_nr",          &m_rand_lumiblock_nr);
     }
   }
 
@@ -73,20 +73,20 @@ void EventInfo::setTree(TTree *tree)
 
     // truth
   if( m_infoSwitch.m_truth && m_mc ) {
-    connectBranch<int  >(tree, "pdgId1",  &m_pdgId1);      
-    connectBranch<int  >(tree, "pdgId2",  &m_pdgId2);      
-    connectBranch<int  >(tree, "pdfId1",  &m_pdfId1);      
-    connectBranch<int  >(tree, "pdfId2",  &m_pdfId2);      
-    connectBranch<float>(tree, "x1",      &m_x1);  
-    connectBranch<float>(tree, "x2",      &m_x2);  
-    //connectBranch<float>(tree, "scale",   &m_scale);       
-    connectBranch<float>(tree, "q",       &m_q);   
-    //connectBranch<float>(tree, "pdf1",    &m_pdf1);        
-    //connectBranch<float>(tree, "pdf2",    &m_pdf2);        
-    connectBranch<float>(tree, "xf1",     &m_xf1); 
-    connectBranch<float>(tree, "xf2",     &m_xf2);    
+    connectBranch<int  >(tree, "pdgId1",  &m_pdgId1);
+    connectBranch<int  >(tree, "pdgId2",  &m_pdgId2);
+    connectBranch<int  >(tree, "pdfId1",  &m_pdfId1);
+    connectBranch<int  >(tree, "pdfId2",  &m_pdfId2);
+    connectBranch<float>(tree, "x1",      &m_x1);
+    connectBranch<float>(tree, "x2",      &m_x2);
+    //connectBranch<float>(tree, "scale",   &m_scale);
+    connectBranch<float>(tree, "q",       &m_q);
+    //connectBranch<float>(tree, "pdf1",    &m_pdf1);
+    //connectBranch<float>(tree, "pdf2",    &m_pdf2);
+    connectBranch<float>(tree, "xf1",     &m_xf1);
+    connectBranch<float>(tree, "xf2",     &m_xf2);
   }
-  
+
   // CaloCluster
   if ( m_infoSwitch.m_caloClus ) {
     std::vector<float>*  m_caloCluster_pt_addr = &m_caloCluster_pt;
@@ -142,9 +142,9 @@ void EventInfo::setBranches(TTree *tree)
       tree->Branch("weight_pileup_down",    &m_weight_pileup_down,"weight_pileup_down/F");
     }
     if(m_mc){
-      tree->Branch("correct_mu"       ,          &m_correct_mu       ,"correct_mu/F"       );          
-      tree->Branch("rand_run_nr"      ,          &m_rand_run_nr      ,"rand_run_nr/I"      );         
-      tree->Branch("rand_lumiblock_nr",          &m_rand_lumiblock_nr,"rand_lumiblock_nr/I");  
+      tree->Branch("correct_mu"       ,          &m_correct_mu       ,"correct_mu/F"       );
+      tree->Branch("rand_run_nr"      ,          &m_rand_run_nr      ,"rand_run_nr/I"      );
+      tree->Branch("rand_lumiblock_nr",          &m_rand_lumiblock_nr,"rand_lumiblock_nr/I");
     }
   }
 
@@ -180,7 +180,7 @@ void EventInfo::setBranches(TTree *tree)
 
   return;
 }
-    
+
 
 void EventInfo::clear()
 {
@@ -226,7 +226,7 @@ void EventInfo::clear()
 }
 
 void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo,  xAOD::TEvent* event) {
-  
+
   m_runNumber             = eventInfo->runNumber();
   m_eventNumber           = eventInfo->eventNumber();
   m_lumiBlock             = eventInfo->lumiBlock();

--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -7,9 +7,9 @@ using namespace xAH;
 using std::vector;  using std::endl;  using std::cout;
 
 
-FatJetContainer::FatJetContainer(const std::string& name, const std::string& detailStr, const std::string& suffix, 
+FatJetContainer::FatJetContainer(const std::string& name, const std::string& detailStr, const std::string& suffix,
 				 float units, bool mc)
-  : ParticleContainer(name,detailStr,units,mc, false, suffix), 
+  : ParticleContainer(name,detailStr,units,mc, false, suffix),
     m_trackJetPtCut(10e3),
     m_trackJetEtaCut(2.5)
 {
@@ -62,32 +62,32 @@ FatJetContainer::FatJetContainer(const std::string& name, const std::string& det
   }
 
   if ( m_infoSwitch.m_constituentAll) {
-    m_constituentWeights  = new std::vector< std::vector<float> >();  
-    m_constituent_pt      = new std::vector< std::vector<float> >();  
-    m_constituent_eta     = new std::vector< std::vector<float> >();  
-    m_constituent_phi     = new std::vector< std::vector<float> >();  
-    m_constituent_e       = new std::vector< std::vector<float> >();  
+    m_constituentWeights  = new std::vector< std::vector<float> >();
+    m_constituent_pt      = new std::vector< std::vector<float> >();
+    m_constituent_eta     = new std::vector< std::vector<float> >();
+    m_constituent_phi     = new std::vector< std::vector<float> >();
+    m_constituent_e       = new std::vector< std::vector<float> >();
   }
 
   if ( m_infoSwitch.m_bosonCount) {
     m_nTQuarks  = new std::vector< int > ();
-    m_nHBosons  = new std::vector< int > ();      
-    m_nWBosons  = new std::vector< int > ();            
-    m_nZBosons  = new std::vector< int > ();      
+    m_nHBosons  = new std::vector< int > ();
+    m_nWBosons  = new std::vector< int > ();
+    m_nZBosons  = new std::vector< int > ();
   }
 
-  if ( m_infoSwitch.m_VTags ) { 
+  if ( m_infoSwitch.m_VTags ) {
     m_WbosonTaggerMedium = new JetSubStructureUtils::BosonTag("medium", "smooth", "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Wtagging_MC15_Prerecommendations_20150809.dat", false, false);
     m_ZbosonTaggerMedium = new JetSubStructureUtils::BosonTag("medium", "smooth", "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Ztagging_MC15_Prerecommendations_20150809.dat", false, false);
 
     m_WbosonTaggerTight = new JetSubStructureUtils::BosonTag("tight", "smooth", "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Wtagging_MC15_Prerecommendations_20150809.dat", false, false);
     m_ZbosonTaggerTight = new JetSubStructureUtils::BosonTag("tight", "smooth", "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Ztagging_MC15_Prerecommendations_20150809.dat", false, false);
 
-    m_Wtag_medium  = new std::vector< int > ();            
-    m_Ztag_medium  = new std::vector< int > ();            
+    m_Wtag_medium  = new std::vector< int > ();
+    m_Ztag_medium  = new std::vector< int > ();
 
-    m_Wtag_tight  = new std::vector< int > ();            
-    m_Ztag_tight  = new std::vector< int > ();            
+    m_Wtag_tight  = new std::vector< int > ();
+    m_Ztag_tight  = new std::vector< int > ();
   }
 
   if( m_infoSwitch.m_trackJets ){
@@ -103,7 +103,7 @@ FatJetContainer::FatJetContainer(const std::string& name, const std::string& det
 
 FatJetContainer::~FatJetContainer()
 {
-  if(m_debug) cout << " Deleting FatJetContainer "  << endl;  
+  if(m_debug) cout << " Deleting FatJetContainer "  << endl;
 
   if ( m_infoSwitch.m_scales ) {
       delete m_JetConstitScaleMomentum_eta ;
@@ -152,11 +152,11 @@ FatJetContainer::~FatJetContainer()
   }
 
   if ( m_infoSwitch.m_constituentAll) {
-    delete m_constituentWeights;  
-    delete m_constituent_pt    ;  
-    delete m_constituent_eta   ;  
-    delete m_constituent_phi   ;  
-    delete m_constituent_e     ;  
+    delete m_constituentWeights;
+    delete m_constituent_pt    ;
+    delete m_constituent_eta   ;
+    delete m_constituent_phi   ;
+    delete m_constituent_e     ;
   }
 
   if ( m_infoSwitch.m_bosonCount) {
@@ -166,7 +166,7 @@ FatJetContainer::~FatJetContainer()
     delete m_nZBosons;
   }
 
-  if ( m_infoSwitch.m_VTags ) { 
+  if ( m_infoSwitch.m_VTags ) {
     delete m_WbosonTaggerMedium;
     delete m_ZbosonTaggerMedium;
 
@@ -199,7 +199,7 @@ void FatJetContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "JetConstitScaleMomentum_phi", &m_JetConstitScaleMomentum_phi);
     connectBranch<float>(tree, "JetConstitScaleMomentum_m", &m_JetConstitScaleMomentum_m);
     connectBranch<float>(tree, "JetConstitScaleMomentum_pt", &m_JetConstitScaleMomentum_pt);
-    
+
     connectBranch<float>(tree, "JetEMScaleMomentum_eta", &m_JetEMScaleMomentum_eta);
     connectBranch<float>(tree, "JetEMScaleMomentum_phi", &m_JetEMScaleMomentum_phi);
     connectBranch<float>(tree, "JetEMScaleMomentum_m", &m_JetEMScaleMomentum_m);
@@ -263,7 +263,7 @@ void FatJetContainer::setTree(TTree *tree)
     connectBranch< int >(tree, "Wtag_tight",   &m_Wtag_tight);
     connectBranch< int >(tree, "Ztag_tight",   &m_Ztag_tight);
   }
-  
+
   if( m_infoSwitch.m_trackJets ){
     m_trkJets->JetContainer::setTree(tree, "MV2c10");
     connectBranch< vector<unsigned int> >(tree, "trkJetsIdx",   &m_trkJetsIdx);
@@ -273,7 +273,7 @@ void FatJetContainer::setTree(TTree *tree)
 void FatJetContainer::updateParticle(uint idx, FatJet& fatjet)
 {
   if(m_debug) cout << "in FatJetContainer::updateParticle " << endl;
-  ParticleContainer::updateParticle(idx,fatjet);  
+  ParticleContainer::updateParticle(idx,fatjet);
 
   if ( m_infoSwitch.m_scales ) {
       fatjet.JetConstitScaleMomentum_eta = m_JetConstitScaleMomentum_eta ->at(idx);
@@ -321,11 +321,11 @@ void FatJetContainer::updateParticle(uint idx, FatJet& fatjet)
   }
 
   if ( m_infoSwitch.m_constituentAll) {
-    fatjet.constituentWeights = m_constituentWeights  ->at(idx);  
-    fatjet.constituent_pt     = m_constituent_pt      ->at(idx);  
-    fatjet.constituent_eta    = m_constituent_eta     ->at(idx);  
-    fatjet.constituent_phi    = m_constituent_phi     ->at(idx);  
-    fatjet.constituent_e      = m_constituent_e       ->at(idx);  
+    fatjet.constituentWeights = m_constituentWeights  ->at(idx);
+    fatjet.constituent_pt     = m_constituent_pt      ->at(idx);
+    fatjet.constituent_eta    = m_constituent_eta     ->at(idx);
+    fatjet.constituent_phi    = m_constituent_phi     ->at(idx);
+    fatjet.constituent_e      = m_constituent_e       ->at(idx);
   }
 
   if(m_infoSwitch.m_bosonCount){
@@ -378,13 +378,13 @@ void FatJetContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_area ) {
-    setBranch<float>(tree, "GhostArea", m_GhostArea); 
-    setBranch<float>(tree, "ActiveArea", m_ActiveArea); 
-    setBranch<float>(tree, "VoronoiArea", m_VoronoiArea); 
-    setBranch<float>(tree, "ActiveArea4vec_pt", m_ActiveArea4vec_pt); 
-    setBranch<float>(tree, "ActiveArea4vec_eta", m_ActiveArea4vec_eta); 
-    setBranch<float>(tree, "ActiveArea4vec_phi", m_ActiveArea4vec_phi); 
-    setBranch<float>(tree, "ActiveArea4vec_m", m_ActiveArea4vec_m); 
+    setBranch<float>(tree, "GhostArea", m_GhostArea);
+    setBranch<float>(tree, "ActiveArea", m_ActiveArea);
+    setBranch<float>(tree, "VoronoiArea", m_VoronoiArea);
+    setBranch<float>(tree, "ActiveArea4vec_pt", m_ActiveArea4vec_pt);
+    setBranch<float>(tree, "ActiveArea4vec_eta", m_ActiveArea4vec_eta);
+    setBranch<float>(tree, "ActiveArea4vec_phi", m_ActiveArea4vec_phi);
+    setBranch<float>(tree, "ActiveArea4vec_m", m_ActiveArea4vec_m);
 
   }
 
@@ -433,7 +433,7 @@ void FatJetContainer::setBranches(TTree *tree)
     setBranch< int >(tree, "Wtag_tight",       m_Wtag_tight);
     setBranch< int >(tree, "Ztag_tight",       m_Ztag_tight);
   }
- 
+
   if( m_infoSwitch.m_trackJets ){
     m_trkJets->setBranches(tree);
     setBranch< vector<unsigned int> >(tree, "trkJetsIdx",       m_trkJetsIdx);
@@ -441,11 +441,11 @@ void FatJetContainer::setBranches(TTree *tree)
 
   return;
 }
-    
+
 
 void FatJetContainer::clear()
 {
-  
+
   ParticleContainer::clear();
 
   if ( m_infoSwitch.m_scales ) {
@@ -461,13 +461,13 @@ void FatJetContainer::clear()
   }
 
   if ( m_infoSwitch.m_area ) {
-    m_GhostArea->clear(); 
-    m_ActiveArea->clear(); 
-    m_VoronoiArea->clear(); 
-    m_ActiveArea4vec_pt->clear(); 
-    m_ActiveArea4vec_eta->clear(); 
-    m_ActiveArea4vec_phi->clear(); 
-    m_ActiveArea4vec_m->clear(); 
+    m_GhostArea->clear();
+    m_ActiveArea->clear();
+    m_VoronoiArea->clear();
+    m_ActiveArea4vec_pt->clear();
+    m_ActiveArea4vec_eta->clear();
+    m_ActiveArea4vec_phi->clear();
+    m_ActiveArea4vec_m->clear();
   }
 
   if ( m_infoSwitch.m_substructure ) {
@@ -494,11 +494,11 @@ void FatJetContainer::clear()
   }
 
   if ( m_infoSwitch.m_constituentAll) {
-    m_constituentWeights->clear();  
-    m_constituent_pt    ->clear();  
-    m_constituent_eta   ->clear();  
-    m_constituent_phi   ->clear();  
-    m_constituent_e     ->clear();  
+    m_constituentWeights->clear();
+    m_constituent_pt    ->clear();
+    m_constituent_eta   ->clear();
+    m_constituent_phi   ->clear();
+    m_constituent_e     ->clear();
   }
 
   if(m_infoSwitch.m_bosonCount){
@@ -556,19 +556,19 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
 
   if ( m_infoSwitch.m_area ) {
     static SG::AuxElement::ConstAccessor<float> acc_GhostArea("GhostArea");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_GhostArea, m_GhostArea, -999); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_GhostArea, m_GhostArea, -999);
     static SG::AuxElement::ConstAccessor<float> acc_ActiveArea("ActiveArea");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea, m_ActiveArea, -999); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea, m_ActiveArea, -999);
     static SG::AuxElement::ConstAccessor<float> acc_VoronoiArea("VoronoiArea");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_VoronoiArea, m_VoronoiArea, -999); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_VoronoiArea, m_VoronoiArea, -999);
     static SG::AuxElement::ConstAccessor<float> acc_ActiveArea4vec_pt("ActiveArea4vec_pt");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_pt, m_ActiveArea4vec_pt, -999, m_units); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_pt, m_ActiveArea4vec_pt, -999, m_units);
     static SG::AuxElement::ConstAccessor<float> acc_ActiveArea4vec_eta("ActiveArea4vec_eta");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_eta, m_ActiveArea4vec_eta, -999); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_eta, m_ActiveArea4vec_eta, -999);
     static SG::AuxElement::ConstAccessor<float> acc_ActiveArea4vec_phi("ActiveArea4vec_phi");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_phi, m_ActiveArea4vec_phi, -999); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_phi, m_ActiveArea4vec_phi, -999);
     static SG::AuxElement::ConstAccessor<float> acc_ActiveArea4vec_m("ActiveArea4vec_m");
-    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_m, m_ActiveArea4vec_m, -999, m_units); 
+    safeFill<float, float, xAOD::Jet>(fatjet, acc_ActiveArea4vec_m, m_ActiveArea4vec_m, -999, m_units);
   }
 
   if( m_infoSwitch.m_substructure ){
@@ -613,7 +613,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
     static SG::AuxElement::ConstAccessor<float> acc_ECF2("ECF2");
     safeFill<float, float, xAOD::Jet>(fatjet, acc_ECF2, m_ECF2, -999, m_units);
 
-    static SG::AuxElement::ConstAccessor<float> acc_ECF3 ("ECF3");      
+    static SG::AuxElement::ConstAccessor<float> acc_ECF3 ("ECF3");
     safeFill<float, float, xAOD::Jet>(fatjet, acc_ECF3, m_ECF3, -999, m_units);
 
     static SG::AuxElement::ConstAccessor<int> NTrimSubjets("NTrimSubjets");
@@ -653,7 +653,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
     xAOD::JetConstituentVector consVec = fatjet->getConstituents();
 
     if( consVec.isValid() ) {
-      
+
       // use the example provided in
       // http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Event/xAOD/xAODJet/xAODJet/JetConstituentVector.h
       xAOD::JetConstituentVector::iterator constit = consVec.begin();
@@ -675,20 +675,20 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
   if(m_infoSwitch.m_bosonCount){
 
     const xAOD::Jet* fatJetParentJet = 0;
-    
+
     try{
       auto el = fatjet->auxdata<ElementLink<xAOD::JetContainer> >("Parent");
       if(!el.isValid()){
-	Warning("executeSingle()", "Invalid link to \"Parent\" from fat-jet.");
+	    //Warning("executeSingle()", "Invalid link to \"Parent\" from fat-jet.");
       }
       else{
 	fatJetParentJet = (*el);
       }
     }catch(...){
-      Warning("executeSingle()", "Unable to get parent jet of fat-jet for truth labeling. Trimmed jet area would be used!");
+      //Warning("executeSingle()", "Unable to get parent jet of fat-jet for truth labeling. Trimmed jet area would be used!");
       fatJetParentJet = fatjet;
     }
-    
+
     if(m_mc){
       static SG::AuxElement::ConstAccessor< int > truthfatjet_TQuarks("GhostTQuarksFinalCount");
       safeFill<int, int, xAOD::Jet>(fatJetParentJet, truthfatjet_TQuarks, m_nTQuarks, -999);
@@ -703,7 +703,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
       safeFill<int, int, xAOD::Jet>(fatJetParentJet, truthfatjet_HBosons, m_nHBosons, -999);
     }
   }
-  
+
   if(m_infoSwitch.m_VTags){
     int Wtag_pass_medium = m_WbosonTaggerMedium->result(*fatjet);
     int Ztag_pass_medium = m_ZbosonTaggerMedium->result(*fatjet);
@@ -724,22 +724,22 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
   if( m_infoSwitch.m_trackJets ){
 
     const xAOD::Jet* fatjet_parent = 0;
-    
+
     try{
       auto el = fatjet->auxdata<ElementLink<xAOD::JetContainer> >("Parent");
       if(!el.isValid()){
-	Warning("execute()", "Invalid link to \"Parent\" from leading calo-jet");
+	    //Warning("execute()", "Invalid link to \"Parent\" from leading calo-jet");
       }
       else{
 	fatjet_parent = (*el);
       }
     }
     catch (...){
-      Warning("execute()", "Unable to fetch \"Parent\" link from leading calo-jet");
+      //Warning("execute()", "Unable to fetch \"Parent\" link from leading calo-jet");
     }
 
     if(fatjet_parent == 0){
-      Warning("execute()", "Trimmed jet area will be used for leading calo-jet");
+      //Warning("execute()", "Trimmed jet area will be used for leading calo-jet");
       fatjet_parent = fatjet;
     }
 
@@ -748,7 +748,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
       assotrkjets = fatjet_parent->getAssociatedObjects<xAOD::Jet>(m_infoSwitch.m_trackJetName);
     }
     catch (...){
-      Warning("execute()", "Unable to fetch \"%s\" link from leading calo-jet", m_infoSwitch.m_trackJetName.data());
+      //Warning("execute()", "Unable to fetch \"%s\" link from leading calo-jet", m_infoSwitch.m_trackJetName.data());
     }
 
     m_trkJetsIdx->push_back(vector<unsigned int>());

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -150,7 +150,7 @@ EL::StatusCode HLTJetGetter :: execute ()
         }//end trigJet loop
     }//end feature container loop
 
-    if ( m_verbose ) { m_store->print(); }
+    ATH_EXEC_VERBOSE(m_store->print());
 
     return EL::StatusCode::SUCCESS;
 }

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -34,11 +34,11 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetGetter)
 
-HLTJetGetter :: HLTJetGetter (std::string className) :
-Algorithm(className),
+HLTJetGetter :: HLTJetGetter () :
+Algorithm("HLTJetGetter"),
 m_trigDecTool(nullptr)
 {
-    ATH_MSG_INFO( "Calling constructor");
+    //ATH_MSG_INFO( "Calling constructor");
 
     // regex list of triggers
     m_triggerList = ".*";

--- a/Root/HLTJetGetter.cxx
+++ b/Root/HLTJetGetter.cxx
@@ -125,7 +125,7 @@ EL::StatusCode HLTJetGetter :: initialize ()
 
 EL::StatusCode HLTJetGetter :: execute ()
 {
-    if ( m_debug ) { ATH_MSG_INFO( "Getting HLT jets... "); }
+    ATH_MSG_DEBUG( "Getting HLT jets... ");
 
     //
     // Create the new container and its auxiliary store.
@@ -159,7 +159,7 @@ EL::StatusCode HLTJetGetter :: execute ()
 
 EL::StatusCode HLTJetGetter :: postExecute ()
 {
-    if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+    ATH_MSG_DEBUG( "Calling postExecute");
     return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -229,8 +229,8 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
   if(m_debug) cout << "Getting the PV " << endl;
   const xAOD::VertexContainer *offline_vertices(nullptr);
   const xAOD::Vertex *offline_pvx(nullptr);
-  if(HelperFunctions::isAvailable<xAOD::VertexContainer>("PrimaryVertices", m_event, m_store, m_verbose)){
-    RETURN_CHECK("HLTJetRoIBuilder::execute()", HelperFunctions::retrieve(offline_vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  if(HelperFunctions::isAvailable<xAOD::VertexContainer>("PrimaryVertices", m_event, m_store, msg())){
+    RETURN_CHECK("HLTJetRoIBuilder::execute()", HelperFunctions::retrieve(offline_vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
     offline_pvx = HelperFunctions::getPrimaryVertex(offline_vertices);
   }
 
@@ -238,7 +238,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
   // get event info
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("HLTJetRoIBuilder::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("HLTJetRoIBuilder::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
 
   //

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -43,8 +43,8 @@ using std::vector;
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetRoIBuilder)
 
-HLTJetRoIBuilder :: HLTJetRoIBuilder (std::string className) :
-  Algorithm(className),
+HLTJetRoIBuilder :: HLTJetRoIBuilder () :
+  Algorithm("HLTJetRoIBuilder"),
   m_trigItem(""),
   m_trigItemVeto(""),
   m_doHLTBJet(true),
@@ -57,7 +57,7 @@ HLTJetRoIBuilder :: HLTJetRoIBuilder (std::string className) :
   m_vtxName("EFHistoPrmVtx"),
   m_onlineBSTool()
 {
-  if(m_debug) ATH_MSG_INFO( "Calling constructor");
+  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
   m_debug                   = false;

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -57,17 +57,12 @@ HLTJetRoIBuilder :: HLTJetRoIBuilder () :
   m_vtxName("EFHistoPrmVtx"),
   m_onlineBSTool()
 {
-  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
-
-  // read debug flag from .config file
-  m_debug                   = false;
-
 }
 
 
 EL::StatusCode HLTJetRoIBuilder :: setupJob (EL::Job& job)
 {
-  if(m_debug) ATH_MSG_INFO( "Calling setupJob");
+  ATH_MSG_DEBUG( "Calling setupJob");
   job.useXAOD ();
   xAOD::Init( "HLTJetRoIBuilder" ).ignore(); // call before opening first file
   return EL::StatusCode::SUCCESS;
@@ -100,7 +95,7 @@ EL::StatusCode HLTJetRoIBuilder :: changeInput (bool /*firstFile*/)
 EL::StatusCode HLTJetRoIBuilder :: initialize ()
 {
 
-  if(m_debug) ATH_MSG_INFO( "Initializing HLTJetRoIBuilder Interface... ");
+  ATH_MSG_DEBUG( "Initializing HLTJetRoIBuilder Interface... ");
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -147,7 +142,7 @@ EL::StatusCode HLTJetRoIBuilder :: initialize ()
 
 EL::StatusCode HLTJetRoIBuilder :: execute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Doing HLT JEt ROI Building... "); }
+  ATH_MSG_DEBUG( "Doing HLT JEt ROI Building... ");
 
   if(m_doHLTBJet){
     return buildHLTBJets();
@@ -157,7 +152,7 @@ EL::StatusCode HLTJetRoIBuilder :: execute ()
 
 
 
-  if ( m_debug ) { m_store->print(); }
+  ATH_EXEC_DEBUG(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 }
@@ -189,21 +184,19 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
     firstItem = false;
   }
 
-  if(m_debug){
-    cout << m_name << " " << m_trigItem << " matches" << endl;
-    cout << m_trigItemAfterVeto << endl;
-    auto triggerChainGroupAfterVeto = m_trigDecTool->getChainGroup(m_trigItemAfterVeto);
-    std::vector<std::string> triggersUsedAfterVeto = triggerChainGroupAfterVeto->getListOfTriggers();
-    for(std::string trig : triggersUsedAfterVeto){
-      cout << " \t " << trig << endl;
-    }
+  ATH_MSG_DEBUG(m_name << " " << m_trigItem << " matches");
+  ATH_MSG_DEBUG(m_trigItemAfterVeto);
+  auto triggerChainGroupAfterVeto = m_trigDecTool->getChainGroup(m_trigItemAfterVeto);
+  std::vector<std::string> triggersUsedAfterVeto = triggerChainGroupAfterVeto->getListOfTriggers();
+  for(std::string trig : triggersUsedAfterVeto){
+    ATH_MSG_DEBUG(" \t " << trig);
   }
 
 
   //
   // Create the new container and its auxiliary store.
   //
-  if(m_debug) cout << "Creating the new container " << endl;
+  ATH_MSG_DEBUG("Creating the new container ");
   xAOD::JetContainer*     hltJets    = new xAOD::JetContainer();
   xAOD::JetAuxContainer*  hltJetsAux = new xAOD::JetAuxContainer();
   hltJets->setStore( hltJetsAux ); //< Connect the two
@@ -211,7 +204,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
   //
   //  For Adding Tracks to the Jet
   //
-  if(m_debug) cout << "Making the decorators " << endl;
+  ATH_MSG_DEBUG("Making the decorators ");
   static xAOD::Jet::Decorator<vector<const xAOD::TrackParticle*> > m_track_decoration      ("HLTBJetTracks");
   static xAOD::Jet::Decorator<const xAOD::Vertex*>                 m_vtx_decoration        ("HLTBJetTracks_vtx");
   static xAOD::Jet::Decorator<const xAOD::Vertex*>                 m_vtx_decoration_bkg    ("HLTBJetTracks_vtx_bkg");
@@ -226,12 +219,12 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
   //
   // get primary vertex
   //
-  if(m_debug) cout << "Getting the PV " << endl;
+  ATH_MSG_DEBUG("Getting the PV ");
   const xAOD::VertexContainer *offline_vertices(nullptr);
   const xAOD::Vertex *offline_pvx(nullptr);
   if(HelperFunctions::isAvailable<xAOD::VertexContainer>("PrimaryVertices", m_event, m_store, msg())){
     RETURN_CHECK("HLTJetRoIBuilder::execute()", HelperFunctions::retrieve(offline_vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-    offline_pvx = HelperFunctions::getPrimaryVertex(offline_vertices);
+    offline_pvx = HelperFunctions::getPrimaryVertex(offline_vertices, msg());
   }
 
   //
@@ -249,7 +242,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
   Trig::FeatureContainer fc = m_trigDecTool->features(m_trigItemAfterVeto, TrigDefs::Physics );
   Trig::FeatureContainer::combination_const_iterator comb   (fc.getCombinations().begin());
   Trig::FeatureContainer::combination_const_iterator combEnd(fc.getCombinations().end());
-  if(m_debug) cout << m_name << " New Event --------------- " << endl;
+  ATH_MSG_DEBUG( m_name << " New Event --------------- ");
 
   for( ; comb!=combEnd ; ++comb) {
     std::vector< Trig::Feature<xAOD::JetContainer> >            jetCollections  = comb->containerFeature<xAOD::JetContainer>(m_jetName);
@@ -291,23 +284,19 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
 
     bool isValid = true;
 
-    if(m_debug) cout << "ncontainers  " << bjetCollections.size() << endl;
+    ATH_MSG_DEBUG("ncontainers  " << bjetCollections.size());
 
     if(jetCollections.size() != bjetCollections.size()){
       cout << "ERROR Problem in container size: " << m_name << " jets: "<< jetCollections.size() << " bjets: "<< bjetCollections.size() << endl;
       isValid = false;
 
-      if(m_debug){
-	auto triggerChainGroupAfterVeto = m_trigDecTool->getChainGroup(m_trigItemAfterVeto);
-	std::vector<std::string> triggersUsedAfterVeto = triggerChainGroupAfterVeto->getListOfTriggers();
-	cout << "Passed Triggers " << endl;
-	for(std::string trig : triggersUsedAfterVeto){
-	  auto trigChain = m_trigDecTool->getChainGroup(trig);
-	  if(trigChain->isPassed())
-	    cout << " \t " << trig << endl;
-	}
+      auto triggerChainGroupAfterVeto = m_trigDecTool->getChainGroup(m_trigItemAfterVeto);
+      std::vector<std::string> triggersUsedAfterVeto = triggerChainGroupAfterVeto->getListOfTriggers();
+      ATH_MSG_DEBUG("Passed Triggers ");
+      for(std::string trig : triggersUsedAfterVeto){
+        auto trigChain = m_trigDecTool->getChainGroup(trig);
+        if(trigChain->isPassed()) ATH_MSG_DEBUG(" \t " << trig);
       }
-
 
     }
 
@@ -344,11 +333,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
     float var_bs_online_vy = m_onlineBSTool.getOnlineBSInfo(eventInfo, xAH::OnlineBeamSpotTool::BSData::BSy);
     float var_bs_online_vz = m_onlineBSTool.getOnlineBSInfo(eventInfo, xAH::OnlineBeamSpotTool::BSData::BSz);
 
-    if(m_debug){
-      cout << " bs_online_vx " << var_bs_online_vx
-	   << " bs_online_vy " << var_bs_online_vy
-	   << " bs_online_vz " << var_bs_online_vz << endl;
-    }
+    ATH_MSG_DEBUG(" bs_online_vx " << var_bs_online_vx << " bs_online_vy " << var_bs_online_vy << " bs_online_vz " << var_bs_online_vz);
 
 
     //cout << " is Valid " << jetCollections.size() << " " << vtxCollections.size() << endl;
@@ -362,7 +347,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
       }
 
       if(!passOverlap) continue;
-      if(m_debug) cout << "New Jet: pt: " << hlt_jet->pt() << " eta: " << hlt_jet->eta() << " phi: " << hlt_jet->phi() << endl;
+      ATH_MSG_DEBUG("New Jet: pt: " << hlt_jet->pt() << " eta: " << hlt_jet->eta() << " phi: " << hlt_jet->phi());
 
       const xAOD::BTagging* hlt_btag = getTrigObject<xAOD::BTagging, xAOD::BTaggingContainer>(bjetCollections.at(ifeat));
       if(!hlt_btag) continue;
@@ -387,13 +372,10 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
       if(m_readHLTTracks){
 
 	vector<const xAOD::TrackParticle*> matchedTracks;
-	if(m_debug)cout << "Trk Size" << hlt_tracks->size() << endl;
+	ATH_MSG_DEBUG("Trk Size" << hlt_tracks->size());
 
 	for(const xAOD::TrackParticle* thisHLTTrk: *hlt_tracks){
-	  if(m_debug) cout <<  "\tAdding  track "
-			   << thisHLTTrk->pt()   << " "
-			   << thisHLTTrk->eta()  << " "
-			   << thisHLTTrk->phi()  << endl;
+	  ATH_MSG_DEBUG("\tAdding  track " << thisHLTTrk->pt()   << " " << thisHLTTrk->eta()  << " " << thisHLTTrk->phi());
 	  matchedTracks.push_back(thisHLTTrk);
 	}
 
@@ -402,33 +384,23 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
 	//
 
 	if(hlt_tracks->size()){
-	  if(m_debug) {
-	    cout << "Found a hlt_tracks   "
-		 << hlt_tracks->at(0)->vx() << " "
-		 << hlt_tracks->at(0)->vy() << " "
-		 << hlt_tracks->at(0)->vz() << endl;
-	    cout << "Compares to variable " << " "
-		 << var_bs_online_vx << " "
-		 << var_bs_online_vy << " "
-		 << var_bs_online_vz << endl;
-	  }
+	    ATH_MSG_DEBUG("Found a hlt_tracks   " << hlt_tracks->at(0)->vx() << " " << hlt_tracks->at(0)->vy() << " " << hlt_tracks->at(0)->vz());
+	    ATH_MSG_DEBUG("Compares to variable " << " " << var_bs_online_vx << " " << var_bs_online_vy << " " << var_bs_online_vz);
 	}
 
 	m_bs_online_vx (*newHLTBJet) = var_bs_online_vx;
 	m_bs_online_vy (*newHLTBJet) = var_bs_online_vy;
 	m_bs_online_vz (*newHLTBJet) = var_bs_online_vz;
 
-	if(m_debug) cout <<  "Adding tracks to jet " << endl;
+	ATH_MSG_DEBUG("Adding tracks to jet ");
 	m_track_decoration(*newHLTBJet)         = matchedTracks;
 
 
       }
 
-      if(m_debug){
-	cout << "Doing it for:        " << m_trigItem << endl;
-	cout << "Check for m_jetName: " << m_jetName << endl;
-	cout << "Check for m_vtxName: " << m_vtxName << endl;
-      }
+	ATH_MSG_DEBUG("Doing it for:        " << m_trigItem);
+	ATH_MSG_DEBUG("Check for m_jetName: " << m_jetName);
+	ATH_MSG_DEBUG("Check for m_vtxName: " << m_vtxName);
 
       //
       // Check for dummy verticies
@@ -438,23 +410,19 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
       //               1 - EFHisto Found Vertex
       //               2 - No Vertex found
 
-      if(!HelperFunctions::getPrimaryVertex(vtxCollections.at(ifeat).cptr(), true)){
+      if(!HelperFunctions::getPrimaryVertex(vtxCollections.at(ifeat).cptr(), msg())){
 
-	if(m_debug){
-	  cout << "HAVE  No Online Vtx!!! m_vtxName is  " << m_vtxName << endl;
-	  for( auto vtx_itr : *(vtxCollections.at(ifeat).cptr()) ){
-	    cout << vtx_itr->vertexType() <<endl;
-	  }
-	}
+	  ATH_MSG_DEBUG("HAVE  No Online Vtx!!! m_vtxName is  " << m_vtxName);
+	  for( auto vtx_itr : *(vtxCollections.at(ifeat).cptr()) ) ATH_MSG_DEBUG(vtx_itr->vertexType());
 
 	//
 	//  Try the HistoPrmVtx
 	//
 	if(backupVtxCollections.size()){
-	  if(m_debug) cout << "Have EFHistoPrmVtx.  " << endl;
+	  ATH_MSG_DEBUG("Have EFHistoPrmVtx.  ");
 	  m_vtx_hadDummyPV  (*newHLTBJet)         = '1';
-	  const xAOD::Vertex *backup_pvx = HelperFunctions::getPrimaryVertex(backupVtxCollections.at(ifeat).cptr());
-	  if(m_debug) cout << "backup_pvx.  " << backup_pvx << endl;
+	  const xAOD::Vertex *backup_pvx = HelperFunctions::getPrimaryVertex(backupVtxCollections.at(ifeat).cptr(), msg());
+	  ATH_MSG_DEBUG("backup_pvx.  " << backup_pvx);
 	  m_vtx_decoration  (*newHLTBJet)         = backup_pvx;
 	  m_vtx_decoration_bkg(*newHLTBJet)       = backup_pvx;
 	}else{
@@ -468,11 +436,11 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
 
       }else{
 
-	m_vtx_decoration  (*newHLTBJet)         = HelperFunctions::getPrimaryVertex(vtxCollections.at(ifeat).cptr());
+	m_vtx_decoration  (*newHLTBJet)         = HelperFunctions::getPrimaryVertex(vtxCollections.at(ifeat).cptr(), msg());
 	m_vtx_hadDummyPV  (*newHLTBJet)         = '0';
 
 	if(backupVtxCollections.size()){
-	  m_vtx_decoration_bkg(*newHLTBJet)     = HelperFunctions::getPrimaryVertex(backupVtxCollections.at(ifeat).cptr());
+	  m_vtx_decoration_bkg(*newHLTBJet)     = HelperFunctions::getPrimaryVertex(backupVtxCollections.at(ifeat).cptr(), msg());
 	}else{
 	  m_vtx_decoration_bkg(*newHLTBJet)     = 0;
 	}
@@ -481,7 +449,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
 
       m_offline_vtx_decoration (*newHLTBJet)  = offline_pvx;
 
-      if(m_debug) cout << "hadDummy and vtxType" << m_vtx_hadDummyPV (*newHLTBJet) << " " << m_vtxName << endl;
+      ATH_MSG_DEBUG("hadDummy and vtxType" << m_vtx_hadDummyPV (*newHLTBJet) << " " << m_vtxName);
 
       //if(m_vtx_hadDummyPV (*newHLTBJet) != '0' ){
       //   cout << "hadDummy and vtxType and m_outContainerName  " << m_vtx_hadDummyPV (*newHLTBJet) << " "
@@ -489,7 +457,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
       //}
 
       hltJets->push_back( newHLTBJet );
-      if(m_debug) cout << "pushed back " << endl;
+      ATH_MSG_DEBUG("pushed back ");
 
     }//feature
 
@@ -507,7 +475,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTBJets ()
 
 EL::StatusCode HLTJetRoIBuilder :: buildHLTJets ()
 {
-  if(m_debug) cout << "In buildHLTJets  " <<endl;
+  ATH_MSG_DEBUG("In buildHLTJets  ");
   //
   // Create the new container and its auxiliary store.
   //
@@ -518,7 +486,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTJets ()
   Trig::FeatureContainer fc = m_trigDecTool->features(m_trigItem);
   auto jetFeatureContainers = fc.containerFeature<xAOD::JetContainer>();
 
-  if(m_debug) cout << "ncontainers  " << jetFeatureContainers.size() << endl;
+  ATH_MSG_DEBUG("ncontainers  " << jetFeatureContainers.size());
 
   //DataModel_detail::const_iterator<JetContainer >::reference {aka const xAOD::Jet_v1*}
 
@@ -534,7 +502,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTJets ()
 
   RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJets,    m_outContainerName),     "Failed to record selected dijets");
   RETURN_CHECK("PlotHLTBJetFex::selected()", m_store->record( hltJetsAux, m_outContainerName+"Aux."), "Failed to record selected dijetsAux.");
-  if(m_debug) cout << "Left buildHLTJets  " <<endl;
+  ATH_MSG_DEBUG("Left buildHLTJets  ");
   return EL::StatusCode::SUCCESS;
 }
 
@@ -542,7 +510,7 @@ EL::StatusCode HLTJetRoIBuilder :: buildHLTJets ()
 
 EL::StatusCode HLTJetRoIBuilder :: postExecute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
   return EL::StatusCode::SUCCESS;
 }
 
@@ -550,7 +518,7 @@ EL::StatusCode HLTJetRoIBuilder :: postExecute ()
 
 EL::StatusCode HLTJetRoIBuilder :: finalize ()
 {
-  if(m_debug) ATH_MSG_INFO( "Deleting tool instances...");
+  ATH_MSG_DEBUG( "Deleting tool instances...");
   return EL::StatusCode::SUCCESS;
 }
 
@@ -558,7 +526,7 @@ EL::StatusCode HLTJetRoIBuilder :: finalize ()
 
 EL::StatusCode HLTJetRoIBuilder :: histFinalize ()
 {
-  if(m_debug) ATH_MSG_INFO( "Calling histFinalize");
+  ATH_MSG_DEBUG( "Calling histFinalize");
   RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -46,7 +46,7 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   // turn things off it this is data...since TStore is not a needed input
   // default isMC to true so more is added to the tree than less
   const xAOD::EventInfo* eventInfo(nullptr);
-  HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, false);
+  HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store);
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
 }
@@ -592,7 +592,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
   xAH::JetContainer* thisJet = m_jets[jetName];
 
   if( thisJet->m_infoSwitch.m_trackPV || thisJet->m_infoSwitch.m_allTrack ) {
-    HelperFunctions::retrieve( vertices, "PrimaryVertices", m_event, 0 );
+    HelperFunctions::retrieve( vertices, "PrimaryVertices", m_event, 0);
     pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
     if ( pvLocation >= 0 ) pv = vertices->at( pvLocation );
   }
@@ -603,7 +603,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
   //
   if ( m_isMC ) {
     const xAOD::EventInfo* eventInfo(nullptr);
-    HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, false);
+    HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store);
 
     thisJet->FillGlobalBTagSF(eventInfo);
 

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -11,6 +11,13 @@
 #include <fastjet/tools/Filter.hh>
 #include <JetEDM/JetConstituentFiller.h>
 
+
+MsgStream& HelperFunctions::msg( MSG::Level lvl ) {
+  static MsgStream msgStream( "HelperFunctions" );
+  msgStream << lvl;
+  return msgStream;
+}
+
 // Get Number of Vertices with at least Ntracks
 bool HelperFunctions::passPrimaryVertexSelection(const xAOD::VertexContainer* vertexContainer, int Ntracks)
 {
@@ -465,61 +472,61 @@ std::string HelperFunctions::parse_wp( const std::string& type, const std::strin
 {
 
   std::string wp("");
-  
+
   std::size_t init;
   std::size_t end;
-  
+
   if ( type.compare("ISO") == 0 ) {
-    
+
     std::size_t found_iso = config_name.find("_isol");
-    
+
     // Return empty string if no isolation in config name
-    
+
     if ( found_iso == std::string::npos ) { return wp; }
-    
-    init = found_iso + 5; 
+
+    init = found_iso + 5;
     end  = config_name.find(".root");
-  
+
   } else if ( type.compare("ID") == 0 ) {
- 
+
     std::size_t found_ID = config_name.find("LLH");
-    
+
     // Return empty string if no LLH in config name
-    
+
     if ( found_ID == std::string::npos ) { return wp; }
-       
+
     init = string_pos( config_name, '.', 2 );
     end  = found_ID;
-    
+
   } else if ( type.compare("TRIG") == 0 ) {
- 
+
     std::size_t found_trigger = config_name.find("trigger");
-    
+
     // Return empty string if no LLH in config name
-    
+
     if ( found_trigger == std::string::npos ) { return wp; }
-       
+
     init = string_pos( config_name, '.', 3 );
     end  = string_pos( config_name, '.', 2 ) - 1;
-    
+
   } else {
-  
+
     Warning("HelperFunctions::parse_wp()","WP type can be either 'ISO' or 'ID'. Please check passed parameters of this function. Returning empty WP.");
     return wp;
-  
+
   }
-  
+
   wp = config_name.substr( init, (end - init) );
-  
+
   if ( type.compare("ID") == 0 ) { wp += "LLH"; }
 
   return wp;
 }
 
-bool HelperFunctions::has_exact(const std::string input, const std::string flag) 
-{ 
+bool HelperFunctions::has_exact(const std::string input, const std::string flag)
+{
   std::set<std::string> inputSet;
-  
+
   // parse and split by space
   std::string token;
   std::istringstream ss(input);
@@ -527,5 +534,5 @@ bool HelperFunctions::has_exact(const std::string input, const std::string flag)
     inputSet.insert(token);
 
 
-  return inputSet.find(flag) != inputSet.end(); 
+  return inputSet.find(flag) != inputSet.end();
 }

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -45,8 +45,9 @@ int HelperFunctions::countPrimaryVertices(const xAOD::VertexContainer* vertexCon
 
 }
 
-int HelperFunctions::getPrimaryVertexLocation(const xAOD::VertexContainer* vertexContainer)
+int HelperFunctions::getPrimaryVertexLocation(const xAOD::VertexContainer* vertexContainer, MsgStream& msg)
 {
+  msg.setName(msg.name()+".getPrimaryVertexLocation");
   int location(0);
   for( auto vtx_itr : *vertexContainer )
   {
@@ -55,7 +56,7 @@ int HelperFunctions::getPrimaryVertexLocation(const xAOD::VertexContainer* verte
     }
     location++;
   }
-  Warning("HelperFunctions::getPrimaryVertexLocation()","No primary vertex location was found! Returning -1");
+  msg << MSG::WARNING << "No primary vertex location was found! Returning -1" << endmsg;
   return -1;
 }
 
@@ -319,8 +320,10 @@ TLorentzVector HelperFunctions::jetTrimming(
 
 }
 
-const xAOD::Vertex* HelperFunctions::getPrimaryVertex(const xAOD::VertexContainer* vertexContainer, bool quiet)
+const xAOD::Vertex* HelperFunctions::getPrimaryVertex(const xAOD::VertexContainer* vertexContainer, MsgStream& msg)
 {
+  msg.setName(msg.name()+".getPrimaryVertex");
+
   // vertex types are listed on L328 of
   // https://svnweb.cern.ch/trac/atlasoff/browser/Event/xAOD/xAODTracking/trunk/xAODTracking/TrackingPrimitives.h
   for( auto vtx_itr : *vertexContainer )
@@ -329,8 +332,7 @@ const xAOD::Vertex* HelperFunctions::getPrimaryVertex(const xAOD::VertexContaine
     return vtx_itr;
   }
 
-  if(!quiet)
-    Warning("HelperFunctions::getPrimaryVertex()","No primary vertex was found! Returning nullptr");
+  msg << MSG::WARNING << "No primary vertex was found! Returning nullptr" << endmsg;
 
   return 0;
 }
@@ -353,17 +355,18 @@ bool HelperFunctions::sort_pt(xAOD::IParticle* partA, xAOD::IParticle* partB){
 // CP::make_systematics_vector(recSysts); has some similar functionality but does not
 // prune down to 1 systematic if only request that one.  It does however include the
 // nominal case as a null SystematicSet
-std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP::SystematicSet inSysts, std::string systName, float systVal, bool debug ) {
+std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP::SystematicSet inSysts, std::string systName, float systVal, MsgStream& msg ) {
+  msg.setName(msg.name()+".getListofSystematics");
 
   std::vector< CP::SystematicSet > outSystList;
 
-  if ( debug ) { Info("HelperFunctions::getListofSystematics()","systName %s", (systName).c_str()); }
+  msg << MSG::DEBUG << "systName " << systName << endmsg;
 
   // loop over input set
   //
   for ( const auto syst : inSysts ) {
 
-    if ( debug ) { Info("HelperFunctions::getListofSystematics()","  %s", (syst.name()).c_str()); }
+    msg << MSG::DEBUG << syst.name() << endmsg;
 
     // 1.
     // A match with input systName is found in the list:
@@ -371,7 +374,7 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
     //
     if ( systName == syst.basename() ) {
 
-      if ( debug ) { Info("HelperFunctions::getListofSystematics()","Found match! Adding systematic %s", syst.name().c_str()); }
+      msg << MSG::DEBUG << "Found match! Adding systematic " << syst.name() << endmsg;
 
       // continuous systematics - can choose at what sigma to evaluate
       //
@@ -380,7 +383,7 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
         outSystList.push_back(CP::SystematicSet());
 
         if ( systVal == 0 ) {
-          Error("HelperFunctions::getListofSystematics()","Setting continuous systematic to 0 is nominal! Please check!");
+          msg << MSG::ERROR << "Setting continuous systematic to 0 is nominal! Please check!" << endmsg;
           RCU_THROW_MSG("Failure");
         }
 
@@ -400,7 +403,7 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
     //
     else if ( systName.find("All") != std::string::npos ) {
 
-      if ( debug ) { Info("HelperFunctions::getListofSystematics()","Adding systematic %s", syst.name().c_str()); }
+      msg << MSG::DEBUG << "Adding systematic " << syst.name() << endmsg;
 
       // continuous systematics - can choose at what sigma to evaluate
       // add +1 and -1 for when running all
@@ -408,7 +411,7 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
       if ( syst == CP::SystematicVariation (syst.basename(), CP::SystematicVariation::CONTINUOUS) ) {
 
       if ( systVal == 0 ) {
-        Error("HelperFunctions::getListofSystematics()","Setting continuous systematic to 0 is nominal! Please check!");
+        msg << MSG::ERROR << "Setting continuous systematic to 0 is nominal! Please check!" << endmsg;
         RCU_THROW_MSG("Failure");
       }
 
@@ -468,8 +471,9 @@ std::size_t HelperFunctions::string_pos( const std::string& inputstr, const char
 }
 
 
-std::string HelperFunctions::parse_wp( const std::string& type, const std::string& config_name )
+std::string HelperFunctions::parse_wp( const std::string& type, const std::string& config_name, MsgStream& msg )
 {
+  msg.setName(msg.name()+".parse_wp");
 
   std::string wp("");
 
@@ -511,7 +515,7 @@ std::string HelperFunctions::parse_wp( const std::string& type, const std::strin
 
   } else {
 
-    Warning("HelperFunctions::parse_wp()","WP type can be either 'ISO' or 'ID'. Please check passed parameters of this function. Returning empty WP.");
+    msg << MSG::WARNING << "WP type can be either 'ISO' or 'ID'. Please check passed parameters of this function. Returning empty WP." << endmsg;
     return wp;
 
   }

--- a/Root/IParticleHistsAlgo.cxx
+++ b/Root/IParticleHistsAlgo.cxx
@@ -23,8 +23,6 @@ IParticleHistsAlgo :: IParticleHistsAlgo (std::string className) :
   // name of algo input container comes from - only if
   m_inputAlgo               = "";
 
-  m_debug                   = false;
-
 }
 
 EL::StatusCode IParticleHistsAlgo :: setupJob (EL::Job& job)
@@ -47,7 +45,7 @@ EL::StatusCode IParticleHistsAlgo::AddHists( std::string name ) {
   std::string fullname(m_name);
   fullname += name; // add systematic
   IParticleHists* particleHists = new IParticleHists( fullname, m_detailStr, m_histPrefix, m_histTitle ); // add systematic
-  particleHists->m_debug = m_debug;
+  particleHists->m_debug = msg().msgLevel(MSG::DEBUG);
   RETURN_CHECK((m_name+"::AddHists").c_str(), particleHists->initialize(), "");
   particleHists->record( wk() );
   m_plots[name] = particleHists;
@@ -60,7 +58,7 @@ EL::StatusCode IParticleHistsAlgo :: changeInput (bool /*firstFile*/) { return E
 
 EL::StatusCode IParticleHistsAlgo :: initialize ()
 {
-  if(m_debug) ATH_MSG_INFO( m_name);
+  ATH_MSG_DEBUG( m_name);
 
   // in case anything was missing or blank...
   if( m_inContainerName.empty() || m_detailStr.empty() ){
@@ -84,7 +82,7 @@ EL::StatusCode IParticleHistsAlgo :: execute ()
 EL::StatusCode IParticleHistsAlgo :: postExecute () { return EL::StatusCode::SUCCESS; }
 
 EL::StatusCode IParticleHistsAlgo :: finalize () {
-  if(m_debug) ATH_MSG_INFO( m_name );
+  ATH_MSG_DEBUG( m_name );
   for( auto plots : m_plots ) {
     if(plots.second){
       plots.second->finalize();

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -647,7 +647,7 @@ EL::StatusCode JetCalibrator :: execute ()
 
   // look what do we have in TStore
 
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -176,7 +176,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   m_store = wk()->xaodStore();
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("JetCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("JetCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
   ATH_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
@@ -463,7 +463,7 @@ EL::StatusCode JetCalibrator :: execute ()
 
   // get the collection from TEvent or TStore
   const xAOD::JetContainer* inJets(nullptr);
-  RETURN_CHECK("JetCalibrator::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("JetCalibrator::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, msg()) ,"");
 
   //
   // Perform nominal calibration

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -37,16 +37,16 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetCalibrator)
 
-JetCalibrator :: JetCalibrator (std::string className) :
-    Algorithm(className),
+JetCalibrator :: JetCalibrator () :
+    Algorithm("JetCalibrator"),
     m_runSysts(false),          // gets set later is syst applies to this tool
-    m_JetCalibrationTool_handle("JetCalibrationTool/JetCalibrationTool_"+className),
-    m_JetUncertaintiesTool_handle("JetUncertaintiesTool/JetUncertaintiesTool_"+className),
-    m_JERTool_handle("JERTool/JERTool_"+className),
-    m_JERSmearingTool_handle("JERSmearingTool/JERSmearingTool_"+className),
-    m_JVTUpdateTool_handle("JetVertexTaggerTool/JVTUpdateTool_"+className),
-    m_JetCleaningTool_handle("JetCleaningTool/JetCleaningTool_"+className),
-    m_JetTileCorrectionTool_handle("JetTileCorrectionTool/JetTileCorrectionTool_"+className)
+    m_JetCalibrationTool_handle("JetCalibrationTool/JetCalibrationTool_"+m_name),
+    m_JetUncertaintiesTool_handle("JetUncertaintiesTool/JetUncertaintiesTool_"+m_name),
+    m_JERTool_handle("JERTool/JERTool_"+m_name),
+    m_JERSmearingTool_handle("JERSmearingTool/JERSmearingTool_"+m_name),
+    m_JVTUpdateTool_handle("JetVertexTaggerTool/JVTUpdateTool_"+m_name),
+    m_JetCleaningTool_handle("JetCleaningTool/JetCleaningTool_"+m_name),
+    m_JetTileCorrectionTool_handle("JetTileCorrectionTool/JetTileCorrectionTool_"+m_name)
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  Note that you should only put
@@ -55,7 +55,7 @@ JetCalibrator :: JetCalibrator (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
 
   // read debug flag from .config file

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -58,9 +58,6 @@ JetCalibrator :: JetCalibrator () :
   //ATH_MSG_INFO( "Calling constructor");
 
 
-  // read debug flag from .config file
-  m_debug                   = false;
-
   m_sort                    = true;
   // input container to be read from TEvent or TStore
   m_inContainerName         = "";
@@ -304,7 +301,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
-  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
+  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, msg() );
   for(unsigned int i=0; i<m_systList.size(); i++)
     m_systType.insert(m_systType.begin(), 0); // Push systType nominal for this case
 
@@ -338,13 +335,13 @@ EL::StatusCode JetCalibrator :: initialize ()
     //If just one systVal, then push it to the vector
     RETURN_CHECK("JetCalibrator::initialize()", this->parseSystValVector(), "Failed to parse vector of systematic sigma values.");
     if( m_systValVector.size() == 0) {
-      if ( m_debug ){ ATH_MSG_INFO( "Pushing the following systVal to m_systValVector: " << m_systVal ); }
+      ATH_MSG_DEBUG("Pushing the following systVal to m_systValVector: " << m_systVal );
       m_systValVector.push_back(m_systVal);
     }
 
     for(unsigned int iSyst=0; iSyst < m_systValVector.size(); ++iSyst){
       m_systVal = m_systValVector.at(iSyst);
-      std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal, m_debug );
+      std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal, msg() );
 
       for(unsigned int i=0; i < JESSysList.size(); ++i){
         // do not add another nominal syst to the list!!
@@ -405,7 +402,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     const CP::SystematicSet recSysts = m_JERSmearingTool_handle->recommendedSystematics();
     ATH_MSG_INFO( " Initializing JER Systematics :");
 
-    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, 1, m_debug ); //Only 1 sys allowed
+    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, 1, msg() ); //Only 1 sys allowed
     for(unsigned int i=0; i < JERSysList.size(); ++i){
       // do not add another nominal syst to the list!!
       // CP::SystematicSet() creates an empty systematic set, compared to the set at index i
@@ -457,7 +454,7 @@ EL::StatusCode JetCalibrator :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Jet Calibration and Cleaning... "); }
+  ATH_MSG_DEBUG("Applying Jet Calibration and Cleaning... ");
 
   m_numEvent++;
 
@@ -541,7 +538,7 @@ EL::StatusCode JetCalibrator :: execute ()
     if ( m_runSysts ) {
       if ( thisSysType == 1 ){
         // JES Uncertainty Systematic
-        if( m_debug ) { std::cout << "Configure JES for systematic variation : " << syst_it.name() << std::endl; }
+        ATH_MSG_DEBUG("Configure JES for systematic variation : " << syst_it.name());
         if ( m_JetUncertaintiesTool_handle->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
           ATH_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
           return EL::StatusCode::FAILURE;
@@ -563,7 +560,7 @@ EL::StatusCode JetCalibrator :: execute ()
       }//JES
 
       if ( thisSysType == 2 || m_JERApplyNominal){
-        if( m_debug ) { std::cout << "Configure JER for systematic variation : " << syst_it.name() << std::endl; }
+        ATH_MSG_DEBUG("Configure JER for systematic variation : " << syst_it.name());
         if( thisSysType == 2){ //apply this systematic
           if ( m_JERSmearingTool_handle->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
             ATH_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
@@ -660,7 +657,7 @@ EL::StatusCode JetCalibrator :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG("Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetHistsAlgo.cxx
+++ b/Root/JetHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetHistsAlgo)
 
-JetHistsAlgo :: JetHistsAlgo (std::string className) :
-IParticleHistsAlgo(className)
+JetHistsAlgo :: JetHistsAlgo () :
+IParticleHistsAlgo("JetHistsAlgo")
 { }
 
 EL::StatusCode JetHistsAlgo :: setupJob (EL::Job& job)

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -219,7 +219,7 @@ EL::StatusCode JetSelector :: initialize ()
   m_store = wk()->xaodStore();
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("JetSelector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("JetSelector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
   if ( m_useCutFlow ) {
@@ -411,7 +411,7 @@ EL::StatusCode JetSelector :: execute ()
 
   // retrieve event
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // MC event weight
   float mcEvtWeight(1.0);
@@ -433,14 +433,14 @@ EL::StatusCode JetSelector :: execute ()
   const xAOD::JetContainer* inJets(nullptr);
 
   const xAOD::JetContainer *truthJets = nullptr;
-  if ( m_isMC && m_doJVT ) RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(truthJets, m_truthJetContainer, m_event, m_store, m_verbose) ,"");
+  if ( m_isMC && m_doJVT ) RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(truthJets, m_truthJetContainer, m_event, m_store, msg()) ,"");
 
   // if input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
   if ( m_inputAlgo.empty() ) {
 
     // this will be the collection processed - no matter what!!
-    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, msg()) ,"");
 
     // decorate inJets with truth info
     if ( m_isMC && m_doJVT ) {
@@ -464,14 +464,14 @@ EL::StatusCode JetSelector :: execute ()
 
     // get vector of string giving the names
     std::vector<std::string>* systNames(nullptr);
-    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, msg()) ,"");
 
     // loop over systematics
     std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
     bool passOne(false);
     for ( auto systName : *systNames ) {
 
-      RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inContainerName+systName, m_event, m_store, msg()) ,"");
 
       // decorate inJets with truth info
       if ( m_isMC && m_doJVT ) {
@@ -535,7 +535,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   // if doing JVF or JVT get PV location
   if ( m_doJVF ) {
     const xAOD::VertexContainer* vertices(nullptr);
-    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
     m_pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
   }
 
@@ -722,7 +722,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     // Decorator
     SG::AuxElement::Decorator< char > isCleanEventDecor( "cleanEvent_"+m_name );
     const xAOD::EventInfo* eventInfo(nullptr);
-    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
     isCleanEventDecor(*eventInfo) = passEventClean;
   }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -52,10 +52,9 @@ JetSelector :: JetSelector () :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_DEBUG( "Calling constructor");
 
   // read debug flag from .config file
-  m_debug         = false;
   m_useCutFlow    = true;
 
   // input container to be read from TEvent or TStore
@@ -152,7 +151,7 @@ EL::StatusCode JetSelector :: setupJob (EL::Job& job)
   // activated/deactivated when you add/remove the algorithm from your
   // job, which may or may not be of value to you.
 
-  if(m_debug) ATH_MSG_INFO( "Calling setupJob");
+  ATH_MSG_DEBUG( "Calling setupJob");
 
   job.useXAOD ();
   xAOD::Init( "JetSelector" ).ignore(); // call before opening first file
@@ -169,7 +168,7 @@ EL::StatusCode JetSelector :: histInitialize ()
   // trees.  This method gets called before any input files are
   // connected.
 
-  if(m_debug) ATH_MSG_INFO( "Calling histInitialize");
+  ATH_MSG_DEBUG( "Calling histInitialize");
   RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
 
   return EL::StatusCode::SUCCESS;
@@ -182,7 +181,7 @@ EL::StatusCode JetSelector :: fileExecute ()
   // Here you do everything that needs to be done exactly once for every
   // single file, e.g. collect a list of all lumi-blocks processed
 
-  if(m_debug) ATH_MSG_INFO( "Calling fileExecute");
+  ATH_MSG_DEBUG( "Calling fileExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -195,7 +194,7 @@ EL::StatusCode JetSelector :: changeInput (bool /*firstFile*/)
   // e.g. resetting branch addresses on trees.  If you are using
   // D3PDReader or a similar service this method is not needed.
 
-  if(m_debug) ATH_MSG_INFO( "Calling changeInput");
+  ATH_MSG_DEBUG( "Calling changeInput");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -213,7 +212,7 @@ EL::StatusCode JetSelector :: initialize ()
   // you create here won't be available in the output if you have no
   // input events.
 
-  if ( m_debug ) ATH_MSG_INFO( "Calling initialize");
+  ATH_MSG_DEBUG( "Calling initialize");
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -365,16 +364,14 @@ EL::StatusCode JetSelector :: initialize ()
   //
   m_outputSystNamesJVT = m_outputSystNamesJVT + "_JVT_" + m_WorkingPointJVT;
 
-  if ( m_debug ) {
-    CP::SystematicSet affectSystsJVT = m_JVT_tool_handle->affectingSystematics();
-    for ( const auto& syst_it : affectSystsJVT ) { ATH_MSG_INFO("JetJvtEfficiency tool can be affected by JVT efficiency systematic: " << syst_it.name()); }
-  }
+  CP::SystematicSet affectSystsJVT = m_JVT_tool_handle->affectingSystematics();
+  for ( const auto& syst_it : affectSystsJVT ) { ATH_MSG_DEBUG("JetJvtEfficiency tool can be affected by JVT efficiency systematic: " << syst_it.name()); }
   //
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
   const CP::SystematicSet recSystsJVT = m_JVT_tool_handle->recommendedSystematics();
-  m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, m_debug );
+  m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, msg() );
 
   ATH_MSG_INFO("Will be using JetJvtEfficiency tool JVT efficiency systematic:");
   for ( const auto& syst_it : m_systListJVT ) {
@@ -385,7 +382,7 @@ EL::StatusCode JetSelector :: initialize ()
     ATH_MSG_INFO("\t " << syst_it.name());
   }
 
-  if(m_debug) ATH_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
+  ATH_MSG_DEBUG( "Number of events in file: " << m_event->getEntries() );
 
   m_numEvent      = 0;
   m_numObject     = 0;
@@ -393,7 +390,7 @@ EL::StatusCode JetSelector :: initialize ()
   m_weightNumEventPass  = 0;
   m_numObjectPass = 0;
 
-  if(m_debug) ATH_MSG_INFO( "JetSelector Interface succesfully initialized!" );
+  ATH_MSG_DEBUG( "JetSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
 }
@@ -407,7 +404,7 @@ EL::StatusCode JetSelector :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Jet Selection... " << m_name); }
+  ATH_MSG_DEBUG( "Applying Jet Selection... " << m_name);
 
   // retrieve event
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -512,7 +509,7 @@ EL::StatusCode JetSelector :: execute ()
     wk()->skipEvent();
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Leave Jet Selection... "); }
+  ATH_MSG_DEBUG( "Leave Jet Selection... ");
 
   return EL::StatusCode::SUCCESS;
 
@@ -524,7 +521,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     std::string outContainerName
     )
 {
-  if ( m_debug ) { ATH_MSG_INFO( "in executeSelection... " << m_name); }
+  ATH_MSG_DEBUG("in executeSelection... " << m_name);
 
   // create output container (if requested)
   ConstDataVector<xAOD::JetContainer>* selectedJets(nullptr);
@@ -536,7 +533,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   if ( m_doJVF ) {
     const xAOD::VertexContainer* vertices(nullptr);
     RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-    m_pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
+    m_pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices, msg() );
   }
 
   //
@@ -597,7 +594,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
         // If any of the N leading jets are not clean the event should be removed
         if( m_markCleanEvent || m_cleanEvent || nObj <= m_cleanEvtLeadJets ){
           passEventClean = false;
-          if (m_debug) ATH_MSG_INFO( "Remove event due to bad jet with pt " << jet_itr->pt() );
+          ATH_MSG_DEBUG("Remove event due to bad jet with pt " << jet_itr->pt() );
         }// if cleaning the event
 
       }// if jet is not clean
@@ -608,7 +605,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
 
     if ( passSel ) {
-      if ( m_debug ) { ATH_MSG_INFO( "passSel"); }
+      ATH_MSG_DEBUG("passSel");
       nPass++;
       if ( m_createSelectedContainer ) {
         selectedJets->push_back( jet_itr );
@@ -637,7 +634,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
            std::string prepend = syst_it.name() + "_";
            sfName.insert( 0, prepend );
         }
-        if ( m_debug ) { ATH_MSG_INFO( "JVT SF sys name (to be recorded in xAOD::TStore) is: " << sfName); }
+        ATH_MSG_DEBUG("JVT SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
         sysVariationNamesJVT->push_back(sfName);
 
         // apply syst
@@ -646,14 +643,14 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           ATH_MSG_ERROR( "Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
           return EL::StatusCode::FAILURE;
         }
-        if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematic: " << syst_it.name()); }
+        ATH_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());
 
         // and now apply JVT SF!
         //
         unsigned int idx(0);
         for ( auto jet : *(selectedJets) ) {
 
-          if ( m_debug ) { ATH_MSG_INFO( "Applying JVT SF" ); }
+          ATH_MSG_DEBUG("Applying JVT SF" );
 
           // obtain JVT SF as a float (to be stored away separately)
           //
@@ -676,19 +673,17 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           //
           sfVecJVT( *jet ).push_back( jvtSF );
 
-          if ( m_debug ) {
-            ATH_MSG_INFO( "===>>>");
-            ATH_MSG_INFO( " ");
-            ATH_MSG_INFO( "Jet " << idx << ", pt = " << jet->pt()*1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) );
-            ATH_MSG_INFO( " ");
-            ATH_MSG_INFO( "JVT SF decoration: " << m_outputSystNamesJVT );
-            ATH_MSG_INFO( " ");
-            ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-            ATH_MSG_INFO( " ");
-            ATH_MSG_INFO( "JVT SF:");
-            ATH_MSG_INFO( "\t " << jvtSF << " (from getEfficiencyScaleFactor())" );
-            ATH_MSG_INFO( "--------------------------------------");
-          }
+          ATH_MSG_DEBUG( "===>>>");
+          ATH_MSG_DEBUG( " ");
+          ATH_MSG_DEBUG( "Jet " << idx << ", pt = " << jet->pt()*1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) );
+          ATH_MSG_DEBUG( " ");
+          ATH_MSG_DEBUG( "JVT SF decoration: " << m_outputSystNamesJVT );
+          ATH_MSG_DEBUG( " ");
+          ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+          ATH_MSG_DEBUG( " ");
+          ATH_MSG_DEBUG( "JVT SF:");
+          ATH_MSG_DEBUG( "\t " << jvtSF << " (from getEfficiencyScaleFactor())" );
+          ATH_MSG_DEBUG( "--------------------------------------");
 
           ++idx;
         }
@@ -718,7 +713,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   //  Mark Event as pass/fail cleaning for nominal selection
   //
   if ( m_markCleanEvent && count ) {
-    if ( m_debug ) ATH_MSG_INFO("Marking Clean");
+    ATH_MSG_DEBUG("Marking Clean");
     // Decorator
     SG::AuxElement::Decorator< char > isCleanEventDecor( "cleanEvent_"+m_name );
     const xAOD::EventInfo* eventInfo(nullptr);
@@ -742,7 +737,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     m_weightNumEventPass += mcEvtWeight;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "leave executeSelection... "); }
+  ATH_MSG_DEBUG("leave executeSelection... ");
   return true;
 }
 
@@ -753,7 +748,7 @@ EL::StatusCode JetSelector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG("Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -772,10 +767,10 @@ EL::StatusCode JetSelector :: finalize ()
   // merged.  This is different from histFinalize() in that it only
   // gets called on worker nodes that processed input events.
 
-  if(m_debug) ATH_MSG_INFO( m_name );
+  ATH_MSG_DEBUG( m_name );
 
   if ( m_useCutFlow ) {
-    if(m_debug) ATH_MSG_INFO( "Filling cutflow");
+    ATH_MSG_DEBUG( "Filling cutflow");
     m_cutflowHist ->SetBinContent( m_cutflow_bin, m_numEventPass        );
     m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
   }
@@ -800,13 +795,13 @@ EL::StatusCode JetSelector :: histFinalize ()
   // that it gets called on all worker nodes regardless of whether
   // they processed input events.
 
-  if(m_debug) ATH_MSG_INFO( "Calling histFinalize");
+  ATH_MSG_DEBUG( "Calling histFinalize");
   RETURN_CHECK("xAH::Algorithm::algFinalize()", xAH::Algorithm::algFinalize(), "");
   return EL::StatusCode::SUCCESS;
 }
 
 int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
-  if ( m_debug ) { ATH_MSG_INFO( "In pass cuts"); }
+  ATH_MSG_DEBUG("In pass cuts");
 
   // fill cutflow bin 'all' before any cut
   if(m_useCutFlow) m_jet_cutflowHist_1->Fill( m_jet_cutflow_all, 1 );
@@ -857,8 +852,8 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
 
   // JVF pileup cut
   if ( m_doJVF ){
-    if ( m_debug ) { ATH_MSG_INFO( "Doing JVF"); }
-    if ( m_debug ) { ATH_MSG_INFO( "Jet Pt " << jet->pt()); }
+    ATH_MSG_DEBUG("Doing JVF");
+    ATH_MSG_DEBUG("Jet Pt " << jet->pt());
     if ( jet->pt() < m_pt_max_JVF ) {
       xAOD::JetFourMom_t jetScaleP4 = jet->getAttribute< xAOD::JetFourMom_t >( m_jetScaleType.c_str() );
       if ( fabs(jetScaleP4.eta()) < m_eta_max_JVF ){
@@ -871,15 +866,13 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
 
   if(m_dofJVT){
     if(jet->auxdata<char>("passFJVT")!=1){
-      if(m_debug) {
-	ATH_MSG_INFO("jet pt = "<<jet->pt()<<",eta = "<<jet->eta()<<",phi = "<<jet->phi());
-        ATH_MSG_INFO("Failed forward JVT");
-      }
+      ATH_MSG_DEBUG("jet pt = "<<jet->pt()<<",eta = "<<jet->eta()<<",phi = "<<jet->phi());
+      ATH_MSG_DEBUG("Failed forward JVT");
       if(m_dofJVTVeto)return 0;
     }
-    else if (m_debug && TMath::Abs(jet->eta()>2.5) ) {
-      ATH_MSG_INFO("jet pt = " << jet->pt() << ",eta = "<<jet->eta()<<",phi = "<<jet->phi());
-      ATH_MSG_INFO("Passed forward JVT");
+    else if (TMath::Abs(jet->eta()>2.5) ) {
+      ATH_MSG_DEBUG("jet pt = " << jet->pt() << ",eta = "<<jet->eta()<<",phi = "<<jet->phi());
+      ATH_MSG_DEBUG("Passed forward JVT");
     }
 
   }//do forward JVT
@@ -887,28 +880,25 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   // JVT pileup cut
   //
   if ( m_doJVT ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Checking JVT cut..."); }
-    if ( m_debug ) {
-      if ( m_JVTCut > 0 && jet->getAttribute< float >( "Jvt" ) < m_JVTCut ) { ATH_MSG_INFO( " pt/eta = "<<jet->pt()<<"/" << jet->eta() ); }
-    }
+    ATH_MSG_DEBUG("Checking JVT cut...");
+    if ( m_JVTCut > 0 && jet->getAttribute< float >( "Jvt" ) < m_JVTCut ) { ATH_MSG_DEBUG( " pt/eta = "<<jet->pt()<<"/" << jet->eta() ); }
 
     // Old usage: check manually whether this jet passes JVT cut
     //
     if ( m_JVTCut > 0 ) {
       if ( jet->pt() < m_pt_max_JVT ) {
-	if ( m_debug ) { ATH_MSG_INFO( "Pass JVT-pT Cut"); }
-	xAOD::JetFourMom_t jetScaleP4 = jet->getAttribute< xAOD::JetFourMom_t >( m_jetScaleType.c_str() );
-	if ( fabs(jetScaleP4.eta()) < m_eta_max_JVT ){
-	  if ( m_debug ) ATH_MSG_INFO( " Pass JVT-Eta Cut " );
-
-	  if ( m_debug ) { ATH_MSG_INFO( " JVT = " << jet->getAttribute< float >( "Jvt" ) ); }
+        ATH_MSG_DEBUG("Pass JVT-pT Cut");
+        xAOD::JetFourMom_t jetScaleP4 = jet->getAttribute< xAOD::JetFourMom_t >( m_jetScaleType.c_str() );
+        if ( fabs(jetScaleP4.eta()) < m_eta_max_JVT ){
+          ATH_MSG_DEBUG(" Pass JVT-Eta Cut " );
+          ATH_MSG_DEBUG(" JVT = " << jet->getAttribute< float >( "Jvt" ) );
           if ( jet->getAttribute< float >( "Jvt" ) < m_JVTCut ) {
-	    if ( m_debug ) { ATH_MSG_INFO( " upper JVTCut is " << m_JVTCut << " - cutting this jet!!" ); }
+            ATH_MSG_DEBUG(" upper JVTCut is " << m_JVTCut << " - cutting this jet!!" );
             return 0;
           } else {
-	    if ( m_debug ) { ATH_MSG_INFO( " upper JVTCut is " << m_JVTCut << " - jet passes JVT "); }
-	  }
-	}
+            ATH_MSG_DEBUG(" upper JVTCut is " << m_JVTCut << " - jet passes JVT ");
+          }
+        }
       }
     } else {
       if ( !m_JVT_tool_handle->passesJvtCut(*jet) ) { return 0; }
@@ -920,7 +910,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   //  BTagging
   //
   if ( m_doBTagCut ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Doing BTagging"); }
+    ATH_MSG_DEBUG("Doing BTagging");
     if ( m_BJetSelectTool->accept( jet ) ) {
       if(m_useCutFlow) m_jet_cutflowHist_1->Fill( m_jet_cutflow_btag_cut, 1 );
     } else {
@@ -981,7 +971,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   //  Truth Label
   //
   if ( m_truthLabel != -1 ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Doing Truth Label"); }
+    ATH_MSG_DEBUG("Doing Truth Label");
     int this_TruthLabel = 0;
 
     static SG::AuxElement::ConstAccessor<int> HadronConeExclTruthLabelID ("HadronConeExclTruthLabelID");
@@ -1005,7 +995,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
 
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Passed Cuts"); }
+  ATH_MSG_DEBUG("Passed Cuts");
   return 1;
 }
 

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -37,8 +37,8 @@
 ClassImp(JetSelector)
 
 
-JetSelector :: JetSelector (std::string className) :
-    Algorithm(className),
+JetSelector :: JetSelector () :
+    Algorithm("JetSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_jet_cutflowHist_1(nullptr),
@@ -52,7 +52,7 @@ JetSelector :: JetSelector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  if(m_debug) ATH_MSG_INFO( "Calling constructor");
+  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
   m_debug         = false;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -506,7 +506,7 @@ EL::StatusCode JetSelector :: execute ()
   }
 
   // look what we have in TStore
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if ( !pass ) {
     wk()->skipEvent();

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -66,8 +66,6 @@ METConstructor :: METConstructor () :
     Algorithm("METConstructor")
 {
 
-  m_debug                 = false;
-
   m_referenceMETContainer = "MET_Reference_AntiKt4LCTopo";
   m_mapName               = "METAssoc_AntiKt4LCTopo";
   m_coreName              = "MET_Core_AntiKt4LCTopo";
@@ -205,14 +203,14 @@ EL::StatusCode METConstructor :: initialize ()
   if(!m_runNominal && !m_systName.empty()) { //  m_systName is set by default to m_systName= "All", do not change it
       // get the syst from met syst tool
       const CP::SystematicSet recSyst = m_metSyst_handle->recommendedSystematics();
-      sysList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
+      sysList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, msg() );
 
   } else { //run nominal
     sysList.push_back(CP::SystematicSet()); // add empty systematic (Nominal case)
   }
 
   for ( const auto& syst_it : sysList ) {
-    if (m_debug) cout<<"syst_it = "<<syst_it.name()<<endl;
+    ATH_MSG_DEBUG("syst_it = "<<syst_it.name());
     ATH_MSG_INFO("\t " << syst_it.name());
   }
 
@@ -223,7 +221,7 @@ EL::StatusCode METConstructor :: initialize ()
   RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
-  if ( m_debug ) { ATH_MSG_INFO( "Is MC? " << static_cast<int>(m_isMC) ); }
+  ATH_MSG_DEBUG( "Is MC? " << static_cast<int>(m_isMC) );
 
 
   return EL::StatusCode::SUCCESS;
@@ -237,7 +235,7 @@ EL::StatusCode METConstructor :: execute ()
    // histograms and trees.  This is where most of your actual analysis
    // code will go.
 
-   if(m_debug) ATH_MSG_INFO( "Performing MET reconstruction...");
+   ATH_MSG_DEBUG( "Performing MET reconstruction...");
 
    m_numEvent ++ ;
    //if (m_debug) cout<< "number of processed events now is : "<< m_numEvent <<endl;
@@ -267,7 +265,7 @@ EL::StatusCode METConstructor :: execute ()
 
      for ( auto systName : *sysJetsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
-     if ( m_debug ) cout<< "jet syst added is = "<< systName<< endl;
+       ATH_MSG_DEBUG("jet syst added is = "<< systName);
      }
    }
 
@@ -278,7 +276,7 @@ EL::StatusCode METConstructor :: execute ()
 
      for ( auto systName : *sysElectronsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())  ) sysList.push_back(CP::SystematicSet(systName));
-     if ( m_debug ) cout<< "ele syst added is = "<< systName<< endl;
+       ATH_MSG_DEBUG("ele syst added is = "<< systName);
      }
    }
 
@@ -289,7 +287,7 @@ EL::StatusCode METConstructor :: execute ()
 
      for ( auto systName : *sysMuonsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
-     if ( m_debug ) cout<< "muon syst added is = "<< systName<< endl;
+       ATH_MSG_DEBUG("muon syst added is = "<< systName);
      }
    }
 
@@ -300,7 +298,7 @@ EL::StatusCode METConstructor :: execute ()
 
      for ( auto systName : *sysPhotonsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
-     if ( m_debug ) cout<< "photon syst added is = "<< systName<< endl;
+       ATH_MSG_DEBUG("photon syst added is = "<< systName);
      }
    }
 
@@ -321,7 +319,7 @@ EL::StatusCode METConstructor :: execute ()
       std::string sysListItrString;// just for convenience, to retrieve the containers
       sysListItrString= (*sysListItr).name();
 
-      if (m_debug) cout<<" loop over systematic = "<<sysListItr->name() <<endl;
+      ATH_MSG_DEBUG(" loop over systematic = "<<sysListItr->name());
 
       vecOutContainerNames->push_back( sysListItr->name() );
 
@@ -343,7 +341,7 @@ EL::StatusCode METConstructor :: execute ()
          const xAOD::ElectronContainer* eleCont(0);
          if ( m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString ) ) {
            RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving electron cont.");
-           if (m_debug) cout<< "retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met "<< endl;
+           ATH_MSG_DEBUG("retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met ");
          }else{
            RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
          }
@@ -366,7 +364,7 @@ EL::StatusCode METConstructor :: execute ()
          const xAOD::PhotonContainer* phoCont(0);
          if ( m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString ) ) {
            RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving photon cont.");
-           if (m_debug) cout<< "retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met "<< endl;
+           ATH_MSG_DEBUG("retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met ");
          } else {
          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
       }
@@ -408,7 +406,7 @@ EL::StatusCode METConstructor :: execute ()
         if ( m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
 
           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving photon cont.");
-          if (m_debug) cout<< "retrieving tau container "<< m_inputTaus.Data()+sysListItrString << " to be added to the met "<< endl;
+          ATH_MSG_DEBUG("retrieving tau container "<< m_inputTaus.Data()+sysListItrString << " to be added to the met ");
 
         } else {
         RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
@@ -457,14 +455,14 @@ EL::StatusCode METConstructor :: execute ()
 
      const xAOD::JetContainer* jetCont(0);
      std::string m_inputJets_Syst =  m_inputJets.Data() +sysListItrString;// just for convenience
-     if (m_debug) cout<<" the jet container name is : "<<m_inputJets_Syst<< endl;
+     ATH_MSG_DEBUG(" the jet container name is : "<<m_inputJets_Syst);
 
      if ( m_store->contains<xAOD::JetContainer>(m_inputJets.Data()+sysListItrString ) ) {
-       if (m_debug) cout << "syst is = "<<sysListItrString <<endl;
+       ATH_MSG_DEBUG("syst is = "<<sysListItrString);
        //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont,m_inputJets_Syst  ), "");// is this necessary?
        RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, msg()), " Failed retrieving jet cont.");
      } else {
-       if (m_debug) cout<<" not found this jet container : "<< m_inputJets.Data()+sysListItrString<< endl;
+       ATH_MSG_DEBUG(" not found this jet container : "<< m_inputJets.Data()+sysListItrString);
        //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont, m_inputJets.Data() ), "");// is this necessary?
        RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, msg()), " Failed retrieving jet cont.");
      }
@@ -502,14 +500,14 @@ EL::StatusCode METConstructor :: execute ()
      if( m_isMC && m_metSyst_handle->applyCorrection(*softClusMet) != CP::CorrectionCode::Ok) {
        ATH_MSG_ERROR( "Could not apply correction to soft clus met !!!! ");
      }
-     if (m_debug) std::cout << "Soft cluster met term met : " << softClusMet->met() << std::endl;
+     ATH_MSG_DEBUG("Soft cluster met term met : " << softClusMet->met());
 
      //get the track soft term, and applyCorrection
      xAOD::MissingET * softTrkMet = (*newMet)["PVSoftTrk"];
      if( m_isMC && m_metSyst_handle->applyCorrection(*softTrkMet) != CP::CorrectionCode::Ok) {
        ATH_MSG_ERROR( "Could not apply correction to soft track met !!!! ");
      }
-     if (m_debug) std::cout << "track met soft term : " << softTrkMet->met() << std::endl;
+     ATH_MSG_DEBUG("track met soft term : " << softTrkMet->met());
 
      //only for track jets
      /*xAOD::MissingET * jetMet = (*newMet)["RefJet"];
@@ -526,10 +524,10 @@ EL::StatusCode METConstructor :: execute ()
      RETURN_CHECK("METConstructor::execute()", m_store->record(newMet, (m_outputContainer+sysListItr->name()).Data() ), "Failed to store MET output container.");
      RETURN_CHECK("METConstructor::execute()", m_store->record(metAuxCont, (m_outputContainer+sysListItr->name() + "Aux.").Data()), "Failed to store MET output container.");
 
-     if (m_debug) std::cout << " FinalClus met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalClus"))->met() << std::endl;
-     if (m_debug) std::cout << " FinalTrk met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalTrk"))->met() << std::endl;
-     if (m_debug) cout<< "storing met container :  " << (m_outputContainer+ sysListItr->name()).Data() << endl;
-     if (m_debug) cout<< "storing  Aux met container :  "<< (m_outputContainer+ sysListItr->name() + "Aux.").Data() << endl;
+     ATH_MSG_DEBUG(" FinalClus met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalClus"))->met());
+     ATH_MSG_DEBUG(" FinalTrk met, for syst " << sysListItr->name() << " is = " << (*newMet->find("FinalTrk"))->met());
+     ATH_MSG_DEBUG("storing met container :  " << (m_outputContainer+ sysListItr->name()).Data());
+     ATH_MSG_DEBUG("storing  Aux met container :  "<< (m_outputContainer+ sysListItr->name() + "Aux.").Data());
 
 
      /* something causes a crash down here
@@ -577,7 +575,7 @@ EL::StatusCode METConstructor :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if(m_debug) ATH_MSG_INFO( "Calling postExecute");
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -62,8 +62,8 @@ using std::string;
 ClassImp(METConstructor)
 
 
-METConstructor :: METConstructor (std::string className) :
-    Algorithm(className)
+METConstructor :: METConstructor () :
+    Algorithm("METConstructor")
 {
 
   m_debug                 = false;

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -220,7 +220,7 @@ EL::StatusCode METConstructor :: initialize ()
 
   // define m_isMC
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
   if ( m_debug ) { ATH_MSG_INFO( "Is MC? " << static_cast<int>(m_isMC) ); }
@@ -244,10 +244,10 @@ EL::StatusCode METConstructor :: execute ()
 
 
    const xAOD::MissingETContainer* coreMet(0);
-   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Core.");
+   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(coreMet, m_coreName.Data(), m_event, m_store, msg()), "Failed retrieving MET Core.");
 
    const xAOD::MissingETAssociationMap* metMap = 0;
-   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(metMap,  m_mapName.Data(), m_event, m_store, m_debug), "Failed retrieving MET Map.");
+   RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(metMap,  m_mapName.Data(), m_event, m_store, msg()), "Failed retrieving MET Map.");
 
    std::vector<CP::SystematicSet>::const_iterator sysListItr;
    std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
@@ -263,7 +263,7 @@ EL::StatusCode METConstructor :: execute ()
    //add the syst for jets
    if(!m_runNominal && !m_jetSystematics.empty()){
      std::vector<std::string>* sysJetsNames(nullptr);
-     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysJetsNames, m_jetSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysJetsNames, m_jetSystematics, 0, m_store, msg()), "Failed retrieving object systematics.");
 
      for ( auto systName : *sysJetsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
@@ -274,7 +274,7 @@ EL::StatusCode METConstructor :: execute ()
    //add the syst for electrons
    if(!m_runNominal && !m_eleSystematics.empty()){
      std::vector<std::string>* sysElectronsNames(nullptr);
-     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysElectronsNames, m_eleSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysElectronsNames, m_eleSystematics, 0, m_store, msg()), "Failed retrieving object systematics.");
 
      for ( auto systName : *sysElectronsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())  ) sysList.push_back(CP::SystematicSet(systName));
@@ -285,7 +285,7 @@ EL::StatusCode METConstructor :: execute ()
    //add the syst for muons
    if(!m_runNominal && !m_muonSystematics.empty()){
      std::vector<std::string>* sysMuonsNames(nullptr);
-     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysMuonsNames, m_muonSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysMuonsNames, m_muonSystematics, 0, m_store, msg()), "Failed retrieving object systematics.");
 
      for ( auto systName : *sysMuonsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
@@ -296,7 +296,7 @@ EL::StatusCode METConstructor :: execute ()
    //add the syst for photons
    if(!m_runNominal && !m_phoSystematics.empty()){
      std::vector<std::string>* sysPhotonsNames(nullptr);
-     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysPhotonsNames, m_phoSystematics, 0, m_store, m_debug), "Failed retrieving object systematics.");
+     RETURN_CHECK("METConstructor::initialize()", HelperFunctions::retrieve(sysPhotonsNames, m_phoSystematics, 0, m_store, msg()), "Failed retrieving object systematics.");
 
      for ( auto systName : *sysPhotonsNames ) {
        if (systName != "" && !(std::find(sysList.begin(), sysList.end(), CP::SystematicSet(systName)) != sysList.end())) sysList.push_back(CP::SystematicSet(systName));
@@ -342,10 +342,10 @@ EL::StatusCode METConstructor :: execute ()
       if( m_inputElectrons.Length() > 0  && m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString )) {
          const xAOD::ElectronContainer* eleCont(0);
          if ( m_store->contains<xAOD::ElectronContainer>(m_inputElectrons.Data()+sysListItrString ) ) {
-           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving electron cont.");
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving electron cont.");
            if (m_debug) cout<< "retrieving ele container "<<    m_inputElectrons.Data() +sysListItrString << " to be added to the met "<< endl;
          }else{
-           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(eleCont, m_inputElectrons.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
          }
 
          if (m_doElectronCuts) {
@@ -365,10 +365,10 @@ EL::StatusCode METConstructor :: execute ()
       if( m_inputPhotons.Length() > 0  && m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString )) {
          const xAOD::PhotonContainer* phoCont(0);
          if ( m_store->contains<xAOD::PhotonContainer>(m_inputPhotons.Data()+sysListItrString ) ) {
-           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
+           RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving photon cont.");
            if (m_debug) cout<< "retrieving ph container "<<    m_inputPhotons.Data() +sysListItrString << " to be added to the met "<< endl;
          } else {
-         RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+         RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(phoCont, m_inputPhotons.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
       }
 
       if (m_doPhotonCuts) {
@@ -407,11 +407,11 @@ EL::StatusCode METConstructor :: execute ()
         const xAOD::TauJetContainer* tauCont(0);
         if ( m_store->contains<xAOD::TauJetContainer>(m_inputTaus.Data()+sysListItrString ) ) {
 
-          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, m_verbose), "Failed retrieving photon cont.");
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving photon cont.");
           if (m_debug) cout<< "retrieving tau container "<< m_inputTaus.Data()+sysListItrString << " to be added to the met "<< endl;
 
         } else {
-        RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, m_debug), "Failed retrieving electron cont.");
+        RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(tauCont, m_inputTaus.Data(), m_event, m_store, msg()), "Failed retrieving electron cont.");
       }
 
        if (m_doTauCuts) {
@@ -438,9 +438,9 @@ EL::StatusCode METConstructor :: execute ()
        std::string m_inputMuons_Syst =  m_inputMuons.Data() +sysListItrString;
         const xAOD::MuonContainer* muonCont(0);
         if ( m_store->contains<xAOD::MuonContainer>(m_inputMuons.Data()+sysListItrString ) ) {
-          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data()+sysListItrString, m_event, m_store, m_debug), "Failed retrieving muon cont.");
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data()+sysListItrString, m_event, m_store, msg()), "Failed retrieving muon cont.");
         } else {
-          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data(), m_event, m_store, m_debug), "Failed retrieving electronmuon cont.");
+          RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(muonCont, m_inputMuons.Data(), m_event, m_store, msg()), "Failed retrieving electronmuon cont.");
         }
         if (m_doMuonCuts) {
           ConstDataVector<xAOD::MuonContainer> metMuons(SG::VIEW_ELEMENTS);
@@ -462,11 +462,11 @@ EL::StatusCode METConstructor :: execute ()
      if ( m_store->contains<xAOD::JetContainer>(m_inputJets.Data()+sysListItrString ) ) {
        if (m_debug) cout << "syst is = "<<sysListItrString <<endl;
        //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont,m_inputJets_Syst  ), "");// is this necessary?
-       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont,m_inputJets_Syst, m_event, m_store, msg()), " Failed retrieving jet cont.");
      } else {
        if (m_debug) cout<<" not found this jet container : "<< m_inputJets.Data()+sysListItrString<< endl;
        //RETURN_CHECK( "METConstructor::execute()", m_metSyst_handle->evtStore()->retrieve( jetCont, m_inputJets.Data() ), "");// is this necessary?
-       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, m_debug  ), " Failed retrieving jet cont.");
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(jetCont, m_inputJets.Data(), m_event, m_store, msg()), " Failed retrieving jet cont.");
      }
 
      // the jet term and soft term(s) are built simultaneously using METMaker::rebuildJetMET(...) or METMaker::rebuildTrackMET(...)
@@ -535,7 +535,7 @@ EL::StatusCode METConstructor :: execute ()
      /* something causes a crash down here
      if ( m_debug ) {
        const xAOD::MissingETContainer* oldMet(0);
-       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(oldMet, m_referenceMETContainer.Data(), m_event, m_store, m_verbose) ,"");
+       RETURN_CHECK("METConstructor::execute()", HelperFunctions::retrieve(oldMet, m_referenceMETContainer.Data(), m_event, m_store, msg()) ,"");
        //xAOD::MissingETContainer::const_iterator final(oldMet->find("FinalClus"));
        //xAOD::MissingETContainer::const_iterator newfinal(newMet->find("FinalClus"));
        ATH_MSG_INFO( ">>>>>>>>>>>>>>>>>>>>>>>>>>>>");

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -563,7 +563,7 @@ EL::StatusCode METConstructor :: execute ()
       RETURN_CHECK( "METConstructor::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names.");
    }
 
-   if ( m_verbose ) m_store->print();// print TStore content
+   ATH_EXEC_VERBOSE(m_store->print());// print TStore content
 
   return EL::StatusCode::SUCCESS;
 

--- a/Root/MetContainer.cxx
+++ b/Root/MetContainer.cxx
@@ -12,7 +12,7 @@ MetContainer::MetContainer(const std::string& detailStr, float units)
 
 MetContainer::~MetContainer()
 {
-  if(m_debug) cout << " Deleting MetContainer "  << endl;  
+  if(m_debug) cout << " Deleting MetContainer "  << endl;
 }
 
 void MetContainer::setTree(TTree *tree)
@@ -30,7 +30,7 @@ void MetContainer::setTree(TTree *tree)
   connectBranch<float>(tree, "metFinalTrkPy",        &m_metFinalTrkPy	 );
   connectBranch<float>(tree, "metFinalTrkSumEt",     &m_metFinalTrkSumEt );
   connectBranch<float>(tree, "metFinalTrkPhi",       &m_metFinalTrkPhi   );
-   
+
   if ( m_infoSwitch.m_refEle ) {
     connectBranch<float>(tree, "metEle",             &m_metEle       );
     connectBranch<float>(tree, "metEleSumEt",        &m_metEleSumEt  );
@@ -149,7 +149,7 @@ void MetContainer::setBranches(TTree *tree)
 
   return;
 }
-    
+
 
 void MetContainer::clear()
 {
@@ -191,9 +191,9 @@ void MetContainer::clear()
 }
 
 void MetContainer::FillMET( const xAOD::MissingETContainer* met) {
-  
 
-  if ( m_debug ) { Info("HelpTreeBase::FillMET()", "Filling MET info"); }
+
+  //if ( m_debug ) { Info("HelpTreeBase::FillMET()", "Filling MET info"); }
 
   const xAOD::MissingET* final_clus = *met->find("FinalClus"); // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based onleares)
   m_metFinalClus      = final_clus->met() / m_units;

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MetHistsAlgo)
 
-MetHistsAlgo :: MetHistsAlgo (std::string className) :
-    Algorithm(className),
+MetHistsAlgo :: MetHistsAlgo () :
+    Algorithm("MetHistsAlgo"),
     m_plots(nullptr)
 {
   m_inContainerName         = "";

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -63,7 +63,7 @@ EL::StatusCode MetHistsAlgo :: initialize ()
 EL::StatusCode MetHistsAlgo :: execute ()
 {
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MetHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MetHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
 
   float eventWeight(1);
@@ -72,7 +72,7 @@ EL::StatusCode MetHistsAlgo :: execute ()
   }
 
   const xAOD::MissingETContainer* met(nullptr);
-  RETURN_CHECK("MetHistsAlgo::execute()", HelperFunctions::retrieve(met, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MetHistsAlgo::execute()", HelperFunctions::retrieve(met, m_inContainerName, m_event, m_store, msg()) ,"");
 
   RETURN_CHECK("MetHistsAlgo::execute()", m_plots->execute( met, eventWeight ), "");
 

--- a/Root/MetHistsAlgo.cxx
+++ b/Root/MetHistsAlgo.cxx
@@ -18,7 +18,6 @@ MetHistsAlgo :: MetHistsAlgo () :
 {
   m_inContainerName         = "";
   m_detailStr               = "";
-  m_debug                   = false;
 }
 
 EL::StatusCode MetHistsAlgo :: setupJob (EL::Job& job)

--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -138,8 +138,7 @@ EL::StatusCode MinixAOD :: initialize ()
   if(m_copyFileMetaData){
     m_fileMetaDataTool = new xAODMaker::FileMetaDataTool();
 
-    if(m_verbose)
-      RETURN_CHECK("MinixAOD::initialize()", m_fileMetaDataTool->setProperty("OutputLevel", MSG::VERBOSE ), "Could not set verbosity on fileMenuMetaDataTool");
+    RETURN_CHECK("MinixAOD::initialize()", m_fileMetaDataTool->setProperty("OutputLevel", msg().level() ), "Could not set verbosity on fileMenuMetaDataTool");
 
 
     RETURN_CHECK("MinixAOD::initialize()", m_fileMetaDataTool->initialize(), "Could not initialize FileMetaDataTool");
@@ -149,8 +148,7 @@ EL::StatusCode MinixAOD :: initialize ()
   if(m_copyTriggerInfo){
     m_trigMetaDataTool = new xAODMaker::TriggerMenuMetaDataTool();
 
-    if(m_verbose)
-      RETURN_CHECK("MinixAOD::initialize()", m_trigMetaDataTool->setProperty("OutputLevel", MSG::VERBOSE ), "Could not set verbosity on TriggerMenuMetaDataTool");
+    RETURN_CHECK("MinixAOD::initialize()", m_trigMetaDataTool->setProperty("OutputLevel", msg().level() ), "Could not set verbosity on TriggerMenuMetaDataTool");
 
     RETURN_CHECK("MinixAOD::initialize()", m_trigMetaDataTool->initialize(), "Could not initialize TriggerMenuMetaDataTool");
     if(m_debug) ATH_MSG_INFO( "TriggerMenuMetaDataTool initialized...");
@@ -202,7 +200,7 @@ EL::StatusCode MinixAOD :: initialize ()
 
 EL::StatusCode MinixAOD :: execute ()
 {
-  if(m_verbose) ATH_MSG_INFO( "Dumping objects...");
+  ATH_MSG_VERBOSE( "Dumping objects...");
 
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, msg()) ,"");
@@ -235,7 +233,7 @@ EL::StatusCode MinixAOD :: execute ()
     auto out_key = keypair.second;
 
     const xAOD::IParticleContainer* cont(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, in_key, nullptr, m_store, msg()), std::string("Could not retrieve container "+in_key+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, in_key, nullptr, m_store, msg()), std::string("Could not retrieve container "+in_key+" from TStore. Enable verbosity to find out why.").c_str());
 
     if(const xAOD::ElectronContainer* t_cont = dynamic_cast<const xAOD::ElectronContainer*>(cont)){
       RETURN_CHECK("MinixAOD::execute()", (HelperFunctions::makeDeepCopy<xAOD::ElectronContainer, xAOD::ElectronAuxContainer, xAOD::Electron>(m_store, out_key.c_str(), t_cont)), std::string("Could not deep copy "+in_key+" to "+out_key+".").c_str());
@@ -281,7 +279,7 @@ EL::StatusCode MinixAOD :: execute ()
     auto parent = keypair.second;
 
     std::vector<std::string>* vector(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(vector, vectorName, nullptr, m_store, msg()), std::string("Could not retrieve vector "+vectorName+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(vector, vectorName, nullptr, m_store, msg()), std::string("Could not retrieve vector "+vectorName+" from TStore. Enable verbosity to find out why.").c_str());
 
     // only add the parent if it doesn't exist
     if(!parent.empty()) m_copyFromStoreToEventKeys_vec.push_back(parent);
@@ -305,7 +303,7 @@ EL::StatusCode MinixAOD :: execute ()
   // all we need to do is retrieve it and figure out what type it is to record it and we're done
   for(const auto& key: m_copyFromStoreToEventKeys_vec){
     const xAOD::IParticleContainer* cont(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, key, nullptr, m_store, msg()), std::string("Could not retrieve container "+key+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, key, nullptr, m_store, msg()), std::string("Could not retrieve container "+key+" from TStore. Enable verbosity to find out why.").c_str());
 
     if(dynamic_cast<const xAOD::ElectronContainer*>(cont)){
       RETURN_CHECK("MinixAOD::execute()", (HelperFunctions::recordOutput<xAOD::ElectronContainer, xAOD::ElectronAuxContainer>(m_event, m_store, key)), std::string("Could not copy "+key+" from TStore to TEvent.").c_str());

--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -41,8 +41,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MinixAOD)
 
-MinixAOD :: MinixAOD (std::string className) :
-    Algorithm(className),
+MinixAOD :: MinixAOD () :
+    Algorithm("MinixAOD"),
     m_simpleCopyKeys_vec(),
     m_shallowCopyKeys_vec(),
     m_deepCopyKeys_vec(),
@@ -50,7 +50,7 @@ MinixAOD :: MinixAOD (std::string className) :
     m_fileMetaDataTool(nullptr),
     m_trigMetaDataTool(nullptr)
 {
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_outputFileName = "out_miniXAOD";
   m_createOutputFile = true;

--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -205,7 +205,7 @@ EL::StatusCode MinixAOD :: execute ()
   if(m_verbose) ATH_MSG_INFO( "Dumping objects...");
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("BasicEventSelection::initialize()", HelperFunctions::retrieve(eventInfo, "EventInfo", m_event, m_store, msg()) ,"");
 
   //
   // Fill cutbookkeeper
@@ -235,7 +235,7 @@ EL::StatusCode MinixAOD :: execute ()
     auto out_key = keypair.second;
 
     const xAOD::IParticleContainer* cont(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, in_key, nullptr, m_store, m_verbose), std::string("Could not retrieve container "+in_key+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, in_key, nullptr, m_store, msg()), std::string("Could not retrieve container "+in_key+" from TStore. Enable m_verbose to find out why.").c_str());
 
     if(const xAOD::ElectronContainer* t_cont = dynamic_cast<const xAOD::ElectronContainer*>(cont)){
       RETURN_CHECK("MinixAOD::execute()", (HelperFunctions::makeDeepCopy<xAOD::ElectronContainer, xAOD::ElectronAuxContainer, xAOD::Electron>(m_store, out_key.c_str(), t_cont)), std::string("Could not deep copy "+in_key+" to "+out_key+".").c_str());
@@ -281,7 +281,7 @@ EL::StatusCode MinixAOD :: execute ()
     auto parent = keypair.second;
 
     std::vector<std::string>* vector(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(vector, vectorName, nullptr, m_store, m_verbose), std::string("Could not retrieve vector "+vectorName+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(vector, vectorName, nullptr, m_store, msg()), std::string("Could not retrieve vector "+vectorName+" from TStore. Enable m_verbose to find out why.").c_str());
 
     // only add the parent if it doesn't exist
     if(!parent.empty()) m_copyFromStoreToEventKeys_vec.push_back(parent);
@@ -305,7 +305,7 @@ EL::StatusCode MinixAOD :: execute ()
   // all we need to do is retrieve it and figure out what type it is to record it and we're done
   for(const auto& key: m_copyFromStoreToEventKeys_vec){
     const xAOD::IParticleContainer* cont(nullptr);
-    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, key, nullptr, m_store, m_verbose), std::string("Could not retrieve container "+key+" from TStore. Enable m_verbose to find out why.").c_str());
+    RETURN_CHECK("MinixAOD::execute()", HelperFunctions::retrieve(cont, key, nullptr, m_store, msg()), std::string("Could not retrieve container "+key+" from TStore. Enable m_verbose to find out why.").c_str());
 
     if(dynamic_cast<const xAOD::ElectronContainer*>(cont)){
       RETURN_CHECK("MinixAOD::execute()", (HelperFunctions::recordOutput<xAOD::ElectronContainer, xAOD::ElectronAuxContainer>(m_event, m_store, key)), std::string("Could not copy "+key+" from TStore to TEvent.").c_str());

--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -65,7 +65,7 @@ MinixAOD :: MinixAOD () :
 
 EL::StatusCode MinixAOD :: setupJob (EL::Job& job)
 {
-  if(m_debug) ATH_MSG_INFO( "Calling setupJob");
+  ATH_MSG_DEBUG("Calling setupJob");
 
   job.useXAOD ();
   xAOD::Init( "MinixAOD" ).ignore(); // call before opening first file
@@ -126,7 +126,7 @@ EL::StatusCode MinixAOD :: fileExecute () { return EL::StatusCode::SUCCESS; }
 
 EL::StatusCode MinixAOD :: initialize ()
 {
-  if(m_debug) ATH_MSG_INFO( "Calling initialize");
+  ATH_MSG_DEBUG("Calling initialize");
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
@@ -142,7 +142,7 @@ EL::StatusCode MinixAOD :: initialize ()
 
 
     RETURN_CHECK("MinixAOD::initialize()", m_fileMetaDataTool->initialize(), "Could not initialize FileMetaDataTool");
-    if(m_debug) ATH_MSG_INFO( "FileMetaDataTool initialized...");
+    ATH_MSG_DEBUG("FileMetaDataTool initialized...");
   }
 
   if(m_copyTriggerInfo){
@@ -151,9 +151,9 @@ EL::StatusCode MinixAOD :: initialize ()
     RETURN_CHECK("MinixAOD::initialize()", m_trigMetaDataTool->setProperty("OutputLevel", msg().level() ), "Could not set verbosity on TriggerMenuMetaDataTool");
 
     RETURN_CHECK("MinixAOD::initialize()", m_trigMetaDataTool->initialize(), "Could not initialize TriggerMenuMetaDataTool");
-    if(m_debug) ATH_MSG_INFO( "TriggerMenuMetaDataTool initialized...");
+    ATH_MSG_DEBUG("TriggerMenuMetaDataTool initialized...");
 
-    if(m_debug) std::cout << "Adding xTrigDecision and TrigConfKeys to the list of keys copied from the input file." << std::endl;
+    ATH_MSG_DEBUG("Adding xTrigDecision and TrigConfKeys to the list of keys copied from the input file.");
     m_simpleCopyKeys_vec.push_back("xTrigDecision");
     m_simpleCopyKeys_vec.push_back("TrigConfKeys");
   }
@@ -193,7 +193,7 @@ EL::StatusCode MinixAOD :: initialize ()
     m_vectorCopyKeys_vec.push_back(std::pair<std::string, std::string>(token.substr(0, pos), token.substr(pos+1)));
   }
 
-  if(m_debug) ATH_MSG_INFO( "MinixAOD Interface succesfully initialized!" );
+  ATH_MSG_DEBUG("MinixAOD Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
 }
@@ -224,7 +224,7 @@ EL::StatusCode MinixAOD :: execute ()
   // simple copy is easiest - it's in the input, copy over, no need for types
   for(const auto& key: m_simpleCopyKeys_vec){
     RETURN_CHECK("MinixAOD::execute()", m_event->copy(key), std::string("Could not copy "+key+" from input file.").c_str());
-    if(m_debug) std::cout << "Copying " << key << " from input file" << std::endl;
+    ATH_MSG_DEBUG("Copying " << key << " from input file");
   }
 
   // we need to make deep copies
@@ -253,7 +253,7 @@ EL::StatusCode MinixAOD :: execute ()
     }
     m_copyFromStoreToEventKeys_vec.push_back(out_key);
 
-    if(m_debug) std::cout << "Deep-Copied " << in_key << " to " << out_key << " to record to output file" << std::endl;
+    ATH_MSG_DEBUG("Deep-Copied " << in_key << " to " << out_key << " to record to output file");
   }
 
   // shallow IO handling (if no parent, assume deep copy)
@@ -264,11 +264,8 @@ EL::StatusCode MinixAOD :: execute ()
     // only add the parent if it doesn't exist
     if(!parent.empty()) m_copyFromStoreToEventKeys_vec.push_back(parent);
 
-    if(m_debug){
-      std::cout << "Copying " << key;
-      if(!parent.empty()) std::cout << " as well as it's parent " << parent;
-      std::cout << std::endl;
-    }
+    ATH_MSG_DEBUG("Copying " << key);
+    if(!parent.empty()) ATH_MSG_DEBUG(" as well as it's parent " << parent);
 
     m_copyFromStoreToEventKeys_vec.push_back(key);
   }
@@ -286,10 +283,10 @@ EL::StatusCode MinixAOD :: execute ()
 
     std::cout << "The following containers are being copied over:" << std::endl;
     for(const auto& key: *vector){
-      if(m_debug) std::cout << "\t" << key << std::endl;
+      ATH_MSG_DEBUG("\t" << key);
       m_copyFromStoreToEventKeys_vec.push_back(key);
     }
-    if(m_debug && !parent.empty()) std::cout << "... along with their parent " << parent << std::endl;
+    if(!parent.empty()) ATH_MSG_DEBUG("... along with their parent " << parent);
 
   }
 
@@ -322,12 +319,12 @@ EL::StatusCode MinixAOD :: execute ()
       return EL::StatusCode::FAILURE;
     }
 
-    if(m_debug) std::cout << "Copied " << key << " and it's auxiliary container from TStore to TEvent" << std::endl;
+    ATH_MSG_DEBUG("Copied " << key << " and it's auxiliary container from TStore to TEvent");
   }
 
 
   m_event->fill();
-  if(m_debug) ATH_MSG_INFO( "Finished dumping objects...");
+  ATH_MSG_DEBUG("Finished dumping objects...");
 
   return EL::StatusCode::SUCCESS;
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -159,7 +159,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   // Check if is MC
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_debug) ,"");
+  RETURN_CHECK("MuonCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
 
   // Create a ToolHandle of the PRW tool which is used for the random generation
@@ -281,7 +281,7 @@ EL::StatusCode MuonCalibrator :: execute ()
   }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_debug) ,"");
+  RETURN_CHECK("MuonCalibrator::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   std::string randYear = "Data16";
 
@@ -315,9 +315,9 @@ EL::StatusCode MuonCalibrator :: execute ()
 
   // get the collections from TEvent or TStore
   //
-  RETURN_CHECK("MuonCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   const xAOD::MuonContainer* inMuons(nullptr);
-  RETURN_CHECK("MuonCalibrator::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonCalibrator::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName, m_event, m_store, msg()) ,"");
 
   // loop over available systematics - remember syst == EMPTY_STRING --> baseline
   // prepare a vector of the names of CDV containers

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -412,7 +412,7 @@ EL::StatusCode MuonCalibrator :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if ( m_debug ) { ATH_MSG_INFO( "Left "); }
   return EL::StatusCode::SUCCESS;

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -382,7 +382,7 @@ EL::StatusCode MuonCalibrator :: execute ()
     // save pointers in ConstDataVector with same order
     //
     if ( m_debug ) { ATH_MSG_INFO( "makeSubsetCont"); }
-    RETURN_CHECK( "MuonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibMuonsSC.first, calibMuonsCDV), "");
+    RETURN_CHECK( "MuonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibMuonsSC.first, calibMuonsCDV, msg()), "");
     if ( m_debug ) { ATH_MSG_INFO( "done makeSubsetCont"); }
 
     // sort after coping to CDV

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -37,8 +37,8 @@ using HelperClasses::ToolName;
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonCalibrator)
 
-MuonCalibrator :: MuonCalibrator (std::string className) :
-    Algorithm(className)
+MuonCalibrator :: MuonCalibrator () :
+    Algorithm("MuonCalibrator")
     //m_muonCalibrationAndSmearingTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
@@ -48,7 +48,7 @@ MuonCalibrator :: MuonCalibrator (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -50,8 +50,6 @@ MuonCalibrator :: MuonCalibrator () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
-
   // input container to be read from TEvent or TStore
   //
   m_inContainerName         = "";
@@ -244,7 +242,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
-  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, m_debug );
+  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, msg() );
 
   ATH_MSG_INFO("Will be using MuonCalibrationAndSmearingTool systematic:");
   std::vector< std::string >* SystMuonsNames = new std::vector< std::string >;
@@ -272,7 +270,7 @@ EL::StatusCode MuonCalibrator :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Muon Calibration And Smearing ... "); }
+  ATH_MSG_DEBUG( "Applying Muon Calibration And Smearing ... ");
 
   m_numEvent++;
 
@@ -360,61 +358,61 @@ EL::StatusCode MuonCalibrator :: execute ()
 
       for ( auto muSC_itr : *(calibMuonsSC.first) ) {
 
-	if ( m_debug ) { ATH_MSG_INFO( "  uncailbrated muon " << idx << ", pt = " << muSC_itr->pt()*1e-3 << " GeV"); }
+	ATH_MSG_DEBUG( "  uncailbrated muon " << idx << ", pt = " << muSC_itr->pt()*1e-3 << " GeV");
 	if(muSC_itr-> primaryTrackParticle()){
 	  if ( m_muonCalibrationAndSmearingTools[randYear]->applyCorrection(*muSC_itr) == CP::CorrectionCode::Error ) {  // Can have CorrectionCode values of Ok, OutOfValidityRange, or Error. Here only checking for Error.
 	    ATH_MSG_WARNING( "MuonCalibrationAndSmearingTool returned Error CorrectionCode");		  // If OutOfValidityRange is returned no modification is made and the original muon values are taken.
 	  }
 	}
 
-	if ( m_debug ) { ATH_MSG_INFO( "  corrected muon pt = " << muSC_itr->pt()*1e-3 << " GeV"); }
+	ATH_MSG_DEBUG( "  corrected muon pt = " << muSC_itr->pt()*1e-3 << " GeV");
 
 	++idx;
 
       } // close calibration loop
     }
 
-    if ( m_debug ) { ATH_MSG_INFO( "setOriginalObjectLink"); }
+    ATH_MSG_DEBUG( "setOriginalObjectLink");
     if ( !xAOD::setOriginalObjectLink(*inMuons, *(calibMuonsSC.first)) ) {
       ATH_MSG_ERROR( "Failed to set original object links -- MET rebuilding cannot proceed.");
     }
 
     // save pointers in ConstDataVector with same order
     //
-    if ( m_debug ) { ATH_MSG_INFO( "makeSubsetCont"); }
+    ATH_MSG_DEBUG( "makeSubsetCont");
     RETURN_CHECK( "MuonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibMuonsSC.first, calibMuonsCDV, msg()), "");
-    if ( m_debug ) { ATH_MSG_INFO( "done makeSubsetCont"); }
+    ATH_MSG_DEBUG( "done makeSubsetCont");
 
     // sort after coping to CDV
     if ( m_sort ) {
-      if ( m_debug ) { ATH_MSG_INFO( "sorting"); }
+      ATH_MSG_DEBUG( "sorting");
       std::sort( calibMuonsCDV->begin(), calibMuonsCDV->end(), HelperFunctions::sort_pt );
     }
 
     // add SC container to TStore
     //
-    if ( m_debug ) { ATH_MSG_INFO( "recording calibMuonsSC"); }
+    ATH_MSG_DEBUG( "recording calibMuonsSC");
     RETURN_CHECK( "MuonCalibrator::execute()", m_store->record( calibMuonsSC.first,  outSCContainerName  ), "Failed to store container.");
     RETURN_CHECK( "MuonCalibrator::execute()", m_store->record( calibMuonsSC.second, outSCAuxContainerName ), "Failed to store aux container.");
 
     //
     // add ConstDataVector to TStore
     //
-    if ( m_debug ) { ATH_MSG_INFO( "record calibMuonsCDV"); }
+    ATH_MSG_DEBUG( "record calibMuonsCDV");
     RETURN_CHECK( "MuonCalibrator::execute()", m_store->record( calibMuonsCDV, outContainerName), "Failed to store const data container.");
 
   } // close loop on systematics
 
   // add vector<string container_names_syst> to TStore
   //
-  if ( m_debug ) { ATH_MSG_INFO( "record m_outputAlgoSystNames"); }
+  ATH_MSG_DEBUG( "record m_outputAlgoSystNames");
   RETURN_CHECK( "MuonCalibrator::execute()", m_store->record( vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names.");
 
   // look what we have in TStore
   //
   ATH_EXEC_VERBOSE(m_store->print());
 
-  if ( m_debug ) { ATH_MSG_INFO( "Left "); }
+  ATH_MSG_DEBUG( "Left ");
   return EL::StatusCode::SUCCESS;
 
 }
@@ -425,7 +423,7 @@ EL::StatusCode MuonCalibrator :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -192,7 +192,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonEfficiencyCorrector::initialize()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) );
 
   m_numEvent      = 0;
@@ -495,7 +495,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // initialise containers
   //
@@ -515,7 +515,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
     // if muons are only allowed in systematic instances, hence, we have to check for the existence of the nominal container
     //
     if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName )  ) {
-       RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+       RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, msg()) ,"");
 
        if ( m_debug ) { ATH_MSG_INFO( "Number of muons: " << static_cast<int>(inputMuons->size()) ); }
 
@@ -536,7 +536,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
         //
         for ( auto sysInput : m_sysNames ) {
           std::vector<std::string>* it_systNames(nullptr);
-          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(it_systNames, sysInput, 0, m_store, m_verbose) ,"");
+          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(it_systNames, sysInput, 0, m_store, msg()) ,"");
           systNames.insert( systNames.end(), it_systNames->begin(), it_systNames->end() );
         }
         // and now remove eventual duplicates
@@ -551,7 +551,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
         if ( !m_sysNamesForParCont.empty() )  {
           std::vector<std::string>* par_systNames(nullptr);
 
-          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(par_systNames, m_sysNamesForParCont, 0, m_store, m_verbose) ,"");
+          RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(par_systNames, m_sysNamesForParCont, 0, m_store, msg()) ,"");
 
           for ( auto sys : *par_systNames ) {
              if ( !sys.empty() && !m_store->contains<xAOD::MuonContainer>( m_inContainerName+sys ) ) {
@@ -559,7 +559,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
                if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName ) ) {
 
-                  RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(tmpMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+                  RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(tmpMuons, m_inContainerName, m_event, m_store, msg()) ,"");
                   RETURN_CHECK("MuonEfficiencyCorrector::execute()", (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_inContainerName+sys, tmpMuons)), "");
 
                } // the nominal container is copied therefore it has to exist!
@@ -579,13 +579,13 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
            bool isNomMuonSelection = systName.empty();
 
            if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName+systName )  ) {
-              RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
+              RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, msg()) ,"");
 
               if ( !m_store->contains<xAOD::MuonContainer>( m_outContainerName+systName ) ) {
                  RETURN_CHECK("MuonEfficiencyCorrector::execute()", (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_outContainerName+systName, inputMuons)), "");
               }
 
-              RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, m_verbose) ,"");
+              RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, msg()) ,"");
 
     	      if ( m_debug ){
 	        ATH_MSG_INFO( "Number of muons: " << static_cast<int>(outputMuons->size()) );

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -52,8 +52,6 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                      = false;
-
   // Input container to be read from TEvent or TStore
   //
   m_inContainerName            = "";
@@ -253,16 +251,14 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     //
     m_outputSystNamesReco = m_outputSystNamesReco + "_Reco" + m_WorkingPointReco;
 
-    if ( m_debug ) {
-      CP::SystematicSet affectSystsReco = m_muRecoSF_tool->affectingSystematics();
-      for ( const auto& syst_it : affectSystsReco ) { ATH_MSG_INFO("MuonEfficiencyScaleFactors tool can be affected by reco efficiency systematic: " << syst_it.name()); }
-    }
+    CP::SystematicSet affectSystsReco = m_muRecoSF_tool->affectingSystematics();
+    for ( const auto& syst_it : affectSystsReco ) { ATH_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by reco efficiency systematic: " << syst_it.name()); }
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsReco = m_muRecoSF_tool->recommendedSystematics();
-    m_systListReco = HelperFunctions::getListofSystematics( recSystsReco, m_systNameReco, m_systValReco, m_debug );
+    m_systListReco = HelperFunctions::getListofSystematics( recSystsReco, m_systNameReco, m_systValReco, msg() );
 
     ATH_MSG_INFO("Will be using MuonEfficiencyScaleFactors tool reco efficiency systematic:");
     for ( const auto& syst_it : m_systListReco ) {
@@ -298,16 +294,14 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     //
     m_outputSystNamesIso = m_outputSystNamesIso + "_Iso" + m_WorkingPointIso;
 
-    if ( m_debug ) {
-      CP::SystematicSet affectSystsIso = m_muIsoSF_tool->affectingSystematics();
-      for ( const auto& syst_it : affectSystsIso ) { ATH_MSG_INFO("MuonEfficiencyScaleFactors tool can be affected by iso efficiency systematic: " << syst_it.name()); }
-    }
+    CP::SystematicSet affectSystsIso = m_muIsoSF_tool->affectingSystematics();
+    for ( const auto& syst_it : affectSystsIso ) { ATH_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by iso efficiency systematic: " << syst_it.name()); }
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsIso = m_muIsoSF_tool->recommendedSystematics();
-    m_systListIso = HelperFunctions::getListofSystematics( recSystsIso, m_systNameIso, m_systValIso, m_debug );
+    m_systListIso = HelperFunctions::getListofSystematics( recSystsIso, m_systNameIso, m_systValIso, msg() );
 
     ATH_MSG_INFO("Will be using MuonEfficiencyScaleFactors tool iso efficiency systematic:");
     for ( const auto& syst_it : m_systListIso ) {
@@ -404,16 +398,14 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   m_outputSystNamesTrig      = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
   m_outputSystNamesTrigMCEff = m_outputSystNamesTrigMCEff + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
 
-  if ( m_debug ) {
-    CP::SystematicSet affectSystsTrig = m_muTrigSF_tools[m_YearsList[0]]->affectingSystematics();
-    for ( const auto& syst_it : affectSystsTrig ) { ATH_MSG_INFO("MuonEfficiencyScaleFactors tool can be affected by trigger efficiency systematic: " << syst_it.name()); }
-  }
+  CP::SystematicSet affectSystsTrig = m_muTrigSF_tools[m_YearsList[0]]->affectingSystematics();
+  for ( const auto& syst_it : affectSystsTrig ) { ATH_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by trigger efficiency systematic: " << syst_it.name()); }
   //
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
   const CP::SystematicSet recSystsTrig = m_muTrigSF_tools[m_YearsList[0]]->recommendedSystematics();
-  m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, m_debug );
+  m_systListTrig = HelperFunctions::getListofSystematics( recSystsTrig, m_systNameTrig, m_systValTrig, msg() );
 
   ATH_MSG_INFO("Will be using MuonEfficiencyScaleFactors tool trigger efficiency systematic:");
   for ( const auto& syst_it : m_systListTrig ) {
@@ -448,16 +440,14 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     //
     m_outputSystNamesTTVA = m_outputSystNamesTTVA + "_" + m_WorkingPointTTVA;
 
-    if ( m_debug ) {
-      CP::SystematicSet affectSystsTTVA = m_muTTVASF_tool->affectingSystematics();
-      for ( const auto& syst_it : affectSystsTTVA ) { ATH_MSG_INFO("MuonEfficiencyScaleFactors tool can be affected by TTVA efficiency systematic: " << syst_it.name()); }
-    }
+    CP::SystematicSet affectSystsTTVA = m_muTTVASF_tool->affectingSystematics();
+    for ( const auto& syst_it : affectSystsTTVA ) { ATH_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by TTVA efficiency systematic: " << syst_it.name()); }
     //
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
     //
     const CP::SystematicSet recSystsTTVA = m_muTTVASF_tool->recommendedSystematics();
-    m_systListTTVA = HelperFunctions::getListofSystematics( recSystsTTVA, m_systNameTTVA, m_systValTTVA, m_debug );
+    m_systListTTVA = HelperFunctions::getListofSystematics( recSystsTTVA, m_systNameTTVA, m_systValTTVA, msg() );
 
     ATH_MSG_INFO("Will be using MuonEfficiencyScaleFactors tool TTVA efficiency systematic:");
     for ( const auto& syst_it : m_systListTTVA ) {
@@ -491,7 +481,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
     return EL::StatusCode::SUCCESS;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Muon Efficiency corrections... "); }
+  ATH_MSG_DEBUG( "Applying Muon Efficiency corrections... ");
 
 
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -517,7 +507,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
     if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName )  ) {
        RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, msg()) ,"");
 
-       if ( m_debug ) { ATH_MSG_INFO( "Number of muons: " << static_cast<int>(inputMuons->size()) ); }
+       ATH_MSG_DEBUG( "Number of muons: " << static_cast<int>(inputMuons->size()) );
 
        // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
        //
@@ -587,14 +577,12 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
               RETURN_CHECK("MuonEfficiencyCorrector::execute()", HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, msg()) ,"");
 
-    	      if ( m_debug ){
-	        ATH_MSG_INFO( "Number of muons: " << static_cast<int>(outputMuons->size()) );
-	        ATH_MSG_INFO( "Input syst: " << systName );
-	        unsigned int idx(0);
-    	        for ( auto mu : *(outputMuons) ) {
-    	          ATH_MSG_INFO( "Input muon " << idx << ", pt = " << mu->pt()*1e-3 << " GeV ");
-    	          ++idx;
-    	        }
+              ATH_MSG_DEBUG( "Number of muons: " << static_cast<int>(outputMuons->size()) );
+              ATH_MSG_DEBUG( "Input syst: " << systName );
+              unsigned int idx(0);
+              for ( auto mu : *(outputMuons) ) {
+                ATH_MSG_DEBUG( "Input muon " << idx << ", pt = " << mu->pt()*1e-3 << " GeV ");
+                ++idx;
     	      }
 
 	      // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
@@ -629,7 +617,7 @@ EL::StatusCode MuonEfficiencyCorrector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -712,7 +700,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Muon reco efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName); }
+      ATH_MSG_DEBUG( "Muon reco efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesReco->push_back(sfName);
 
       // apply syst
@@ -721,14 +709,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
         ATH_MSG_ERROR("Failed to configure MuonEfficiencyScaleFactors for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematic: " << syst_it.name()); }
+      ATH_MSG_DEBUG( "Successfully applied systematic: " << syst_it.name());
 
       // and now apply reco efficiency SF!
       //
       unsigned int idx(0);
       for ( auto mu_itr : *(inputMuons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying reco efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying reco efficiency SF" );
 
     	 // a)
     	 // decorate directly the muon with reco efficiency (useful at all?), and the corresponding SF
@@ -769,22 +757,20 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
          }
     	 sfVecReco_sysNames( *mu_itr ).push_back( syst_it.name().c_str() );
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV" );
-  	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Reco eff. SF decoration: " << m_outputSystNamesReco );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-    	   //ATH_MSG_INFO("Reco efficiency:");
-    	   //ATH_MSG_INFO("\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
-    	   ATH_MSG_INFO( "and its SF:");
-    	   //ATH_MSG_INFO("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
-    	   ATH_MSG_INFO( "\t " << recoEffSF << " (from getEfficiencyScaleFactor())" );
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV" );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Reco eff. SF decoration: " << m_outputSystNamesReco );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         //ATH_MSG_DEBUG("Reco efficiency:");
+         //ATH_MSG_DEBUG("\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
+         ATH_MSG_DEBUG( "and its SF:");
+         //ATH_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
+         ATH_MSG_DEBUG( "\t " << recoEffSF << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -830,7 +816,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName); }
+      ATH_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesIso->push_back(sfName);
 
       // apply syst
@@ -839,14 +825,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	ATH_MSG_ERROR("Failed to configure MuonEfficiencyScaleFactors for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematic: " << syst_it.name()); }
+      ATH_MSG_DEBUG( "Successfully applied systematic: " << syst_it.name());
 
       // and now apply Iso efficiency SF!
       //
       unsigned int idx(0);
       for ( auto mu_itr : *(inputMuons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying iso efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying iso efficiency SF" );
 
     	 // a)
     	 // decorate directly the muon with iso efficiency (useful at all?), and the corresponding SF
@@ -878,22 +864,20 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //
     	 sfVecIso( *mu_itr ).push_back(IsoEffSF);
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-  	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Isolation SF decoration: " << m_outputSystNamesIso );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-    	   ATH_MSG_INFO( " ");
-           //ATH_MSG_INFO("Iso efficiency:");
-           //ATH_MSG_INFO("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
-    	   ATH_MSG_INFO( "and its SF:");
-    	   //ATH_MSG_INFO("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
-    	   ATH_MSG_INFO( "\t " << IsoEffSF << " (from getEfficiencyScaleFactor())");
-    	   ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Isolation SF decoration: " << m_outputSystNamesIso );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+         ATH_MSG_DEBUG( " ");
+         //ATH_MSG_DEBUG("Iso efficiency:");
+         //ATH_MSG_DEBUG("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
+         ATH_MSG_DEBUG( "and its SF:");
+         //ATH_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
+         ATH_MSG_DEBUG( "\t " << IsoEffSF << " (from getEfficiencyScaleFactor())");
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 
@@ -968,8 +952,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
     } else {
 
-      if ( m_debug ) ATH_MSG_WARNING( "Random runNumber generated outside hardcoded run number ranges");
-      if ( m_debug ) ATH_MSG_WARNING( "Setting the year as randomly chosen in the years list");
+      ATH_MSG_DEBUG( "Random runNumber generated outside hardcoded run number ranges");
+      ATH_MSG_DEBUG( "Setting the year as randomly chosen in the years list");
       std::srand ( unsigned ( std::time(0) ) );
       std::vector<std::string> randomYearsList = m_YearsList;
       std::random_shuffle ( randomYearsList.begin(), randomYearsList.end() );
@@ -979,11 +963,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
     if ( runNumber == 0 && randYear == "2016") {
       runNumber = m_runNumber2016;
-      if ( m_debug ) ATH_MSG_INFO( "runNumber is 0. Setting the tool to randYear 2016");
+      ATH_MSG_DEBUG("runNumber is 0. Setting the tool to randYear 2016");
     }
     if ( runNumber == 0 && randYear == "2015") {
       runNumber = m_runNumber2015;
-      if ( m_debug ) ATH_MSG_INFO( "runNumber is 0. Setting the tool to randYear 2015");
+      ATH_MSG_DEBUG("runNumber is 0. Setting the tool to randYear 2015");
     }
 
 
@@ -1053,7 +1037,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            std::string prepend = syst_it.name() + "_";
            sfName.insert( 0, prepend );
         }
-        if ( m_debug ) { ATH_MSG_INFO( "Trigger efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName); }
+        ATH_MSG_DEBUG( "Trigger efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
         if(countSyst==0) sysVariationNamesTrig->push_back(sfName);
 
         // apply syst
@@ -1062,14 +1046,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
           ATH_MSG_ERROR( "Failed to configure MuonTriggerScaleFactors for trigger " << trig_it << " systematic " << syst_it.name());
           return EL::StatusCode::FAILURE;
         }
-        if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematic " << syst_it.name() << " for trigger " << trig_it); }
+        ATH_MSG_DEBUG( "Successfully applied systematic " << syst_it.name() << " for trigger " << trig_it);
 
         // and now apply trigger efficiency SF!
         //
         unsigned int idx(0);
         for ( auto mu_itr : *(inputMuons) ) {
 
-           if ( m_debug ) { ATH_MSG_INFO( "Applying trigger efficiency SF and MC efficiency" ); }
+           ATH_MSG_DEBUG( "Applying trigger efficiency SF and MC efficiency" );
 
            // Pass a container with only the muon in question to the tool
            // (use a view container to be light weight)
@@ -1129,23 +1113,21 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            sfVecTrig( *mu_itr ).push_back(triggerEffSF);
 
 
-           if ( m_debug ) {
-             ATH_MSG_INFO( "===>>>");
-             ATH_MSG_INFO( " ");
-             ATH_MSG_INFO( "Random year: " << randYear.c_str() );
-             ATH_MSG_INFO( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-             ATH_MSG_INFO( " ");
-             ATH_MSG_INFO( "Trigger efficiency SF decoration: " << m_outputSystNamesTrig );
-             ATH_MSG_INFO( "Trigger MC efficiency decoration: " << m_outputSystNamesTrigMCEff );
-             ATH_MSG_INFO( " ");
-             ATH_MSG_INFO( "Systematic: " << syst_it.name() );
-             ATH_MSG_INFO( " ");
-             ATH_MSG_INFO( "Trigger efficiency SF:");
-             ATH_MSG_INFO( "\t " << triggerEffSF << " (from getTriggerScaleFactor())" );
-             ATH_MSG_INFO( "Trigger MC efficiency:");
-             ATH_MSG_INFO( "\t " << triggerDataEff << " (from getTriggerEfficiency())" );
-             ATH_MSG_INFO( "--------------------------------------");
-           }
+           ATH_MSG_DEBUG( "===>>>");
+           ATH_MSG_DEBUG( " ");
+           ATH_MSG_DEBUG( "Random year: " << randYear.c_str() );
+           ATH_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
+           ATH_MSG_DEBUG( " ");
+           ATH_MSG_DEBUG( "Trigger efficiency SF decoration: " << m_outputSystNamesTrig );
+           ATH_MSG_DEBUG( "Trigger MC efficiency decoration: " << m_outputSystNamesTrigMCEff );
+           ATH_MSG_DEBUG( " ");
+           ATH_MSG_DEBUG( "Systematic: " << syst_it.name() );
+           ATH_MSG_DEBUG( " ");
+           ATH_MSG_DEBUG( "Trigger efficiency SF:");
+           ATH_MSG_DEBUG( "\t " << triggerEffSF << " (from getTriggerScaleFactor())" );
+           ATH_MSG_DEBUG( "Trigger MC efficiency:");
+           ATH_MSG_DEBUG( "\t " << triggerDataEff << " (from getTriggerEfficiency())" );
+           ATH_MSG_DEBUG( "--------------------------------------");
 
            ++idx;
 
@@ -1193,7 +1175,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 std::string prepend = syst_it.name() + "_";
     	 sfName.insert( 0, prepend );
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName); }
+      ATH_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
       if(countSyst == 0) sysVariationNamesTTVA->push_back(sfName);
 
       // apply syst
@@ -1206,14 +1188,14 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
        	ATH_MSG_ERROR("Failed to configure MuonEfficiencyScaleFactors for systematic " << syst_it.name());
     	return EL::StatusCode::FAILURE;
       }
-      if ( m_debug ) { ATH_MSG_INFO( "Successfully applied systematic: " << syst_it.name()); }
+      ATH_MSG_DEBUG( "Successfully applied systematic: " << syst_it.name());
 
       // and now apply TTVA efficiency SF!
       //
       unsigned int idx(0);
       for ( auto mu_itr : *(inputMuons) ) {
 
-    	 if ( m_debug ) { ATH_MSG_INFO( "Applying TTVA efficiency SF" ); }
+    	 ATH_MSG_DEBUG( "Applying TTVA efficiency SF" );
 
     	 // a)
     	 // decorate directly the muon with TTVA efficiency (useful at all?), and the corresponding SF
@@ -1245,22 +1227,20 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //
     	 sfVecTTVA( *mu_itr ).push_back(TTVAEffSF);
 
-    	 if ( m_debug ) {
-    	   ATH_MSG_INFO( "===>>>");
-    	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-  	   ATH_MSG_INFO( " ");
-  	   ATH_MSG_INFO( "TTVA SF decoration: " << m_outputSystNamesTTVA );
-  	   ATH_MSG_INFO( " ");
-    	   ATH_MSG_INFO( "Systematic: " << syst_it.name());
-    	   ATH_MSG_INFO( " ");
-           //ATH_MSG_INFO("TTVA efficiency:");
-           //ATH_MSG_INFO("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
-    	   ATH_MSG_INFO( "and its SF:");
-    	   //ATH_MSG_INFO("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
-    	   ATH_MSG_INFO( "\t " << TTVAEffSF << " (from getEfficiencyScaleFactor())" );
-           ATH_MSG_INFO( "--------------------------------------");
-    	 }
+         ATH_MSG_DEBUG( "===>>>");
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "TTVA SF decoration: " << m_outputSystNamesTTVA );
+         ATH_MSG_DEBUG( " ");
+         ATH_MSG_DEBUG( "Systematic: " << syst_it.name());
+         ATH_MSG_DEBUG( " ");
+         //ATH_MSG_DEBUG("TTVA efficiency:");
+         //ATH_MSG_DEBUG("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
+         ATH_MSG_DEBUG( "and its SF:");
+         //ATH_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
+         ATH_MSG_DEBUG( "\t " << TTVAEffSF << " (from getEfficiencyScaleFactor())" );
+         ATH_MSG_DEBUG( "--------------------------------------");
 
     	 ++idx;
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -616,7 +616,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -35,8 +35,8 @@ using HelperClasses::ToolName;
 ClassImp(MuonEfficiencyCorrector)
 
 
-MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
-    Algorithm(className),
+MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
+    Algorithm("MuonEfficiencyCorrector"),
     m_muRecoSF_tool(nullptr),
     m_muIsoSF_tool(nullptr),
     m_muTTVASF_tool(nullptr)
@@ -50,7 +50,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                      = false;
 

--- a/Root/MuonEfficiencyCorrector_AnaToolHandle.txt
+++ b/Root/MuonEfficiencyCorrector_AnaToolHandle.txt
@@ -31,8 +31,8 @@ using HelperClasses::ToolName;
 ClassImp(MuonEfficiencyCorrector)
 
 
-MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
-    Algorithm(className),
+MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
+    Algorithm("MuonEfficiencyCorrector"),
     m_muRecoSF_tool_handle("CP::MuonEfficiencyScaleFactors/MuRecoSFToolName", nullptr),
     m_muIsoSF_tool_handle("CP::MuonEfficiencyScaleFactors/MuIsoSFToolName", nullptr),
     m_muTrigSF_tool_handle("CP::MuonTriggerScaleFactors/MuTrigSFToolName", nullptr),
@@ -54,7 +54,7 @@ MuonEfficiencyCorrector :: MuonEfficiencyCorrector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  Info("MuonEfficiencyCorrector()", "Calling constructor");
+  //Info("MuonEfficiencyCorrector()", "Calling constructor");
 
   m_debug                      = false;
 

--- a/Root/MuonEfficiencyCorrector_AnaToolHandle.txt
+++ b/Root/MuonEfficiencyCorrector_AnaToolHandle.txt
@@ -510,7 +510,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 

--- a/Root/MuonHistsAlgo.cxx
+++ b/Root/MuonHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonHistsAlgo)
 
-MuonHistsAlgo :: MuonHistsAlgo (std::string className) :
-IParticleHistsAlgo(className)
+MuonHistsAlgo :: MuonHistsAlgo () :
+IParticleHistsAlgo("MuonHistsAlgo")
 { }
 
 EL::StatusCode MuonHistsAlgo :: setupJob (EL::Job& job)

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -56,7 +56,6 @@ MuonSelector :: MuonSelector () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
   m_useCutFlow              = true;
 
   // checks if the algorithm has been used already
@@ -344,7 +343,7 @@ EL::StatusCode MuonSelector :: initialize ()
   m_isolationSelectionTool_handle.setTypeAndName(isolationSelectionTool_handle_name);
   // Do this only for the first WP in the list
   //
-  if ( m_debug ) { ATH_MSG_INFO( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" ); }
+  ATH_MSG_DEBUG( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" );
   RETURN_CHECK("MuonSelector::initialize()", m_isolationSelectionTool_handle.setProperty("MuonWP", (m_IsoKeys.at(0)).c_str()), "Failed to configure base WP" );
   RETURN_CHECK("MuonSelector::initialize()", m_isolationSelectionTool_handle.initialize(), "Failed to properly initialize IsolationSelectionTool." );
 
@@ -353,7 +352,7 @@ EL::StatusCode MuonSelector :: initialize ()
   //
   for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {
 
-     if ( m_debug ) { ATH_MSG_INFO( "Adding extra isolation WP " << *WP_itr << " to IsolationSelectionTool" ); }
+     ATH_MSG_DEBUG( "Adding extra isolation WP " << *WP_itr << " to IsolationSelectionTool" );
 
      if ( (*WP_itr).find("UserDefined") != std::string::npos ) {
 
@@ -430,7 +429,7 @@ EL::StatusCode MuonSelector :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Muon Selection..." ); }
+  ATH_MSG_DEBUG( "Applying Muon Selection..." );
 
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
@@ -524,14 +523,14 @@ EL::StatusCode MuonSelector :: execute ()
     // must be a pointer to be recorded in TStore
     //
     std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-    if ( m_debug ) { ATH_MSG_INFO( " input list of syst size: " << static_cast<int>(systNames->size()) ); }
+    ATH_MSG_DEBUG( " input list of syst size: " << static_cast<int>(systNames->size()) );
 
     // loop over systematic sets
     //
     bool eventPassThisSyst(false);
     for ( auto systName : *systNames ) {
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  input container name: " << m_inContainerName+systName );
 
       RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName + systName, m_event, m_store, msg()) ,"");
 
@@ -556,7 +555,7 @@ EL::StatusCode MuonSelector :: execute ()
       //
       eventPass = ( eventPass || eventPassThisSyst );
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  output container name: " << m_outContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  output container name: " << m_outContainerName+systName );
 
       if ( m_createSelectedContainer ) {
         if ( eventPassThisSyst ) {
@@ -571,7 +570,7 @@ EL::StatusCode MuonSelector :: execute ()
 
     } // close loop over syst sets
 
-    if ( m_debug ) {  ATH_MSG_INFO( " output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) ); }
+    ATH_MSG_DEBUG(" output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) );
 
     // record in TStore the list of systematics names that should be considered down stream
     //
@@ -588,7 +587,7 @@ EL::StatusCode MuonSelector :: execute ()
     return EL::StatusCode::SUCCESS;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Left Muon Selection..." ); }
+  ATH_MSG_DEBUG( "Left Muon Selection..." );
   return EL::StatusCode::SUCCESS;
 
 }
@@ -597,10 +596,10 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 					    ConstDataVector<xAOD::MuonContainer>* selectedMuons )
 {
 
-  if ( m_debug ) { ATH_MSG_INFO( "In  executeSelection..." ); }
+  ATH_MSG_DEBUG( "In  executeSelection..." );
   const xAOD::VertexContainer* vertices(nullptr);
   RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
+  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices, msg());
 
   int nPass(0); int nObj(0);
   static SG::AuxElement::Decorator< char > passSelDecor( "passSel" );
@@ -627,7 +626,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
     // Remove events with isBadMuon (poor q/p)
     if( m_removeEventBadMuon && passSel ){
       if( m_muonSelectionTool_handle->isBadMuon( *mu_itr ) ){
-        if( m_debug )  ATH_MSG_INFO( "Rejecting event with bad muon (pt = "<<mu_itr->pt()<<")" );
+        ATH_MSG_DEBUG("Rejecting event with bad muon (pt = "<<mu_itr->pt()<<")");
         return false;
       }
     }
@@ -647,16 +646,16 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
     m_numObjectPass += nPass;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Initial muons: " << nObj << " - Selected muons: " << nPass ); }
+  ATH_MSG_DEBUG( "Initial muons: " << nObj << " - Selected muons: " << nPass );
 
   // apply event selection based on minimal/maximal requirements on the number of objects per event passing cuts
   //
   if ( m_pass_min > 0 && nPass < m_pass_min ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Reject event: nSelectedMuons ("<<nPass<<") < nPassMin ("<<m_pass_min<<")" ); }
+    ATH_MSG_DEBUG( "Reject event: nSelectedMuons ("<<nPass<<") < nPassMin ("<<m_pass_min<<")" );
     return false;
   }
   if ( m_pass_max > 0 && nPass > m_pass_max ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Reject event: nSelectedMuons ("<<nPass<<") > nPassMax ("<<m_pass_max<<")" ); }
+    ATH_MSG_DEBUG( "Reject event: nSelectedMuons ("<<nPass<<") > nPassMax ("<<m_pass_max<<")" );
     return false;
   }
 
@@ -682,11 +681,11 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
     if ( nSelectedMuons > 0 ) {
 
-      if ( m_debug ) { ATH_MSG_INFO( "Doing single muon trigger matching..."); }
+      ATH_MSG_DEBUG( "Doing single muon trigger matching...");
 
       for ( auto const &chain : m_singleMuTrigChainsList ) {
 
-        if ( m_debug ) { ATH_MSG_INFO( "\t checking trigger chain " << chain); }
+        ATH_MSG_DEBUG( "\t checking trigger chain " << chain);
 
         for ( auto const muon : *selectedMuons ) {
 
@@ -700,7 +699,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
           char matched = ( m_trigMuonMatchTool_handle->match( *muon, chain, m_minDeltaR ) );
 
-          if ( m_debug ) { ATH_MSG_INFO( "\t\t is muon trigger matched? " << matched); }
+          ATH_MSG_DEBUG( "\t\t is muon trigger matched? " << matched);
 
           ( isTrigMatchedMapMuDecor( *muon ) )[chain] = matched;
         }
@@ -722,7 +721,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
     if ( nSelectedMuons > 1 && !m_diMuTrigChains.empty() ) {
 
-      if ( m_debug ) { ATH_MSG_INFO( "Doing di-muon trigger matching..."); }
+      ATH_MSG_DEBUG( "Doing di-muon trigger matching...");
 
       const xAOD::EventInfo* eventInfo(nullptr);
       RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
@@ -733,7 +732,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
       for ( auto const &chain : m_diMuTrigChainsList ) {
 
-      	if ( m_debug ) { ATH_MSG_INFO( "\t checking trigger chain " << chain); }
+      	ATH_MSG_DEBUG( "\t checking trigger chain " << chain);
 
       	//  If decoration map doesn't exist for this event yet, create it (will be done only for the 1st iteration on the chain names)
       	//
@@ -757,7 +756,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
             //
       	    char matched = m_trigMuonMatchTool_handle->match( myMuons, chain, m_minDeltaR );
 
-      	    if ( m_debug ) { ATH_MSG_INFO( "\t\t is the muon pair ("<<imu<<","<<jmu<<") trigger matched? " << matched); }
+      	    ATH_MSG_DEBUG( "\t\t is the muon pair ("<<imu<<","<<jmu<<") trigger matched? " << matched);
 
       	    std::pair <unsigned int, unsigned int>  chain_idxs = std::make_pair(imu,jmu);
             dimuon_trigmatch_pair  chain_decision = std::make_pair(chain_idxs,matched);
@@ -769,7 +768,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
     } //if nSelectedMuons > 1 && !m_diMuTrigChains.empty()
   } //if m_doTrigMatch && selectedMuons
 
-  if ( m_debug ) { ATH_MSG_INFO( "Left  executeSelection..." ); }
+  ATH_MSG_DEBUG( "Left  executeSelection..." );
   return true;
 }
 
@@ -780,7 +779,7 @@ EL::StatusCode MuonSelector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -832,11 +831,11 @@ EL::StatusCode MuonSelector :: histFinalize ()
 
 int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primaryVertex  ) {
 
-  if ( m_debug ) { ATH_MSG_INFO( "In  passCuts..." ); }
+  ATH_MSG_DEBUG( "In  passCuts..." );
   // fill cutflow bin 'all' before any cut
   if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_all, 1 );
   if ( m_isUsedBefore && m_useCutFlow ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_all, 1 ); }
-  if ( m_debug ) { ATH_MSG_INFO( "In  passCuts2..." ); }
+  ATH_MSG_DEBUG( "In  passCuts2..." );
   // *********************************************************************************************************************************************************************
   //
   // MuonSelectorTool cut: quality & |eta| acceptance cut
@@ -848,18 +847,18 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   static SG::AuxElement::Decorator< char > isMediumQDecor("isMediumQ");
   static SG::AuxElement::Decorator< char > isTightQDecor("isTightQ");
 
-  if ( m_debug ) { ATH_MSG_INFO( "Got the decors" ); }
+  ATH_MSG_DEBUG( "Got the decors" );
   int this_quality = static_cast<int>( m_muonSelectionTool_handle->getQuality( *muon ) );
-  if ( m_debug ) { ATH_MSG_INFO( "Got quality" ); }
+  ATH_MSG_DEBUG( "Got quality" );
 
   isVeryLooseQDecor( *muon ) = ( this_quality == static_cast<int>(xAOD::Muon::VeryLoose) ) ? 1 : 0;
   isLooseQDecor( *muon )     = ( this_quality == static_cast<int>(xAOD::Muon::Loose) )     ? 1 : 0;
   isMediumQDecor( *muon )    = ( this_quality == static_cast<int>(xAOD::Muon::Medium) )    ? 1 : 0;
   isTightQDecor( *muon )     = ( this_quality == static_cast<int>(xAOD::Muon::Tight) )     ? 1 : 0;
-  if ( m_debug ) { ATH_MSG_INFO( "Doing muon quality" ); }
+  ATH_MSG_DEBUG( "Doing muon quality" );
   // this will accept the muon based on the settings at initialization : eta, ID track info, muon quality
   if ( ! m_muonSelectionTool_handle->accept( *muon ) ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Muon failed requirements of MuonSelectionTool."); }
+    ATH_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
     return 0;
   }
 
@@ -870,10 +869,10 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   //
   // pT max cut
   //
-  if ( m_debug ) { ATH_MSG_INFO( "Doing pt cuts" ); }
+  ATH_MSG_DEBUG( "Doing pt cuts" );
   if ( m_pT_max != 1e8 ) {
     if (  muon->pt() > m_pT_max ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Muon failed pT max cut."); }
+      ATH_MSG_DEBUG( "Muon failed pT max cut.");
       return 0;
     }
   }
@@ -886,7 +885,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   //
   if ( m_pT_min != 1e8 ) {
     if ( muon->pt() < m_pT_min ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Muon failed pT min cut."); }
+      ATH_MSG_DEBUG( "Muon failed pT min cut.");
       return 0;
     }
   }
@@ -900,7 +899,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   //HelperClasses::EnumParser<xAOD::Muon::MuonType> muTypeParser;
   //if ( !m_muonType.empty() ) {
   //  if ( muon->muonType() != static_cast<int>(muTypeParser.parseEnum(m_muonType))) {
-  //    if ( m_debug ) { ATH_MSG_INFO( "Muon type: %d - required: %s . Failed", muon->muonType(), m_muonType.c_str()); }
+  //    ATH_MSG_DEBUG( "Muon type: %d - required: %s . Failed", muon->muonType(), m_muonType.c_str());
   //    return 0;
   //  }
   //}
@@ -924,7 +923,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   const xAOD::TrackParticle* tp = muon->primaryTrackParticle();
 
   if ( !tp ) {
-    if ( m_debug ) ATH_MSG_INFO( "Muon has no TrackParticle. Won't be selected.");
+    ATH_MSG_DEBUG("Muon has no TrackParticle. Won't be selected.");
     return 0;
   }
 
@@ -942,7 +941,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   // z0*sin(theta) cut
   //
   if ( !( fabs(z0sintheta) < m_z0sintheta_max ) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Muon failed z0*sin(theta) cut."); }
+      ATH_MSG_DEBUG( "Muon failed z0*sin(theta) cut.");
       return 0;
   }
   if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_z0sintheta_cut, 1 );
@@ -955,7 +954,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   // d0 cut
   //
   if ( !( tp->d0() < m_d0_max ) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Muon failed d0 cut."); }
+      ATH_MSG_DEBUG( "Muon failed d0 cut.");
       return 0;
   }
   if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_d0_cut, 1 );
@@ -964,7 +963,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   // d0sig cut
   //
   if ( !( d0_significance < m_d0sig_max ) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Muon failed d0 significance cut."); }
+      ATH_MSG_DEBUG( "Muon failed d0 significance cut.");
       return 0;
   }
   if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_d0sig_cut, 1 );
@@ -990,7 +989,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
     std::string decorWP = base_decor + "_" + WP_itr;
 
-    if ( m_debug ) { ATH_MSG_INFO( "Decorate muon with " << decorWP << " - accept() ? " << accept_list.getCutResult( WP_itr.c_str()) ); }
+    ATH_MSG_DEBUG( "Decorate muon with " << decorWP << " - accept() ? " << accept_list.getCutResult( WP_itr.c_str()) );
     muon->auxdecor<char>(decorWP) = static_cast<char>( accept_list.getCutResult( WP_itr.c_str() ) );
 
   }
@@ -998,7 +997,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   // Apply the cut if needed
   //
   if ( !m_MinIsoWPCut.empty() && !accept_list.getCutResult( m_MinIsoWPCut.c_str() ) ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Muon failed isolation cut " <<  m_MinIsoWPCut ); }
+    ATH_MSG_DEBUG( "Muon failed isolation cut " <<  m_MinIsoWPCut );
     return 0;
   }
   if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_iso_cut, 1 );
@@ -1011,7 +1010,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
     double muon_z0_exPV = tp->z0() + tp->vz() - pv_z;
 
     if( fabs(muon_z0_exPV) >= 1.0 || fabs(muon_d0) >= 0.2 ){
-      if ( m_debug )   ATH_MSG_INFO( "Muon failed cosmic cut" );
+      ATH_MSG_DEBUG("Muon failed cosmic cut" );
       return 0;
     }
     if(m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_cosmic_cut, 1 );
@@ -1020,7 +1019,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
 
 
-  if ( m_debug ) { ATH_MSG_INFO( "Leave passCuts... pass" ); }
+  ATH_MSG_DEBUG( "Leave passCuts... pass" );
   return 1;
 }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -581,7 +581,7 @@ EL::StatusCode MuonSelector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if( !eventPass ) {
     wk()->skipEvent();

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -433,7 +433,7 @@ EL::StatusCode MuonSelector :: execute ()
   if ( m_debug ) { ATH_MSG_INFO( "Applying Muon Selection..." ); }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // MC event weight
   //
@@ -490,7 +490,7 @@ EL::StatusCode MuonSelector :: execute ()
 
     // this will be the collection processed - no matter what!!
     //
-    RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName, m_event, m_store, msg()) ,"");
 
     // create output container (if requested)
     //
@@ -518,7 +518,7 @@ EL::StatusCode MuonSelector :: execute ()
     // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
     //
     std::vector< std::string >* systNames(nullptr);
-    RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) ,"");
 
     // prepare a vector of the names of CDV containers for usage by downstream algos
     // must be a pointer to be recorded in TStore
@@ -533,7 +533,7 @@ EL::StatusCode MuonSelector :: execute ()
 
       if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
 
-      RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName + systName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName + systName, m_event, m_store, msg()) ,"");
 
       // create output container (if requested) - one for each systematic
       //
@@ -599,7 +599,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
   if ( m_debug ) { ATH_MSG_INFO( "In  executeSelection..." ); }
   const xAOD::VertexContainer* vertices(nullptr);
-  RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
 
   int nPass(0); int nObj(0);
@@ -725,7 +725,7 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
       if ( m_debug ) { ATH_MSG_INFO( "Doing di-muon trigger matching..."); }
 
       const xAOD::EventInfo* eventInfo(nullptr);
-      RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("MuonSelector::executeSelection()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
       typedef std::pair< std::pair<unsigned int,unsigned int>, char> dimuon_trigmatch_pair;
       typedef std::multimap< std::string, dimuon_trigmatch_pair >    dimuon_trigmatch_pair_map;
@@ -929,7 +929,7 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("MuonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   double d0_significance = fabs( xAOD::TrackingHelpers::d0significance( tp, eventInfo->beamPosSigmaX(), eventInfo->beamPosSigmaY(), eventInfo->beamPosSigmaXY() ) );
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -36,8 +36,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonSelector)
 
-MuonSelector :: MuonSelector (std::string className) :
-    Algorithm(className),
+MuonSelector :: MuonSelector () :
+    Algorithm("MuonSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_mu_cutflowHist_1(nullptr),
@@ -54,7 +54,7 @@ MuonSelector :: MuonSelector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
   m_useCutFlow              = true;

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -263,7 +263,7 @@ EL::StatusCode OverlapRemover :: execute ()
   executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus, NOMINAL);
 
   // look what do we have in TStore
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   // -----------------------------------------------------------------------------------------------
   //
@@ -370,7 +370,7 @@ EL::StatusCode OverlapRemover :: execute ()
   RETURN_CHECK( "OverlapRemover::execute()", m_store->record( m_vecOutContainerNames, m_outputAlgoSystNames), "Failed to record vector of output container names.");
 
   // look what do we have in TStore
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -65,8 +65,6 @@ OverlapRemover :: OverlapRemover () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  // read debug flag from .config file
-  m_debug         = false;
   m_useCutFlow    = true;
 
   // input container(s) to be read from TEvent or TStore
@@ -243,7 +241,7 @@ EL::StatusCode OverlapRemover :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Overlap Removal... "); }
+  ATH_MSG_DEBUG("Applying Overlap Removal... ");
 
   m_numEvent++;
 
@@ -382,7 +380,7 @@ EL::StatusCode OverlapRemover :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG("Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -474,23 +472,20 @@ EL::StatusCode OverlapRemover :: fillObjectCutflow (const xAOD::IParticleContain
         break;
     }
 
-    if ( m_debug ) {
-      SG::AuxElement::Decorator< char > isBTag( m_bTagWP );
-      int isBTagged = 0;
-      if( isBTag.isAvailable( *obj_itr ) && isBTag(*obj_itr)==true )
-        isBTagged = 1;
+    SG::AuxElement::Decorator< char > isBTag( m_bTagWP );
+    int isBTagged = 0;
+    if( isBTag.isAvailable( *obj_itr ) && isBTag(*obj_itr)==true ) isBTagged = 1;
 
-      if(selectAcc.isAvailable(*obj_itr)){
-        ATH_MSG_INFO( type << " pt " << obj_itr->pt()/1e3 << " eta " << obj_itr->eta() << " phi " << obj_itr->phi() << " btagged " << isBTagged << " selected " << selectAcc(*obj_itr) << " passesOR  " << overlapAcc( *obj_itr ) );
-      } else {
-        ATH_MSG_INFO( type << " pt " << obj_itr->pt()/1e3 << " eta " << obj_itr->eta() << " phi " << obj_itr->phi() << " btagged " << isBTagged << " selected N/A" << " passesOR  " << overlapAcc( *obj_itr ) );
-      }
-      // Check for overlap object link
-      if ( objLinkAcc.isAvailable( *obj_itr ) && objLinkAcc( *obj_itr ).isValid() ) {
-        const xAOD::IParticle* overlapObj = *objLinkAcc( *obj_itr );
-        std::stringstream ss_or; ss_or << overlapObj->type();
-        ATH_MSG_INFO( " Overlap: type " << ss_or.str() << " pt " << overlapObj->pt()/1e3);
-      }
+    if(selectAcc.isAvailable(*obj_itr)){
+      ATH_MSG_DEBUG( type << " pt " << obj_itr->pt()/1e3 << " eta " << obj_itr->eta() << " phi " << obj_itr->phi() << " btagged " << isBTagged << " selected " << selectAcc(*obj_itr) << " passesOR  " << overlapAcc( *obj_itr ) );
+    } else {
+      ATH_MSG_DEBUG( type << " pt " << obj_itr->pt()/1e3 << " eta " << obj_itr->eta() << " phi " << obj_itr->phi() << " btagged " << isBTagged << " selected N/A" << " passesOR  " << overlapAcc( *obj_itr ) );
+    }
+    // Check for overlap object link
+    if ( objLinkAcc.isAvailable( *obj_itr ) && objLinkAcc( *obj_itr ).isValid() ) {
+      const xAOD::IParticle* overlapObj = *objLinkAcc( *obj_itr );
+      std::stringstream ss_or; ss_or << overlapObj->type();
+      ATH_MSG_DEBUG( " Overlap: type " << ss_or.str() << " pt " << overlapObj->pt()/1e3);
     }
 
   }
@@ -520,7 +515,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
     case NOMINAL:  // this is the nominal case
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing nominal case"); }
+      ATH_MSG_DEBUG("Doing nominal case");
       bool nomContainerNotFound(false);
 
       if( m_useElectrons ) {
@@ -568,25 +563,23 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( nomContainerNotFound ) {return EL::StatusCode::SUCCESS;}
 
-      if ( m_debug ) {
-        if ( m_useElectrons ) { ATH_MSG_INFO(  "inElectrons : " << inElectrons->size()); }
-        if ( m_useMuons )     { ATH_MSG_INFO(  "inMuons : " << inMuons->size()); }
-        ATH_MSG_INFO(  "inJets : " << inJets->size() );
-        if ( m_usePhotons )   { ATH_MSG_INFO(  "inPhotons : " << inPhotons->size());  }
-        if ( m_useTaus    )   { ATH_MSG_INFO(  "inTaus : " << inTaus->size());  }
-      }
+      if ( m_useElectrons ) { ATH_MSG_DEBUG(  "inElectrons : " << inElectrons->size()); }
+      if ( m_useMuons )     { ATH_MSG_DEBUG(  "inMuons : " << inMuons->size()); }
+      ATH_MSG_DEBUG(  "inJets : " << inJets->size() );
+      if ( m_usePhotons )   { ATH_MSG_DEBUG(  "inPhotons : " << inPhotons->size());  }
+      if ( m_useTaus    )   { ATH_MSG_DEBUG(  "inTaus : " << inTaus->size());  }
 
       // do the actual OR
       //
-      if ( m_debug ) { ATH_MSG_INFO(  "Calling removeOverlaps()"); }
+      ATH_MSG_DEBUG(  "Calling removeOverlaps()");
       RETURN_CHECK( "OverlapRemover::execute()", m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons), "");
-      if ( m_debug ) { ATH_MSG_INFO(  "Done Calling removeOverlaps()"); }
+      ATH_MSG_DEBUG(  "Done Calling removeOverlaps()");
 
       std::string ORdecor("passOR");
       if(m_useCutFlow){
         // fill cutflow histograms
         //
-        if ( m_debug ) { ATH_MSG_INFO(  "Filling Cut Flow Histograms"); }
+        ATH_MSG_DEBUG(  "Filling Cut Flow Histograms");
         if ( m_useElectrons ) fillObjectCutflow(inElectrons);
         if ( m_useMuons )     fillObjectCutflow(inMuons);
         fillObjectCutflow(inJets);
@@ -597,7 +590,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // make a copy of input container(s) with selected objects
       //
       if ( m_createSelectedContainers ) {
-        if ( m_debug ) { ATH_MSG_INFO(  "Creating selected Containers"); }
+        ATH_MSG_DEBUG(  "Creating selected Containers");
         if( m_useElectrons ) selectedElectrons  = new ConstDataVector<xAOD::ElectronContainer>(SG::VIEW_ELEMENTS);
         if( m_useMuons )     selectedMuons      = new ConstDataVector<xAOD::MuonContainer>(SG::VIEW_ELEMENTS);
         selectedJets      = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
@@ -609,25 +602,23 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       //
       // if an object has been flagged as 'passOR', it will be stored in the 'selected' container
       //
-      if ( m_debug ) { ATH_MSG_INFO(  "Resizing"); }
+      ATH_MSG_DEBUG(  "Resizing");
       if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
       if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
       RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
       if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
       if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
-      if ( m_debug ) {
-        if ( m_useElectrons) { ATH_MSG_INFO(  "selectedElectrons : " << selectedElectrons->size()); }
-        if ( m_useMuons )    { ATH_MSG_INFO(  "selectedMuons : " << selectedMuons->size()); }
-        ATH_MSG_INFO(  "selectedJets : " << selectedJets->size());
-        if ( m_usePhotons )  { ATH_MSG_INFO(  "selectedPhotons : " << selectedPhotons->size()); }
-        if ( m_useTaus )     { ATH_MSG_INFO(  "selectedTaus : " << selectedTaus->size() ); }
-      }
+      if ( m_useElectrons) { ATH_MSG_DEBUG(  "selectedElectrons : " << selectedElectrons->size()); }
+      if ( m_useMuons )    { ATH_MSG_DEBUG(  "selectedMuons : " << selectedMuons->size()); }
+      ATH_MSG_DEBUG(  "selectedJets : " << selectedJets->size());
+      if ( m_usePhotons )  { ATH_MSG_DEBUG(  "selectedPhotons : " << selectedPhotons->size()); }
+      if ( m_useTaus )     { ATH_MSG_DEBUG(  "selectedTaus : " << selectedTaus->size() ); }
 
       // add ConstDataVector to TStore
       //
       if ( m_createSelectedContainers ) {
-        if ( m_debug ) { ATH_MSG_INFO(  "Recording"); }
+        ATH_MSG_DEBUG(  "Recording");
         if ( m_useElectrons ){ RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedElectrons,   m_outContainerName_Electrons ), "Failed to store const data container"); }
         if ( m_useMuons )    { RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedMuons,  m_outContainerName_Muons ), "Failed to store const data container"); }
         RETURN_CHECK( "OverlapRemover::execute()", m_store->record( selectedJets,  m_outContainerName_Jets ), "Failed to store const data container");
@@ -640,14 +631,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
     }
     case ELSYST : // electron syst
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing  electron systematics"); }
+      ATH_MSG_DEBUG(  "Doing  electron systematics");
       bool nomContainerNotFound(false);
 
       // just to check everything is fine
-      if ( m_debug ) {
-         ATH_MSG_INFO("will consider the following ELECTRON systematics:" );
-         for ( auto it : *sysVec ){ ATH_MSG_INFO("\t " << it); }
-      }
+      ATH_MSG_DEBUG("will consider the following ELECTRON systematics:" );
+      for ( auto it : *sysVec ){ ATH_MSG_DEBUG("\t " << it); }
 
       // these input containers won't change in the electron syst loop ...
       if( m_useMuons ) {
@@ -747,14 +736,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
     }
     case MUSYST: // muon syst
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing  muon systematics"); }
+      ATH_MSG_DEBUG(  "Doing  muon systematics");
       bool nomContainerNotFound(false);
 
       // just to check everything is fine
-      if ( m_debug ) {
-         ATH_MSG_INFO("will consider the following MUON systematics:" );
-         for ( auto it : *sysVec ){ ATH_MSG_INFO("\t " << it); }
-      }
+      ATH_MSG_DEBUG("will consider the following MUON systematics:" );
+      for ( auto it : *sysVec ){ ATH_MSG_DEBUG("\t " << it); }
 
       // these input containers won't change in the muon syst loop ...
       if( m_useElectrons ) {
@@ -854,14 +841,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
     }
     case JETSYST: // jet systematics
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing  jet systematics"); }
+      ATH_MSG_DEBUG(  "Doing  jet systematics");
       bool nomContainerNotFound(false);
 
       // just to check everything is fine
-      if ( m_debug ) {
-        ATH_MSG_INFO("will consider the following JET systematics:" );
-        for ( auto it : *sysVec ) { ATH_MSG_INFO("\t " << it);  }
-      }
+      ATH_MSG_DEBUG("will consider the following JET systematics:" );
+      for ( auto it : *sysVec ) { ATH_MSG_DEBUG("\t " << it);  }
 
       // these input containers won't change in the jet syst loop ...
       if( m_useElectrons ) {
@@ -963,14 +948,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
     }
     case PHSYST : // photon systematics
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing  photon systematics"); }
+      ATH_MSG_DEBUG(  "Doing  photon systematics");
       bool nomContainerNotFound(false);
 
       // just to check everything is fine
-      if ( m_debug ) {
-        ATH_MSG_INFO("will consider the following PHOTON systematics:" );
-        for ( auto it : *sysVec ) { ATH_MSG_INFO("\t " << it);  }
-      }
+      ATH_MSG_DEBUG("will consider the following PHOTON systematics:" );
+      for ( auto it : *sysVec ) { ATH_MSG_DEBUG("\t " << it);  }
 
       // these input containers won't change in the photon syst loop ...
       if( m_useElectrons ) {
@@ -1071,14 +1054,12 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
     }
     case TAUSYST : // tau systematics
     {
-      if ( m_debug ) { ATH_MSG_INFO(  "Doing tau systematics"); }
+      ATH_MSG_DEBUG(  "Doing tau systematics");
       bool nomContainerNotFound(false);
 
       // just to check everything is fine
-      if ( m_debug ) {
-        ATH_MSG_INFO("output vector already contains the following TAU systematics:" );
-        for ( auto it : *sysVec ) { ATH_MSG_INFO("\t " << it);  }
-      }
+      ATH_MSG_DEBUG("output vector already contains the following TAU systematics:" );
+      for ( auto it : *sysVec ) { ATH_MSG_DEBUG("\t " << it);  }
 
       // these input containers won't change in the tau syst loop ...
       if( m_useElectrons ) {

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -282,7 +282,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     // get vector of string giving the syst names (rememeber: 1st element is a blank string: nominal case!)
     std::vector<std::string>* systNames_el(nullptr);
-    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_el, m_inputAlgoElectrons, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_el, m_inputAlgoElectrons, 0, m_store, msg()) ,"");
 
     if ( HelperFunctions::found_non_dummy_sys(systNames_el) ) {
       executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  ELSYST, systNames_el);
@@ -302,7 +302,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     // get vector of string giving the syst names (rememeber: 1st element is a blank string: nominal case!)
     std::vector<std::string>* systNames_mu(nullptr);
-    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_mu, m_inputAlgoMuons, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_mu, m_inputAlgoMuons, 0, m_store, msg()) ,"");
 
     if ( HelperFunctions::found_non_dummy_sys(systNames_mu) ) {
       executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  MUSYST, systNames_mu);
@@ -322,7 +322,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     // get vector of string giving the syst names (rememeber: 1st element is a blank string: nominal case!)
     std::vector<std::string>* systNames_jet;
-    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_jet, m_inputAlgoJets, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_jet, m_inputAlgoJets, 0, m_store, msg()) ,"");
 
     if ( HelperFunctions::found_non_dummy_sys(systNames_jet) ) {
       executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  JETSYST, systNames_jet);
@@ -342,7 +342,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     // get vector of string giving the syst names (rememeber: 1st element is a blank string: nominal case!)
     std::vector<std::string>* systNames_photon;
-    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_photon, m_inputAlgoPhotons, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_photon, m_inputAlgoPhotons, 0, m_store, msg()) ,"");
 
     executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus,  PHSYST, systNames_photon);
 
@@ -360,7 +360,7 @@ EL::StatusCode OverlapRemover :: execute ()
 
     // get vector of string giving the syst names (rememeber: 1st element is a blank string: nominal case!)
     std::vector<std::string>* systNames_tau;
-    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_tau, m_inputAlgoTaus, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(systNames_tau, m_inputAlgoTaus, 0, m_store, msg()) ,"");
 
     executeOR(inElectrons, inMuons, inJets, inPhotons, inTaus, TAUSYST, systNames_tau);
 
@@ -525,7 +525,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Electrons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -534,7 +534,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Muons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -542,7 +542,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Jets << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -550,7 +550,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_usePhotons ) {
         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Photons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -559,7 +559,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_useTaus ) {
         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Taus << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -652,7 +652,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the electron syst loop ...
       if( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Muons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -660,7 +660,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Jets << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -668,7 +668,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_usePhotons ) {
         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Photons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -677,7 +677,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_useTaus ) {
         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Taus << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -694,7 +694,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the electron input container will be different for each syst
         //
         std::string el_syst_cont_name = m_inContainerName_Electrons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Electrons syst container "+el_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, el_syst_cont_name, 0, m_store, msg()) , ("Could not find Electrons syst container "+el_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         // do the actual OR
         //
@@ -759,7 +759,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the muon syst loop ...
       if( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Electrons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -767,7 +767,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Jets << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -775,7 +775,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_usePhotons ) {
         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Photons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -784,7 +784,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_useTaus ) {
         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Taus << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -801,7 +801,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the muon input container will be different for each syst
         //
         std::string mu_syst_cont_name = m_inContainerName_Muons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Muons Systematic container "+mu_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, mu_syst_cont_name, 0, m_store, msg()) , ("Could not find Muons Systematic container "+mu_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         // do the actual OR
         //
@@ -866,7 +866,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the jet syst loop ...
       if( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Electrons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -875,7 +875,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Muons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -884,7 +884,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_usePhotons ) {
         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Photons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -893,7 +893,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_useTaus ) {
         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Taus << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -909,7 +909,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the jet input container will be different for each syst
         //
         std::string jet_syst_cont_name = m_inContainerName_Jets + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Jets container "+jet_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, jet_syst_cont_name, 0, m_store, msg()) , ("Could not find Jets container "+jet_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         // do the actual OR
         //
@@ -975,7 +975,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the photon syst loop ...
       if( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Electrons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -984,7 +984,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Muons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -992,7 +992,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Jets << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -1000,7 +1000,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_useTaus ) {
         if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Taus << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -1016,7 +1016,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the photon input container will be different for each syst
         //
         std::string photon_syst_cont_name = m_inContainerName_Photons + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Photons systematic container "+photon_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, photon_syst_cont_name, 0, m_store, msg()) , ("Could not find Photons systematic container "+photon_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         // do the actual OR
         //
@@ -1083,7 +1083,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // these input containers won't change in the tau syst loop ...
       if( m_useElectrons ) {
         if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Electrons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case...");  }
@@ -1092,7 +1092,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if( m_useMuons ) {
         if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Muons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -1100,7 +1100,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) ,"");
       } else {
         nomContainerNotFound = true;
         if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Jets << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -1108,7 +1108,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       if ( m_usePhotons ) {
         if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
-          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, m_verbose) ,"");
+          RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) ,"");
         } else {
           nomContainerNotFound = true;
           if ( m_numEvent == 1 ) { ATH_MSG_WARNING( "Could not find nominal container " << m_inContainerName_Photons << " in xAOD::TStore. Overlap Removal will not be done for the 'all-nominal' case..."); }
@@ -1124,7 +1124,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         // ... instead, the tau input container will be different for each syst
         //
         std::string tau_syst_cont_name = m_inContainerName_Taus + systName;
-        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, 0, m_store, m_verbose) , ("Could not find Taus container "+tau_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
+        RETURN_CHECK("OverlapRemover::execute()", HelperFunctions::retrieve(inTaus, tau_syst_cont_name, 0, m_store, msg()) , ("Could not find Taus container "+tau_syst_cont_name+" in xAOD::TStore. Aborting").c_str() );
 
         // do the actual OR
         //

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -610,11 +610,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       // if an object has been flagged as 'passOR', it will be stored in the 'selected' container
       //
       if ( m_debug ) { ATH_MSG_INFO(  "Resizing"); }
-      if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-      if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-      RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-      if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-      if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+      if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+      if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
       if ( m_debug ) {
         if ( m_useElectrons) { ATH_MSG_INFO(  "selectedElectrons : " << selectedElectrons->size()); }
@@ -723,11 +723,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
         // resize containers basd on OR decision
         //
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_useMuons )  {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_usePhotons ){ RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if ( m_useTaus )   {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_useMuons )  {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons ){ RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )   {  RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
         //
@@ -829,11 +829,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
         // resize containers based on OR decision
         //
-        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), "");
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
         //
@@ -938,11 +938,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
         // resize containers basd on OR decision
         //
-        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )   { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if ( m_useTaus )      { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
         //
@@ -1046,11 +1046,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
         // resize containers based on OR decision
         //
-        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_useTaus )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_useTaus )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
 
         // add ConstDataVector to TStore
         //
@@ -1153,11 +1153,11 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
         // resize containers based on OR decision
         //
-        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, ORdecor.c_str(), ToolName::SELECTOR), "");
-        if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, ORdecor.c_str(), ToolName::SELECTOR), ""); }
-        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, ORdecor.c_str(), ToolName::SELECTOR), "");
+        if( m_useElectrons ) { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inElectrons, selectedElectrons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        if( m_useMuons )     { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inMuons, selectedMuons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inJets, selectedJets, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
+        if ( m_usePhotons )  { RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inPhotons, selectedPhotons, msg(), ORdecor.c_str(), ToolName::SELECTOR), ""); }
+        RETURN_CHECK( "OverlapRemover::execute()", HelperFunctions::makeSubsetCont(inTaus, selectedTaus, msg(), ORdecor.c_str(), ToolName::SELECTOR), "");
 
         // add ConstDataVector to TStore
         //

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -44,8 +44,8 @@ using HelperClasses::ToolName;
 ClassImp(OverlapRemover)
 
 
-OverlapRemover :: OverlapRemover (std::string className) :
-    Algorithm(className),
+OverlapRemover :: OverlapRemover () :
+    Algorithm("OverlapRemover"),
     m_useElectrons(false),
     m_useMuons(false),
     m_usePhotons(false),
@@ -63,7 +63,7 @@ OverlapRemover :: OverlapRemover (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
   m_debug         = false;

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -422,7 +422,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
 
     // save pointers in ConstDataVector with same order
     //
-    RETURN_CHECK( "PhotonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibPhotonsSC.first, calibPhotonsCDV), "");
+    RETURN_CHECK( "PhotonCalibrator::execute()", HelperFunctions::makeSubsetCont(calibPhotonsSC.first, calibPhotonsCDV, msg()), "");
 
     // Sort after copying to CDV.
     if ( m_sort ) {

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -445,7 +445,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -322,7 +322,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
   // get the collection from TEvent or TStore
   //
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("PhotonCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,
+  RETURN_CHECK("PhotonCalibrator::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,
 	       Form("Failed in retrieving %s in %s", m_inContainerName.c_str(), m_name.c_str() ));
   m_isMC = ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) ) ? true : false;
 
@@ -333,7 +333,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
 
 
   const xAOD::PhotonContainer* inPhotons(nullptr);
-  RETURN_CHECK("PhotonCalibrator::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName, m_event, m_store, m_verbose) ,
+  RETURN_CHECK("PhotonCalibrator::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName, m_event, m_store, msg()) ,
 	       Form("Failed in retrieving %s in %s", m_inContainerName.c_str(), m_name.c_str() ));
 
   if ( m_debug ) { ATH_MSG_INFO( "Retrieve has been completed with container name = " << m_inContainerName); }

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -56,8 +56,8 @@ using HelperClasses::ToolName;
 ClassImp(PhotonCalibrator)
 
 
-PhotonCalibrator :: PhotonCalibrator (std::string className) :
-    Algorithm(className),
+PhotonCalibrator :: PhotonCalibrator () :
+    Algorithm("PhotonCalibrator"),
     m_EgammaCalibrationAndSmearingTool(nullptr),
     m_photonFudgeMCTool(nullptr),
     m_photonTightIsEMSelector(nullptr),
@@ -74,7 +74,7 @@ PhotonCalibrator :: PhotonCalibrator (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
 

--- a/Root/PhotonContainer.cxx
+++ b/Root/PhotonContainer.cxx
@@ -24,13 +24,13 @@ PhotonContainer::PhotonContainer(const std::string& name, const std::string& det
     m_topoetcone20                = new std::vector<float> ();
     m_topoetcone30                = new std::vector<float> ();
     m_topoetcone40                = new std::vector<float> ();
-  }    
+  }
 
       // PID
   if(m_infoSwitch.m_PID){
     m_n_IsLoose  = 0;
     m_n_IsMedium = 0;
-    m_n_IsTight  = 0;  
+    m_n_IsTight  = 0;
 
     m_IsLoose    = new std::vector<int>   ();
     m_IsMedium   = new std::vector<int>   ();
@@ -51,7 +51,7 @@ PhotonContainer::PhotonContainer(const std::string& name, const std::string& det
       m_eratio     = new std::vector<float> ();
       //std::vector<float> m_w1
   }
-  
+
   if(m_infoSwitch.m_effSF && m_mc){
     m_LooseEffSF =new std::vector<float>();
     m_MediumEffSF=new std::vector<float>();
@@ -82,7 +82,7 @@ PhotonContainer::~PhotonContainer()
     delete m_topoetcone20	   ;
     delete m_topoetcone30	   ;
     delete m_topoetcone40          ;
-  }    
+  }
 
   // PID
   if(m_infoSwitch.m_PID){
@@ -142,7 +142,7 @@ void PhotonContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "topoetcone20",              &m_topoetcone20              );
     connectBranch<float>(tree, "topoetcone30",              &m_topoetcone30              );
     connectBranch<float>(tree, "topoetcone40",              &m_topoetcone40              );
-  }    
+  }
 
   // PID
   if(m_infoSwitch.m_PID){
@@ -159,7 +159,7 @@ void PhotonContainer::setTree(TTree *tree)
     connectBranch<int>(tree,  "IsTight"  , &m_IsTight );
   }
 
-  
+
   if(m_infoSwitch.m_purity){
     connectBranch<float>(tree,"radhad1", &m_radhad1);
     connectBranch<float>(tree,"radhad" , &m_radhad );
@@ -208,7 +208,7 @@ void PhotonContainer::updateParticle(uint idx, Photon& photon)
     photon.topoetcone20 =               m_topoetcone20              ->at(idx);
     photon.topoetcone30 =               m_topoetcone30              ->at(idx);
     photon.topoetcone40 =               m_topoetcone40              ->at(idx);
-  }    
+  }
 
   // PID
   if(m_infoSwitch.m_PID){
@@ -217,7 +217,7 @@ void PhotonContainer::updateParticle(uint idx, Photon& photon)
     photon.IsTight =   m_IsTight ->at(idx);
   }
 
-  
+
   if(m_infoSwitch.m_purity){
     photon.radhad1 = m_radhad1->at(idx);
     photon.radhad =  m_radhad ->at(idx);
@@ -266,7 +266,7 @@ void PhotonContainer::setBranches(TTree *tree)
     setBranch<float>(tree, "topoetcone20",              m_topoetcone20              );
     setBranch<float>(tree, "topoetcone30",              m_topoetcone30              );
     setBranch<float>(tree, "topoetcone40",              m_topoetcone40              );
-  }    
+  }
 
   // PID
   if(m_infoSwitch.m_PID){
@@ -317,7 +317,7 @@ void PhotonContainer::setBranches(TTree *tree)
 
 void PhotonContainer::clear()
 {
-  
+
   ParticleContainer::clear();
 
   if(m_infoSwitch.m_isolation){
@@ -333,7 +333,7 @@ void PhotonContainer::clear()
     m_topoetcone20	  -> clear() ;
     m_topoetcone30	  -> clear() ;
     m_topoetcone40        -> clear();
-  }    
+  }
 
   // PID
   if(m_infoSwitch.m_PID){
@@ -385,7 +385,7 @@ void PhotonContainer::FillPhoton( const xAOD::Photon* photon ){
   return FillPhoton(static_cast<const xAOD::IParticle*>(photon));
 }
 
-void PhotonContainer::FillPhoton( const xAOD::IParticle* particle ) 
+void PhotonContainer::FillPhoton( const xAOD::IParticle* particle )
 {
 
   ParticleContainer::FillParticle(particle);
@@ -394,10 +394,10 @@ void PhotonContainer::FillPhoton( const xAOD::IParticle* particle )
 
 
   if ( m_infoSwitch.m_isolation ) {
-    
+
     static SG::AuxElement::Accessor<char> isIsoCone40CaloOnlyAcc    ("isIsolated_FixedCutTightCaloOnly");
     safeFill<char, int, xAOD::Photon>(photon, isIsoCone40CaloOnlyAcc, m_isIsolated_Cone40CaloOnly, -1);
-    
+
     static SG::AuxElement::Accessor<char> isIsoCone40Acc            ("isIsolated_FixedCutTight");
     safeFill<char, int, xAOD::Photon>(photon, isIsoCone40Acc, m_isIsolated_Cone40, -1);
 
@@ -413,11 +413,11 @@ void PhotonContainer::FillPhoton( const xAOD::IParticle* particle )
     m_topoetcone20 -> push_back( photon->isolation( xAOD::Iso::topoetcone20) / m_units  );
     m_topoetcone30 -> push_back( photon->isolation( xAOD::Iso::topoetcone30) / m_units  );
     m_topoetcone40 -> push_back( photon->isolation( xAOD::Iso::topoetcone40) / m_units  );
-    
+
   }
 
   if ( m_infoSwitch.m_PID ) {
-  
+
     static SG::AuxElement::Accessor<bool> phLooseAcc  ("PhotonID_Loose");
     safeFill<bool, int, xAOD::Photon>(photon, phLooseAcc, m_IsLoose, -1);
 
@@ -441,7 +441,7 @@ void PhotonContainer::FillPhoton( const xAOD::IParticle* particle )
     //static SG::AuxElement::Accessor<float> w1       ("w1"     );
     static SG::AuxElement::Accessor<float> deltae   ("DeltaE" );
     static SG::AuxElement::Accessor<float> eratio   ("Eratio" );
-    
+
     m_radhad1  -> push_back( radhad1(*photon) );
     m_radhad   -> push_back( radhad (*photon) );
     m_e277     -> push_back( e277   (*photon) );

--- a/Root/PhotonHistsAlgo.cxx
+++ b/Root/PhotonHistsAlgo.cxx
@@ -12,8 +12,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(PhotonHistsAlgo)
 
-PhotonHistsAlgo :: PhotonHistsAlgo (std::string className) :
-IParticleHistsAlgo(className)
+PhotonHistsAlgo :: PhotonHistsAlgo () :
+IParticleHistsAlgo("PhotonHistsAlgo")
 { }
 
 EL::StatusCode PhotonHistsAlgo :: setupJob (EL::Job& job)

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -50,7 +50,6 @@ PhotonSelector :: PhotonSelector () :
   // initialize().
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
   m_useCutFlow              = true;
 
   // input container to be read from TEvent or TStore
@@ -240,12 +239,12 @@ EL::StatusCode PhotonSelector :: initialize ()
   } else {
     m_IsolationSelectionTool = new CP::IsolationSelectionTool(isoToolName.c_str());
   }
-  if ( m_debug ) { ATH_MSG_INFO( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" ); }
+  ATH_MSG_DEBUG( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" );
   RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->setProperty("PhotonWP", (m_IsoKeys.at(0)).c_str()), "Failed to configure base WP" );
   RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->initialize(), "Failed to properly initialize IsolationSelectionTool." );
 
   for ( auto WP_itr = std::next(m_IsoKeys.begin()); WP_itr != m_IsoKeys.end(); ++WP_itr ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Adding extra isolation WP " << *WP_itr << " to IsolationSelectionTool" ); }
+    ATH_MSG_DEBUG( "Adding extra isolation WP " << *WP_itr << " to IsolationSelectionTool" );
     RETURN_CHECK( "PhotonSelector::initialize()", m_IsolationSelectionTool->addPhotonWP( (*WP_itr).c_str() ), "Failed to add isolation WP" );
   }
 
@@ -264,7 +263,7 @@ EL::StatusCode PhotonSelector :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Photon Selection... "); }
+  ATH_MSG_DEBUG( "Applying Photon Selection... ");
 
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,
@@ -325,14 +324,14 @@ EL::StatusCode PhotonSelector :: execute ()
     // must be a pointer to be recorded in TStore
     //
     std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-    if ( m_debug ) { ATH_MSG_INFO( " input list of syst size: " << static_cast<int>(systNames->size()) ); }
+    ATH_MSG_DEBUG( " input list of syst size: " << static_cast<int>(systNames->size()) );
 
     // loop over systematic sets
     //
     bool eventPassThisSyst(false);
     for ( auto systName : *systNames) {
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  input container name: " << m_inContainerName+systName );
 
       RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName + systName, m_event, m_store, msg()), "");
 
@@ -357,7 +356,7 @@ EL::StatusCode PhotonSelector :: execute ()
       //
       eventPass = ( eventPass || eventPassThisSyst );
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  output container name: " << m_outContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  output container name: " << m_outContainerName+systName );
 
       if ( m_createSelectedContainer ) {
         if ( eventPassThisSyst ) {
@@ -372,7 +371,7 @@ EL::StatusCode PhotonSelector :: execute ()
       }
     }
 
-    if ( m_debug ) {  ATH_MSG_INFO( " output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) ); }
+    ATH_MSG_DEBUG(" output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) );
 
     // record in TStore the list of systematics names that should be considered down stream
     //
@@ -480,7 +479,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if( m_doAuthorCut ) {
     if( ! ( (photon->author() & xAOD::EgammaParameters::AuthorPhoton) || (photon->author() & xAOD::EgammaParameters::AuthorAmbiguous) ) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed author kinematic cut." ); }
+      ATH_MSG_DEBUG( "Photon failed author kinematic cut." );
       return false;
     }
   }
@@ -492,7 +491,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if ( m_doOQCut ) {
     if ( (oq & 134217728) != 0 && (reta > 0.98 || rphi > 1.0 || (oq & 67108864) != 0) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Electron failed Object Quality cut." ); }
+      ATH_MSG_DEBUG( "Electron failed Object Quality cut." );
       return 0;
     }
   }
@@ -505,7 +504,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   if ( m_photonIdCut != "None" ) {
     // it crashes in case the "PhotonID_X" is not stored on purpose
     if ( ! photon->auxdecor< bool >( photonIDKeyName ) ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed ID cut." ); }
+      ATH_MSG_DEBUG( "Photon failed ID cut." );
       return false;
     }
   }
@@ -517,7 +516,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if ( m_pT_max != 1e8 ) {
     if ( et > m_pT_max ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed pT max cut." ); }
+      ATH_MSG_DEBUG( "Photon failed pT max cut." );
       return false;
     }
   }
@@ -529,7 +528,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if ( m_pT_min != 1e8 ) {
     if ( et < m_pT_min ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed pT min cut." ); }
+      ATH_MSG_DEBUG( "Photon failed pT min cut." );
       return false;
     }
   }
@@ -544,7 +543,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if ( m_eta_max != 1e8 ) {
     if ( fabs(eta) > m_eta_max ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed |eta| max cut." ); }
+      ATH_MSG_DEBUG( "Photon failed |eta| max cut." );
       return false;
     }
   }
@@ -552,7 +551,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   //
   if ( m_vetoCrack ) {
     if ( fabs( eta ) > 1.37 && fabs( eta ) < 1.52 ) {
-      if ( m_debug ) { ATH_MSG_INFO( "Photon failed |eta| crack veto cut." ); }
+      ATH_MSG_DEBUG( "Photon failed |eta| crack veto cut." );
       return false;
     }
   }
@@ -575,7 +574,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
 
     std::string decorWP = base_decor + "_" + WP_itr;
 
-    if ( m_debug ) { ATH_MSG_INFO( "Decorate photon with " << decorWP << " - accept() ? " << accept_list.getCutResult( WP_itr.c_str()) ); }
+    ATH_MSG_DEBUG( "Decorate photon with " << decorWP << " - accept() ? " << accept_list.getCutResult( WP_itr.c_str()) );
     photon->auxdecor<char>(decorWP) = static_cast<char>( accept_list.getCutResult( WP_itr.c_str() ) );
 
   }
@@ -583,7 +582,7 @@ bool PhotonSelector :: passCuts( const xAOD::Photon* photon )
   // Apply the cut if needed
   //
   if ( !m_MinIsoWPCut.empty() && !accept_list.getCutResult( m_MinIsoWPCut.c_str() ) ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Photon failed isolation cut " << m_MinIsoWPCut ); }
+    ATH_MSG_DEBUG( "Photon failed isolation cut " << m_MinIsoWPCut );
     return false;
   }
   if(m_useCutFlow) m_ph_cutflowHist_1->Fill( m_ph_cutflow_iso_cut, 1 );
@@ -598,7 +597,7 @@ EL::StatusCode PhotonSelector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -625,14 +624,14 @@ EL::StatusCode PhotonSelector :: finalize ()
     m_cutflowHistW->SetBinContent( m_cutflow_bin, m_weightNumEventPass  );
   }
 
-  if (m_debug) { ATH_MSG_INFO( "Cutflow filled"); }
+  ATH_MSG_DEBUG("Cutflow filled");
 
   if (m_IsolationSelectionTool) {
     delete m_IsolationSelectionTool;
     m_IsolationSelectionTool = nullptr;
   }
 
-  if (m_debug) { ATH_MSG_INFO( "Isolation Tool deleted"); }
+  ATH_MSG_DEBUG("Isolation Tool deleted");
 
 /*
   if (m_match_Tool) {
@@ -641,7 +640,7 @@ EL::StatusCode PhotonSelector :: finalize ()
   }
 */
 
-  if (m_debug) { ATH_MSG_INFO( "Matching Tool deleted"); }
+  ATH_MSG_DEBUG("Matching Tool deleted");
 
   ATH_MSG_INFO( "Finalization done.");
   return EL::StatusCode::SUCCESS;

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -381,7 +381,7 @@ EL::StatusCode PhotonSelector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if( !eventPass ) {
     wk()->skipEvent();

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -267,7 +267,7 @@ EL::StatusCode PhotonSelector :: execute ()
   if ( m_debug ) { ATH_MSG_INFO( "Applying Photon Selection... "); }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,
+  RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,
 	       Form("Failed in retrieving %s in %s", m_eventInfoContainerName.c_str(), m_name.c_str() ));
 
   // MC event weight
@@ -293,7 +293,7 @@ EL::StatusCode PhotonSelector :: execute ()
 
     // this will be the collection processed - no matter what!!
     //
-    RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName, m_event, m_store, m_verbose) , "");
+    RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName, m_event, m_store, msg()) , "");
 
     // create output container (if requested)
     ConstDataVector<xAOD::PhotonContainer>* selectedPhotons(nullptr);
@@ -319,7 +319,7 @@ EL::StatusCode PhotonSelector :: execute ()
     // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
     //
     std::vector< std::string >* systNames(nullptr);
-    RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) ,"");
 
     // prepare a vector of the names of CDV containers for usage by downstream algos
     // must be a pointer to be recorded in TStore
@@ -334,7 +334,7 @@ EL::StatusCode PhotonSelector :: execute ()
 
       if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
 
-      RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName + systName, m_event, m_store, m_verbose), "");
+      RETURN_CHECK("PhotonSelector::execute()", HelperFunctions::retrieve(inPhotons, m_inContainerName + systName, m_event, m_store, msg()), "");
 
       // create output container (if requested) - one for each systematic
       //

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -35,8 +35,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(PhotonSelector)
 
-PhotonSelector :: PhotonSelector (std::string className) :
-    Algorithm(className),
+PhotonSelector :: PhotonSelector () :
+    Algorithm("PhotonSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_ph_cutflowHist_1(nullptr),
@@ -48,7 +48,7 @@ PhotonSelector :: PhotonSelector (std::string className) :
   // called on both the submission and the worker node.  Most of your
   // initialization code will go into histInitialize() and
   // initialize().
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
   m_useCutFlow              = true;

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -271,7 +271,7 @@ EL::StatusCode TauSelector :: execute ()
   if ( m_debug ) { ATH_MSG_INFO( "Applying Tau Selection..." ); }
 
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // MC event weight
   //
@@ -298,7 +298,7 @@ EL::StatusCode TauSelector :: execute ()
 
     // this will be the collection processed - no matter what!!
     //
-    RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName, m_event, m_store, msg()) ,"");
 
     // create output container (if requested)
     //
@@ -326,7 +326,7 @@ EL::StatusCode TauSelector :: execute ()
     // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
     //
     std::vector< std::string >* systNames(nullptr);
-    RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) ,"");
 
     // prepare a vector of the names of CDV containers for usage by downstream algos
     // must be a pointer to be recorded in TStore
@@ -341,7 +341,7 @@ EL::StatusCode TauSelector :: execute ()
 
       if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
 
-      RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName + systName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName + systName, m_event, m_store, msg()) ,"");
 
       // create output container (if requested) - one for each systematic
       //

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -389,7 +389,7 @@ EL::StatusCode TauSelector :: execute ()
 
   // look what we have in TStore
   //
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if( !eventPass ) {
     wk()->skipEvent();

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -55,7 +55,6 @@ TauSelector :: TauSelector () :
 
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug                   = false;
   m_useCutFlow              = true;
 
   // checks if the algorithm has been used already
@@ -268,7 +267,7 @@ EL::StatusCode TauSelector :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Tau Selection..." ); }
+  ATH_MSG_DEBUG( "Applying Tau Selection..." );
 
   const xAOD::EventInfo* eventInfo(nullptr);
   RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
@@ -332,14 +331,14 @@ EL::StatusCode TauSelector :: execute ()
     // must be a pointer to be recorded in TStore
     //
     std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-    if ( m_debug ) { ATH_MSG_INFO( " input list of syst size: " << static_cast<int>(systNames->size()) ); }
+    ATH_MSG_DEBUG( " input list of syst size: " << static_cast<int>(systNames->size()) );
 
     // loop over systematic sets
     //
     bool eventPassThisSyst(false);
     for ( auto systName : *systNames ) {
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name: " << m_inContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  input container name: " << m_inContainerName+systName );
 
       RETURN_CHECK("TauSelector::execute()", HelperFunctions::retrieve(inTaus, m_inContainerName + systName, m_event, m_store, msg()) ,"");
 
@@ -364,7 +363,7 @@ EL::StatusCode TauSelector :: execute ()
       //
       eventPass = ( eventPass || eventPassThisSyst );
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  output container name: " << m_outContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  output container name: " << m_outContainerName+systName );
 
       if ( m_createSelectedContainer ) {
         if ( eventPassThisSyst ) {
@@ -379,7 +378,7 @@ EL::StatusCode TauSelector :: execute ()
 
     } // close loop over syst sets
 
-    if ( m_debug ) {  ATH_MSG_INFO( " output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) ); }
+    ATH_MSG_DEBUG(" output list of syst size: " << static_cast<int>(vecOutContainerNames->size()) );
 
     // record in TStore the list of systematics names that should be considered down stream
     //
@@ -407,7 +406,7 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
   int nPass(0); int nObj(0);
   static SG::AuxElement::Decorator< char > passSelDecor( "passSel" );
 
-  if ( m_debug ) { ATH_MSG_INFO( "Initial Taus: " << static_cast<uint32_t>(inTaus->size()) ); }
+  ATH_MSG_DEBUG( "Initial Taus: " << static_cast<uint32_t>(inTaus->size()) );
 
   for ( auto tau_itr : *inTaus ) { // duplicated of basic loop
 
@@ -443,16 +442,16 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
     m_numObjectPass += nPass;
   }
 
-  if ( m_debug ) { ATH_MSG_INFO( "Initial Taus (count obj): " << nObj << " - Selected Taus: " << nPass ); }
+  ATH_MSG_DEBUG( "Initial Taus (count obj): " << nObj << " - Selected Taus: " << nPass );
 
   // apply event selection based on minimal/maximal requirements on the number of objects per event passing cuts
   //
   if ( m_pass_min > 0 && nPass < m_pass_min ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Reject event: nSelectedTaus ("<<nPass<<") < nPassMin ("<<m_pass_min<<")" ); }
+    ATH_MSG_DEBUG( "Reject event: nSelectedTaus ("<<nPass<<") < nPassMin ("<<m_pass_min<<")" );
     return false;
   }
   if ( m_pass_max > 0 && nPass > m_pass_max ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Reject event: nSelectedTaus ("<<nPass<<") > nPassMax ("<<m_pass_max<<")" ); }
+    ATH_MSG_DEBUG( "Reject event: nSelectedTaus ("<<nPass<<") > nPassMax ("<<m_pass_max<<")" );
     return false;
   }
 
@@ -473,7 +472,7 @@ EL::StatusCode TauSelector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -538,14 +537,14 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
   //
 
   if ( tau->pt() <= m_minPtDAOD ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Tau failed minimal pT requirement for usage with derivations"); }
+    ATH_MSG_DEBUG( "Tau failed minimal pT requirement for usage with derivations");
     return 0;
   }
 
   if ( m_setTauOverlappingEleLLHDecor ) { m_TOELLHDecorator->decorate( *tau ); }
 
   if ( ! m_TauSelTool->accept( *tau ) ) {
-    if ( m_debug ) { ATH_MSG_INFO( "Tau failed requirements of TauSelectionTool"); }
+    ATH_MSG_DEBUG( "Tau failed requirements of TauSelectionTool");
     return 0;
   }
 

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -37,8 +37,8 @@
 ClassImp(TauSelector)
 
 
-TauSelector :: TauSelector (std::string className) :
-    Algorithm(className),
+TauSelector :: TauSelector () :
+    Algorithm("TauSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_tau_cutflowHist_1(nullptr),
@@ -53,7 +53,7 @@ TauSelector :: TauSelector (std::string className) :
   // initialization code will go into histInitialize() and
   // initialize().
 
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug                   = false;
   m_useCutFlow              = true;

--- a/Root/TrackContainer.cxx
+++ b/Root/TrackContainer.cxx
@@ -64,7 +64,7 @@ TrackContainer::~TrackContainer()
     delete m_expectNextToInnermostPixelLayerHit;
     delete m_numberDoF;
   }
- 
+
   if(m_infoSwitch.m_numbers){
     delete m_numberOfInnermostPixelLayerHits;
     delete m_numberOfNextToInnermostPixelLayerHits;
@@ -129,12 +129,12 @@ void TrackContainer::setTree(TTree *tree)
     connectBranch<unsigned char>(tree, "numberOfSCTSharedHits", &m_numberOfSCTSharedHits);
     connectBranch<unsigned char>(tree, "numberOfTRTHits", &m_numberOfTRTHits);
     connectBranch<unsigned char>(tree, "numberOfTRTOutliers", &m_numberOfTRTOutliers);
-  }    
-  
+  }
+
   connectBranch<float>(tree, "phi", &m_phi);
   connectBranch<float>(tree, "qOverP", &m_qOverP);
   connectBranch<float>(tree, "theta", &m_theta);
-  
+
   if(m_infoSwitch.m_vertex){
     /*
       connectBranch<Int_t>(tree, "vertexLink", &m_vertexLink);
@@ -177,7 +177,7 @@ void TrackContainer::updateParticle(uint idx, TrackPart& track)
     track.numberOfSCTSharedHits = m_numberOfSCTSharedHits->at(idx);
     track.numberOfTRTHits = m_numberOfTRTHits->at(idx);
     track.numberOfTRTOutliers = m_numberOfTRTOutliers->at(idx);
-  }  
+  }
 
   track.phi = m_phi->at(idx);
   track.qOverP = m_qOverP->at(idx);
@@ -191,7 +191,7 @@ void TrackContainer::updateParticle(uint idx, TrackPart& track)
     */
     track.vz = m_vz->at(idx);
     track.z0 = m_z0->at(idx);
-  }  
+  }
 
   if(m_debug) std::cout << "leaving TrackContainer::updateParticle" << std::endl;
   return;
@@ -301,7 +301,7 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
 
   const xAOD::TrackParticle* track=dynamic_cast<const xAOD::TrackParticle*>(particle);
   if(m_debug) std::cout << "Got TrackParticle" << std::endl;
-  
+
   if(m_infoSwitch.m_fitpars){
     if(m_debug) std::cout << "Filling fitpars" << std::endl;
 
@@ -311,7 +311,7 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
     //m_definingParametersCovMatrix ->push_back(track->definingParametersCovMatrix() ); // fix this too
 
     static SG::AuxElement::ConstAccessor<char> expectInnermostPixelLayerHit("expectInnermostPixelLayerHit");
-    //safeFill<char, int, xAOD::TrackParticle>(track, expectInnermostPixelLayerHit, m_expectInnermostPixelLayerHit, -999);    
+    //safeFill<char, int, xAOD::TrackParticle>(track, expectInnermostPixelLayerHit, m_expectInnermostPixelLayerHit, -999);
     m_expectInnermostPixelLayerHit->push_back(expectInnermostPixelLayerHit(*track));
 
     //m_expectNextToInnermostPixelLayerHit->push_back(track->expectNextToInnermostPixelLayerHit() );
@@ -374,7 +374,7 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
   m_phi->push_back(track->phi() );
   m_qOverP->push_back(track->qOverP() );
   m_theta->push_back(track->theta() );
-  
+
   if(m_infoSwitch.m_vertex){
     if(m_debug) std::cout << "Filling vertex" << std::endl;
 
@@ -385,7 +385,7 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
       //m_vertexLink_persKey->push_back(track->vertexLink.m_persKey() );
       m_vertexLink_persIndex->push_back( -999 );
       m_vertexLink_persKey->push_back( -999 );
-    */    
+    */
     m_vz->push_back(track->vz() );
     m_z0->push_back(track->z0() );
   }

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -13,8 +13,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TrackHistsAlgo)
 
-TrackHistsAlgo :: TrackHistsAlgo (std::string className) :
-    Algorithm(className),
+TrackHistsAlgo :: TrackHistsAlgo () :
+    Algorithm("TrackHistsAlgo"),
     m_plots(nullptr)
 {
   m_inContainerName         = "";

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -67,7 +67,7 @@ EL::StatusCode TrackHistsAlgo :: initialize ()
 EL::StatusCode TrackHistsAlgo :: execute ()
 {
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
 
   float eventWeight(1);
@@ -76,11 +76,11 @@ EL::StatusCode TrackHistsAlgo :: execute ()
   }
 
   const xAOD::TrackParticleContainer* tracks(nullptr);
-  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(tracks, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(tracks, m_inContainerName, m_event, m_store, msg()) ,"");
 
   // get primary vertex
   const xAOD::VertexContainer *vertices(nullptr);
-  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
 
   RETURN_CHECK("TrackHistsAlgo::execute()", m_plots->execute( tracks, pvx, eventWeight, eventInfo ), "");

--- a/Root/TrackHistsAlgo.cxx
+++ b/Root/TrackHistsAlgo.cxx
@@ -19,7 +19,6 @@ TrackHistsAlgo :: TrackHistsAlgo () :
 {
   m_inContainerName         = "";
   m_detailStr               = "";
-  m_debug                   = false;
 
 }
 
@@ -81,7 +80,7 @@ EL::StatusCode TrackHistsAlgo :: execute ()
   // get primary vertex
   const xAOD::VertexContainer *vertices(nullptr);
   RETURN_CHECK("TrackHistsAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
+  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices, msg());
 
   RETURN_CHECK("TrackHistsAlgo::execute()", m_plots->execute( tracks, pvx, eventWeight, eventInfo ), "");
 

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -28,10 +28,8 @@ TrackSelector :: TrackSelector () :
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr)
 {
-  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
-  m_debug         = false;
   m_useCutFlow    = true;
 
   // input container to be read from TEvent or TStore
@@ -83,7 +81,7 @@ EL::StatusCode TrackSelector :: setupJob (EL::Job& job)
   // activated/deactivated when you add/remove the algorithm from your
   // job, which may or may not be of value to you.
 
-  if(m_debug) ATH_MSG_INFO( "Calling setupJob");
+  ATH_MSG_DEBUG("Calling setupJob");
 
   job.useXAOD ();
   xAOD::Init( "TrackSelector" ).ignore(); // call before opening first file
@@ -100,7 +98,7 @@ EL::StatusCode TrackSelector :: histInitialize ()
   // trees.  This method gets called before any input files are
   // connected.
 
-  if(m_debug) ATH_MSG_INFO( "Calling histInitialize");
+  ATH_MSG_DEBUG("Calling histInitialize");
   RETURN_CHECK("xAH::Algorithm::algInitialize()", xAH::Algorithm::algInitialize(), "");
   return EL::StatusCode::SUCCESS;
 }
@@ -112,7 +110,7 @@ EL::StatusCode TrackSelector :: fileExecute ()
   // Here you do everything that needs to be done exactly once for every
   // single file, e.g. collect a list of all lumi-blocks processed
 
-  if(m_debug) ATH_MSG_INFO( "Calling fileExecute");
+  ATH_MSG_DEBUG("Calling fileExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -125,7 +123,7 @@ EL::StatusCode TrackSelector :: changeInput (bool /*firstFile*/)
   // e.g. resetting branch addresses on trees.  If you are using
   // D3PDReader or a similar service this method is not needed.
 
-  if(m_debug) ATH_MSG_INFO( "Calling changeInput");
+  ATH_MSG_DEBUG("Calling changeInput");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -172,14 +170,14 @@ EL::StatusCode TrackSelector :: initialize ()
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
-  if(m_debug) ATH_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
+  ATH_MSG_DEBUG("Number of events in file: " << m_event->getEntries() );
 
   m_numEvent      = 0;
   m_numObject     = 0;
   m_numEventPass  = 0;
   m_numObjectPass = 0;
 
-  if(m_debug) ATH_MSG_INFO( "TrackSelector Interface succesfully initialized!" );
+  ATH_MSG_DEBUG("TrackSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
 }
@@ -189,7 +187,7 @@ EL::StatusCode TrackSelector :: initialize ()
 EL::StatusCode TrackSelector :: execute ()
 {
 
-  if(m_debug) ATH_MSG_INFO( "Applying Track Selection... " << m_name);
+  ATH_MSG_DEBUG("Applying Track Selection... " << m_name);
 
   if(m_doTracksInJets){
     return executeTracksInJets();
@@ -213,7 +211,7 @@ EL::StatusCode TrackSelector :: executeTrackCollection ()
   // get primary vertex
   const xAOD::VertexContainer *vertices(nullptr);
   RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
+  const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices, msg());
 
 
   // create output container (if requested) - deep copy
@@ -282,7 +280,7 @@ EL::StatusCode TrackSelector :: executeTrackCollection ()
 
 EL::StatusCode TrackSelector :: executeTracksInJets ()
 {
-  if(m_debug) ATH_MSG_INFO( "Applying TracksInJet Selection... " << m_inJetContainerName);
+  ATH_MSG_DEBUG("Applying TracksInJet Selection... " << m_inJetContainerName);
   m_numEvent++;
 
   // get input jet collection
@@ -292,7 +290,7 @@ EL::StatusCode TrackSelector :: executeTracksInJets ()
   //// get primary vertex
   //const xAOD::VertexContainer *vertices(nullptr);
   //RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
-  //const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
+  //const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices, msg());
 
   int nPass(0); int nObj(0);
 
@@ -355,7 +353,7 @@ EL::StatusCode TrackSelector :: postExecute ()
   // processing.  This is typically very rare, particularly in user
   // code.  It is mainly used in implementing the NTupleSvc.
 
-  if(m_debug) ATH_MSG_INFO( "Calling postExecute");
+  ATH_MSG_DEBUG("Calling postExecute");
 
   return EL::StatusCode::SUCCESS;
 }
@@ -374,7 +372,7 @@ EL::StatusCode TrackSelector :: finalize ()
   // merged.  This is different from histFinalize() in that it only
   // gets called on worker nodes that processed input events.
 
-  if(m_debug) ATH_MSG_INFO( "Deleting tool instances...");
+  ATH_MSG_DEBUG("Deleting tool instances...");
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -208,11 +208,11 @@ EL::StatusCode TrackSelector :: executeTrackCollection ()
 
   // get the collection from TEvent or TStore
   const xAOD::TrackParticleContainer* inTracks(nullptr);
-  RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(inTracks, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(inTracks, m_inContainerName, m_event, m_store, msg()) ,"");
 
   // get primary vertex
   const xAOD::VertexContainer *vertices(nullptr);
-  RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
 
 
@@ -287,11 +287,11 @@ EL::StatusCode TrackSelector :: executeTracksInJets ()
 
   // get input jet collection
   const xAOD::JetContainer* inJets(nullptr);
-  RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inJetContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("JetSelector::execute()", HelperFunctions::retrieve(inJets, m_inJetContainerName, m_event, m_store, msg()) ,"");
 
   //// get primary vertex
   //const xAOD::VertexContainer *vertices(nullptr);
-  //RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  //RETURN_CHECK("TrackSelector::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   //const xAOD::Vertex *pvx = HelperFunctions::getPrimaryVertex(vertices);
 
   int nPass(0); int nObj(0);

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -23,12 +23,12 @@ using std::vector;
 ClassImp(TrackSelector)
 
 
-TrackSelector :: TrackSelector (std::string className) :
-    Algorithm(className),
+TrackSelector :: TrackSelector () :
+    Algorithm("TrackSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr)
 {
-  if(m_debug) ATH_MSG_INFO( "Calling constructor");
+  //if(m_debug) ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
   m_debug         = false;

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -18,8 +18,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TreeAlgo)
 
-TreeAlgo :: TreeAlgo (std::string className) :
-    Algorithm(className),
+TreeAlgo :: TreeAlgo () :
+    Algorithm("TreeAlgo"),
     m_trees({})
 {
   this->SetName("TreeAlgo"); // needed if you want to retrieve this algo with wk()->getAlg(ALG_NAME) downstream

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -163,7 +163,7 @@ EL::StatusCode TreeAlgo :: execute ()
   // note that the way we set this up, none of the below ##SystNames vectors contain the nominal case
   // TODO: do we really need to check for duplicates? Maybe, maybe not.
   if(!m_muSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_muSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_muSystsVec, 0, m_store, msg()) ,"");
     for(const auto& systName: *systNames){
       if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
       event_systNames.push_back(systName);
@@ -172,7 +172,7 @@ EL::StatusCode TreeAlgo :: execute ()
   }
 
   if(!m_elSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_elSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_elSystsVec, 0, m_store, msg()) ,"");
     for(const auto& systName: *systNames){
       if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
       event_systNames.push_back(systName);
@@ -181,7 +181,7 @@ EL::StatusCode TreeAlgo :: execute ()
   }
 
   if(!m_jetSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_jetSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_jetSystsVec, 0, m_store, msg()) ,"");
     for(const auto& systName: *systNames){
       if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
       event_systNames.push_back(systName);
@@ -189,7 +189,7 @@ EL::StatusCode TreeAlgo :: execute ()
     }
   }
   if(!m_fatJetSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_fatJetSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_fatJetSystsVec, 0, m_store, msg()) ,"");
     for(const auto& systName: *systNames){
       if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
       event_systNames.push_back(systName);
@@ -197,7 +197,7 @@ EL::StatusCode TreeAlgo :: execute ()
     }
   }
   if(!m_photonSystsVec.empty()){
-    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_photonSystsVec, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(systNames, m_photonSystsVec, 0, m_store, msg()) ,"");
     for(const auto& systName: *systNames){
       if (std::find(event_systNames.begin(), event_systNames.end(), systName) != event_systNames.end()) continue;
       event_systNames.push_back(systName);
@@ -269,9 +269,9 @@ EL::StatusCode TreeAlgo :: execute ()
 
   // Get EventInfo and the PrimaryVertices
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
   const xAOD::VertexContainer* vertices(nullptr);
-  RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   // get the primaryVertex
   const xAOD::Vertex* primaryVertex = HelperFunctions::getPrimaryVertex( vertices );
 
@@ -312,38 +312,38 @@ EL::StatusCode TreeAlgo :: execute ()
     // for the containers the were supplied, fill the appropriate vectors
     if ( !m_muContainerName.empty() ) {
       const xAOD::MuonContainer* inMuon(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inMuon, m_muContainerName+muSuffix, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inMuon, m_muContainerName+muSuffix, m_event, m_store, msg()) ,"");
       helpTree->FillMuons( inMuon, primaryVertex );
     }
 
     if ( !m_elContainerName.empty() ) {
       const xAOD::ElectronContainer* inElec(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inElec, m_elContainerName+elSuffix, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inElec, m_elContainerName+elSuffix, m_event, m_store, msg()) ,"");
       helpTree->FillElectrons( inElec, primaryVertex );
     }
     if ( !m_jetContainerName.empty() ) {
       for(unsigned int ll=0;ll<m_jetContainers.size();++ll){ // Systs only for first jet container
         const xAOD::JetContainer* inJets(nullptr);
-        if(ll==0) RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll)+jetSuffix, m_event, m_store, m_verbose) ,"");
-        else{     RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll), m_event, m_store, m_verbose) ,""); }
+        if(ll==0) RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll)+jetSuffix, m_event, m_store, msg()) ,"");
+        else{     RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll), m_event, m_store, msg()) ,""); }
         helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices), m_jetBranches.at(ll) );
       }
 
     }
     if ( !m_l1JetContainerName.empty() ){
       const xAOD::JetRoIContainer* inL1Jets(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inL1Jets, m_l1JetContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inL1Jets, m_l1JetContainerName, m_event, m_store, msg()) ,"");
       helpTree->FillL1Jets( inL1Jets);
     }
     if ( !m_trigJetContainerName.empty() ) {
       const xAOD::JetContainer* inTrigJets(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrigJets, m_trigJetContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrigJets, m_trigJetContainerName, m_event, m_store, msg()) ,"");
       helpTree->FillJets( inTrigJets, HelperFunctions::getPrimaryVertexLocation(vertices), "trigJet" );
     }
     if ( !m_truthJetContainerName.empty() ) {
      for(unsigned int ll=0;ll<m_truthJetContainers.size();++ll){
         const xAOD::JetContainer* inTruthJets(nullptr);
-        RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthJets, m_truthJetContainers.at(ll), m_event, m_store, m_verbose) ,"");
+        RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthJets, m_truthJetContainers.at(ll), m_event, m_store, msg()) ,"");
         helpTree->FillJets( inTruthJets, HelperFunctions::getPrimaryVertexLocation(vertices), m_truthJetBranches.at(ll) );
       }
     }
@@ -352,38 +352,38 @@ EL::StatusCode TreeAlgo :: execute ()
       std::istringstream ss(m_fatJetContainerName);
       while ( std::getline(ss, token, ' ') ){
       	const xAOD::JetContainer* inFatJets(nullptr);
-	RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inFatJets, token+fatJetSuffix, m_event, m_store, m_verbose) ,"");
+	RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inFatJets, token+fatJetSuffix, m_event, m_store, msg()) ,"");
       	helpTree->FillFatJets( inFatJets, token );
       }
     }
     if ( !m_truthFatJetContainerName.empty() ) {
       const xAOD::JetContainer* inTruthFatJets(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthFatJets, m_truthFatJetContainerName, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthFatJets, m_truthFatJetContainerName, m_event, m_store, msg()) ,"");
       helpTree->FillTruthFatJets( inTruthFatJets );
     }
     if ( !m_tauContainerName.empty() ) {
       const xAOD::TauJetContainer* inTaus(nullptr);
-      RETURN_CHECK("HTopMultilepTreeAlgo::execute()", HelperFunctions::retrieve(inTaus, m_tauContainerName, m_event, m_store, m_verbose) , "");
+      RETURN_CHECK("HTopMultilepTreeAlgo::execute()", HelperFunctions::retrieve(inTaus, m_tauContainerName, m_event, m_store, msg()) , "");
       helpTree->FillTaus( inTaus );
     }
     if ( !m_METContainerName.empty() ) {
       const xAOD::MissingETContainer* inMETCont(nullptr);
-      RETURN_CHECK("HTopMultilepTreeAlgo::execute()", HelperFunctions::retrieve(inMETCont, m_METContainerName, m_event, m_store, m_debug) , "");
+      RETURN_CHECK("HTopMultilepTreeAlgo::execute()", HelperFunctions::retrieve(inMETCont, m_METContainerName, m_event, m_store, msg()) , "");
       helpTree->FillMET( inMETCont );
     }
     if ( !m_photonContainerName.empty() ) {
       const xAOD::PhotonContainer* inPhotons(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inPhotons, m_photonContainerName+photonSuffix, m_event, m_store, m_verbose) ,"");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inPhotons, m_photonContainerName+photonSuffix, m_event, m_store, msg()) ,"");
       helpTree->FillPhotons( inPhotons );
     }
     if ( !m_truthParticlesContainerName.empty() ) {
       const xAOD::TruthParticleContainer* inTruthParticles(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthParticles, m_truthParticlesContainerName, m_event, m_store, m_verbose), "");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthParticles, m_truthParticlesContainerName, m_event, m_store, msg()), "");
       helpTree->FillTruth("xAH_truth", inTruthParticles);
     }
     if ( !m_trackParticlesContainerName.empty() ) {
       const xAOD::TrackParticleContainer* inTrackParticles(nullptr);
-      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrackParticles, m_trackParticlesContainerName, m_event, m_store, m_verbose), "");
+      RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrackParticles, m_trackParticlesContainerName, m_event, m_store, msg()), "");
       helpTree->FillTracks(m_trackParticlesContainerName, inTrackParticles);
     }
 

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -39,8 +39,6 @@ TreeAlgo :: TreeAlgo () :
   m_truthParticlesDetailStr     = "";
   m_trackParticlesDetailStr     = "";
 
-  m_debug                       = false;
-
   m_outHistDir                  = false;
 
   m_muContainerName             = "";
@@ -221,7 +219,7 @@ EL::StatusCode TreeAlgo :: execute ()
       return EL::StatusCode::FAILURE;
     }
 
-    m_trees[systName] = new HelpTreeBase( m_event, outTree, treeFile, m_units, m_debug );
+    m_trees[systName] = new HelpTreeBase( m_event, outTree, treeFile, m_units, msg().msgLevel(MSG::DEBUG) );
     const auto& helpTree = m_trees[systName];
 
     // tell the tree to go into the file
@@ -273,7 +271,7 @@ EL::StatusCode TreeAlgo :: execute ()
   const xAOD::VertexContainer* vertices(nullptr);
   RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(vertices, "PrimaryVertices", m_event, m_store, msg()) ,"");
   // get the primaryVertex
-  const xAOD::Vertex* primaryVertex = HelperFunctions::getPrimaryVertex( vertices );
+  const xAOD::Vertex* primaryVertex = HelperFunctions::getPrimaryVertex( vertices , msg());
 
   for(const auto& systName: event_systNames){
     auto& helpTree = m_trees[systName];
@@ -326,7 +324,7 @@ EL::StatusCode TreeAlgo :: execute ()
         const xAOD::JetContainer* inJets(nullptr);
         if(ll==0) RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll)+jetSuffix, m_event, m_store, msg()) ,"");
         else{     RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inJets, m_jetContainers.at(ll), m_event, m_store, msg()) ,""); }
-        helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices), m_jetBranches.at(ll) );
+        helpTree->FillJets( inJets, HelperFunctions::getPrimaryVertexLocation(vertices, msg()), m_jetBranches.at(ll) );
       }
 
     }
@@ -338,13 +336,13 @@ EL::StatusCode TreeAlgo :: execute ()
     if ( !m_trigJetContainerName.empty() ) {
       const xAOD::JetContainer* inTrigJets(nullptr);
       RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTrigJets, m_trigJetContainerName, m_event, m_store, msg()) ,"");
-      helpTree->FillJets( inTrigJets, HelperFunctions::getPrimaryVertexLocation(vertices), "trigJet" );
+      helpTree->FillJets( inTrigJets, HelperFunctions::getPrimaryVertexLocation(vertices, msg()), "trigJet" );
     }
     if ( !m_truthJetContainerName.empty() ) {
      for(unsigned int ll=0;ll<m_truthJetContainers.size();++ll){
         const xAOD::JetContainer* inTruthJets(nullptr);
         RETURN_CHECK("TreeAlgo::execute()", HelperFunctions::retrieve(inTruthJets, m_truthJetContainers.at(ll), m_event, m_store, msg()) ,"");
-        helpTree->FillJets( inTruthJets, HelperFunctions::getPrimaryVertexLocation(vertices), m_truthJetBranches.at(ll) );
+        helpTree->FillJets( inTruthJets, HelperFunctions::getPrimaryVertexLocation(vertices, msg()), m_truthJetBranches.at(ll) );
       }
     }
     if ( !m_fatJetContainerName.empty() ) {

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -42,8 +42,6 @@ TrigMatcher :: TrigMatcher ()
   // initialize().
   //ATH_MSG_INFO( "Calling constructor");
 
-  m_debug           = false;
-
   // input container to be read from TEvent or TStore
   //
   m_inContainerName = "";
@@ -111,7 +109,7 @@ EL::StatusCode TrigMatcher :: initialize ()
   //  everything went fine, let's initialise the tool!
   //
   m_trigMatchTool = new Trig::MatchingTool("TrigMatchTool_"+m_name);
-  if(m_debug) ANA_CHECK( m_trigMatchTool->setProperty( "OutputLevel", MSG::DEBUG) );
+  ANA_CHECK( m_trigMatchTool->setProperty( "OutputLevel", msg().level()) );
 
   // **********************************************************************************************
 
@@ -127,7 +125,7 @@ EL::StatusCode TrigMatcher :: execute ()
   // histograms and trees.  This is where most of your actual analysis
   // code will go.
 
-  if ( m_debug ) { ATH_MSG_INFO( "Applying trigger matching... "); }
+  ATH_MSG_DEBUG( "Applying trigger matching... ");
 
   const xAOD::IParticleContainer* inParticles(nullptr);
 
@@ -152,7 +150,7 @@ EL::StatusCode TrigMatcher :: execute ()
     //
     for ( auto systName : *systNames) {
 
-      if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name:  " << m_inContainerName+systName ); }
+      ATH_MSG_DEBUG( " syst name: " << systName << "  input container name:  " << m_inContainerName+systName );
 
       RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName + systName, m_event, m_store, msg()), "");
       ANA_CHECK( executeMatching( inParticles ) );
@@ -169,16 +167,16 @@ EL::StatusCode TrigMatcher :: executeMatching ( const xAOD::IParticleContainer* 
 
   for( auto particle : *inParticles )
     {
-      if ( m_debug ) { ATH_MSG_INFO( "Trigger matching an object"); }
+      ATH_MSG_DEBUG( "Trigger matching an object");
 
       if ( !isTrigMatchedDecor.isAvailable( *particle ) )
 	isTrigMatchedDecor( *particle ) = std::vector<std::string>();
 
       for ( auto const &chain : m_trigChainsList ) {
-	if ( m_debug ) { ATH_MSG_INFO( "\t checking trigger chain " << chain); }
+	ATH_MSG_DEBUG( "\t checking trigger chain " << chain);
 
 	bool matched = m_trigMatchTool->match( *particle, chain, 0.07 );
-	if ( m_debug ) { ATH_MSG_INFO( "\t\t result = " << matched ); }
+	ATH_MSG_DEBUG( "\t\t result = " << matched );
 	if(matched) isTrigMatchedDecor( *particle ).push_back( chain );
       }
     }

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -138,7 +138,7 @@ EL::StatusCode TrigMatcher :: execute ()
 
     // this will be the collection processed - no matter what!!
     //
-    RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName, m_event, m_store, m_verbose) , "");
+    RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName, m_event, m_store, msg()) , "");
     ANA_CHECK( executeMatching( inParticles ) );
 
   } else { // get the list of systematics to run over
@@ -146,7 +146,7 @@ EL::StatusCode TrigMatcher :: execute ()
     // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
     //
     std::vector< std::string >* systNames(nullptr);
-    RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(systNames, m_systNames, 0, m_store, m_verbose) ,"");
+    RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(systNames, m_systNames, 0, m_store, msg()) ,"");
 
     // loop over systematic sets
     //
@@ -154,7 +154,7 @@ EL::StatusCode TrigMatcher :: execute ()
 
       if ( m_debug ) { ATH_MSG_INFO( " syst name: " << systName << "  input container name:  " << m_inContainerName+systName ); }
 
-      RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName + systName, m_event, m_store, m_verbose), "");
+      RETURN_CHECK("TrigMatcher::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName + systName, m_event, m_store, msg()), "");
       ANA_CHECK( executeMatching( inParticles ) );
     }
 

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -30,8 +30,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TrigMatcher)
 
-TrigMatcher :: TrigMatcher (const std::string& className)
-: Algorithm(className),
+TrigMatcher :: TrigMatcher ()
+: Algorithm("TrigMatcher"),
   m_trigMatchTool(nullptr)
 {
   // Here you put any code for the base initialization of variables,
@@ -40,7 +40,7 @@ TrigMatcher :: TrigMatcher (const std::string& className)
   // called on both the submission and the worker node.  Most of your
   // initialization code will go into histInitialize() and
   // initialize().
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   m_debug           = false;
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -209,7 +209,7 @@ EL::StatusCode TruthSelector :: execute ()
   pass = executeSelection( inTruthParts, mcEvtWeight, count, m_outContainerName);
 
   // look what we have in TStore
-  if ( m_verbose ) { m_store->print(); }
+  ATH_EXEC_VERBOSE(m_store->print());
 
   if ( !pass ) {
     wk()->skipEvent();

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -49,8 +49,6 @@ TruthSelector :: TruthSelector () :
 {
   //ATH_MSG_INFO( "Calling constructor");
 
-  // read debug flag from .config file
-  m_debug         = false;
   m_useCutFlow    = true;
 
   // input container to be read from TEvent or TStore
@@ -177,7 +175,7 @@ EL::StatusCode TruthSelector :: initialize ()
 
 EL::StatusCode TruthSelector :: execute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Applying Jet Selection... "); }
+  ATH_MSG_DEBUG( "Applying Jet Selection... ");
 
   // retrieve event
   const xAOD::EventInfo* eventInfo(nullptr);
@@ -291,7 +289,7 @@ bool TruthSelector :: executeSelection ( const xAOD::TruthParticleContainer* inT
 
 EL::StatusCode TruthSelector :: postExecute ()
 {
-  if ( m_debug ) { ATH_MSG_INFO( "Calling postExecute"); }
+  ATH_MSG_DEBUG( "Calling postExecute");
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -41,13 +41,13 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(TruthSelector)
 
-TruthSelector :: TruthSelector (std::string className) :
-    Algorithm(className),
+TruthSelector :: TruthSelector () :
+    Algorithm("TruthSelector"),
     m_cutflowHist(nullptr),
     m_cutflowHistW(nullptr),
     m_truth_cutflowHist_1(nullptr)
 {
-  ATH_MSG_INFO( "Calling constructor");
+  //ATH_MSG_INFO( "Calling constructor");
 
   // read debug flag from .config file
   m_debug         = false;

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -181,7 +181,7 @@ EL::StatusCode TruthSelector :: execute ()
 
   // retrieve event
   const xAOD::EventInfo* eventInfo(nullptr);
-  RETURN_CHECK("TruthSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TruthSelector::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
   // MC event weight
   float mcEvtWeight(1.0);
@@ -204,7 +204,7 @@ EL::StatusCode TruthSelector :: execute ()
   // then get the one collection and be done with it
 
   // this will be the collection processed - no matter what!!
-  RETURN_CHECK("TruthSelector::execute()", HelperFunctions::retrieve(inTruthParts, m_inContainerName, m_event, m_store, m_verbose) ,"");
+  RETURN_CHECK("TruthSelector::execute()", HelperFunctions::retrieve(inTruthParts, m_inContainerName, m_event, m_store, msg()) ,"");
 
   pass = executeSelection( inTruthParts, mcEvtWeight, count, m_outContainerName);
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -16,8 +16,8 @@ ClassImp(Writer)
 
 
 
-Writer :: Writer (std::string className) :
-    Algorithm(className)
+Writer :: Writer () :
+    Algorithm("Writer")
 {
   m_outputLabel               = "";
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -24,7 +24,6 @@ Writer :: Writer () :
   m_jetContainerNamesStr      = "";
   m_electronContainerNamesStr = "";
   m_muonContainerNamesStr     = "";
-  m_debug                   = false;
 
 }
 

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -134,7 +134,7 @@ EL::StatusCode Writer :: execute ()
 
     const xAOD::JetContainer* inJetsConst(nullptr);
     // look in event
-    if ( HelperFunctions::retrieve(inJetsConst, contName.Data(), m_event, 0, m_verbose).isSuccess() ) {
+    if ( HelperFunctions::retrieve(inJetsConst, contName.Data(), m_event, 0, msg()).isSuccess() ) {
       // without modifying the contents of it:
       ATH_MSG_INFO( " Write a collection " << contName.Data() << inJetsConst->size() );
       m_event->copy( contName.Data() );
@@ -144,7 +144,7 @@ EL::StatusCode Writer :: execute ()
 
     // look in store
     xAOD::JetContainer* inJets(nullptr);
-    if ( HelperFunctions::retrieve(inJets, contName.Data(), 0, m_store, m_verbose).isSuccess() ){
+    if ( HelperFunctions::retrieve(inJets, contName.Data(), 0, m_store, msg()).isSuccess() ){
 //      // FIXME add something like this
 //      jets_shallowCopy.second->setShallowIO( false ); // true = shallow copy, false = deep copy
 //      // if true should have something like this line somewhere:
@@ -161,7 +161,7 @@ EL::StatusCode Writer :: execute ()
       xAOD::JetAuxContainer* inJetsAux = 0;
       ATH_MSG_INFO( " Wrote a aux store " << contName.Data());
       TString auxName( contName + "Aux." );
-      if ( HelperFunctions::retrieve(inJetsAux, auxName.Data(), 0, m_store, m_verbose).isSuccess() ){
+      if ( HelperFunctions::retrieve(inJetsAux, auxName.Data(), 0, m_store, msg()).isSuccess() ){
         ATH_MSG_ERROR(m_name << ": Could not get Aux data for " << contName.Data());
         return EL::StatusCode::FAILURE;
       }

--- a/docs/HowToDocumentation.rst
+++ b/docs/HowToDocumentation.rst
@@ -153,7 +153,6 @@ which will render as expected if we were writing it inside a standard ``.rst`` f
                     JetHists(std::string name, std::string detailStr);
                     virtual ~JetHists() ;
 
-                    bool m_debug;
                     StatusCode initialize();
                     StatusCode execute( const xAOD::JetContainer* jets, float eventWeight, int pvLoc = -1);
                     StatusCode execute( const xAOD::Jet* jet, float eventWeight, int pvLoc = -1 );

--- a/docs/UsingUs.rst
+++ b/docs/UsingUs.rst
@@ -61,7 +61,6 @@ Next, we should probably add some obvious configurations that work for us. I loo
     [
       { "class": "BasicEventSelection",
         "configs": {
-          "m_debug": false,
           "m_truthLevelOnly": false,
           "m_applyGRLCut": true,
           "m_GRLxml": "$ROOTCOREBIN/data/xAODAnaHelpers/data12_8TeV.periodAllYear_DetStatus-v61-pro14-02_DQDefects-00-01-00_PHYS_StandardGRL_All_Good.xml",
@@ -73,7 +72,6 @@ Next, we should probably add some obvious configurations that work for us. I loo
       {
         "class": "JetPlotsAlgo",
         "configs": {
-          "m_debug": false,
           "m_inContainerName": "AntiKt4LCTopoJets",
           "m_detailStr": "kinematic",
           "m_name": "NoPreSel"
@@ -81,7 +79,7 @@ Next, we should probably add some obvious configurations that work for us. I loo
       }
     ]
 
-and I save this into ``xah_run_example.json``. If you want more variables in your plots, add other possibilities in the detailStr field, separated by a space. 
+and I save this into ``xah_run_example.json``. If you want more variables in your plots, add other possibilities in the detailStr field, separated by a space.
 
 Running the script
 ^^^^^^^^^^^^^^^^^^

--- a/scripts/xAH_config.py
+++ b/scripts/xAH_config.py
@@ -5,31 +5,42 @@ class xAH_config(object):
     self._algorithms = []
     self._log        = []
 
-  def setalg(self, name, val):
-      #
-      # Construct the given constructor
-      #    (complicated b/c we have to deal nesting of namespaces)
-      #
-      alg = reduce(lambda x,y: getattr(x, y, None), name.split('.'), ROOT)
-      if alg is None:
-        raise AttributeError(name)
+  def setalg(self, className, options):
+    # check first argument
+    if not isinstance(className, str):
+      raise ValueError("className must be a string")
 
-      #
-      # Construct an instance of the alg and set its attributes
-      #
-      alg_obj = alg()
-      self._log.append((alg,))
-      for k,v in val.iteritems():
-        if not hasattr(alg_obj, k):
-          raise AttributeError(k)
-        self._log.append((alg, k, v))
-        setattr(alg_obj, k, v)
-      #print
+    if not isinstance(options, dict):
+      raise ValueError("Must pass in a dictionary of options")
 
+    algName = options.get("m_name", None)
+    if algName is None:
+      raise KeyError("'m_name' is not set for instance of {0:s}".format(className))
+    if not isinstance(algName, str):
+      raise ValueError("'m_name' must be a string for instance of {0:s}".format(className))
 
-      #
-      # Add the constructed algo to the list of algorithms to run
-      #
-      self._algorithms.append(alg_obj)
+    #
+    # Construct the given constructor
+    #    (complicated b/c we have to deal nesting of namespaces)
+    #
+    alg = reduce(lambda x,y: getattr(x, y, None), className.split('.'), ROOT)
+    if alg is None:
+      raise AttributeError(className)
 
+    #
+    # Construct an instance of the alg and set its attributes
+    #
+    alg_obj = alg()
+    alg_obj.SetName(algName)
+    self._log.append((alg,algName))
+    for k,v in options.iteritems():
+      if not hasattr(alg_obj, k):
+        raise AttributeError(k)
+      self._log.append((alg, k, v))
+      setattr(alg_obj, k, v)
+    #print
 
+    #
+    # Add the constructed algo to the list of algorithms to run
+    #
+    self._algorithms.append(alg_obj)

--- a/scripts/xAH_config.py
+++ b/scripts/xAH_config.py
@@ -2,6 +2,10 @@ import ROOT
 # load this for the MSG::level values. See https://its.cern.ch/jira/browse/ATLASG-270
 ROOT.asg.ToolStore()
 
+import logging
+logger = logging.getLogger("xAH_config")
+logger.setLevel(10) # we use info
+
 class xAH_config(object):
   def __init__(self):
     self._algorithms = []
@@ -20,6 +24,9 @@ class xAH_config(object):
       raise KeyError("'m_name' is not set for instance of {0:s}".format(className))
     if not isinstance(algName, str):
       raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
+
+    if 'm_debug' in options:
+      logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 .")
 
     debugLevel = options.get("m_debugLevel", "info")
     if not isinstance(debugLevel, str):

--- a/scripts/xAH_config.py
+++ b/scripts/xAH_config.py
@@ -1,4 +1,6 @@
 import ROOT
+# load this for the MSG::level values. See https://its.cern.ch/jira/browse/ATLASG-270
+ROOT.asg.ToolStore()
 
 class xAH_config(object):
   def __init__(self):
@@ -8,16 +10,24 @@ class xAH_config(object):
   def setalg(self, className, options):
     # check first argument
     if not isinstance(className, str):
-      raise ValueError("className must be a string")
+      raise TypeError("className must be a string")
 
     if not isinstance(options, dict):
-      raise ValueError("Must pass in a dictionary of options")
+      raise TypeError("Must pass in a dictionary of options")
 
     algName = options.get("m_name", None)
     if algName is None:
       raise KeyError("'m_name' is not set for instance of {0:s}".format(className))
     if not isinstance(algName, str):
-      raise ValueError("'m_name' must be a string for instance of {0:s}".format(className))
+      raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
+
+    debugLevel = options.get("m_debug", "info")
+    if not isinstance(debugLevel, str):
+      raise TypeError("'m_debug' must be a string for instance of {0:s}".format(className))
+    if not hasattr(ROOT.MSG, debugLevel.upper()):
+      raise ValueError("'m_debug' must be a valid MSG::level: {0:s}".format(debugLevel))
+    debugLevel = getattr(ROOT.MSG, debugLevel.upper())
+    options['m_debug'] = debugLevel
 
     #
     # Construct the given constructor
@@ -32,6 +42,7 @@ class xAH_config(object):
     #
     alg_obj = alg()
     alg_obj.SetName(algName)
+    alg_obj.setLevel(debugLevel)
     self._log.append((alg,algName))
     for k,v in options.iteritems():
       if not hasattr(alg_obj, k):

--- a/scripts/xAH_config.py
+++ b/scripts/xAH_config.py
@@ -21,13 +21,13 @@ class xAH_config(object):
     if not isinstance(algName, str):
       raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 
-    debugLevel = options.get("m_debug", "info")
+    debugLevel = options.get("m_debugLevel", "info")
     if not isinstance(debugLevel, str):
-      raise TypeError("'m_debug' must be a string for instance of {0:s}".format(className))
+      raise TypeError("'m_debugLevel' must be a string for instance of {0:s}".format(className))
     if not hasattr(ROOT.MSG, debugLevel.upper()):
-      raise ValueError("'m_debug' must be a valid MSG::level: {0:s}".format(debugLevel))
+      raise ValueError("'m_debugLevel' must be a valid MSG::level: {0:s}".format(debugLevel))
     debugLevel = getattr(ROOT.MSG, debugLevel.upper())
-    options['m_debug'] = debugLevel
+    options['m_debugLevel'] = debugLevel
 
     #
     # Construct the given constructor
@@ -42,7 +42,7 @@ class xAH_config(object):
     #
     alg_obj = alg()
     alg_obj.SetName(algName)
-    alg_obj.setLevel(debugLevel)
+    alg_obj.msg().setLevel(debugLevel)
     self._log.append((alg,algName))
     for k,v in options.iteritems():
       if not hasattr(alg_obj, k):

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -523,6 +523,9 @@ if __name__ == "__main__":
         if not isinstance(algName, str):
           raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 
+        if 'm_debug' in algorithm_configuration['configs']:
+          xAH_logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 .")
+
         debugLevel = algorithm_configuration['configs'].get("m_debugLevel", "info")
         if not isinstance(debugLevel, str):
           raise TypeError("'m_debugLevel' must be a string for instance of {0:s}".format(className))

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -329,6 +329,8 @@ if __name__ == "__main__":
 
     # load the standard algorithm since pyroot delays quickly
     ROOT.EL.Algorithm()
+    # load this to get ROOT.MSG working: https://its.cern.ch/jira/browse/ATLASG-270
+    ROOT.asg.ToolStore()
 
     # check that we have appropriate drivers
     if args.driver == 'prun':
@@ -519,11 +521,19 @@ if __name__ == "__main__":
         if algName is None:
           raise KeyError("'m_name' is not set for instance of {0:s}".format(className))
         if not isinstance(algName, str):
-          raise ValueError("'m_name' must be a string for instance of {0:s}".format(className))
+          raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
+
+        debugLevel = algorithm_configuration['configs'].get("m_debug", "info")
+        if not isinstance(debugLevel, str):
+          raise TypeError("'m_debug' must be a string for instance of {0:s}".format(className))
+        if not hasattr(ROOT.MSG, debugLevel.upper()):
+          raise ValueError("'m_debug' must be a valid MSG::level: {0:s}".format(debugLevel))
+        debugLevel = getattr(ROOT.MSG, debugLevel.upper())
+        algorithm_configuration['configs']['m_debug'] = debugLevel
 
         alg = alg()
         alg.SetName(algName)
-
+        alg.setLevel(debugLevel)
         for config_name, config_val in algorithm_configuration['configs'].iteritems():
           xAH_logger.debug("\t%s", printStr.format(className, config_name, config_val))
           algorithmConfiguration_string.append(printStr.format(className, config_name, config_val))

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -523,17 +523,17 @@ if __name__ == "__main__":
         if not isinstance(algName, str):
           raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 
-        debugLevel = algorithm_configuration['configs'].get("m_debug", "info")
+        debugLevel = algorithm_configuration['configs'].get("m_debugLevel", "info")
         if not isinstance(debugLevel, str):
-          raise TypeError("'m_debug' must be a string for instance of {0:s}".format(className))
+          raise TypeError("'m_debugLevel' must be a string for instance of {0:s}".format(className))
         if not hasattr(ROOT.MSG, debugLevel.upper()):
-          raise ValueError("'m_debug' must be a valid MSG::level: {0:s}".format(debugLevel))
+          raise ValueError("'m_debugLevel' must be a valid MSG::level: {0:s}".format(debugLevel))
         debugLevel = getattr(ROOT.MSG, debugLevel.upper())
-        algorithm_configuration['configs']['m_debug'] = debugLevel
+        algorithm_configuration['configs']['m_debugLevel'] = debugLevel
 
         alg = alg()
         alg.SetName(algName)
-        alg.setLevel(debugLevel)
+        alg.msg().setLevel(debugLevel)
         for config_name, config_val in algorithm_configuration['configs'].iteritems():
           xAH_logger.debug("\t%s", printStr.format(className, config_name, config_val))
           algorithmConfiguration_string.append(printStr.format(className, config_name, config_val))

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -506,30 +506,38 @@ if __name__ == "__main__":
 
       # this is where we go over and process all algorithms
       for algorithm_configuration in algorithm_configurations:
-        alg_name = algorithm_configuration['class']
-        xAH_logger.info("creating algorithm %s", alg_name)
-        algorithmConfiguration_string.append("{0} algorithm options".format(alg_name))
+        className = algorithm_configuration['class']
+        xAH_logger.info("creating algorithm %s", className)
+        algorithmConfiguration_string.append("{0} algorithm options".format(className))
 
         # handle namespaces
-        alg = reduce(lambda x,y: getattr(x, y, None), alg_name.split('.'), ROOT)
+        alg = reduce(lambda x,y: getattr(x, y, None), className.split('.'), ROOT)
         if not alg:
-          raise ValueError("Algorithm %s does not exist" % alg_name)
+          raise ValueError("Algorithm %s does not exist" % className)
+
+        algName = algorithm_configuration['configs'].get("m_name", None)
+        if algName is None:
+          raise KeyError("'m_name' is not set for instance of {0:s}".format(className))
+        if not isinstance(algName, str):
+          raise ValueError("'m_name' must be a string for instance of {0:s}".format(className))
+
         alg = alg()
+        alg.SetName(algName)
 
         for config_name, config_val in algorithm_configuration['configs'].iteritems():
-          xAH_logger.debug("\t%s", printStr.format(alg_name, config_name, config_val))
-          algorithmConfiguration_string.append(printStr.format(alg_name, config_name, config_val))
+          xAH_logger.debug("\t%s", printStr.format(className, config_name, config_val))
+          algorithmConfiguration_string.append(printStr.format(className, config_name, config_val))
           alg_attr = getattr(alg, config_name, None)
           if alg_attr is None:
-            raise ValueError("Algorithm %s does not have attribute %s" % (alg_name, config_name))
+            raise ValueError("Algorithm %s does not have attribute %s" % (className, config_name))
 
           #handle unicode from json
           if isinstance(config_val, unicode):
-            setattr(alg, config_name, config_val.encode('utf-8'))
-          else:
-            setattr(alg, config_name, config_val)
+            config_val = config_val.encode('utf-8')
 
-        xAH_logger.debug("adding algorithm %s to job", alg_name)
+          setattr(alg, config_name, config_val)
+
+        xAH_logger.debug("adding algorithm %s to job", className)
         algorithmConfiguration_string.append("\n")
         job.algsAdd(alg)
     else:
@@ -563,9 +571,9 @@ if __name__ == "__main__":
           map(job.algsAdd, v._algorithms)
 
           for configLog in v._log:
-            if len(configLog) == 1:  # this is when we have just the algorithm name
-              xAH_logger.info("creating algorithm %s", configLog[0])
-              algorithmConfiguration_string.append("{0} algorithm options".format(*configLog))
+            if len(configLog) == 2:  # this is when we have just the algorithm name
+              xAH_logger.info("creating algorithm %s with name %s", configLog[0], configLog[1])
+              algorithmConfiguration_string.append("{0}: {1} options".format(*configLog))
             elif len(configLog) == 3:
               xAH_logger.debug("\t%s", printStr.format(*configLog))
               algorithmConfiguration_string.append(printStr.format(*configLog))

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -20,6 +20,19 @@
 #include <AsgTools/MsgStream.h>
 #include <AsgTools/MsgStreamMacros.h>
 
+/// Macro used to execute "protected" code
+#define ATH_EXEC_LVL( lvl, expr )               \
+   do {                                         \
+      if( msg().msgLevel( lvl ) ) {             \
+         expr;                                  \
+      }                                         \
+   } while( 0 )
+
+/// Macro executing verbose expressions
+#define ATH_EXEC_VERBOSE( expr )  ATH_EXEC_LVL( MSG::VERBOSE, expr )
+/// Macro executing debug expressions
+#define ATH_EXEC_DEBUG( expr )    ATH_EXEC_LVL( MSG::DEBUG, expr )
+
 namespace xAH {
 
     /**

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -51,7 +51,7 @@ namespace xAH {
                     // ...
                 }
 
-            which this class will automatically register all instances of for you. Each instance can have a different name :cpp:member:`~xAH::Algorithm::m_name` but will have the same :cpp:member:`~xAH::Algorithm::m_className` so we can track how many references have been made. This is useful for selectors to deal with cutflows, but can be useful for other algorithms that need to know how many times they've been instantiated in a single job.
+            which this class will automatically register all instances of for you. Each instance can have a different algorithm name but will have the same :cpp:member:`~xAH::Algorithm::m_className` so we can track how many references have been made. This is useful for selectors to deal with cutflows, but can be useful for other algorithms that need to know how many times they've been instantiated in a single job.
 
         @endrst
 
@@ -79,13 +79,6 @@ namespace xAH {
         StatusCode algFinalize();
 
         /**
-            @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)
-            @param name         The name of the instance
-         */
-        Algorithm* SetName(std::string name = "UnnamedAlgorithm");
-        using EL::Algorithm::SetName;
-
-        /**
             @rst
                 Set the level of verbosity in algorithms.
 
@@ -102,8 +95,11 @@ namespace xAH {
          */
         Algorithm* setLevel(int level);
 
+        /**
+            @brief All algorithms initialized should have a unique name, to differentiate them at the TObject level.
 
-        /** All algorithms initialized should have a unique name, to differentiate them at the TObject level */
+            Note, :code:`GetName()` returns a :code:`char*` while this returns a :code:`std::string`.
+        */
         std::string m_name;
 
         /** Enable debug output */
@@ -150,6 +146,14 @@ namespace xAH {
         int m_isMC;
 
       protected:
+        /**
+            @rst
+                The moniker by which all instances are tracked in :cpp:member:`xAH::Algorithm::m_instanceRegistry`
+
+            @endrst
+         */
+        std::string m_className;
+
         /** The TEvent object */
         xAOD::TEvent* m_event; //!
         /** The TStore object */
@@ -172,14 +176,6 @@ namespace xAH {
             @endrst
          */
         int isMC();
-
-        /**
-            @rst
-                The moniker by which all instances are tracked in :cpp:member:`xAH::Algorithm::m_instanceRegistry`
-
-            @endrst
-         */
-        std::string m_className;
 
         /**
             @rst

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -98,6 +98,9 @@ namespace xAH {
         */
         std::string m_name;
 
+        /** m_debug is being deprecated */
+        bool m_debug = false;
+
         /** debug level */
         MSG::Level m_debugLevel;
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -92,23 +92,6 @@ namespace xAH {
         StatusCode algFinalize();
 
         /**
-            @rst
-                Set the level of verbosity in algorithms.
-
-                ===== ====== ===== =======
-                Value Binary Debug Verbose
-                ===== ====== ===== =======
-                0     00
-                1     01     x
-                2     10           x
-                3     11     x     x
-                ===== ====== ===== =======
-
-            @endrst
-         */
-        Algorithm* setLevel(int level);
-
-        /**
             @brief All algorithms initialized should have a unique name, to differentiate them at the TObject level.
 
             Note, :code:`GetName()` returns a :code:`char*` while this returns a :code:`std::string`.
@@ -117,8 +100,6 @@ namespace xAH {
 
         /** debug level */
         MSG::Level m_debugLevel;
-        /** Enable debug output */
-        bool m_debug;
 
         /** If running systematics, the name of the systematic */
         std::string m_systName;

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -118,9 +118,7 @@ namespace xAH {
         /** debug level */
         MSG::Level m_debugLevel;
         /** Enable debug output */
-        bool m_debug,
-        /** Enable verbose output */
-             m_verbose;
+        bool m_debug;
 
         /** If running systematics, the name of the systematic */
         std::string m_systName;

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -102,6 +102,8 @@ namespace xAH {
         */
         std::string m_name;
 
+        /** debug level */
+        MSG::Level m_debugLevel;
         /** Enable debug output */
         bool m_debug,
         /** Enable verbose output */

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -82,7 +82,8 @@ namespace xAH {
             @brief Set the name of this particular instance to something unique (used for ROOT's TObject name primarily)
             @param name         The name of the instance
          */
-        Algorithm* setName(std::string name);
+        Algorithm* SetName(std::string name = "UnnamedAlgorithm");
+        using EL::Algorithm::SetName;
 
         /**
             @rst
@@ -240,9 +241,9 @@ namespace xAH {
 
             @endrst
          */
-	inline bool isToolAlreadyUsed( const std::string& tool_name ) {
-	   return ( m_toolAlreadyUsed.find(tool_name)->second );
-	}
+        inline bool isToolAlreadyUsed( const std::string& tool_name ) {
+           return ( m_toolAlreadyUsed.find(tool_name)->second );
+        }
 
       private:
         /**
@@ -251,17 +252,27 @@ namespace xAH {
 
             @endrst
          */
-	static std::map<std::string, int> m_instanceRegistry;
+        static std::map<std::string, int> m_instanceRegistry;
 
         /**
             @rst
                 Map containing info about whether a CP Tool of a given name has been already used or not by this :cpp:class:`xAH::Algorithm`.
 
-		Its content gets set through :cpp:func:`xAH::Algorithm::checkToolStore`, depending on whether the tool it's created from scratch, or retrieved from :cpp:class:`asg::ToolStore`
+                Its content gets set through :cpp:func:`xAH::Algorithm::checkToolStore`, depending on whether the tool it's created from scratch, or retrieved from :cpp:class:`asg::ToolStore`
 
             @endrst
          */
         std::map<std::string, bool> m_toolAlreadyUsed; //!
+
+        /**
+            @rst
+              A boolean to keep track of whether this instance was registered or not.
+
+              Calling :cpp:func:`xAH::Algorithm::registerInstance` multiple times won't inflate the number of instances of a class made because of me.
+
+            @endrst
+        */
+        bool m_registered; //!
 
   };
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -68,7 +68,7 @@ private:
 public:
 
   // this is a standard constructor
-  BJetEfficiencyCorrector (std::string className = "BJetEfficiencyCorrector");
+  BJetEfficiencyCorrector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -217,7 +217,7 @@ class BasicEventSelection : public xAH::Algorithm
     //
 
     // this is a standard constructor
-    BasicEventSelection (std::string className = "BasicEventSelection");
+    BasicEventSelection ();
 
     // these are the functions inherited from Algorithm
     virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ClusterHistsAlgo.h
+++ b/xAODAnaHelpers/ClusterHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  ClusterHistsAlgo (std::string className = "ClusterHistsAlgo");
+  ClusterHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/DebugTool.h
+++ b/xAODAnaHelpers/DebugTool.h
@@ -18,7 +18,7 @@ public:
 public:
 
   // this is a standard constructor
-  DebugTool (std::string className = "DebugTool");
+  DebugTool ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -96,7 +96,7 @@ public:
 
 
   // this is a standard constructor
-  ElectronCalibrator (std::string className = "ElectronCalibrator");
+  ElectronCalibrator ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -136,7 +136,7 @@ public:
 
 
   // this is a standard constructor
-  ElectronEfficiencyCorrector (std::string className = "ElectronEfficiencyCorrector");
+  ElectronEfficiencyCorrector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronHistsAlgo.h
+++ b/xAODAnaHelpers/ElectronHistsAlgo.h
@@ -17,7 +17,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  ElectronHistsAlgo (std::string className = "ElectronHistsAlgo");
+  ElectronHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -262,7 +262,7 @@ public:
 
   /* this is a standard constructor */
 
-  ElectronSelector (std::string className = "ElectronSelector");
+  ElectronSelector ();
 
   ~ElectronSelector();
 

--- a/xAODAnaHelpers/HLTJetGetter.h
+++ b/xAODAnaHelpers/HLTJetGetter.h
@@ -45,7 +45,7 @@ private:
 public:
 
   // this is a standard constructor
-  HLTJetGetter (std::string className = "HLTJetGetter");
+  HLTJetGetter ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -67,7 +67,7 @@ private:
 public:
 
   // this is a standard constructor
-  HLTJetRoIBuilder (std::string className = "HLTJetRoIBuilder");
+  HLTJetRoIBuilder ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -273,6 +273,8 @@ namespace HelperFunctions {
   /* retrieve() overload for no msgStream object passed in */
   template <typename T>
   StatusCode retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return retrieve<T>(cont, name, event, store, msg()); }
+  template <typename T>
+  StatusCode retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store, bool debug) { msg() << MSG::WARNING << "retrieve<T>(..., bool) is deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882" << endmsg; return retrieve<T>(cont, name, event, store, msg()); }
 
   /*  isAvailable()    return true if an arbitrary object from TStore / TEvent is availible
         - tries to make your life simple by providing a one-stop container check shop for all types

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -39,11 +39,7 @@ namespace HelperFunctions {
   /**
     Static object that provides athena-based message logging functionality
   */
-  MsgStream& msg( MSG::Level lvl = MSG::INFO ) {
-    static MsgStream msgStream( "HelperFunctions" );
-    msgStream << lvl;
-    return msgStream;
-  }
+  MsgStream& msg( MSG::Level lvl = MSG::INFO );
 
   // primary vertex
   bool passPrimaryVertexSelection(const xAOD::VertexContainer* vertexContainer, int Ntracks = 2);
@@ -268,9 +264,6 @@ namespace HelperFunctions {
   template <typename T>
   StatusCode retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return retrieve<T>(cont, name, event, store, msg()); }
 
-  /* isAvailable() overload for no msgStream object passed in */
-  template <typename T>
-  bool isAvailable(std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return isAvailable<T>(name, event, store, msg()); }
   /*  isAvailable()    return true if an arbitrary object from TStore / TEvent is availible
         - tries to make your life simple by providing a one-stop container check shop for all types
         @ name  : the name of the object to look up
@@ -310,8 +303,9 @@ namespace HelperFunctions {
     }
     return false;
   }
-
-
+  /* isAvailable() overload for no msgStream object passed in */
+  template <typename T>
+  bool isAvailable(std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return isAvailable<T>(name, event, store, msg()); }
 
   /* update with better logic
       -- call HelperFunctions::retrieve() instead

--- a/xAODAnaHelpers/HistogramManager.h
+++ b/xAODAnaHelpers/HistogramManager.h
@@ -180,7 +180,7 @@ class HistogramManager {
      */
     TProfile* book(std::string name, std::string title,
 		   std::string xlabel, int xbins, double xlow, double xhigh,
-		   std::string ylabel, double ylow, double yhigh, 
+		   std::string ylabel, double ylow, double yhigh,
 		   std::string option = "");
 
     /**

--- a/xAODAnaHelpers/IParticleHists.h
+++ b/xAODAnaHelpers/IParticleHists.h
@@ -69,7 +69,7 @@ class IParticleHists : public HistogramManager
     std::vector< TH1F* > m_NM;        //!
     std::vector< TH1F* > m_NE;        //!
     std::vector< TH1F* > m_NRapidity; //!
-    
+
     // kinematic
     std::vector< TH1F* > m_NEt;       //!
     std::vector< TH1F* > m_NEt_m;       //!
@@ -82,7 +82,7 @@ StatusCode IParticleHists::execute( const xAH::ParticleContainer<T_PARTICLE, T_I
   unsigned int nPart = particles->size();
   for(unsigned int i = 0;  i<nPart; ++i){
     RETURN_CHECK("IParticleHists::execute()", this->execute( static_cast<const xAH::Particle*>(&particles->at(i)), eventWeight, eventInfo), "");
-    
+
   }
 
   if( m_infoSwitch->m_numLeading > 0){
@@ -99,7 +99,7 @@ StatusCode IParticleHists::execute( const xAH::ParticleContainer<T_PARTICLE, T_I
       m_NM.at(iParticle)->         Fill( partP4.M(),    eventWeight);
       m_NE.at(iParticle)->         Fill( partP4.E(),    eventWeight);
       m_NRapidity.at(iParticle)->  Fill( partP4.Rapidity(), eventWeight);
-      
+
       if(m_infoSwitch->m_kinematic){
 	m_NEt  .at(iParticle)->        Fill( partP4.Et(),   eventWeight);
 	m_NEt_m.at(iParticle)->        Fill( partP4.Et(),   eventWeight);

--- a/xAODAnaHelpers/IParticleHistsAlgo.h
+++ b/xAODAnaHelpers/IParticleHistsAlgo.h
@@ -69,7 +69,7 @@ public:
     static SG::AuxElement::Accessor< float > mcEvtWeightAcc("mcEventWeight");
 
     const xAOD::EventInfo* eventInfo(nullptr);
-    RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, m_verbose) ,"");
+    RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) ,"");
 
     float eventWeight(1);
     if ( mcEvtWeightAcc.isAvailable( *eventInfo ) ) {
@@ -89,7 +89,7 @@ public:
     // if input comes from xAOD, or just running one collection,
     // then get the one collection and be done with it
     if( m_inputAlgo.empty() ) {
-      RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName, m_event, m_store, m_verbose) ,("Failed to get "+m_inContainerName).c_str());
+      RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName, m_event, m_store, msg()) ,("Failed to get "+m_inContainerName).c_str());
 
       // pass the photon collection
       RETURN_CHECK("IParticleHistsAlgo::execute()", static_cast<HIST_T*>(m_plots[""])->execute( inParticles, eventWeight, eventInfo ), "");
@@ -98,11 +98,11 @@ public:
 
       // get vector of string giving the names
       std::vector<std::string>* systNames(nullptr);
-      RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, m_verbose) ,"");
+      RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(systNames, m_inputAlgo, 0, m_store, msg()) ,"");
 
       // loop over systematics
       for( auto systName : *systNames ) {
-	RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName+systName, m_event, m_store, m_verbose) ,"");
+	RETURN_CHECK("IParticleHistsAlgo::execute()", HelperFunctions::retrieve(inParticles, m_inContainerName+systName, m_event, m_store, msg()) ,"");
 	if( m_plots.find( systName ) == m_plots.end() ) { this->AddHists( systName ); }
 	RETURN_CHECK("IParticleHistsAlgo::execute()", static_cast<HIST_T*>(m_plots[systName])->execute( inParticles, eventWeight, eventInfo ), "");
       }

--- a/xAODAnaHelpers/IParticleHistsAlgo.h
+++ b/xAODAnaHelpers/IParticleHistsAlgo.h
@@ -132,7 +132,7 @@ public:
     std::string fullname(m_name);
     fullname += name; // add systematic
     HIST_T* particleHists = new HIST_T( fullname, m_detailStr ); // add systematic
-    particleHists->m_debug = m_debug;
+    particleHists->m_debug = msg().msgLevel(MSG::DEBUG);
     RETURN_CHECK((m_name+"::AddHists").c_str(), particleHists->initialize(), "");
     particleHists->record( wk() );
     m_plots[name] = particleHists;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -146,7 +146,7 @@ private:
 public:
 
   // this is a standard constructor
-  JetCalibrator (std::string className = "JetCalibrator");
+  JetCalibrator ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/JetHistsAlgo.h
+++ b/xAODAnaHelpers/JetHistsAlgo.h
@@ -20,7 +20,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  JetHistsAlgo (std::string className = "JetHistsAlgo");
+  JetHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -195,7 +195,7 @@ public:
 
 
   // this is a standard constructor
-  JetSelector (std::string className = "JetSelector");
+  JetSelector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -59,10 +59,10 @@ public:
   bool    m_useTrackJetTerm;
 
   bool m_runNominal;
-  
-  bool m_isMC; //add bool 
 
-  
+  bool m_isMC; //add bool
+
+
   float m_systVal;
   std::string m_systName;
 
@@ -90,7 +90,7 @@ public:
   std::string m_phoSystematics;
 
   std::string m_outputAlgoSystNames;
-  
+
 
 private:
 
@@ -100,7 +100,7 @@ private:
   // tools
   asg::AnaToolHandle<IMETMaker> m_metmaker_handle; //!
 
-  asg::AnaToolHandle<IMETSystematicsTool> m_metSyst_handle; //!   
+  asg::AnaToolHandle<IMETSystematicsTool> m_metSyst_handle; //!
 
   TauAnalysisTools::TauSelectionTool* m_tauSelTool; //!
 
@@ -117,7 +117,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  METConstructor (std::string className = "METConstructor");
+  METConstructor ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MetContainer.h
+++ b/xAODAnaHelpers/MetContainer.h
@@ -11,25 +11,25 @@
 
 namespace xAH {
 
-  class MetContainer 
+  class MetContainer
   {
   public:
     MetContainer(const std::string& detailStr="", float units = 1e3);
     ~MetContainer();
-    
+
     void setTree    (TTree *tree);
     void setBranches(TTree *tree);
     void clear();
     void FillMET( const xAOD::MissingETContainer* met);
-    template <typename T_BR> 
+    template <typename T_BR>
       void connectBranch(TTree *tree, std::string name, T_BR *variable);
 
   public:
-  
+
     HelperClasses::METInfoSwitch  m_infoSwitch;
     bool m_debug;
     float m_units;
-      
+
   public:
 
     // met

--- a/xAODAnaHelpers/MetHistsAlgo.h
+++ b/xAODAnaHelpers/MetHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MetHistsAlgo (std::string className = "MetHistsAlgo");
+  MetHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MinixAOD.h
+++ b/xAODAnaHelpers/MinixAOD.h
@@ -171,7 +171,7 @@ private:
 
 public:
   // this is a standard constructor
-  MinixAOD (std::string className = "MinixAOD");
+  MinixAOD ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -25,7 +25,7 @@ public:
 
   // sort after calibration
   bool    m_sort;
-  
+
   bool         m_do_sagittaCorr;
   std::string  m_sagittaRelease;
   bool         m_do_sagittaMCDistortion;
@@ -65,10 +65,10 @@ private:
 
   // tools
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                            //!
-  std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;  //!   
+  std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;  //!
   std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                      //!
   std::vector<std::string> m_YearsList;                                                           //!
-  
+
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker
   // node (done by the //!)
@@ -77,7 +77,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonCalibrator (std::string className = "MuonCalibrator");
+  MuonCalibrator ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -63,15 +63,15 @@ public:
   // systematics
   std::string   m_inputAlgoSystNames;  // this is the name of the vector of names of the systematically varied containers produced by the
   			               // upstream algo (e.g., the SC containers with calibration systematics)
-  
-  std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to 
+
+  std::string   m_outputAlgoSystNames; // this is the name of the vector of names of the systematically varied containers to be fed to
                                        // the downstream algos. We need that as we deepcopy the input containers
 
 
   std::string   m_sysNamesForParCont;  // this is the name of the vector of names for the systematics to be used for the creation of
                                        // a parallel container. This will be just a copy of the nominal one with the sys name appended.
-                                       // Use cases: MET-specific systematics. 
-  
+                                       // Use cases: MET-specific systematics.
+
   float         m_systValReco;
   float         m_systValIso;
   float         m_systValTrig;
@@ -85,7 +85,7 @@ public:
   std::string   m_outputSystNamesTrig;
   std::string   m_outputSystNamesTrigMCEff;
   std::string   m_outputSystNamesTTVA;
-  
+
   bool          m_decorateWithNomOnInputSys; // will consider efficiency decorations only for the nominal run
 
 private:
@@ -111,7 +111,7 @@ private:
   std::string m_recoEffSF_tool_name;                                       //!
   CP::MuonEfficiencyScaleFactors* m_muIsoSF_tool;                          //!
   std::string m_isoEffSF_tool_name;                                        //!
-  std::map<std::string, CP::MuonTriggerScaleFactors*>  m_muTrigSF_tools;   //!   
+  std::map<std::string, CP::MuonTriggerScaleFactors*>  m_muTrigSF_tools;   //!
   std::map<std::string, std::string> m_trigEffSF_tool_names;               //!
   std::vector<std::string> m_YearsList;                                    //!
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool;                         //!
@@ -128,7 +128,7 @@ public:
   // TH1 *myHist;  //!
 
   // this is a standard constructor
-  MuonEfficiencyCorrector (std::string className = "MuonEfficiencyCorrector");
+  MuonEfficiencyCorrector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonEfficiencyCorrector_AnaToolHandle.txt
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector_AnaToolHandle.txt
@@ -97,12 +97,12 @@ private:
   std::string m_isoEffSF_tool_name;                                            //!
   asg::AnaToolHandle<CP::IMuonTriggerScaleFactors> m_muTrigSF_tool_handle;     //!
   std::string m_trigEffSF_tool_name;                                           //!
-  /* 
-  
+  /*
+
   TEMP! Commenting this out b/c stupid AnaToolHandle does not work as it should...
-  
+
   asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muTTVASF_tool_handle;  //!
-  
+
   */
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool;                             //!
   std::string m_TTVAEffSF_tool_name;                                           //!
@@ -118,7 +118,7 @@ public:
   // TH1 *myHist;  //!
 
   // this is a standard constructor
-  MuonEfficiencyCorrector (std::string className = "MuonEfficiencyCorrector");
+  MuonEfficiencyCorrector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonHistsAlgo.h
+++ b/xAODAnaHelpers/MuonHistsAlgo.h
@@ -17,7 +17,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonHistsAlgo (std::string className = "MuonHistsAlgo");
+  MuonHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -143,7 +143,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  MuonSelector (std::string className = "MuonSelector");
+  MuonSelector ();
 
   ~MuonSelector();
 

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -240,16 +240,7 @@ class OverlapRemover : public xAH::Algorithm
 public:
 
   // this is a standard constructor
-  /**
-     @brief Constructor
-     @param className
-     @rst
-         This is the name of the class that inherits from :cpp:class:`~xAH::Algorithm`
-
-     @endrst
-
-  */
-  OverlapRemover (std::string className = "OverlapRemover");
+  OverlapRemover ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/ParticleContainer.h
+++ b/xAODAnaHelpers/ParticleContainer.h
@@ -19,18 +19,18 @@ namespace xAH {
     class ParticleContainer
     {
     public:
-    ParticleContainer(const std::string& name, 
-		      const std::string& detailStr="", 
-		      float units = 1e3, 
-		      bool mc = false, 
-		      bool useMass=false, 
+    ParticleContainer(const std::string& name,
+		      const std::string& detailStr="",
+		      float units = 1e3,
+		      bool mc = false,
+		      bool useMass=false,
 		      const std::string& suffix="")
-      : m_name(name), 
-	m_infoSwitch(detailStr), 
-	m_mc(mc), 
-	m_debug(false), 
-	m_units(units), 
-	m_useMass(useMass), 
+      : m_name(name),
+	m_infoSwitch(detailStr),
+	m_mc(mc),
+	m_debug(false),
+	m_units(units),
+	m_useMass(useMass),
 	m_suffix(suffix)
       {
 	m_n = 0;
@@ -42,7 +42,7 @@ namespace xAH {
         m_E   =new std::vector<float>();
         m_M   =new std::vector<float>();
       }
-    
+
       virtual ~ParticleContainer()
       {
         // kinematic
@@ -54,7 +54,7 @@ namespace xAH {
 	  delete m_M;
 	}
       }
-    
+
       virtual void setTree(TTree *tree)
       {
 
@@ -85,7 +85,7 @@ namespace xAH {
       {
 
 	std::string              counterName = "n"+m_name;
-	if (!m_suffix.empty()) { counterName += "_" + m_suffix; }	
+	if (!m_suffix.empty()) { counterName += "_" + m_suffix; }
 
 	tree->Branch(counterName.c_str(),    &m_n, (counterName+"/I").c_str());
 
@@ -127,7 +127,7 @@ namespace xAH {
       void updateEntry()
       {
         m_particles.clear();
-    
+
         for(int i=0;i<m_n;i++)
           {
 	    T_PARTICLE particle;
@@ -135,16 +135,16 @@ namespace xAH {
 	    m_particles.push_back(particle);
           }
       }
-    
+
       T_PARTICLE& at_nonConst(uint idx)
 	{ return m_particles[idx]; }
 
       const T_PARTICLE& at(uint idx) const
       { return m_particles[idx]; }
-    
+
       const T_PARTICLE& operator[](uint idx) const
       { return m_particles[idx]; }
-    
+
       uint size() const
       { return m_particles.size(); }
 
@@ -183,10 +183,10 @@ namespace xAH {
 
 	if ( accessor.isAvailable( *xAODObj ) ) {
 	  for(U itemInVec : accessor(*xAODObj))        destination->back().push_back(itemInVec / units);
-	} 
+	}
 	return;
       }
-      
+
       virtual void updateParticle(uint idx, T_PARTICLE& particle)
       {
         if(m_infoSwitch.m_kinematic)
@@ -205,11 +205,11 @@ namespace xAH {
 	    }
 	  }
       }
-    
+
       std::string m_name;
-    
+
       std::vector<T_PARTICLE> m_particles;
-    
+
     public:
       T_INFOSWITCH m_infoSwitch;
       bool m_mc;
@@ -217,15 +217,15 @@ namespace xAH {
       float m_units;
 
       int m_n;
-    
-    
+
+
     private:
       bool        m_useMass;
       std::string m_suffix;
 
       //
       // Vector branches
-    
+
       // kinematic
       std::vector<float> *m_pt;
       std::vector<float> *m_eta;

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -38,7 +38,7 @@ class ElectronLHPIDManager
     {
       m_selectedWP = WP;
       m_debug      = debug;
-      
+
       /*  fill the multimap with WPs and corresponding tools */
       std::pair < std::string, AsgElectronLikelihoodTool* > veryloose = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
       std::pair < std::string, AsgElectronLikelihoodTool* > loose     = std::make_pair( std::string("Loose"),     m_asgElectronLikelihoodTool_Loose     );
@@ -199,7 +199,7 @@ class ElectronCutBasedPIDManager
 
       HelperClasses::EnumParser<egammaPID::egammaIDQuality> selectedWP_parser;
       unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(m_selectedWP) );
-  
+
       /* By converting the string to the corresponding egammaPID, we can exploit the ordering of the enum itself
       / ( see ElectronPhotonID/ElectronPhotonSelectorTools/trunk/ElectronPhotonSelectorTools/TElectronIsEMSelector.h for definition)
       / to initialise ONLY the tools with WP tighter (or equal) the selected one.
@@ -208,50 +208,50 @@ class ElectronCutBasedPIDManager
       / egammaPID enums :http://acode-browser.usatlas.bnl.gov/lxr/source/atlas/Reconstruction/egamma/egammaEvent/egammaEvent/egammaPIDdefs.h
       */
       if ( configTools ) {
-  
+
         for ( auto it : (m_allWPTools) ) {
-  
+
           const std::string WP            = it.first;
           /* instantiate tools (do it for all) */
           std::string tool_name = WP + selector_name;
           it.second =  new AsgElectronIsEMSelector( tool_name.c_str() );
-  
+
           HelperClasses::EnumParser<egammaPID::egammaIDQuality>  itWP_parser;
           unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(WP) );
-  
+
           /* if this WP is looser than user's WP, skip to next */
           if ( itWP_enum < selectedWP_enum ) { continue; }
-  
+
           /* configure and initialise only tools with (WP >= selectedWP) */
-  
+
           it.second->msg().setLevel( MSG::INFO); /* ERROR, VERBOSE, DEBUG, INFO */
-  
+
           RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->setProperty("WorkingPoint", WP+"Electron" ), ("Failed to set working point "+WP+"Electron").c_str() );
-  
+
           RETURN_CHECK( "ParticlePIDManager::setupWPs()", it.second->initialize(), "Failed to initialize tool." );
-  
+
           /* copy map element into container of valid tools for later usage */
           m_validWPTools.insert( it );
-  
+
         }
-  
+
       } else {
-  
+
         for ( auto it : (m_allWPAuxDecors) ) {
-  
+
           HelperClasses::EnumParser<egammaPID::egammaIDQuality>  itWP_parser;
           unsigned int itWP_enum = static_cast<unsigned int>( itWP_parser.parseEnum(it) );
-  
+
           /* if this WP is looser than user's WP, skip to next */
           if ( itWP_enum < selectedWP_enum ) { continue; }
-  
+
           /* copy map element into container of valid WPs for later usage */
           m_validWPs.insert( it );
-  
+
         }
-  
+
       }
-  
+
       return StatusCode::SUCCESS;
     };
 

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -94,7 +94,7 @@ public:
 
 
   // this is a standard constructor
-  PhotonCalibrator (std::string className = "PhotonCalibrator");
+  PhotonCalibrator ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/PhotonHistsAlgo.h
+++ b/xAODAnaHelpers/PhotonHistsAlgo.h
@@ -17,7 +17,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  PhotonHistsAlgo (std::string className = "PhotonHistsAlgo");
+  PhotonHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/PhotonSelector.h
+++ b/xAODAnaHelpers/PhotonSelector.h
@@ -81,7 +81,7 @@ public:
 
   /* this is a standard constructor */
 
-  PhotonSelector (std::string className = "PhotonSelector");
+  PhotonSelector ();
 
   ~PhotonSelector();
 

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -41,8 +41,8 @@ public:
   float          m_minPtDAOD;                /* a minimal pT threshold b/c some derivations may apply
                                                 a thinning on tau tracks' features needed by the TauSelectionTool,
 						which would cause a crash at runtime */
-						
-  bool           m_setTauOverlappingEleLLHDecor; 						
+
+  bool           m_setTauOverlappingEleLLHDecor;
 
   std::string    m_passAuxDecorKeys;
   std::string    m_failAuxDecorKeys;
@@ -82,7 +82,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TauSelector (std::string className = "TauSelector");
+  TauSelector ();
 
   ~TauSelector();
 

--- a/xAODAnaHelpers/TrackHistsAlgo.h
+++ b/xAODAnaHelpers/TrackHistsAlgo.h
@@ -27,7 +27,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TrackHistsAlgo (std::string className = "TrackHistsAlgo");
+  TrackHistsAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -70,7 +70,7 @@ public:
 
 
   // this is a standard constructor
-  TrackSelector (std::string className = "TrackSelector");
+  TrackSelector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -70,7 +70,7 @@ protected:
 public:
 
   // this is a standard constructor
-  TreeAlgo (std::string className = "TreeAlgo");                                           //!
+  TreeAlgo ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);           //!

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -88,7 +88,7 @@ public:
 
   /* this is a standard constructor */
 
-  TrigMatcher (const std::string& className = "TrigMatcher");
+  TrigMatcher ();
 
   ~TrigMatcher();
 

--- a/xAODAnaHelpers/TruthSelector.h
+++ b/xAODAnaHelpers/TruthSelector.h
@@ -68,7 +68,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  TruthSelector (std::string className = "TruthSelector");
+  TruthSelector ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);

--- a/xAODAnaHelpers/Writer.h
+++ b/xAODAnaHelpers/Writer.h
@@ -32,7 +32,7 @@ public:
   // TH1 *myHist; //!
 
   // this is a standard constructor
-  Writer (std::string className = "Writer");
+  Writer ();
 
   // these are the functions inherited from Algorithm
   virtual EL::StatusCode setupJob (EL::Job& job);


### PR DESCRIPTION
See #635 for details as well as #887, #617.

# Changes

- `m_registered` now keeps track of whether a given instance was registered in the registry instance or not [only to prevent accidental multiple calls of `registerInstance()` on grid, but will not prevent this from happening between client and job]
- constructors are all empty, they do not take any parameters/arguments. `xAH::Algorithm` takes in a `className` which just defines the name of the class, for tracking in the instance registry
- (most) functions in `HelperFunctions` now want a `MsgStream` object passed in from the algorithm in order to print out information/messaging
- `m_debug` and `m_verbose` are no more
- verbosity of an algorithm is set using the `m_debugLevel` configuration which takes case-insensitive string values that are part of the `MSG::Level` enum: 
  - `nil` (0)
  - `verbose` (1)
  - `debug` (2) 
  - `info` (3)
  - `warning` (4)
  - `error` (5) 
  - `fatal` (6)
  - `always` (7)

  Most people will only use `verbose`, `debug`, and `warning`. `info` is used by default.
- to set an algorithm verbosity outside of `xAH_run.py`, you want to do something like

  ```python
  import ROOT; ROOT.gROOT.Macro("$ROOTCOREDIR/scripts/load_packages.C")
  ROOT.asg.ToolStore # fix because of https://its.cern.ch/jira/browse/ATLASG-270
  alg = ROOT.JetSelector()
  alg.msg().setLevel(ROOT.MSG.VERBOSE)
  ```

## To Do
- [x] migrate constructors to empty constructors and rely on `m_name` and `TNamed::SetName`
- [x] migrate some of the functions in `HelperFunctions` (the big ones such as `retrieve`)
- [x] update runner scripts to allow for `TNamed::SetName` calls automagically if `m_name` is a configurable option
- [x] require `m_name` as an option to any algorithm
- [x] finish up the rest of the functions in `HelperFunctions`
- ~[ ] get rid of any other Error/Info/Warning/Debug calls scattered throughout the code~
- [x] deprecate `m_debug` and `m_verbose` everywhere (direct references to `m_debug/verbose` shouldn't really be used for anything
- [x] update xAH_run/xAH_config to allow the verbosity of an algorithm to be configurable via `m_debugLevel`