### PR TITLE
Clean up MET Constructor logic for rebuilding MET from Jets/Tracks

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -437,8 +437,8 @@ EL::StatusCode METConstructor :: execute ()
      // By default: rebuild MET using jets without soft cluster terms (just TST, no CST)
      // You can configure to add Cluster Soft Term (only affects the "use Jets" option)
      //         or to rebuild MET using the Tracks in Calorimeter Jets which doesn't make sense to have CST
-     if( !m_useTracksInJetTerms ) {
-       if( m_useSoftClusterTerms ){
+     if( !m_rebuildUsingTracksInJets ) {
+       if( m_addSoftClusterTerms ){
          ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
        } else {
          ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
@@ -456,7 +456,7 @@ EL::StatusCode METConstructor :: execute ()
        }
      }
 
-     if(!m_useTracksInJetTerms && m_useSoftClusterTerms){
+     if(!m_rebuildUsingTracksInJets && m_addSoftClusterTerms){
        //get the soft cluster term, and applyCorrection
        xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
        //assert( softClusMet != 0); //check we retrieved the clust term

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -434,33 +434,37 @@ EL::StatusCode METConstructor :: execute ()
 
      // NOTE: you have to set m_doJVTCut correctly when running!
 
-     if ( m_useCaloJetTerm ) {
-       ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
-     } else if ( m_useTrackJetTerm ) {
-       ANA_CHECK( m_metmaker_handle->rebuildTrackMET("RefJetTrk", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
+     // By default: rebuild MET using jets without soft cluster terms (just TST, no CST)
+     // You can configure to add Cluster Soft Term (only affects the "use Jets" option)
+     //         or to rebuild MET using the Tracks in Calorimeter Jets which doesn't make sense to have CST
+     if( !m_useTrackJetTerms ) {
+       if( m_useSoftClusterTerms ){
+         ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
+       } else {
+         ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
+       }
      } else {
-       ANA_MSG_ERROR( "Both m_useCaloJetTerm and m_useTrackJetTerm appear to be set to 'false'. This should not happen. Please check your MET configuration file");
-       return EL::StatusCode::FAILURE;
+       ANA_CHECK( m_metmaker_handle->rebuildTrackMET("RefJetTrk", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
      }
 
      //now tell the m_metSyst_handle that we are using this SystematicSet (of one SystematicVariation for now)
      //after this call, when we use applyCorrection, the given met term will be adjusted with this systematic applied
      // assert(   m_metSyst_handle->applySystematicVariation(iSysSet) );
-     //
-
      if (m_isMC) {
        if( m_metSyst_handle->applySystematicVariation(iSysSet) != CP::SystematicCode::Ok) {
          cout<<"Error !!! not able to applySystematicVariation "<< endl;
        }
      }
 
-     //get the soft cluster term, and applyCorrection
-     xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
-     //assert( softClusMet != 0); //check we retrieved the clust term
-     if( m_isMC && m_metSyst_handle->applyCorrection(*softClusMet) != CP::CorrectionCode::Ok) {
-       ANA_MSG_ERROR( "Could not apply correction to soft clus met !!!! ");
+     if(!m_useTrackJetTerms && m_useSoftClusterTerms){
+       //get the soft cluster term, and applyCorrection
+       xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
+       //assert( softClusMet != 0); //check we retrieved the clust term
+       if( m_isMC && m_metSyst_handle->applyCorrection(*softClusMet) != CP::CorrectionCode::Ok) {
+         ANA_MSG_ERROR( "Could not apply correction to soft clus met !!!! ");
+       }
+       ANA_MSG_DEBUG("Soft cluster met term met : " << softClusMet->met());
      }
-     ANA_MSG_DEBUG("Soft cluster met term met : " << softClusMet->met());
 
      //get the track soft term, and applyCorrection
      xAOD::MissingET * softTrkMet = (*newMet)["PVSoftTrk"];

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -437,7 +437,7 @@ EL::StatusCode METConstructor :: execute ()
      // By default: rebuild MET using jets without soft cluster terms (just TST, no CST)
      // You can configure to add Cluster Soft Term (only affects the "use Jets" option)
      //         or to rebuild MET using the Tracks in Calorimeter Jets which doesn't make sense to have CST
-     if( !m_useTrackJetTerms ) {
+     if( !m_useTracksInJetTerms ) {
        if( m_useSoftClusterTerms ){
          ANA_CHECK( m_metmaker_handle->rebuildJetMET("RefJet", "SoftClus", "PVSoftTrk", newMet, jetCont, coreMet, metMap, m_doJVTCut));
        } else {
@@ -456,7 +456,7 @@ EL::StatusCode METConstructor :: execute ()
        }
      }
 
-     if(!m_useTrackJetTerms && m_useSoftClusterTerms){
+     if(!m_useTracksInJetTerms && m_useSoftClusterTerms){
        //get the soft cluster term, and applyCorrection
        xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
        //assert( softClusMet != 0); //check we retrieved the clust term

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -55,8 +55,15 @@ public:
   bool    m_doIsolMuonEloss = false;
   bool    m_doJVTCut = false;
 
-  bool    m_useCaloJetTerm = true;
-  bool    m_useTrackJetTerm = false;
+  /// Rebuild MET using track jet terms
+  bool    m_useTrackJetTerms = false;
+  /**
+    @rst
+      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_useTrackJetTerms` is false)
+
+    @endrst
+  */
+  bool    m_useSoftClusterTerms = false;
 
   // used for systematics
   /// @brief set to false if you want to run met systematics

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -56,14 +56,14 @@ public:
   bool    m_doJVTCut = false;
 
   /// Rebuild MET using tracks in calo jets
-  bool    m_useTracksInJetTerms = false;
+  bool    m_rebuildUsingTracksInJets = false;
   /**
     @rst
-      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_useTracksInJetTerms` is false)
+      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_rebuildUsingTracksInJets` is false)
 
     @endrst
   */
-  bool    m_useSoftClusterTerms = false;
+  bool    m_addSoftClusterTerms = false;
 
   // used for systematics
   /// @brief set to false if you want to run met systematics

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -55,11 +55,11 @@ public:
   bool    m_doIsolMuonEloss = false;
   bool    m_doJVTCut = false;
 
-  /// Rebuild MET using track jet terms
-  bool    m_useTrackJetTerms = false;
+  /// Rebuild MET using tracks in calo jets
+  bool    m_useTracksInJetTerms = false;
   /**
     @rst
-      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_useTrackJetTerms` is false)
+      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_useTracksInJetTerms` is false)
 
     @endrst
   */


### PR DESCRIPTION
This closes #952 and fixes a segfault that N.Whallon has observed via xAH mailing list.

By default, MET is rebuilt using jets with no cluster soft term (only track soft terms). Enable the cluster soft terms option (`m_addSoftClusterTerms`) if using jets. If you want to rebuild MET using tracks in calo jets, enable the `m_rebuildUsingTracksInJets` option instead.

```c++
  /// Rebuild MET using tracks in calo jets
  bool    m_rebuildUsingTracksInJets = false;
  /** 
    @rst
      Include soft cluster terms if rebuilding MET using jet terms (only considered if :cpp:member:`~METConstructor::m_rebuildUsingTracksInJets` is false)

    @endrst
  */
  bool    m_addSoftClusterTerms = false;
```