### PR TITLE
Protect JVFCorrName for r20.7

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -345,7 +345,10 @@ EL::StatusCode JetCalibrator :: initialize ()
   if( m_redoJVT ){
     setToolName(m_JVTUpdateTool_handle);
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVTFileName", PathResolverFindCalibFile("JetMomentTools/JVTlikelihood_20140805.root")));
-    ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVFCorrName", m_JvtAuxName) )
+
+    if( ! m_JvtAuxName.empty() ){
+      ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVFCorrName", m_JvtAuxName) )
+    }
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JVTUpdateTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JVTUpdateTool_handle);

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -103,8 +103,8 @@ public:
   /// @brief Recalculate JVT using the calibrated jet pT
   bool m_redoJVT = false;
 
-  /// @brief Name of Jvt aux decoration.  Was "JvtJvfcorr" in Rel 20.7, is now "JVFCorr" in Rel 21. 
-  std::string m_JvtAuxName = "JVFCorr";
+  /// @brief Name of Jvt aux decoration.  Was "JvtJvfcorr" in Rel 20.7, is now "JVFCorr" in Rel 21. Leave empty to use JetMomentTools default.  This must be left empty for RootCore (r20.7) code! 
+  std::string m_JvtAuxName = "";
   /// @brief Sort the processed container elements by transverse momentum
   bool    m_sort = true;
   /// @brief Apply jet cleaning to parent jet


### PR DESCRIPTION
Solves #946. The JVT Update tool accesses aux data with a different name between r20.7 and r21.  Unfortunately many mc16a samples have the old name, so a new property "JVFCorrName" was added to the tool to specify the name.  This property is only available in the r21 JetMomentTools tag, and after discussions with the experts it would be inconvenient to update the r20.7 tag to include it, especially given that no r20.7 samples have the r21 name.   I've therefore edited the logic so JVFCorrName will only be set if m_JvtAuxName is not empty, keeping backwards compatibility.