### PR TITLE
Move fJVT calculation to JetCalibrator

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -357,6 +357,17 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_JVTUpdateTool_handle);
   }
 
+  if ( m_calculatefJVT ) {
+    setToolName(m_fJVTTool_handle);
+    ANA_CHECK(m_fJVTTool_handle.setProperty("CentralMaxPt", m_fJVTCentralMaxPt));
+    if ( m_fJVTWorkingPoint == "Tight" ) {
+      ANA_CHECK(m_fJVTTool_handle.setProperty("UseTightOP", true));
+    }
+    ANA_CHECK(m_fJVTTool_handle.setProperty("OutputLevel", msg().level()));
+    ANA_CHECK(m_fJVTTool_handle.retrieve());
+    ANA_MSG_DEBUG("Retrieved tool: " << m_fJVTTool_handle);
+  }
+
   std::vector< std::string >* SystJetsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
     if ( m_systName.empty() ) {
@@ -550,6 +561,11 @@ EL::StatusCode JetCalibrator :: execute ()
       for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
         jet_itr->auxdata< float >("Jvt") = m_JVTUpdateTool_handle->updateJvt(*jet_itr);
       }
+    }
+
+    // Calculate fJVT using calibrated Jets
+    if ( m_calculatefJVT ) {
+      m_fJVTTool_handle->modify(*(uncertCalibJetsSC.first));
     }
 
     // save pointers in ConstDataVector with same order

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -383,7 +383,7 @@ EL::StatusCode JetSelector :: execute ()
       }
     }
 
-    pass = executeSelection( inJets, mcEvtWeight, count, m_inContainerName, m_outContainerName, true );
+    pass = executeSelection( inJets, mcEvtWeight, count, m_outContainerName, true );
 
   }  else { // get the list of systematics to run over
 
@@ -414,7 +414,7 @@ EL::StatusCode JetSelector :: execute ()
         }
       }
 
-      passOne = executeSelection( inJets, mcEvtWeight, count, m_inContainerName+systName, m_outContainerName+systName, systName.empty() );
+      passOne = executeSelection( inJets, mcEvtWeight, count, m_outContainerName+systName, systName.empty() );
       if ( count ) { count = false; } // only count for 1 collection
       // save the string if passing the selection
       if ( passOne ) {
@@ -446,7 +446,6 @@ EL::StatusCode JetSelector :: execute ()
 bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     float mcEvtWeight,
     bool count,
-    std::string inContainerName,
     std::string outContainerName,
     bool isNominal
     )

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -107,6 +107,13 @@ public:
   /// @brief Recalculate JVT using the calibrated jet pT
   bool m_redoJVT = false;
 
+  /// @brief Calculate fJVT using the calibrated jet pT
+  bool m_calculatefJVT = false;
+  /// @brief Maximum pT of central jets used to compute fJVT decision
+  double m_fJVTCentralMaxPt = -1;
+  /// @brief fJVT working point
+  std::string m_fJVTWorkingPoint = "Medium";
+
   /// @brief Name of Jvt aux decoration.  Was "JvtJvfcorr" in Rel 20.7, is now "JVFCorr" in Rel 21. Leave empty to use JetMomentTools default.  This must be left empty for RootCore (r20.7) code! 
   std::string m_JvtAuxName = "";
   /// @brief Sort the processed container elements by transverse momentum
@@ -138,6 +145,7 @@ private:
   asg::AnaToolHandle<IJERTool>                   m_JERTool_handle{"JERTool"};                               //!
   asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle{"JERSmearingTool"};               //!
   asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle{"JetVertexTaggerTool"};             //!
+  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle{"JetForwardJvtTool"};                    //!
   asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle{"JetCleaningTool"};               //!
   asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool"};   //!
 

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -288,7 +288,7 @@ public:
   virtual EL::StatusCode histFinalize ();
 
   // these are the functions not inherited from Algorithm
-  virtual bool executeSelection( const xAOD::JetContainer* inJets, float mcEvtWeight, bool count, std::string inContainerName, std::string outContainerName, bool isNominal );
+  virtual bool executeSelection( const xAOD::JetContainer* inJets, float mcEvtWeight, bool count, std::string outContainerName, bool isNominal );
 
   // added functions not from Algorithm
   // why does this need to be virtual?

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -258,7 +258,6 @@ private:
   std::vector<CP::SystematicSet> m_systListfJVT; //!
 
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::JetJvtEfficiency"};         //!
-  asg::AnaToolHandle<IJetModifier>           m_fJVT_tool_handle{"JetForwardJvtTool"};           //!
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency"};    //!
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
 


### PR DESCRIPTION
In continuous effort to try to reduce the amount of needed deep copies, I moved fJVT calculation to JetCalibrator. JVT is also recalculated there so this might be a better location for it.

Two configuration properties are also supported now:
 - `CentralMaxPt` - to limit max pt of central jets, required by MET recommendations
 - `UseTightOP` - if one wants to use Tight working point

Note that this is a breaking change. I'm open to suggestions if some of the introduced `JetCalibrator` properties should be renamed.