### PR TITLE
Compile21.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
+set( release_libs )
+if( AnalysisBase_VERSION GREATER_EQUAL 21 )
+  # 21.X
+  set( release_libs xAODTriggerCnvLib )
+else()
+  # 2.6.X
+  set( release_libs xAODTriggerCnv )
+endif()
+
 # Declare the package's dependencies:
 atlas_depends_on_subdirs( PUBLIC
                           Control/AthContainers
@@ -89,9 +98,9 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    AssociationUtilsLib JetEDM JetUncertaintiesLib
                    JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
-                   TriggerMatchingToolLib xAODMetaDataCnv xAODTriggerCnvLib
-                   xAODMetaData JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils
-                   JetTileCorrectionLib
+                   TriggerMatchingToolLib xAODMetaDataCnv xAODMetaData
+                   JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils JetTileCorrectionLib
+                   ${release_libs}
 )
 
 # Install files from the package:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 atlas_subdir( xAODAnaHelpers )
 
 set( release_libs )
-if( AtlasVersion GREATER_EQUAL 21 )
+if( AtlasVersion MATCHES "^21" )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 atlas_subdir( xAODAnaHelpers )
 
 set( release_libs )
-if( ${AtlasVersion} GREATER_EQUAL 21 )
+if( AtlasVersion GREATER_EQUAL 21 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    AssociationUtilsLib JetEDM JetUncertaintiesLib
                    JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
-                   TriggerMatchingToolLib xAODMetaDataCnv xAODTriggerCnv
+                   TriggerMatchingToolLib xAODMetaDataCnv xAODTriggerCnvLib
                    xAODMetaData JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils
                    JetTileCorrectionLib
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
-set( release_libs )
+set( release_libs xAODTriggerCnvLib )
 if( $ENV{AtlasVersion} GREATER_EQUAL 21 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 atlas_subdir( xAODAnaHelpers )
 
 set( release_libs )
-if( AnalysisBase_VERSION GREATER_EQUAL 21 )
+if( ${AtlasVersion} GREATER_EQUAL 21 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 atlas_subdir( xAODAnaHelpers )
 
 set( release_libs )
-if( AtlasVersion MATCHES "^21" )
+if( $ENV{AtlasVersion} GREATER_EQUAL 21 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
 else()


### PR DESCRIPTION
This checks the dependency for AnalysisBase releases with CMake and changes the name of the `xAODTriggerCnv` library link.

@johnda102 will confirm this works in 21.X. This PR will check it in 2.6.X.