### PR TITLE
Electron Efficiency Corrector simplification

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -7,7 +7,7 @@ using namespace xAH;
 
 FatJetContainer::FatJetContainer(const std::string& name, const std::string& detailStr, const std::string& suffix,
 				 float units, bool mc)
-  : ParticleContainer(name,detailStr,units,mc, false, suffix),
+  : ParticleContainer(name,detailStr,units,mc, false, true, suffix),
     m_trackJetPtCut(10e3),
     m_trackJetEtaCut(2.5)
 {

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -437,7 +437,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr, const std::string e
 
   if(m_debug)  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
 
-  m_elecs[elecName] = new xAH::ElectronContainer(elecName, detailStr, m_units, m_isMC);
+  m_elecs[elecName] = new xAH::ElectronContainer(elecName, detailStr, m_units, m_isMC, strcmp(m_tree->GetName(), "nominal") == 0);
 
   xAH::ElectronContainer* thisElec = m_elecs[elecName];
 
@@ -942,4 +942,3 @@ bool HelpTreeBase::writeTo( TFile* file ) {
   if ( status == 0 ) { return false; }
   return true;
 }
-

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -53,11 +53,8 @@ namespace xAH {
     // scale factors w/ sys
     // per object
     std::vector< float > RecoEff_SF;
-    std::vector< float > PIDEff_SF_LHLooseAndBLayer;
-    std::vector< float > PIDEff_SF_LHLoose;
-    std::vector< float > PIDEff_SF_LHMedium;
-    std::vector< float > PIDEff_SF_LHTight;
-    
+
+    std::map< std::string, std::vector< float > > PIDEff_SF;
     std::map< std::string, std::vector< float > > IsoEff_SF;
     std::map< std::string, std::vector< float > > TrigEff_SF;
     std::map< std::string, std::vector< float > > TrigMCEff;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -19,7 +19,7 @@ namespace xAH {
   class ElectronContainer : public ParticleContainer<Electron,HelperClasses::ElectronInfoSwitch>
     {
     public:
-      ElectronContainer(const std::string& name = "el", const std::string& detailStr="", float units = 1e3, bool mc = false);
+      ElectronContainer(const std::string& name = "el", const std::string& detailStr="", float units = 1e3, bool mc = false, bool storeSystSFs = true);
       virtual ~ElectronContainer();
     
       virtual void setTree(TTree *tree);
@@ -85,11 +85,8 @@ namespace xAH {
       // scale factors w/ sys
       // per object
       std::vector< std::vector< float > >* m_RecoEff_SF;
-      std::vector< std::vector< float > >* m_PIDEff_SF_LHLooseAndBLayer;
-      std::vector< std::vector< float > >* m_PIDEff_SF_LHLoose;
-      std::vector< std::vector< float > >* m_PIDEff_SF_LHMedium;
-      std::vector< std::vector< float > >* m_PIDEff_SF_LHTight;
-    
+
+      std::map< std::string, std::vector< std::vector< float > > >* m_PIDEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -42,34 +42,14 @@ class ElectronEfficiencyCorrector : public xAH::Algorithm
 public:
   /// @brief The name of the input container for this algorithm to read from ``TEvent`` or ``TStore``
   std::string  m_inContainerName = "";
-  /**
-      @brief The name of the nominal output container written by the algorithm to ``TStore``
-
-      If the algorithm applies systematic variations, for each shallow copy saved to ``TStore``, the systematic name will be appended to this.
-  */
-  std::string  m_outContainerName = "";
 
 // systematics
   /**
-    @brief The name of the vector containing the names of the systematically-varied containers from the upstream algorithm, which will be processed by this algorithm.
+    @brief The name of the vector containing the names of the systematically-varied electrons-related containers from the upstream algorithm, which will be processed by this algorithm.
 
     This vector is retrieved from the ``TStore``. If left blank, it means there is no upstream algorithm which applies systematics. This is the case when processing straight from the original ``xAOD`` or ``DxAOD``.
   */
-  std::string m_inputAlgoSystNames;
-
-  /**
-    @brief The name of the vector containing the names of the systematically-varied containers created by by this algorithm.
-
-    @rst
-      If :cpp:member:`~xAH::Algorithm::m_systName` is empty, the vector will contain only an empty string. When running on systematics, this is the string a downstream algorithm needs to process electrons.
-
-      .. note:: We need this as we deep-copy the input containers.
-    @endrst
-  */
-  std::string   m_outputAlgoSystNames;
-
-  std::string   m_sysNamesForParCont; 
-  // this is the name of the vector of names for the systematics to be used for the creation of a parallel container. This will be just a copy of the nominal one with the sys name appended. Use cases: MET-specific systematics.
+  std::string m_inputSystNamesElectrons;
 
   /** @brief Force AFII flag in calibration, in case metadata is broken */
   bool m_setAFII;
@@ -97,9 +77,6 @@ public:
   std::string m_corrFileNameTrig = "";
   std::string m_corrFileNameTrigMCEff = "";
 
-  /// @brief will consider efficiency decorations only for the nominal run
-  bool          m_decorateWithNomOnInputSys = true;
-
 private:
   int m_numEvent;         //!
   int m_numObject;        //!
@@ -119,8 +96,6 @@ private:
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
   std::vector<CP::SystematicSet> m_systListTrigMCEff; //!
-
-  std::vector<std::string> m_sysNames; //!
 
   // tools
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID = nullptr;  //!
@@ -159,7 +134,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual EL::StatusCode executeSF ( const xAOD::ElectronContainer* inputElectrons, unsigned int countSyst, bool isNomSel );
+  virtual EL::StatusCode executeSF ( const xAOD::ElectronContainer* inputElectrons, bool nominal, bool writeSystNames );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/ParticleContainer.h
+++ b/xAODAnaHelpers/ParticleContainer.h
@@ -24,12 +24,14 @@ namespace xAH {
 		      float units = 1e3,
 		      bool mc = false,
 		      bool useMass=false,
+          bool storeSystSFs = true,
 		      const std::string& suffix="")
       : m_name(name),
 	m_infoSwitch(detailStr),
 	m_mc(mc),
 	m_debug(false),
 	m_units(units),
+  m_storeSystSFs(storeSystSFs),
 	m_useMass(useMass),
 	m_suffix(suffix)
       {
@@ -187,6 +189,18 @@ namespace xAH {
 	return;
       }
 
+      template<typename T, typename V> void safeSFVecFill(const V* xAODObj, SG::AuxElement::ConstAccessor<std::vector<T> >& accessor, std::vector<std::vector<T> >* destination, const std::vector<T> &defaultValue) {
+        if ( accessor.isAvailable( *xAODObj ) ) {
+          if ( m_storeSystSFs ) {
+            destination->push_back( accessor(*xAODObj) );
+          } else {
+            destination->push_back( std::vector< float > ({accessor(*xAODObj)[0]}) );
+          }
+        } else {
+          destination->push_back( defaultValue );
+        }
+      }
+
       virtual void updateParticle(uint idx, T_PARTICLE& particle)
       {
         if(m_infoSwitch.m_kinematic)
@@ -215,6 +229,7 @@ namespace xAH {
       bool m_mc;
       bool m_debug;
       float m_units;
+      bool m_storeSystSFs;
 
       int m_n;
 


### PR DESCRIPTION
This acts as a prototype of what I proposed in #964. I'm open for comments and criticism. This PR can later be either improved or closed.

Outline of the changes:
 - el. efficiency corrector modifies existing containers - no deep copying anymore, output flag removed
 - systematics list is computed in advanced - removal of duplicated code for no syst vs. syst case
 - only accepts upstream electron systematics - input flag renamed to be explicit
 - systematics SFs are only written for nominal tree (new `safeSFVectorFill` function)
 - <s>no sys names output specifications - to be able to successfully write out in the tree</s>
 - <s>nominal and systematics SFs in separate branches (the latter currently still contains nominal SFs - to be discussed)</s>