### PR TITLE
Muon Efficiency Corrector simplification

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -595,7 +595,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
       if ( !syst_it.name().empty() && !nominal ) continue; 
 
-      ANA_MSG_DEBUG("Electron PID efficiency sys name (to be recorded in xAOD::TStore) is: " << sfName);
+      ANA_MSG_DEBUG("Electron PID efficiency sys name (to be recorded in xAOD::TStore) is: " << syst_it.name());
       if ( writeSystNames ) sysVariationNamesPID->push_back(syst_it.name());
 
       // apply syst

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -1,5 +1,6 @@
 // c++ include(s):
 #include <iostream>
+#include <memory>
 
 // EL include(s):
 #include <EventLoop/Job.h>
@@ -569,11 +570,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
   //
   // These vector<string> are eventually stored in TStore
   //
-  std::vector< std::string >* sysVariationNamesPID       = nullptr;
-  std::vector< std::string >* sysVariationNamesReco      = nullptr;
-  std::vector< std::string >* sysVariationNamesIso       = nullptr;
-  std::vector< std::string >* sysVariationNamesTrig      = nullptr;
-  std::vector< std::string >* sysVariationNamesTrigMCEff = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesPID       = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesReco      = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesIso       = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesTrig      = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesTrigMCEff = nullptr;
 
   // 1.
   // PID efficiency SFs - this is a per-ELECTRON weight
@@ -586,7 +587,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
   //
   if ( !m_corrFileNamePID.empty() && !isToolAlreadyUsed(m_pidEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesPID = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesPID = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     // Create the names of the SF weights to be recorded
     std::string sfName = "ElPIDEff_SF_syst_" + m_PID_WP;
@@ -673,7 +674,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesPID ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesPID, m_outputSystNamesPID ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesPID), m_outputSystNamesPID ));
     }
 
   }
@@ -689,7 +690,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
   //
   if ( !m_corrFileNameIso.empty() && !isToolAlreadyUsed(m_IsoEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesIso = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesIso = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     // Create the names of the SF weights to be recorded
     std::string sfName = "ElIsoEff_SF_syst_" + m_IsoPID_WP + "_isol" + m_Iso_WP;
@@ -776,7 +777,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesIso ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesIso, m_outputSystNamesIso ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesIso), m_outputSystNamesIso ));
     }
 
   }
@@ -792,7 +793,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
   //
   if ( !m_corrFileNameReco.empty() && !isToolAlreadyUsed(m_RecoEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesReco = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesReco = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     // Create the names of the SF weights to be recorded
     std::string sfName = "ElRecoEff_SF_syst";
@@ -879,7 +880,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesReco ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesReco, m_outputSystNamesReco ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesReco), m_outputSystNamesReco ));
     }
 
   }
@@ -898,7 +899,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
   if ( !m_corrFileNameTrig.empty() && !isToolAlreadyUsed(m_TrigEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesTrig = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesTrig = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     // Create the names of the SF weights to be recorded
     std::string sfName = "ElTrigEff_SF_syst_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
@@ -989,7 +990,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesTrig ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesTrig, m_outputSystNamesTrig ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesTrig), m_outputSystNamesTrig ));
     }
 
   }
@@ -1005,7 +1006,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
   //
   if ( !m_corrFileNameTrigMCEff.empty() && !isToolAlreadyUsed(m_TrigMCEff_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesTrigMCEff = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesTrigMCEff = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     // Create the names of the SF weights to be recorded
     std::string sfName = "ElTrigMCEff_syst_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
@@ -1096,7 +1097,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesTrigMCEff ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesTrigMCEff, m_outputSystNamesTrigMCEff ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesTrigMCEff), m_outputSystNamesTrigMCEff ));
     }
 
   }

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -287,7 +287,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
 
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
-  m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC);
+  m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC, strcmp(m_tree->GetName(), "nominal") == 0);
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = thisMuon->m_infoSwitch;
 

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -6,8 +6,8 @@ using namespace xAH;
 using std::vector;
 using std::string;
 
-MuonContainer::MuonContainer(const std::string& name, const std::string& detailStr, float units, bool mc)
-  : ParticleContainer(name, detailStr, units, mc, true)
+MuonContainer::MuonContainer(const std::string& name, const std::string& detailStr, float units, bool mc, bool storeSystSFs)
+  : ParticleContainer(name, detailStr, units, mc, true, storeSystSFs)
 {
 
   // trigger
@@ -780,60 +780,35 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
 
     std::vector<float> junkSF(1,1.0);
     std::vector<float> junkEff(1,0.0);
-    
-    static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuonEfficiencyCorrector_TTVASyst_TTVA");
-    
+
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accRecoSF;
-    
     for (auto& reco : m_infoSwitch.m_recoWPs) {
-            
-      std::string recoEffSF = "MuonEfficiencyCorrector_RecoSyst_" + reco;
+      std::string recoEffSF = "MuRecoEff_SF_syst_" + reco;
       accRecoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( reco , SG::AuxElement::Accessor< std::vector< float > >( recoEffSF ) ) );
-      if( (accRecoSF.at( reco  )).isAvailable( *muon ) ) { 
-        m_RecoEff_SF->at( reco ).push_back( (accRecoSF.at( reco ))( *muon ) ); 
-      }else { 
-        m_RecoEff_SF->at( reco  ).push_back( junkSF ); 
-      }
-    
+      safeSFVecFill<float, xAOD::Muon>( muon, accRecoSF.at( reco ), &m_RecoEff_SF->at( reco ), junkSF );
     }
-    
+
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accIsoSF;
-    
     for (auto& isol : m_infoSwitch.m_isolWPs) {
-            
-      std::string isolEffSF = "MuonEfficiencyCorrector_IsoSyst_" + isol;
+      std::string isolEffSF = "MuIsoEff_SF_syst_" + isol;
       accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( isol , SG::AuxElement::Accessor< std::vector< float > >( isolEffSF ) ) );
-      if( (accIsoSF.at( isol  )).isAvailable( *muon ) ) { 
-        m_IsoEff_SF->at( isol ).push_back( (accIsoSF.at( isol ))( *muon ) ); 
-      }else { 
-        m_IsoEff_SF->at( isol  ).push_back( junkSF ); 
-      }
+      safeSFVecFill<float, xAOD::Muon>( muon, accIsoSF.at( isol ), &m_IsoEff_SF->at( isol ), junkSF );
     }
-    
+
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigSF;
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigEFF;
-    
     for (auto& trig : m_infoSwitch.m_trigWPs) {
-            
-      std::string trigEffSF = "MuonEfficiencyCorrector_TrigSyst_" + trig;
+      std::string trigEffSF = "MuTrigEff_SF_syst_" + trig;
       accTrigSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig , SG::AuxElement::Accessor< std::vector< float > >( trigEffSF ) ) );
-      if( (accTrigSF.at( trig  )).isAvailable( *muon ) ) { 
-        m_TrigEff_SF->at( trig ).push_back( (accTrigSF.at( trig ))( *muon ) ); 
-      }else { 
-        m_TrigEff_SF->at( trig  ).push_back( junkSF ); 
-      }
-      
-      std::string trigMCEff = "MuonEfficiencyCorrector_TrigMCEff_" + trig;
+      safeSFVecFill<float, xAOD::Muon>( muon, accTrigSF.at( trig ), &m_TrigEff_SF->at( trig ), junkSF );
+
+      std::string trigMCEff = "MuTrigMCEff_syst_" + trig;
       accTrigEFF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig , SG::AuxElement::Accessor< std::vector< float > >( trigMCEff ) ) );
-      if( (accTrigEFF.at( trig  )).isAvailable( *muon ) ) { 
-        m_TrigMCEff->at( trig  ).push_back( (accTrigEFF.at( trig  ))( *muon ) ); 
-      } else { 
-        m_TrigMCEff->at( trig  ).push_back( junkEff ); 
-      }
+      safeSFVecFill<float, xAOD::Muon>( muon, accTrigEFF.at( trig ), &m_TrigMCEff->at( trig ), junkEff );
     }
 
-
-    if( accTTVASF.isAvailable( *muon ) )         { m_TTVAEff_SF->push_back( accTTVASF( *muon ) ); } else { m_TTVAEff_SF->push_back( junkSF ); }
+    static SG::AuxElement::Accessor< std::vector< float > > accTTVASF("MuTTVAEff_SF_syst_TTVA");
+    safeSFVecFill<float, xAOD::Muon>( muon, accTTVASF, m_TTVAEff_SF, junkSF );
 
   }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -389,12 +389,11 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
 
   // if m_inputSystNamesMuons = "" --> input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
-  std::vector<std::string>* systNames(nullptr);
-  if ( m_inputSystNamesMuons.empty() ) {
-    *systNames = std::vector<std::string>{""};
-  } else {
-    ANA_CHECK( HelperFunctions::retrieve(systNames, m_inputSystNamesMuons, 0, m_store, msg()) );
-  }
+  std::vector<std::string>* systNames_ptr(nullptr);
+  if ( !m_inputSystNamesMuons.empty() ) ANA_CHECK( HelperFunctions::retrieve(systNames_ptr, m_inputSystNamesMuons, 0, m_store, msg()) );
+
+  std::vector<std::string> systNames{""};
+  if (systNames_ptr) systNames = *systNames_ptr;
 
   // Declare a write status set to true
   // For the systematically varied input containers, we won't store again the vector with efficiency systs in TStore ( it will be always the same!)
@@ -402,7 +401,7 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   bool writeSystNames(true);
 
   // loop over systematic sets available
-  for ( auto systName : *systNames ) {
+  for ( auto systName : systNames ) {
     const xAOD::MuonContainer* inputMuons(nullptr);
 
     // some systematics might have rejected the event

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -506,13 +506,13 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
-  std::vector< std::string >* sysVariationNamesReco  = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesReco = nullptr;
 
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_recoEffSF_tool_name) ) {
 
-    if( writeSystNames ) sysVariationNamesReco  = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesReco = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     for ( const auto& syst_it : m_systListReco ) {
       if ( !syst_it.name().empty() && !nominal ) continue;
@@ -594,7 +594,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesReco ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesReco, m_outputSystNamesReco ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesReco), m_outputSystNamesReco ));
     }
 
   }
@@ -606,13 +606,13 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
-  std::vector< std::string >* sysVariationNamesIso   = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesIso = nullptr;
 
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_isoEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesIso  = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesIso = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     for ( const auto& syst_it : m_systListIso ) {
       if ( !syst_it.name().empty() && !nominal ) continue;
@@ -685,7 +685,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesIso ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesIso, m_outputSystNamesIso ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesIso), m_outputSystNamesIso ));
     }
 
   }
@@ -791,8 +791,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
     for ( const auto& trig_it : m_SingleMuTriggers ) {
 
-      std::vector< std::string >* sysVariationNamesTrig  = nullptr;
-      if ( writeSystNames ) sysVariationNamesTrig  = new std::vector< std::string >;
+      std::unique_ptr< std::vector< std::string > > sysVariationNamesTrig = nullptr;
+      if ( writeSystNames ) sysVariationNamesTrig = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
       // this is used to put the list of sys strings in the store.
       // The original string needs to be updated with the name of
       // the trigger for every item in the trigger loop.
@@ -911,7 +911,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
       // Add list of systematics names to TStore
       // We only do this once per event if the list does not exist yet
       if ( writeSystNames && !m_store->contains<std::vector<std::string>>( sf_string ) ) {
-        ANA_CHECK( m_store->record( sysVariationNamesTrig, sf_string ));
+        ANA_CHECK( m_store->record( std::move(sysVariationNamesTrig), sf_string ));
       }
     } // close  trigger loop
 
@@ -924,13 +924,13 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   // Every systematic will correspond to a different SF!
   //
 
-  std::vector< std::string >* sysVariationNamesTTVA  = nullptr;
+  std::unique_ptr< std::vector< std::string > > sysVariationNamesTTVA = nullptr;
 
   // Do it only if a tool with *this* name hasn't already been used
   //
   if ( !isToolAlreadyUsed(m_TTVAEffSF_tool_name) ) {
 
-    if ( writeSystNames ) sysVariationNamesTTVA  = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesTTVA = std::unique_ptr<std::vector<std::string>>(new std::vector<std::string>);
 
     for ( const auto& syst_it : m_systListTTVA ) {
       if ( !syst_it.name().empty() && !nominal ) continue;
@@ -1007,7 +1007,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     // Add list of systematics names to TStore
     // We only do this once per event if the list does not exist yet
     if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesTTVA ) ) {
-      ANA_CHECK( m_store->record( sysVariationNamesTTVA, m_outputSystNamesTTVA ));
+      ANA_CHECK( m_store->record( std::move(sysVariationNamesTTVA), m_outputSystNamesTTVA ));
     }
   }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -125,23 +125,6 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   // *******************************************************
 
-  // several lists of systematics could be configured
-  // this is the case when MET sys should be added
-  // to the OR ones
-  std::string tmp_sysNames = m_inputAlgoSystNames;
-
-  while ( tmp_sysNames.size() > 0) {
-    size_t pos = tmp_sysNames.find_first_of(',');
-    if ( pos == std::string::npos ) {
-      pos = tmp_sysNames.size();
-      m_sysNames.push_back(tmp_sysNames.substr(0, pos));
-      tmp_sysNames.erase(0, pos);
-    } else {
-      m_sysNames.push_back(tmp_sysNames.substr(0, pos));
-      tmp_sysNames.erase(0, pos+1);
-    }
-  }
-
   // Create a ToolHandle of the PRW tool which is passed to the MuonEfficiencyScaleFactors class later
   //
   if( m_isMC ){
@@ -312,10 +295,10 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
     m_SingleMuTriggers.push_back(token);
   }
 
-  //  Add the chosen WP to the string labelling the vector<SF>/vector<eff> decoration
-  //
-  m_outputSystNamesTrig      = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-  m_outputSystNamesTrigMCEff = m_outputSystNamesTrigMCEff + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+  // Remember base output syst. names container
+  m_outputSystNamesTrigBase = m_outputSystNamesTrig;
+  // Add the chosen WP to the string labelling the output syst. names container
+  m_outputSystNamesTrig = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
 
   CP::SystematicSet affectSystsTrig = m_muTrigSF_tools[m_YearsList[0]]->affectingSystematics();
   for ( const auto& syst_it : affectSystsTrig ) { ANA_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by trigger efficiency systematic: " << syst_it.name()); }
@@ -404,120 +387,45 @@ EL::StatusCode MuonEfficiencyCorrector :: execute ()
   const xAOD::EventInfo* eventInfo(nullptr);
   ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
 
-  // initialise containers
-  //
-  const xAOD::MuonContainer* inputMuons(nullptr);
-
-  // if m_inputAlgoSystNames = "" --> input comes from xAOD, or just running one collection,
+  // if m_inputSystNamesMuons = "" --> input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
+  std::vector<std::string>* systNames(nullptr);
+  if ( m_inputSystNamesMuons.empty() ) {
+    *systNames = std::vector<std::string>{""};
+  } else {
+    ANA_CHECK( HelperFunctions::retrieve(systNames, m_inputSystNamesMuons, 0, m_store, msg()) );
+  }
 
-  // Declare a counter, initialised to 0
+  // Declare a write status set to true
   // For the systematically varied input containers, we won't store again the vector with efficiency systs in TStore ( it will be always the same!)
   //
-  unsigned int countInputCont(0);
+  bool writeSystNames(true);
 
-  if ( m_inputAlgoSystNames.empty() ) {
+  // loop over systematic sets available
+  for ( auto systName : *systNames ) {
+    const xAOD::MuonContainer* inputMuons(nullptr);
 
-    // I might not want to decorate sys altered muons but for some events the nominal container might not exist
-    // if muons are only allowed in systematic instances, hence, we have to check for the existence of the nominal container
-    //
-    if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName )  ) {
-       ANA_CHECK( HelperFunctions::retrieve(inputMuons, m_inContainerName, m_event, m_store, msg()) );
+    // some systematics might have rejected the event
+    if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName+systName ) ) {
+      // retrieve input muons
+      ANA_CHECK( HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, msg()) );
 
-       ANA_MSG_DEBUG( "Number of muons: " << static_cast<int>(inputMuons->size()) );
+      ANA_MSG_DEBUG( "Number of muons: " << static_cast<int>(inputMuons->size()) );
+      ANA_MSG_DEBUG( "Input syst: " << systName );
+      unsigned int idx(0);
+      for ( auto mu : *(inputMuons) ) {
+        ANA_MSG_DEBUG( "Input muon " << idx << ", pt = " << mu->pt() * 1e-3 << " GeV" );
+        ++idx;
+      }
 
-       // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
-       //
-       this->executeSF( eventInfo, inputMuons, countInputCont, true );
-    }
+      // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
+      this->executeSF( eventInfo, inputMuons, systName.empty(), writeSystNames );
 
-  } else {
-  // if m_inputAlgo = NOT EMPTY --> you are retrieving syst varied containers from an upstream algo. This is the case of calibrators: one different SC
-  // for each calibration syst applied
+      writeSystNames = false;
 
-	// get vector of string giving the syst names of the upstream algo m_inputAlgo (rememeber: 1st element is a blank string: nominal case!)
-	//
-        std::vector<std::string> systNames;
+    } // check existence of container
 
-        // add each vector of systematics names to the full list
-        //
-        for ( auto sysInput : m_sysNames ) {
-          std::vector<std::string>* it_systNames(nullptr);
-          ANA_CHECK( HelperFunctions::retrieve(it_systNames, sysInput, 0, m_store, msg()) );
-          systNames.insert( systNames.end(), it_systNames->begin(), it_systNames->end() );
-        }
-        // and now remove eventual duplicates
-        //
-        HelperFunctions::remove_duplicates(systNames);
-
-        // create parallel container of muons for met systematics.
-        // this does not get decorated and contains the same elements
-        // of the nominal container. It will be used by the TreeAlgo
-        // as we don't want sys variations for eff in MET sys trees.
-        //
-        if ( !m_sysNamesForParCont.empty() )  {
-          std::vector<std::string>* par_systNames(nullptr);
-
-          ANA_CHECK( HelperFunctions::retrieve(par_systNames, m_sysNamesForParCont, 0, m_store, msg()) );
-
-          for ( auto sys : *par_systNames ) {
-             if ( !sys.empty() && !m_store->contains<xAOD::MuonContainer>( m_inContainerName+sys ) ) {
-               const xAOD::MuonContainer* tmpMuons(nullptr);
-
-               if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName ) ) {
-
-                  ANA_CHECK( HelperFunctions::retrieve(tmpMuons, m_inContainerName, m_event, m_store, msg()) );
-                  ANA_CHECK( (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_inContainerName+sys, tmpMuons)));
-
-               } // the nominal container is copied therefore it has to exist!
-
-             } // skip the nominal case or if the container already exists
-          } // consider all "parallel" systematics specified by the user
-
-        } // do this thing only if required
-
-        // loop over systematic sets available
-	      //
-        std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
-
-        for ( auto systName : systNames ) {
-
-           const xAOD::MuonContainer* outputMuons(nullptr);
-           bool isNomMuonSelection = systName.empty();
-
-           if ( m_store->contains<xAOD::MuonContainer>( m_inContainerName+systName )  ) {
-              ANA_CHECK( HelperFunctions::retrieve(inputMuons, m_inContainerName+systName, m_event, m_store, msg()) );
-
-              if ( !m_store->contains<xAOD::MuonContainer>( m_outContainerName+systName ) ) {
-                 ANA_CHECK( (HelperFunctions::makeDeepCopy<xAOD::MuonContainer, xAOD::MuonAuxContainer, xAOD::Muon>(m_store, m_outContainerName+systName, inputMuons)));
-              }
-
-              ANA_CHECK( HelperFunctions::retrieve(outputMuons, m_outContainerName+systName, m_event, m_store, msg()) );
-
-              ANA_MSG_DEBUG( "Number of muons: " << static_cast<int>(outputMuons->size()) );
-              ANA_MSG_DEBUG( "Input syst: " << systName );
-              unsigned int idx(0);
-              for ( auto mu : *(outputMuons) ) {
-                ANA_MSG_DEBUG( "Input muon " << idx << ", pt = " << mu->pt()*1e-3 << " GeV ");
-                ++idx;
-    	      }
-
-	      // decorate muons w/ SF - there will be a decoration w/ different name for each syst!
-	      //
-              this->executeSF( eventInfo, outputMuons, countInputCont, isNomMuonSelection );
-
-              vecOutContainerNames->push_back( systName );
-              // increment counter
-	      //
-	      ++countInputCont;
-
-           } // check existence of container
-    	} // close loop on systematic sets available from upstream algo
-
-        if ( !m_outputAlgoSystNames.empty() && !m_store->contains< std::vector<std::string> >( m_outputAlgoSystNames ) ) { // might have already been stored by another execution of this algo
-          ANA_CHECK( m_store->record( vecOutContainerNames, m_outputAlgoSystNames));
-        }
-   }
+  } // close loop on systematic sets available from upstream algo
 
   // look what we have in TStore
   //
@@ -577,7 +485,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst, bool isNomSel )
+EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames )
 {
 
   //
@@ -604,21 +512,16 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   //
   if ( !isToolAlreadyUsed(m_recoEffSF_tool_name) ) {
 
-    if(countSyst == 0) sysVariationNamesReco  = new std::vector< std::string >;
+    if( writeSystNames ) sysVariationNamesReco  = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListReco ) {
-      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue;
+      if ( !syst_it.name().empty() && !nominal ) continue;
 
       // Create the name of the SF weight to be recorded
-      //   template:  SYSNAME_MuRecoEff_SF
-      //
-      std::string sfName = "MuRecoEff_SF_" + m_WorkingPointReco;;
-      if ( !syst_it.name().empty() ) {
-    	 std::string prepend = syst_it.name() + "_";
-    	 sfName.insert( 0, prepend );
-      }
-      ANA_MSG_DEBUG( "Muon reco efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
-      if(countSyst == 0) sysVariationNamesReco->push_back(sfName);
+      std::string sfName = "MuRecoEff_SF_syst_Reco" + m_WorkingPointReco;
+
+      ANA_MSG_DEBUG( "Muon reco efficiency SF sys name (to be recorded in xAOD::TStore) is: " << syst_it.name() );
+      if( writeSystNames ) sysVariationNamesReco->push_back(syst_it.name());
 
       // apply syst
       //
@@ -651,7 +554,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
     	 //
 
-    	 SG::AuxElement::Decorator< std::vector<float> > sfVecReco( m_outputSystNamesReco );
+    	 SG::AuxElement::Decorator< std::vector<float> > sfVecReco( sfName );
     	 if ( !sfVecReco.isAvailable( *mu_itr ) ) {
   	   sfVecReco( *mu_itr ) = std::vector<float>();
     	 }
@@ -675,17 +578,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 sfVecReco_sysNames( *mu_itr ).push_back( syst_it.name().c_str() );
 
          ANA_MSG_DEBUG( "===>>>");
-         ANA_MSG_DEBUG( " ");
          ANA_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV" );
-         ANA_MSG_DEBUG( " ");
-         ANA_MSG_DEBUG( "Reco eff. SF decoration: " << m_outputSystNamesReco );
-         ANA_MSG_DEBUG( " ");
+         ANA_MSG_DEBUG( "Reco eff. SF decoration: " << sfName );
          ANA_MSG_DEBUG( "Systematic: " << syst_it.name() );
-         ANA_MSG_DEBUG( " ");
-         //ANA_MSG_DEBUG("Reco efficiency:");
-         //ANA_MSG_DEBUG("\t %f (from applyMCEfficiency())", mu_itr->auxdataConst< float >( "mcEfficiency" ) );
-         ANA_MSG_DEBUG( "and its SF:");
-         //ANA_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "EfficiencyScaleFactor" ) );
+         ANA_MSG_DEBUG( "Reco eff. SF:");
          ANA_MSG_DEBUG( "\t " << recoEffSF << " (from getEfficiencyScaleFactor())" );
          ANA_MSG_DEBUG( "--------------------------------------");
 
@@ -696,14 +592,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     }  // close loop on reco efficiency SF systematics
 
     // Add list of systematics names to TStore
-    //
-    // NB: we need to make sure that this is not pushed more than once in TStore!
-    // This will be the case when this executeSF() function gets called for every syst varied input container,
-    // e.g. the different SC containers w/ calibration systematics upstream.
-    //
-    // Use the counter defined in execute() to check this is done only once per event
-    //
-    if ( countSyst == 0 ) { ANA_CHECK( m_store->record( sysVariationNamesReco, m_outputSystNamesReco)); }
+    // We only do this once per event if the list does not exist yet
+    if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesReco ) ) {
+      ANA_CHECK( m_store->record( sysVariationNamesReco, m_outputSystNamesReco ));
+    }
 
   }
 
@@ -720,21 +612,16 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   //
   if ( !isToolAlreadyUsed(m_isoEffSF_tool_name) ) {
 
-    if(countSyst == 0) sysVariationNamesIso   = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesIso  = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListIso ) {
-      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue;
+      if ( !syst_it.name().empty() && !nominal ) continue;
 
       // Create the name of the SF weight to be recorded
-      //   template:  SYSNAME_MuIsoEff_SF_WP
-      //
-      std::string sfName = "MuIsoEff_SF_" + m_WorkingPointIso;
-      if ( !syst_it.name().empty() ) {
-    	 std::string prepend = syst_it.name() + "_";
-    	 sfName.insert( 0, prepend );
-      }
-      ANA_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
-      if(countSyst == 0) sysVariationNamesIso->push_back(sfName);
+      std::string sfName = "MuIsoEff_SF_syst_Iso" + m_WorkingPointIso;
+
+      ANA_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << syst_it.name() );
+      if ( writeSystNames ) sysVariationNamesIso->push_back(syst_it.name());
 
       // apply syst
       //
@@ -766,7 +653,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //
     	 //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
     	 //
-    	 SG::AuxElement::Decorator< std::vector<float> > sfVecIso( m_outputSystNamesIso );
+    	 SG::AuxElement::Decorator< std::vector<float> > sfVecIso( sfName );
     	 if ( !sfVecIso.isAvailable( *mu_itr ) ) {
   	   sfVecIso( *mu_itr ) = std::vector<float>();
     	 }
@@ -782,17 +669,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 sfVecIso( *mu_itr ).push_back(IsoEffSF);
 
          ANA_MSG_DEBUG( "===>>>");
-         ANA_MSG_DEBUG( " ");
          ANA_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-         ANA_MSG_DEBUG( " ");
-         ANA_MSG_DEBUG( "Isolation SF decoration: " << m_outputSystNamesIso );
-         ANA_MSG_DEBUG( " ");
+         ANA_MSG_DEBUG( "Isolation SF decoration: " << sfName );
          ANA_MSG_DEBUG( "Systematic: " << syst_it.name() );
-         ANA_MSG_DEBUG( " ");
-         //ANA_MSG_DEBUG("Iso efficiency:");
-         //ANA_MSG_DEBUG("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "ISOmcEfficiency" ) );
-         ANA_MSG_DEBUG( "and its SF:");
-         //ANA_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "ISOEfficiencyScaleFactor" ) );
+         ANA_MSG_DEBUG( "Isolation SF:");
          ANA_MSG_DEBUG( "\t " << IsoEffSF << " (from getEfficiencyScaleFactor())");
          ANA_MSG_DEBUG( "--------------------------------------");
 
@@ -803,14 +683,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     }  // close loop on isolation efficiency SF systematics
 
     // Add list of systematics names to TStore
-    //
-    // NB: we need to make sure that this is not pushed more than once in TStore!
-    // This will be the case when this executeSF() function gets called for every syst varied input container,
-    // e.g. the different SC containers w/ calibration systematics upstream.
-    //
-    // Use the counter defined in execute() to check this is done only once per event
-    //
-    if ( countSyst == 0 ) { ANA_CHECK( m_store->record( sysVariationNamesIso, m_outputSystNamesIso)); }
+    // We only do this once per event if the list does not exist yet
+    if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesIso ) ) {
+      ANA_CHECK( m_store->record( sysVariationNamesIso, m_outputSystNamesIso ));
+    }
 
   }
 
@@ -916,46 +792,31 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     for ( const auto& trig_it : m_SingleMuTriggers ) {
 
       std::vector< std::string >* sysVariationNamesTrig  = nullptr;
-      if(countSyst == 0) sysVariationNamesTrig  = new std::vector< std::string >;
+      if ( writeSystNames ) sysVariationNamesTrig  = new std::vector< std::string >;
       // this is used to put the list of sys strings in the store.
       // The original string needs to be updated with the name of
       // the trigger for every item in the trigger loop.
       //
       //std::string m_fullname_outputSystNamesTrig;
 
-      std::string eff_string = m_outputSystNamesTrigMCEff;
-      std::string ineffstr   = "MuonEfficiencyCorrector_TrigMCEff_";
-      std::string outeffstr  = "MuonEfficiencyCorrector_TrigMCEff_" + trig_it + "_";
-
-      for(std::string::size_type i = 0; (i = eff_string.find(ineffstr, i)) != std::string::npos;) {
-        eff_string.replace(i, ineffstr.length(), outeffstr);
-        i += outeffstr.length();
-      }
-
       std::string sf_string = m_outputSystNamesTrig;
-      std::string insfstr   = "MuonEfficiencyCorrector_TrigSyst_";
-      std::string outsfstr  = "MuonEfficiencyCorrector_TrigSyst_" + trig_it + "_";
+      std::string insfstr   = m_outputSystNamesTrigBase + "_";
+      std::string outsfstr  = m_outputSystNamesTrigBase + "_" + trig_it + "_";
 
       for(std::string::size_type i = 0; (i = sf_string.find(insfstr, i)) != std::string::npos;) {
         sf_string.replace(i, insfstr.length(), outsfstr);
         i += outsfstr.length();
       }
-      //if (idx == 0) { m_fullname_outputSystNamesTrig = sf_string; }
-      //ANA_MSG_INFO("This is the new string: " << m_fullname_outputSystNamesTrig);
 
       for ( const auto& syst_it : m_systListTrig ) {
-        if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue;
+        if ( !syst_it.name().empty() && !nominal ) continue;
 
         // Create the name of the SF weight to be recorded
-        //   template:  SYSNAME_MuTrigEff_SF
-        //
-        std::string sfName = "MuTrigEff_SF_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-        if ( !syst_it.name().empty() ) {
-           std::string prepend = syst_it.name() + "_";
-           sfName.insert( 0, prepend );
-        }
-        ANA_MSG_DEBUG( "Trigger efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
-        if(countSyst==0) sysVariationNamesTrig->push_back(sfName);
+        std::string sfName = "MuTrigEff_SF_syst_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+        std::string effName = "MuTrigMCEff_syst_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+
+        ANA_MSG_DEBUG( "Trigger efficiency SF sys name (to be recorded in xAOD::TStore) is: " << syst_it.name() );
+        if ( writeSystNames ) sysVariationNamesTrig->push_back(syst_it.name());
 
         // apply syst
         //
@@ -980,12 +841,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
            //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
            //
-           SG::AuxElement::Decorator< std::vector<float> > effMC( eff_string );
+           SG::AuxElement::Decorator< std::vector<float> > effMC( effName );
            if ( !effMC.isAvailable( *mu_itr ) ) {
              effMC( *mu_itr ) = std::vector<float>();
            }
 
-           SG::AuxElement::Decorator< std::vector<float> > sfVecTrig( sf_string );
+           SG::AuxElement::Decorator< std::vector<float> > sfVecTrig( sfName );
            if ( !sfVecTrig.isAvailable( *mu_itr ) ) {
              sfVecTrig( *mu_itr ) = std::vector<float>();
            }
@@ -1031,15 +892,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
 
            ANA_MSG_DEBUG( "===>>>");
-           ANA_MSG_DEBUG( " ");
            ANA_MSG_DEBUG( "Random year: " << randYear.c_str() );
            ANA_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-           ANA_MSG_DEBUG( " ");
-           ANA_MSG_DEBUG( "Trigger efficiency SF decoration: " << m_outputSystNamesTrig );
-           ANA_MSG_DEBUG( "Trigger MC efficiency decoration: " << m_outputSystNamesTrigMCEff );
-           ANA_MSG_DEBUG( " ");
+           ANA_MSG_DEBUG( "Trigger efficiency SF decoration: " << sfName );
+           ANA_MSG_DEBUG( "Trigger MC efficiency decoration: " << effName );
            ANA_MSG_DEBUG( "Systematic: " << syst_it.name() );
-           ANA_MSG_DEBUG( " ");
            ANA_MSG_DEBUG( "Trigger efficiency SF:");
            ANA_MSG_DEBUG( "\t " << triggerEffSF << " (from getTriggerScaleFactor())" );
            ANA_MSG_DEBUG( "Trigger MC efficiency:");
@@ -1051,18 +908,12 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
         } // close muon loop
       }  // close loop on trigger efficiency SF systematics
 
-      if ( countSyst == 0 ) { ANA_CHECK( m_store->record( sysVariationNamesTrig, sf_string)); }
-
+      // Add list of systematics names to TStore
+      // We only do this once per event if the list does not exist yet
+      if ( writeSystNames && !m_store->contains<std::vector<std::string>>( sf_string ) ) {
+        ANA_CHECK( m_store->record( sysVariationNamesTrig, sf_string ));
+      }
     } // close  trigger loop
-
-    // Add list of systematics names to TStore
-    //
-    // NB: we need to make sure that this is not pushed more than once in TStore!
-    // This will be the case when this executeSF() function gets called for every syst varied input container,
-    // e.g. the different SC containers w/ calibration systematics upstream.
-    //
-    // Use the counter defined in execute() to check this is done only once per event
-    //
 
   }
 
@@ -1079,21 +930,16 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   //
   if ( !isToolAlreadyUsed(m_TTVAEffSF_tool_name) ) {
 
-    if(countSyst == 0) sysVariationNamesTTVA  = new std::vector< std::string >;
+    if ( writeSystNames ) sysVariationNamesTTVA  = new std::vector< std::string >;
 
     for ( const auto& syst_it : m_systListTTVA ) {
-      if ( m_decorateWithNomOnInputSys && !syst_it.name().empty() && !isNomSel ) continue;
+      if ( !syst_it.name().empty() && !nominal ) continue;
 
       // Create the name of the SF weight to be recorded
-      //   template:  SYSNAME_MuTTVAEff_SF_WP
-      //
-      std::string sfName = "MuTTVAEff_SF_" + m_WorkingPointTTVA;
-      if ( !syst_it.name().empty() ) {
-    	 std::string prepend = syst_it.name() + "_";
-    	 sfName.insert( 0, prepend );
-      }
-      ANA_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
-      if(countSyst == 0) sysVariationNamesTTVA->push_back(sfName);
+      std::string sfName = "MuTTVAEff_SF_syst_" + m_WorkingPointTTVA;
+
+      ANA_MSG_DEBUG( "Muon iso efficiency SF sys name (to be recorded in xAOD::TStore) is: " << syst_it.name() );
+      if ( writeSystNames ) sysVariationNamesTTVA->push_back(syst_it.name());
 
       // apply syst
       //
@@ -1129,7 +975,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 //
     	 //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* muon)
     	 //
-    	 SG::AuxElement::Decorator< std::vector<float> > sfVecTTVA( m_outputSystNamesTTVA );
+    	 SG::AuxElement::Decorator< std::vector<float> > sfVecTTVA( sfName );
     	 if ( !sfVecTTVA.isAvailable( *mu_itr ) ) {
   	   sfVecTTVA( *mu_itr ) = std::vector<float>();
     	 }
@@ -1145,17 +991,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     	 sfVecTTVA( *mu_itr ).push_back(TTVAEffSF);
 
          ANA_MSG_DEBUG( "===>>>");
-         ANA_MSG_DEBUG( " ");
          ANA_MSG_DEBUG( "Muon " << idx << ", pt = " << mu_itr->pt()*1e-3 << " GeV " );
-         ANA_MSG_DEBUG( " ");
-         ANA_MSG_DEBUG( "TTVA SF decoration: " << m_outputSystNamesTTVA );
-         ANA_MSG_DEBUG( " ");
+         ANA_MSG_DEBUG( "TTVA SF decoration: " << sfName );
          ANA_MSG_DEBUG( "Systematic: " << syst_it.name());
-         ANA_MSG_DEBUG( " ");
-         //ANA_MSG_DEBUG("TTVA efficiency:");
-         //ANA_MSG_DEBUG("\t %f (from applyIsoEfficiency())", mu_itr->auxdataConst< float >( "TTVAmcEfficiency" ) );
-         ANA_MSG_DEBUG( "and its SF:");
-         //ANA_MSG_DEBUG("\t %f (from applyEfficiencyScaleFactor())", mu_itr->auxdataConst< float >( "TTVAEfficiencyScaleFactor" ) );
+         ANA_MSG_DEBUG( "TTVA SF:");
          ANA_MSG_DEBUG( "\t " << TTVAEffSF << " (from getEfficiencyScaleFactor())" );
          ANA_MSG_DEBUG( "--------------------------------------");
 
@@ -1166,14 +1005,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     }  // close loop on TTVA efficiency SF systematics
 
     // Add list of systematics names to TStore
-    //
-    // NB: we need to make sure that this is not pushed more than once in TStore!
-    // This will be the case when this executeSF() function gets called for every syst varied input container,
-    // e.g. the different SC containers w/ calibration systematics upstream.
-    //
-    // Use the counter defined in execute() to check this is done only once per event
-    //
-    if ( countSyst == 0 ) { ANA_CHECK( m_store->record( sysVariationNamesTTVA, m_outputSystNamesTTVA)); }
+    // We only do this once per event if the list does not exist yet
+    if ( writeSystNames && !m_store->contains<std::vector<std::string>>( m_outputSystNamesTTVA ) ) {
+      ANA_CHECK( m_store->record( sysVariationNamesTTVA, m_outputSystNamesTTVA ));
+    }
   }
 
   return EL::StatusCode::SUCCESS;

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -47,7 +47,7 @@ public:
   /**
     @brief The name of the vector containing the names of the systematically-varied electrons-related containers from the upstream algorithm, which will be processed by this algorithm.
 
-    This vector is retrieved from the ``TStore``. If left blank, it means there is no upstream algorithm which applies systematics. This is the case when processing straight from the original ``xAOD`` or ``DxAOD``.
+    Only electron calibration systematics or any other that create shallow copies of electron containers should be passed to this tool. It is advised to run this algorithm before running algorithms combining multiple calibration systematics (e.g. overlap removal).
   */
   std::string m_inputSystNamesElectrons;
 

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -19,7 +19,7 @@ namespace xAH {
   class MuonContainer : public ParticleContainer<Muon,HelperClasses::MuonInfoSwitch>
     {
     public:
-      MuonContainer(const std::string& name = "muon", const std::string& detailStr="", float units = 1e3, bool mc = false);
+      MuonContainer(const std::string& name = "muon", const std::string& detailStr="", float units = 1e3, bool mc = false, bool storeSystSFs = true);
       virtual ~MuonContainer();
     
       virtual void setTree(TTree *tree);

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -36,7 +36,6 @@ public:
 
   // configuration variables
   std::string   m_inContainerName = "";
-  std::string   m_outContainerName = "";
 
   std::string   m_calibRelease = "Data15_allPeriods_241115";
 
@@ -64,12 +63,8 @@ public:
   std::string   m_WorkingPointTTVA = "TTVA";
 
   // systematics
-  /// @brief this is the name of the vector of names of the systematically varied containers produced by the upstream algo (e.g., the SC containers with calibration systematics)
-  std::string   m_inputAlgoSystNames = "";
-  // this is the name of the vector of names of the systematically varied containers to be fed to the downstream algos. We need that as we deepcopy the input containers
-  std::string   m_outputAlgoSystNames = "";
-  // this is the name of the vector of names for the systematics to be used for the creation of a parallel container. This will be just a copy of the nominal one with the sys name appended. Use cases: MET-specific systematics.
-  std::string   m_sysNamesForParCont = "";
+  /// @brief this is the name of the vector of names of the systematically varied muons-related containers produced by the upstream algo (e.g., the SC containers with calibration systematics)
+  std::string   m_inputSystNamesMuons = "";
 
   float         m_systValReco = 0.0;
   float         m_systValIso = 0.0;
@@ -82,11 +77,7 @@ public:
   std::string   m_outputSystNamesReco = "MuonEfficiencyCorrector_RecoSyst";
   std::string   m_outputSystNamesIso = "MuonEfficiencyCorrector_IsoSyst";
   std::string   m_outputSystNamesTrig = "MuonEfficiencyCorrector_TrigSyst";
-  std::string   m_outputSystNamesTrigMCEff = "MuonEfficiencyCorrector_TrigMCEff";
   std::string   m_outputSystNamesTTVA = "MuonEfficiencyCorrector_TTVASyst";
-
-  /// @brief will consider efficiency decorations only for the nominal run
-  bool          m_decorateWithNomOnInputSys = true;
 
 private:
 
@@ -102,8 +93,8 @@ private:
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
   std::vector<CP::SystematicSet> m_systListTTVA; //!
-
-  std::vector<std::string> m_sysNames; //!
+  
+  std::string m_outputSystNamesTrigBase; //!
 
   // tools
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;     //!
@@ -142,7 +133,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual EL::StatusCode executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, unsigned int countSyst, bool isNomSel );
+  virtual EL::StatusCode executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames );
 
   /// @cond
   // this is needed to distribute the algorithm to the workers

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -63,7 +63,11 @@ public:
   std::string   m_WorkingPointTTVA = "TTVA";
 
   // systematics
-  /// @brief this is the name of the vector of names of the systematically varied muons-related containers produced by the upstream algo (e.g., the SC containers with calibration systematics)
+  /**
+    @brief The name of the vector containing the names of the systematically-varied muons-related containers from the upstream algorithm, which will be processed by this algorithm.
+
+    Only muon calibration systematics or any other that create shallow copies of electron containers should be passed to this tool. It is advised to run this algorithm before running algorithms combining multiple calibration systematics (e.g. overlap removal).
+  */
   std::string   m_inputSystNamesMuons = "";
 
   float         m_systValReco = 0.0;


### PR DESCRIPTION
Muon efficiency corrector simplification similar to what was done for electrons in #972. This also fixes a debug log typo for electrons.

Where could I note that this should be now run on muons before OR (as some jet systematics can cause nominal muon container to contain less muons that jet systematics one)?

This is almost the same change as for electrons. Jets might need some more work so I will do this for them later.