### PR TITLE
Do not output isolation kinematics by default

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -21,7 +21,6 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_isolation ) {
-
     m_isIsolated_LooseTrackOnly              = new std::vector<int>   ();
     m_isIsolated_Loose                       = new std::vector<int>   ();
     m_isIsolated_Tight                       = new std::vector<int>   ();
@@ -32,6 +31,9 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     m_isIsolated_FixedCutTightTrackOnly      = new std::vector<int>   ();
     m_isIsolated_UserDefinedFixEfficiency    = new std::vector<int>   ();
     m_isIsolated_UserDefinedCut              = new std::vector<int>   ();
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_etcone20                               = new std::vector<float> ();
     m_ptcone20                               = new std::vector<float> ();
     m_ptcone30                               = new std::vector<float> ();
@@ -152,6 +154,9 @@ ElectronContainer::~ElectronContainer()
     delete m_isIsolated_FixedCutTightTrackOnly      ;
     delete m_isIsolated_UserDefinedFixEfficiency    ;
     delete m_isIsolated_UserDefinedCut              ;
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     delete m_etcone20                               ;
     delete m_ptcone20                               ;
     delete m_ptcone30                               ;
@@ -238,7 +243,9 @@ void ElectronContainer::setTree(TTree *tree)
     connectBranch<int>(tree, "isIsolated_FixedCutTightTrackOnly",      &m_isIsolated_FixedCutTightTrackOnly);
     connectBranch<int>(tree, "isIsolated_UserDefinedFixEfficiency",    &m_isIsolated_UserDefinedFixEfficiency);
     connectBranch<int>(tree, "isIsolated_UserDefinedCut",              &m_isIsolated_UserDefinedCut);
+  }
 
+  if ( m_infoSwitch.m_isolationKinematics ) {
     connectBranch<float>(tree, "etcone20",         &m_etcone20);
     connectBranch<float>(tree, "ptcone20",         &m_ptcone20);
     connectBranch<float>(tree, "ptcone30",         &m_ptcone30);
@@ -359,6 +366,9 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
     elec.isIsolated_FixedCutTightTrackOnly        =     m_isIsolated_FixedCutTightTrackOnly          ->at(idx);
     elec.isIsolated_UserDefinedFixEfficiency      =     m_isIsolated_UserDefinedFixEfficiency        ->at(idx);
     elec.isIsolated_UserDefinedCut                =     m_isIsolated_UserDefinedCut                  ->at(idx);
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     elec.etcone20                                 =     m_etcone20                                   ->at(idx);
     elec.ptcone20                                 =     m_ptcone20                                   ->at(idx);
     elec.ptcone30                                 =     m_ptcone30                                   ->at(idx);
@@ -459,7 +469,9 @@ void ElectronContainer::setBranches(TTree *tree)
     setBranch<int>(tree, "isIsolated_FixedCutTightTrackOnly",      m_isIsolated_FixedCutTightTrackOnly);
     setBranch<int>(tree, "isIsolated_UserDefinedFixEfficiency",    m_isIsolated_UserDefinedFixEfficiency);
     setBranch<int>(tree, "isIsolated_UserDefinedCut",              m_isIsolated_UserDefinedCut);
+  }
 
+  if ( m_infoSwitch.m_isolationKinematics ) {
     setBranch<float>(tree, "etcone20",         m_etcone20);
     setBranch<float>(tree, "ptcone20",         m_ptcone20);
     setBranch<float>(tree, "ptcone30",         m_ptcone30);
@@ -559,7 +571,6 @@ void ElectronContainer::clear()
   }
 
   if ( m_infoSwitch.m_isolation ) {
-
     m_isIsolated_LooseTrackOnly              ->clear();
     m_isIsolated_Loose                       ->clear();
     m_isIsolated_Tight                       ->clear();
@@ -570,6 +581,9 @@ void ElectronContainer::clear()
     m_isIsolated_FixedCutTightTrackOnly      ->clear();
     m_isIsolated_UserDefinedFixEfficiency    ->clear();
     m_isIsolated_UserDefinedCut              ->clear();
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_etcone20                               ->clear();
     m_ptcone20                               ->clear();
     m_ptcone30                               ->clear();
@@ -731,7 +745,9 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
     static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
     safeFill<char, int, xAOD::Electron>(elec, isIsoUserDefinedCutAcc, m_isIsolated_UserDefinedCut, -1);
+  }
 
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_etcone20    ->push_back( elec->isolation( xAOD::Iso::etcone20 )    /m_units );
     m_ptcone20    ->push_back( elec->isolation( xAOD::Iso::ptcone20 )    /m_units );
     m_ptcone30    ->push_back( elec->isolation( xAOD::Iso::ptcone30 )    /m_units );

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -146,6 +146,7 @@ namespace HelperClasses{
   void MuonInfoSwitch::initialize(){
     m_trigger       = has_exact("trigger");
     m_isolation     = has_exact("isolation");
+    m_isolationKinematics = has_exact("isolationKinematics");
     m_quality       = has_exact("quality");
     m_trackparams   = has_exact("trackparams");
     m_trackhitcont  = has_exact("trackhitcont");
@@ -175,6 +176,7 @@ namespace HelperClasses{
   void ElectronInfoSwitch::initialize(){
     m_trigger       = has_exact("trigger");
     m_isolation     = has_exact("isolation");
+    m_isolationKinematics = has_exact("isolationKinematics");
     m_quality       = has_exact("quality");
     m_PID           = has_exact("PID");
     m_trackparams   = has_exact("trackparams");

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -28,6 +28,9 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_isIsolated_FixedCutTightTrackOnly          = new  vector<int>   ();
     m_isIsolated_UserDefinedFixEfficiency        = new  vector<int>   ();
     m_isIsolated_UserDefinedCut                  = new  vector<int>   ();
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_ptcone20                                   = new  vector<float> ();
     m_ptcone30                                   = new  vector<float> ();
     m_ptcone40                                   = new  vector<float> ();
@@ -119,6 +122,9 @@ MuonContainer::~MuonContainer()
     delete m_isIsolated_FixedCutTightTrackOnly          ;
     delete m_isIsolated_UserDefinedFixEfficiency        ;
     delete m_isIsolated_UserDefinedCut                  ;
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     delete m_ptcone20                                   ;
     delete m_ptcone30                                   ;
     delete m_ptcone40                                   ;
@@ -211,6 +217,9 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<int>(tree,"isIsolated_FixedCutTightTrackOnly", &m_isIsolated_FixedCutTightTrackOnly);
     connectBranch<int>(tree,"isIsolated_UserDefinedFixEfficiency",    &m_isIsolated_UserDefinedFixEfficiency);
     connectBranch<int>(tree,"isIsolated_UserDefinedCut",              &m_isIsolated_UserDefinedCut);
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     connectBranch<float>(tree,"ptcone20",	  &m_ptcone20);
     connectBranch<float>(tree,"ptcone30",	  &m_ptcone30);
     connectBranch<float>(tree,"ptcone40",	  &m_ptcone40);
@@ -313,6 +322,9 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.isIsolated_FixedCutTightTrackOnly        =     m_isIsolated_FixedCutTightTrackOnly          ->at(idx);
     muon.isIsolated_UserDefinedFixEfficiency      =     m_isIsolated_UserDefinedFixEfficiency        ->at(idx);
     muon.isIsolated_UserDefinedCut                =     m_isIsolated_UserDefinedCut                  ->at(idx);
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     muon.ptcone20                                 =     m_ptcone20                                   ->at(idx);
     muon.ptcone30                                 =     m_ptcone30                                   ->at(idx);
     muon.ptcone40                                 =     m_ptcone40                                   ->at(idx);
@@ -415,6 +427,9 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<int>(tree,"isIsolated_FixedCutTightTrackOnly", m_isIsolated_FixedCutTightTrackOnly);
     setBranch<int>(tree,"isIsolated_UserDefinedFixEfficiency",    m_isIsolated_UserDefinedFixEfficiency);
     setBranch<int>(tree,"isIsolated_UserDefinedCut",              m_isIsolated_UserDefinedCut);
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     setBranch<float>(tree,"ptcone20",	  m_ptcone20);
     setBranch<float>(tree,"ptcone30",	  m_ptcone30);
     setBranch<float>(tree,"ptcone40",	  m_ptcone40);
@@ -517,6 +532,9 @@ void MuonContainer::clear()
     m_isIsolated_FixedCutTightTrackOnly->clear();
     m_isIsolated_UserDefinedFixEfficiency->clear();
     m_isIsolated_UserDefinedCut->clear();
+  }
+
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_ptcone20->clear();
     m_ptcone30->clear();
     m_ptcone40->clear();
@@ -661,7 +679,9 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
 
     static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
     safeFill<char, int, xAOD::Muon>(muon, isIsoUserDefinedCutAcc, m_isIsolated_UserDefinedCut, -1);
+  }
 
+  if ( m_infoSwitch.m_isolationKinematics ) {
     m_ptcone20    ->push_back( muon->isolation( xAOD::Iso::ptcone20 )    /m_units );
     m_ptcone30    ->push_back( muon->isolation( xAOD::Iso::ptcone30 )    /m_units );
     m_ptcone40    ->push_back( muon->isolation( xAOD::Iso::ptcone40 )    /m_units );

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -248,17 +248,18 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::IParticleInfoSwitch` class for Muon Information.
 
-        ============== ============ =======
-        Parameter      Pattern      Match
-        ============== ============ =======
-        m_trigger      trigger      exact
-        m_isolation    isolation    exact
-        m_quality      quality      exact
-        m_trackparams  trackparams  exact
-        m_trackhitcont trackhitcont exact
-        m_effSF        effSF        exact
-        m_energyLoss   energyLoss   exact
-        ============== ============ =======
+        ====================== ==================== =======
+        Parameter              Pattern              Match
+        ====================== ==================== =======
+        m_trigger              trigger              exact
+        m_isolation            isolation            exact
+        m_isolationKinematics  isolationKinematics  exact
+        m_quality              quality              exact
+        m_trackparams          trackparams          exact
+        m_trackhitcont         trackhitcont         exact
+        m_effSF                effSF                exact
+        m_energyLoss           energyLoss           exact
+        ====================== ==================== =======
 
     @endrst
    */
@@ -266,6 +267,7 @@ namespace HelperClasses {
   public:
     bool m_trigger;
     bool m_isolation;
+    bool m_isolationKinematics;
     bool m_quality;
     bool m_trackparams;
     bool m_trackhitcont;
@@ -297,6 +299,7 @@ namespace HelperClasses {
         =============================================================================================================================================================== =============================================================================================================================================== =======
         m_trigger                                                                                                                                                       trigger                                                                                                                                         exact
         m_isolation                                                                                                                                                     isolation                                                                                                                                       exact
+        m_isolationKinematics                                                                                                                                           isolationKinematics                                                                                                                             exact
         m_quality                                                                                                                                                       quality                                                                                                                                         exact
         m_PID                                                                                                                                                           PID                                                                                                                                             exact
         m_trackparams                                                                                                                                                   trackparams                                                                                                                                     exact
@@ -336,6 +339,7 @@ namespace HelperClasses {
   public:
     bool m_trigger;
     bool m_isolation;
+    bool m_isolationKinematics;
     bool m_quality;
     bool m_PID;
     bool m_trackparams;


### PR DESCRIPTION
It would be nice to remove isolation kinematics from the ntuples to keep sizes low. This adds another flag `isolationKinematics` in addition to existing `isolation` for electrons and muons. Unfortunately this is a breaking change but keeping backwards compatibility would require two new flags (we can go either way).