### PR TITLE
Deprecate 2.6.X in favor of rel 21.2.X

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV_RC=2.4.31 ABV_CM=21.2.0
+  - ABV_RC=2.4.33 ABV_CM=21.2.0
 
 before_script:
   - ls

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV_RC=2.4.31 ABV_CM=2.6.2
+  - ABV_RC=2.4.31 ABV_CM=2.6.3
 
 before_script:
   - ls

--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV_RC=2.4.31 ABV_CM=2.6.3
+  - ABV_RC=2.4.31 ABV_CM=21.2.0
 
 before_script:
   - ls

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -24,6 +24,8 @@ xAH::Algorithm::~Algorithm()
 StatusCode xAH::Algorithm::algInitialize(){
     // register an instance of the the class
     registerInstance();
+    // set the name this way as duplicate names are handled automatically
+    m_name = name();
     // names will be BasicEventSelection.baseEventSel for example
     msg().setName(m_className + "." + m_name);
     // deprecating m_debug, but this is around for backwards compatibility

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -24,11 +24,8 @@ xAH::Algorithm::~Algorithm()
 StatusCode xAH::Algorithm::algInitialize(){
     // register an instance of the the class
     registerInstance();
-    SetName(m_name.c_str());
     // names will be BasicEventSelection.baseEventSel for example
     msg().setName(m_className + "." + m_name);
-    // set the debug level of the tool
-    setMsgLevel(m_msgLevel);
     // deprecating m_debug, but this is around for backwards compatibility
     m_debug = msgLvl(MSG::DEBUG);
     // deprecating m_verbose, but this is around for backwards compatibility

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -149,7 +149,7 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
 
 	  std::string stream("");
 	  for ( auto cbk : *incompleteCBC ) {
-	      Info ("fileExecute()", "Incomplete cbk name: %s - stream: %s ", (cbk->name()).c_str(), (cbk->inputStream()).c_str());
+	      ANA_MSG_INFO("Incomplete cbk name: " << cbk->name() << " - stream: " << cbk->inputStream());
 	      if ( cbk->inputStream() != "unknownStream" ) {
 		  allFromUnknownStream = false;
 		  stream = cbk->inputStream();
@@ -188,7 +188,7 @@ EL::StatusCode BasicEventSelection :: fileExecute ()
 
       int maxCycle(-1);
       for ( const auto& cbk: *completeCBC ) {
-	  Info ("fileExecute()", "Complete cbk name: %s - stream: %s", (cbk->name()).c_str(), (cbk->inputStream()).c_str() );
+	  ANA_MSG_INFO("Complete cbk name: " << cbk->name() << " - stream: " << cbk->inputStream() );
 	  if ( cbk->cycle() > maxCycle && cbk->name() == "AllExecutedEvents" && cbk->inputStream() == "StreamAOD" ) {
 	      allEventsCBK = cbk;
 	      maxCycle = cbk->cycle();

--- a/Root/MessagePrinterAlgo.cxx
+++ b/Root/MessagePrinterAlgo.cxx
@@ -1,5 +1,3 @@
-#if ROOTCORE_RELEASE_SERIES < 25
-// it's in 2.4.31+ and 2.6.3+
 // EL include(s):
 #include <EventLoop/Job.h>
 #include <EventLoop/Worker.h>
@@ -27,7 +25,6 @@ EL::StatusCode MessagePrinterAlgo :: setupJob (EL::Job& job)
 
 EL::StatusCode MessagePrinterAlgo :: histInitialize ()
 {
-  ANA_MSG_INFO( "Calling histInitialize");
   ANA_CHECK( xAH::Algorithm::algInitialize());
   if(numInstances() != 1){
     ANA_MSG_FATAL( "More than one instance of MessagePrinterAlgo was created. Aborting.");
@@ -53,4 +50,3 @@ EL::StatusCode MessagePrinterAlgo :: histFinalize ()
   ANA_CHECK( xAH::Algorithm::algFinalize());
   return EL::StatusCode::SUCCESS;
 }
-#endif

--- a/docs/Installing.rst
+++ b/docs/Installing.rst
@@ -111,7 +111,7 @@ The last thing you need to do is get your environment set up correctly, so you w
 
   source build/${CMTCONFIG}/setup.sh
 
-Both ``${CMTCONFIG}`` and  ``${BINARY_TAG}`` seem to contain the correct variable which represents the architecture of the system, e.g. ``x86_64-slc6-gcc49-opt``.
+Environment variables like ``${AnalysisBase_PLATFORM}`` seem to contain the correct variable which represents the architecture of the system, e.g. ``x86_64-slc6-gcc49-opt``.
 
 .. warning::
 
@@ -121,4 +121,4 @@ Both ``${CMTCONFIG}`` and  ``${BINARY_TAG}`` seem to contain the correct variabl
 
     export ROOT_INCLUDE_PATH=/cvmfs/atlas.cern.ch/repo/sw/ASG/2.6/AnalysisBase/2.6.1/InstallArea/x86_64-slc6-gcc49-opt/RootCore/include:$ROOT_INCLUDE_PATH
 
-  before running the ``xAH_run.py`` commands. This should fix things up.
+  before running the ``xAH_run.py`` commands. This should fix things up. Don't forget to include the right version if you're using 2.6.X!

--- a/docs/Installing.rst
+++ b/docs/Installing.rst
@@ -121,4 +121,4 @@ Environment variables like ``${AnalysisBase_PLATFORM}`` seem to contain the corr
 
     export ROOT_INCLUDE_PATH=/cvmfs/atlas.cern.ch/repo/sw/ASG/2.6/AnalysisBase/2.6.1/InstallArea/x86_64-slc6-gcc49-opt/RootCore/include:$ROOT_INCLUDE_PATH
 
-  before running the ``xAH_run.py`` commands. This should fix things up. Don't forget to include the right version if you're using 2.6.X!
+  before running the ``xAH_run.py`` commands. This should fix things up. Don't forget to include the right version if you're using 2.6.X! This should not happen in 21.2 releases.

--- a/scripts/xAH_config.py
+++ b/scripts/xAH_config.py
@@ -27,6 +27,7 @@ class xAH_config(object):
     if algName is None:
       algName = str(xAH_nameGenerator())
       logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
+      options['m_name'] = algName
     if not isinstance(algName, str) and not isinstance(algName, unicode):
       raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -321,7 +321,7 @@ if __name__ == "__main__":
       # env var that tells us if CMAKE was setup
       cmake_setup = '{0:s}_SET_UP'.format(args.cmake_workdir)
       # architecture used for CMake
-      arch = os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>'))
+      arch = os.environ.get('AnalysisBase_PLATFORM', os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>')))
       if not int(os.environ.get(cmake_setup, 0)):
         raise OSError("It doesn't seem like '{0:s}' exists. Did you set up your CMake environment correctly? (Hint: source 'build/{1:s}/setup.sh)".format(cmake_setup, arch))
     #Set up the job for xAOD access:
@@ -530,6 +530,7 @@ if __name__ == "__main__":
         if algName is None:
           algName = str(xAH_nameGenerator())
           xAH_logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
+          algorithm_configurations['configs']['m_name'] = algName
         if not isinstance(algName, str) and not isinstance(algName, unicode):
           raise TypeError("m_name must be a string for instance of {0:s}".format(className))
 

--- a/xAODAnaHelpers/MessagePrinterAlgo.h
+++ b/xAODAnaHelpers/MessagePrinterAlgo.h
@@ -1,5 +1,3 @@
-#if ROOTCORE_RELEASE_SERIES < 25
-// it's in 2.4.31+ and 2.6.3+
 #ifndef xAODAnaHelpers_MessagePrinterAlgo_H
 #define xAODAnaHelpers_MessagePrinterAlgo_H
 
@@ -51,5 +49,4 @@ class MessagePrinterAlgo : public xAH::Algorithm
     /// @endcond
 };
 
-#endif
 #endif


### PR DESCRIPTION
Closes #939. Private tools don't work, but algorithm names are unique, and debug level/algorithm names are streamed now.