### PR TITLE
JVT improvements

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -277,6 +277,20 @@ namespace HelperClasses{
     m_vsLumiBlock         = has_exact("vsLumiBlock");
     m_lumiB_runN          = has_exact("lumiB_runN");
 
+    if( has_match( "sfJVT" ) ) {
+      std::string input(m_configStr);
+      // erase everything before the interesting string
+      input.erase( 0, input.find("sfJVT") );
+      // erase everything after the interesting string
+      // only if there is something after the string
+      if( input.find(" ") != std::string::npos ) {
+        input.erase( input.find_first_of(" "), input.size() );
+      }
+      // remove sfJVT to just leave the working point
+      input.erase(0,5);
+      m_sfJVTName = input;
+    } // sfJVTName
+
     m_sfFTagFix.clear();
     if( has_match( "sfFTagFix" ) ) {
       std::string input(m_configStr);

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -78,6 +78,25 @@ namespace HelperClasses{
     std::string SiliconAssociatedForwardMuon("SiliconAssociatedForwardMuon");   enumMap.insert(std::make_pair(SiliconAssociatedForwardMuon , xAOD::Muon::SiliconAssociatedForwardMuon));
   }
 
+  std::string InfoSwitch::get_working_point(const std::string flag) {
+    for (auto configDetail : m_configDetails) {
+      if (configDetail.compare(0, flag.size(), flag) == 0) {
+        return configDetail.substr(flag.size(), std::string::npos);
+      }
+    }
+    return "";
+  }
+
+  std::vector<std::string>InfoSwitch::get_working_points(const std::string flag) {
+    std::vector<std::string> wps;
+    for (auto configDetail : m_configDetails) {
+      if (configDetail.compare(0, flag.size(), flag) == 0) {
+        wps.push_back(configDetail.substr(flag.size(), std::string::npos));
+      }
+    }
+    return wps;
+  }
+
   /*
             !!!!!!!!!!!!!WARNING!!!!!!!!!!!!!
               If you change the string here,
@@ -277,19 +296,7 @@ namespace HelperClasses{
     m_vsLumiBlock         = has_exact("vsLumiBlock");
     m_lumiB_runN          = has_exact("lumiB_runN");
 
-    if( has_match( "sfJVT" ) ) {
-      std::string input(m_configStr);
-      // erase everything before the interesting string
-      input.erase( 0, input.find("sfJVT") );
-      // erase everything after the interesting string
-      // only if there is something after the string
-      if( input.find(" ") != std::string::npos ) {
-        input.erase( input.find_first_of(" "), input.size() );
-      }
-      // remove sfJVT to just leave the working point
-      input.erase(0,5);
-      m_sfJVTName = input;
-    } // sfJVTName
+    m_sfJVTName           = get_working_point("sfJVT");
 
     m_sfFTagFix.clear();
     if( has_match( "sfFTagFix" ) ) {

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2181,11 +2181,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
   }
   
   if ( m_mc ) {
+    static SG::AuxElement::ConstAccessor< char > jvtPass_Loose("JetJVT_Passed_Loose");
+    static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Loose("JetJvtEfficiency_JVTSyst_JVT_Loose");
+    static SG::AuxElement::ConstAccessor< char > jvtPass_Medium("JetJVT_Passed_Medium");
+    static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Medium("JetJvtEfficiency_JVTSyst_JVT_Medium");
+    static SG::AuxElement::ConstAccessor< char > jvtPass_Tight("JetJVT_Passed_Tight");
+    static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Tight("JetJvtEfficiency_JVTSyst_JVT_Tight");  
+
     std::vector<float> junkSF(1,1.0);
 
     if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Loose" ) {
-      static SG::AuxElement::ConstAccessor< char > jvtPass_Loose("JetJVT_Passed_Loose");
-      static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Loose("JetJvtEfficiency_JVTSyst_JVT_Loose");
       if ( jvtPass_Loose.isAvailable( *jet ) ) {
         m_JvtPass_Loose->push_back( jvtPass_Loose( *jet ) );
       } else {
@@ -2199,8 +2204,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     }
 
     if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Medium" ) {
-      static SG::AuxElement::ConstAccessor< char > jvtPass_Medium("JetJVT_Passed_Medium");
-      static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Medium("JetJvtEfficiency_JVTSyst_JVT_Medium");
       if ( jvtPass_Medium.isAvailable( *jet ) ) {
         m_JvtPass_Medium->push_back( jvtPass_Medium( *jet ) );
       } else {
@@ -2214,8 +2217,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     }
 
     if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Tight" ) {
-      static SG::AuxElement::ConstAccessor< char > jvtPass_Tight("JetJVT_Passed_Tight");
-      static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Tight("JetJvtEfficiency_JVTSyst_JVT_Tight");
       if ( jvtPass_Tight.isAvailable( *jet ) ) {
         m_JvtPass_Tight->push_back( jvtPass_Tight( *jet ) );
       } else {

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -252,6 +252,8 @@ EL::StatusCode JetSelector :: initialize ()
 
   //  Add the chosen WP to the string labelling the vector<SF> decoration
   m_outputSystNamesJVT = m_outputSystNamesJVT + "_JVT_" + m_WorkingPointJVT;
+  //  Create a passed label for JVT cut
+  m_outputJVTPassed = m_outputJVTPassed + "_" + m_WorkingPointJVT;
 
   CP::SystematicSet affectSystsJVT = m_JVT_tool_handle->affectingSystematics();
   for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by JVT efficiency systematic: " << syst_it.name()); }
@@ -518,7 +520,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
         // Create the name of the SF weight to be recorded
         //   template:  SYSNAME_JVTEff_SF
         //
-        std::string sfName = "JVTEff_SF_" + m_WorkingPointJVT;;
+        std::string sfName = "JVTEff_SF_" + m_WorkingPointJVT;
         if ( !syst_it.name().empty() ) {
            std::string prepend = syst_it.name() + "_";
            sfName.insert( 0, prepend );
@@ -540,6 +542,10 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
         for ( auto jet : *(selectedJets) ) {
 
           ANA_MSG_DEBUG("Applying JVT SF" );
+          
+          // create passed JVT decorator
+          static const SG::AuxElement::Decorator<char> passedJVT( m_outputJVTPassed );
+          passedJVT( *jet ) = 1; // passes by default
 
           // obtain JVT SF as a float (to be stored away separately)
           //
@@ -552,9 +558,19 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
           float jvtSF(1.0);
           if ( m_JVT_tool_handle->isInRange(*jet) ) {
-            if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
-              ANA_MSG_WARNING( "Problem in JVT Tool getEfficiencyScaleFactor");
-              jvtSF = 1.0;
+            // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
+            if ( m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) {
+              passedJVT( *jet ) = 0; // mark as not passed
+              if ( m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+                ANA_MSG_WARNING( "Problem in JVT Tool getInefficiencyScaleFactor");
+                jvtSF = 1.0;
+              }
+            } else { // otherwise classic efficiency scale factor
+              passedJVT( *jet ) = 1;
+              if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+                ANA_MSG_WARNING( "Problem in JVT Tool getEfficiencyScaleFactor");
+                jvtSF = 1.0;
+              }
             }
           }
           //
@@ -788,7 +804,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
         }
       }
     } else {
-      if ( !m_JVT_tool_handle->passesJvtCut(*jet) ) { return 0; }
+      if ( !m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) { return 0; }
     }
   } // m_doJVT
   if ( m_useCutFlow ) m_jet_cutflowHist_1->Fill( m_jet_cutflow_jvt_cut, 1 );
@@ -885,5 +901,3 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   ANA_MSG_DEBUG("Passed Cuts");
   return 1;
 }
-
-

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -394,6 +394,7 @@ namespace HelperClasses {
         m_layer          layer          exact
         m_trackPV        trackPV        exact
         m_trackAll       trackAll       exact
+        m_sfJVTName      sfJVT          partial
         m_allTrack       allTrack       exact
         m_allTrackPVSel  allTrackPVSel  exact
         m_allTrackDetail allTrackDetail exact
@@ -419,6 +420,10 @@ namespace HelperClasses {
         ================ ============== =======
 
         .. note::
+        
+            ``sfJVT`` requires a working point after it, for example::
+            
+                m_configStr = "... sfJVTMedium ..."
 
             ``sfFTagFix`` and ``sfFTagFlt`` require a string of numbers pairwise ``AABB..MM..YYZZ`` succeeding it. This will create a vector of numbers (AA, BB, CC, ..., ZZ) associated with that variable. For example::
 
@@ -470,6 +475,7 @@ namespace HelperClasses {
     bool m_JVC;
     std::string      m_trackName;
     std::string      m_trackJetName;
+    std::string      m_sfJVTName;
     std::vector<int> m_sfFTagFix;
     std::vector<int> m_sfFTagFlt;
     JetInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -120,6 +120,21 @@ namespace HelperClasses {
         @param flag     The string we search for.
      */
     bool has_match(const std::string flag) { return m_configStr.find(flag) != std::string::npos; };
+    /**
+        @rst
+            Search for a single flag in :cpp:member:`~HelperClasses::InfoSwitch::m_configDetails` and parse out the working point.
+
+        @endrst
+        @param flag     The string we search for.
+     */
+    std::string get_working_point(const std::string flag);
+    /**
+        @rst
+            Search for multiple flags in :cpp:member:`~HelperClasses::InfoSwitch::m_configDetails` and parse out the working points.
+        @endrst
+        @param flag     The string we search for.
+     */
+    std::vector<std::string> get_working_points(const std::string flag);
   };
 
   /**

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -119,8 +119,11 @@ namespace xAH {
     
       // trackAll or trackPV
       std::vector<float> *m_Jvt;
+      std::vector<char> *m_JvtPass_Loose;
       std::vector< std::vector<float> > *m_JvtEff_SF_Loose;
+      std::vector<char> *m_JvtPass_Medium;
       std::vector< std::vector<float> > *m_JvtEff_SF_Medium;
+      std::vector<char> *m_JvtPass_Tight;
       std::vector< std::vector<float> > *m_JvtEff_SF_Tight;
       std::vector<float> *m_JvtJvfcorr;
       std::vector<float> *m_JvtRpt;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -112,6 +112,8 @@ public:
   float m_JVFCut = 0.5;
   /// @brief check JVT
   bool m_doJVT = false;
+  /// @brief keep JVT-rejected jets and decorate passing status
+  bool m_noJVTVeto = false;
   /// @brief check forward JVT
   bool m_dofJVT = false;
   /// @brief Remove jets that fail fJVT. Like JVT, the default is to clean the collection
@@ -222,6 +224,8 @@ private:
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::JetJvtEfficiency"};         //!
   asg::AnaToolHandle<IJetModifier>           m_fJVT_tool_handle{"JetForwardJvtTool"};           //!
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
+
+  std::string m_outputJVTPassed = "JetJVT_Passed"; //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -251,7 +251,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual bool executeSelection( const xAOD::JetContainer* inJets, float mcEvtWeight, bool count, std::string outContainerName );
+  virtual bool executeSelection( const xAOD::JetContainer* inJets, float mcEvtWeight, bool count, std::string outContainerName, bool isNominal );
 
   // added functions not from Algorithm
   // why does this need to be virtual?


### PR DESCRIPTION
Several improvements for JVT SF calculation:
 - JVT cut can be disabled in `JetSelector` but SFs are still calculated, a decorator is added for passing
 - added inefficiency SFs for above case
 - SFs are only stored for nominal tree
 - only JVT SFs for a specific working point can now be stored