### PR TITLE
Photon fixes

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -345,8 +345,8 @@ EL::StatusCode JetCalibrator :: initialize ()
   if( m_redoJVT ){
     setToolName(m_JVTUpdateTool_handle);
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVTFileName", PathResolverFindCalibFile("JetMomentTools/JVTlikelihood_20140805.root")));
-    ANA_CHECK( m_JVTUpdateTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVFCorrName", m_JvtAuxName) )
+    ANA_CHECK( m_JVTUpdateTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JVTUpdateTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JVTUpdateTool_handle);
   }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -346,6 +346,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     setToolName(m_JVTUpdateTool_handle);
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVTFileName", PathResolverFindCalibFile("JetMomentTools/JVTlikelihood_20140805.root")));
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("OutputLevel", msg().level()));
+    ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVFCorrName", m_JvtAuxName) )
     ANA_CHECK( m_JVTUpdateTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JVTUpdateTool_handle);
   }

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -121,6 +121,8 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   // input events.
 
   ANA_MSG_INFO( "Initializing PhotonCalibrator Interface... ");
+  
+  m_toolInitializationAtTheFirstEventDone = false;
 
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -326,19 +326,19 @@ EL::StatusCode PhotonCalibrator :: execute ()
       ANA_MSG_DEBUG("Checking photon " << idx << " raw pt = " << phSC_itr->pt()*1e-3 << " GeV " );
 
       if ( phSC_itr->pt() > 7e3 && !(phSC_itr->caloCluster()) ){
-	ANA_MSG_WARNING( "photon "<<idx<<", raw pt = "<<phSC_itr->pt()*1e-3<<" GeV, does not have caloCluster()! " );
+        ANA_MSG_WARNING( "photon "<<idx<<", raw pt = "<<phSC_itr->pt()*1e-3<<" GeV, does not have caloCluster()! " );
       }
 
       // apply calibration (w/ syst)
       //
       if ( (phSC_itr->author() & xAOD::EgammaParameters::AuthorPhoton) || (phSC_itr->author() & xAOD::EgammaParameters::AuthorAmbiguous) ) {
-	if ( m_EgammaCalibrationAndSmearingTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
-	  ANA_MSG_WARNING( "Problem in CP::EgammaCalibrationAndSmearingTool::applyCorrection()");
-	}
+        if ( m_EgammaCalibrationAndSmearingTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
+          ANA_MSG_WARNING( "Problem in CP::EgammaCalibrationAndSmearingTool::applyCorrection()");
+        }
 
-	if ( m_IsolationCorrectionTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
-	  ANA_MSG_WARNING( "Problem in CP::IsolationCorrection::applyCorrection()");
-	}
+        if ( m_IsolationCorrectionTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
+          ANA_MSG_WARNING( "Problem in CP::IsolationCorrection::applyCorrection()");
+        }
       }
 
       ANA_MSG_DEBUG("Calibrated pt with systematic: " << syst_it.name() << " , pt = " << phSC_itr->pt() * 1e-3 << " GeV");
@@ -501,7 +501,7 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
     if (cluster) {
       cluster_eta = cluster->etaBE(2);
       if (cluster_eta != 0.0) {
-	cluster_et = cluster->e() / cosh(cluster_eta);
+        cluster_et = cluster->e() / cosh(cluster_eta);
       }
     }
 
@@ -516,29 +516,29 @@ EL::StatusCode PhotonCalibrator :: decorate(xAOD::Photon* photon)
     if(cluster_et > 10000. && fabs(cluster_eta) < 2.37 && !inCrack){
       // SF
       if(m_photonTightEffTool->getEfficiencyScaleFactor(*photon, photonTightEffSF) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
       if(m_photonMediumEffTool->getEfficiencyScaleFactor(*photon, photonMediumEffSF) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
       if(m_photonLooseEffTool->getEfficiencyScaleFactor(*photon, photonLooseEffSF) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactor returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
       // SF error
       if(m_photonTightEffTool->getEfficiencyScaleFactorError(*photon, photonTightEffSFError) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
       if(m_photonMediumEffTool->getEfficiencyScaleFactorError(*photon, photonMediumEffSFError) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
       if(m_photonLooseEffTool->getEfficiencyScaleFactorError(*photon, photonLooseEffSFError) == CP::CorrectionCode::Error){
-	ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
-	return EL::StatusCode::FAILURE;
+        ANA_MSG_ERROR("getEfficiencyScaleFactorError returned CP::CorrectionCode::Error");
+        return EL::StatusCode::FAILURE;
       }
     }
 
@@ -572,9 +572,9 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
     int dataType = PATCore::ParticleDataType::Data;
     if (eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION )) {
       if (m_useAFII) {
-	dataType = PATCore::ParticleDataType::Fast;
+        dataType = PATCore::ParticleDataType::Fast;
       } else {
-	dataType = PATCore::ParticleDataType::Full;
+        dataType = PATCore::ParticleDataType::Full;
       }
     }
 
@@ -617,12 +617,19 @@ EL::StatusCode  PhotonCalibrator :: toolInitializationAtTheFirstEvent ( const xA
       uncEffCalibPath  = PathResolverFindCalibFile(m_uncEffAFIICalibPath );
     }
 
-    ANA_CHECK( m_photonTightEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
-    ANA_CHECK( m_photonTightEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
-    ANA_CHECK( m_photonMediumEffTool->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
-    ANA_CHECK( m_photonMediumEffTool->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
-    ANA_CHECK( m_photonLooseEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
-    ANA_CHECK( m_photonLooseEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
+    // if m_photonCalibMap is set, use it instead of correction files
+    if( m_photonCalibMap.size() > 0 ){
+      ANA_CHECK( m_photonTightEffTool ->setProperty("MapFilePath", m_photonCalibMap) );
+      ANA_CHECK( m_photonMediumEffTool->setProperty("MapFilePath", m_photonCalibMap) );
+      ANA_CHECK( m_photonLooseEffTool ->setProperty("MapFilePath", m_photonCalibMap) );
+    } else {
+      ANA_CHECK( m_photonTightEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
+      ANA_CHECK( m_photonTightEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
+      ANA_CHECK( m_photonMediumEffTool->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
+      ANA_CHECK( m_photonMediumEffTool->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
+      ANA_CHECK( m_photonLooseEffTool ->setProperty("CorrectionFileNameConv"  ,conEffCalibPath));
+      ANA_CHECK( m_photonLooseEffTool ->setProperty("CorrectionFileNameUnconv",uncEffCalibPath));
+    }
 
     // set data type
     ANA_CHECK( m_photonTightEffTool->setProperty("ForceDataType", dataType));

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -39,7 +39,6 @@
 #include <xAODAnaHelpers/PhotonCalibrator.h>
 
 #include "ElectronPhotonFourMomentumCorrection/EgammaCalibrationAndSmearingTool.h"
-#include "IsolationCorrections/IsolationCorrectionTool.h"
 #include "ElectronPhotonSelectorTools/AsgPhotonIsEMSelector.h"
 #include "ElectronPhotonShowerShapeFudgeTool/ElectronPhotonShowerShapeFudgeTool.h"
 
@@ -299,15 +298,9 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   }
 
   //IsolationCorrectionTool
-  const std::string IsoCorrToolName = m_name + "_IsolationCorrectiongTool_Photons";
-  if ( asg::ToolStore::contains<CP::IsolationCorrectionTool>(IsoCorrToolName.c_str()) ) {
-    m_IsolationCorrectionTool = asg::ToolStore::get<CP::IsolationCorrectionTool>(IsoCorrToolName.c_str());
-  } else {
-    m_IsolationCorrectionTool = new CP::IsolationCorrectionTool(IsoCorrToolName.c_str());
-  }
-
-  ANA_CHECK( m_IsolationCorrectionTool->initialize());
-  m_IsolationCorrectionTool->msg().setLevel( msg().level() );
+  setToolName(m_isolationCorrectionTool_handle);
+  ANA_CHECK(m_isolationCorrectionTool_handle.setProperty("OutputLevel", msg().level()));
+  ANA_CHECK(m_isolationCorrectionTool_handle.retrieve());
 
   ANA_MSG_INFO( "PhotonCalibrator Interface succesfully initialized!" );
 
@@ -397,7 +390,7 @@ EL::StatusCode PhotonCalibrator :: execute ()
           ANA_MSG_WARNING( "Problem in CP::EgammaCalibrationAndSmearingTool::applyCorrection()");
         }
 
-        if ( m_IsolationCorrectionTool->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
+        if ( m_isolationCorrectionTool_handle->applyCorrection( *phSC_itr ) != CP::CorrectionCode::Ok ) {
           ANA_MSG_WARNING( "Problem in CP::IsolationCorrection::applyCorrection()");
         }
       }

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -250,7 +250,7 @@ namespace xAH {
          */
         template <typename T>
         bool setToolName(asg::AnaToolHandle<T>& handle, std::string name = "") const {
-          if(name.empty()) name = handle.type() + "_" + m_name + "::" + getAddress();
+          if(name.empty()) name = handle.name() + "_" + m_name + "::" + getAddress();
           handle.setName(name);
           ANA_MSG_DEBUG("Trying to set-up tool: " << handle.typeAndName());
           bool res = handle.isUserConfigured();

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -102,6 +102,9 @@ public:
   bool m_jetCleanUgly = false;
   /// @brief Recalculate JVT using the calibrated jet pT
   bool m_redoJVT = false;
+
+  /// @brief Name of Jvt aux decoration.  Was "JvtJvfcorr" in Rel 20.7, is now "JVFCorr" in Rel 21. 
+  std::string m_JvtAuxName = "JVFCorr";
   /// @brief Sort the processed container elements by transverse momentum
   bool    m_sort = true;
   /// @brief Apply jet cleaning to parent jet

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -67,7 +67,6 @@ public:
   int m_randomRunNumber = -1;
 
 private:
-  bool    m_toolInitializationAtTheFirstEventDone; //!
   bool    m_isMC = false; //!
 
   std::string m_outAuxContainerName;
@@ -77,7 +76,6 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   EL::StatusCode decorate(xAOD::Photon * photon);
-  EL::StatusCode toolInitializationAtTheFirstEvent (const xAOD::EventInfo* eventInfo);
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -33,6 +33,10 @@ public:
   std::string m_outContainerName = "";
 
   // Calibration information
+  // Tool recommends using map, rather than setting individual calib paths.
+  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommendations_for_full_2015_an
+  std::string m_photonCalibMap = "PhotonEfficiencyCorrection/2015_2016/rel20.7/Moriond2017_v1/map0.txt";
+
   // recommended files here: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2#Recommended_input_files
   std::string m_conEffCalibPath = "PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2016.13TeV.rel20.7.25ns.con.v00.root";
   std::string m_uncEffCalibPath = "PhotonEfficiencyCorrection/efficiencySF.offline.Tight.2016.13TeV.rel20.7.25ns.unc.v00.root";

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -81,7 +81,7 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
-  asg::AnaToolHandle<IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
+  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -10,9 +10,11 @@
 #include <xAODEventInfo/EventInfo.h>
 
 // external tools include(s):
+#include "AsgTools/AnaToolHandle.h"
+#include "PhotonEfficiencyCorrection/IAsgPhotonEfficiencyCorrectionTool.h"
+
 class AsgPhotonIsEMSelector;
 class ElectronPhotonShowerShapeFudgeTool;
-class AsgPhotonEfficiencyCorrectionTool;
 
 namespace CP {
   class EgammaCalibrationAndSmearingTool;
@@ -84,13 +86,10 @@ private:
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!
-  AsgPhotonEfficiencyCorrectionTool*    m_photonTightEffTool = nullptr; //!
-  AsgPhotonEfficiencyCorrectionTool*    m_photonMediumEffTool = nullptr; //!
-  AsgPhotonEfficiencyCorrectionTool*    m_photonLooseEffTool = nullptr; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/tight"}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/loose"}; //!
 
-  // variables that don't get filled at submission time should be
-  // protected from being send from the submission node to the worker
-  // node (done by the //!)
 public:
   // Tree *myTree; //!
   // TH1 *myHist; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -12,13 +12,13 @@
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
 #include "PhotonEfficiencyCorrection/IAsgPhotonEfficiencyCorrectionTool.h"
+#include "IsolationCorrections/IIsolationCorrectionTool.h"
 
 class AsgPhotonIsEMSelector;
 class ElectronPhotonShowerShapeFudgeTool;
 
 namespace CP {
   class EgammaCalibrationAndSmearingTool;
-  class IsolationCorrectionTool;
 }
 
 
@@ -81,7 +81,7 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
-  CP::IsolationCorrectionTool*          m_IsolationCorrectionTool = nullptr; //!
+  asg::AnaToolHandle<IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!


### PR DESCRIPTION
Photon fixes, feedback welcome from @kkrizka and @kratsg .

m_toolInitializationAtTheFirstEventDone was accidentally removed in #895 , breaking PhotonCalibrator.  In fact, this functionality is not needed, as we have access to eventInfo in initalize(), so it's been removed.

The general recommendations and examples for the [PhotonCalibrator](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PhotonEfficiencyRun2) suggests only setting "MapFilePath", rather than each configuration input root file.   I guess experts may want to set these manually, so I've just added `std::string m_photonCalibMap` and set it to the default path.  If this path exists, it will only use the map.  If this string is set to empty in a config file, it will instead use each of the config file paths.  The config file paths are also broken, but I did not bother to fix this given the new functionality.

The name of the JVT aux data has changed to JVFCorr in Rel. 21 from JvtJvtcorr in Rel. 20.7.  [A new option in the official tool has been added to choose the name](https://its.cern.ch/jira/browse/ATLJETMET-754), and this is now added to our code as `m_JvtAuxName` (and set to JVFCorr by default).