### PR TITLE
Write out systematics names to metadata

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -257,6 +257,12 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if( m_runAllSyst ){
     ANA_MSG_INFO(" Running w/ All systematics");
   }
+  
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systList, m_outputSystName, fileMD);
+  }
 
   ANA_MSG_INFO( "BJetEfficiencyCorrector Interface succesfully initialized!" );
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -211,6 +211,12 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   ANA_CHECK( m_IsolationCorrectionTool->setProperty("IsMC", m_isMC ));
   ANA_CHECK( m_IsolationCorrectionTool->initialize());
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systList, m_name, fileMD);
+  }
+
   // ***********************************************************
 
   ANA_MSG_INFO( "ElectronCalibrator Interface succesfully initialized!" );
@@ -391,4 +397,3 @@ EL::StatusCode ElectronCalibrator :: histFinalize ()
   ANA_CHECK( xAH::Algorithm::algFinalize());
   return EL::StatusCode::SUCCESS;
 }
-

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -432,6 +432,16 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
 
   }
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systListPID, m_outputSystNamesPID, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListIso, m_outputSystNamesIso, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListReco, m_outputSystNamesReco, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListTrig, m_outputSystNamesTrig, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListTrigMCEff, m_outputSystNamesTrigMCEff, fileMD);
+  }
+
   // *********************************************************************************
 
   ANA_MSG_INFO( "ElectronEfficiencyCorrector Interface succesfully initialized!" );

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -468,6 +468,29 @@ std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP:
 
 }
 
+void HelperFunctions::writeSystematicsListHist( const std::vector< CP::SystematicSet > &systs, std::string histName, TFile *file )
+{
+  std::string folderName = "systematics";
+  std::string name = folderName + "/" + histName;
+  if (!systs.size() || histName.empty() || file->Get(name.c_str())) {
+    return;
+  }
+
+  if (!file->Get(folderName.c_str())) {
+    file->mkdir(folderName.c_str());  
+  }
+  file->cd(folderName.c_str());
+
+  TH1D hist(histName.c_str(), histName.c_str(), systs.size(), 0.5, systs.size() + 0.5);
+  for (size_t i = 0; i < systs.size(); i++) {
+    if (systs[i].name().empty()) {
+      hist.GetXaxis()->SetBinLabel(i + 1, "nominal");
+    } else {
+      hist.GetXaxis()->SetBinLabel(i + 1, systs[i].name().c_str());
+    }
+  }
+  hist.Write();
+}
 
 float HelperFunctions::dPhi(float phi1, float phi2)
 {

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -369,6 +369,11 @@ EL::StatusCode JetCalibrator :: initialize ()
 
   ANA_CHECK(m_store->record(SystJetsNames, "jets_Syst"+m_name ));
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systList, m_name, fileMD);
+  }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -308,6 +308,13 @@ EL::StatusCode JetSelector :: initialize ()
     ANA_MSG_INFO("\t " << syst_it.name());
   }
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systListJVT, m_outputSystNamesJVT, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListfJVT, m_outputSystNamesfJVT, fileMD);
+  }
+
   ANA_MSG_DEBUG( "Number of events in file: " << m_event->getEntries() );
 
   m_numEvent      = 0;

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -180,6 +180,11 @@ EL::StatusCode METConstructor :: initialize ()
   m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
   ANA_MSG_DEBUG( "Is MC? " << static_cast<int>(m_isMC) );
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(sysList, m_name, fileMD);
+  }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -222,6 +222,12 @@ EL::StatusCode MuonCalibrator :: initialize ()
   }
 
   ANA_CHECK(m_store->record(SystMuonsNames, "muons_Syst"+m_name ));
+  
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systList, m_name, fileMD);
+  }
 
   ANA_MSG_INFO( "MuonCalibrator Interface succesfully initialized!" );
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -359,6 +359,15 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     }
   }
 
+  // Write output sys names
+  if ( m_writeSystToMetadata ) {
+    TFile *fileMD = wk()->getOutputFile ("metadata");
+    HelperFunctions::writeSystematicsListHist(m_systListReco, m_outputSystNamesReco, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListIso, m_outputSystNamesIso, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListTrig, m_outputSystNamesTrig, fileMD);
+    HelperFunctions::writeSystematicsListHist(m_systListTTVA, m_outputSystNamesTTVA, fileMD);
+  }
+
   // *********************************************************************************
 
   ANA_MSG_INFO( "MuonEfficiencyCorrector Interface succesfully initialized!" );

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -33,6 +33,7 @@ public:
   // systematics
   std::string m_systName = "";
   std::string m_outputSystName = "BJetEfficiency_Algo";
+  bool        m_writeSystToMetadata = false;
 
   std::string m_corrFileName = "xAODBTaggingEfficiency/13TeV/2016-20_7-13TeV-MC15-CDI-July12_v1.root";
 

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -62,6 +62,11 @@ public:
   */
   std::string m_outputAlgoSystNames = "ElectronCalibrator_Syst";
 
+  /**
+    @brief Write systematics names to metadata
+  */
+  bool        m_writeSystToMetadata = false;
+
   std::string m_esModel = "";
   std::string m_decorrelationModel = "";
 

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -51,6 +51,9 @@ public:
   */
   std::string m_inputSystNamesElectrons;
 
+  /// @brief Write systematics names to metadata
+  bool m_writeSystToMetadata = false;
+
   /** @brief Force AFII flag in calibration, in case metadata is broken */
   bool m_setAFII;
 

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -30,6 +30,7 @@
 #include "TTree.h"
 #include "TBranch.h"
 #include "TFile.h"
+#include "TH1D.h"
 #include "TObjArray.h"
 
 // messaging includes
@@ -151,6 +152,8 @@ namespace HelperFunctions {
     @param msg        the MsgStream object with appropriate level for debugging
   */
   std::vector< CP::SystematicSet > getListofSystematics( const CP::SystematicSet inSysts, std::string systNames, float systVal, MsgStream& msg );
+
+  void writeSystematicsListHist( const std::vector< CP::SystematicSet > &systs, std::string histName, TFile *file );
 
   /*    type_name<T>()      The awesome type demangler!
           - normally, typeid(T).name() is gibberish with gcc. This decodes it. Fucking magic man.
@@ -507,4 +510,3 @@ namespace HelperFunctions {
 } // close namespace HelperFunctions
 
 # endif
-

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -55,6 +55,8 @@ public:
   std::string m_jetAlgo = "";
   /// @brief name of vector holding names of jet systematics given by the JetEtmiss Tools
   std::string m_outputAlgo = "";
+  /// @brief Write systematics names to metadata
+  bool        m_writeSystToMetadata = false;
   /// @brief config for JetCalibrationTool for Data
   std::string m_calibConfigData = "JES_MC15Prerecommendation_April2015.config";
   /// @brief config for JetCalibrationTool for Full Sim MC

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -47,6 +47,8 @@ public:
   std::string m_inputAlgo = "";
   /// @brief output type - this is how the vector<string> w/ syst names will be saved in TStore
   std::string m_outputAlgo = "";
+  /// @brief Write systematics names to metadata
+  bool        m_writeSystToMetadata = false;
   /// @brief Type of Scale Momementum
   std::string m_jetScaleType = "";
   /// @brief The decoration key written to passing objects

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -71,6 +71,9 @@ public:
   /// @brief do not change it, not useful
   std::string m_systName = "All";
   float m_systVal = 1.0;
+  
+  /// @brief Write systematics names to metadata
+  bool        m_writeSystToMetadata = false;
 
   std::string m_SoftTermSystConfigFile = "TrackSoftTerms.config";
 

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -36,6 +36,8 @@ public:
   std::string m_inputAlgoSystNames = "";
   // this is the name of the vector of names of the systematically varied containers produced by THIS algo (these will be the m_inputAlgoSystNames of the algo downstream)
   std::string m_outputAlgoSystNames = "MuonCalibrator_Syst";
+  /// @brief Write systematics names to metadata
+  bool        m_writeSystToMetadata = false;
 
   float       m_systVal = 0.0;
   std::string m_systName = "";

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -70,6 +70,9 @@ public:
   */
   std::string   m_inputSystNamesMuons = "";
 
+  /// @brief Write systematics names to metadata
+  bool          m_writeSystToMetadata = false;
+
   float         m_systValReco = 0.0;
   float         m_systValIso = 0.0;
   float         m_systValTrig = 0.0;


### PR DESCRIPTION
I was looking for the best way to store systematics names and probably this is the most optimal. It stores syst. names in bin names of a histogram and it's:
 - easy to store (it's as complicated to store a list of strings to root file and to read it then as using a histogram for it)
 - hadd friendly (no effect when merging)
 - stored once per job so also disk space friendly

This stores all systematics. For scale factors, they should all exist always anyway (at least we rely on it as we use vectors to store them). For calibrations, we can read tree names anyway but it's useful to have them for filtering (i.e. doing only jet systematics).

This feature is disabled by default but this can be changed.