### PR TITLE
Add MET significance calculation

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV_RC=2.4.37 ABV_CM=21.2.0
+  - ABV_RC=2.4.37 ABV_CM=21.2.3
 
 before_script:
   - ls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ atlas_depends_on_subdirs( PUBLIC
                           Reconstruction/Jet/JetResolution
                           Reconstruction/Jet/JetSubStructureUtils
                           Reconstruction/Jet/JetUncertainties
+                          Reconstruction/MET/METInterface
                           Reconstruction/MET/METUtilities
                           Tools/PathResolver
                           Trigger/TrigAnalysis/TrigDecisionTool

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -374,6 +374,8 @@ namespace HelperClasses{
   }
 
   void METInfoSwitch::initialize(){
+    m_metClus   = has_exact("metClus");
+    m_metTrk    = has_exact("metTrk");
     m_sigClus   = has_exact("sigClus")  || has_exact("all");
     m_sigTrk    = has_exact("sigTrk")   || has_exact("all");
     m_sigResolutionClus = has_exact("sigResolutionClus") || has_exact("all");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -374,6 +374,10 @@ namespace HelperClasses{
   }
 
   void METInfoSwitch::initialize(){
+    m_sigClus   = has_exact("sigClus")  || has_exact("all");
+    m_sigTrk    = has_exact("sigTrk")   || has_exact("all");
+    m_sigResolutionClus = has_exact("sigResolutionClus") || has_exact("all");
+    m_sigResolutionTrk  = has_exact("sigResolutionTrk")  || has_exact("all");
     m_refEle    = has_exact("refEle")   || has_exact("all");
     m_refGamma  = has_exact("refGamma") || has_exact("all");
     m_refTau    = has_exact("refTau")   || has_exact("all");

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -9,6 +9,7 @@
 // top of file, outside of algorithm declaration
 // #include "METUtilities/METRebuilder.h"
 #include "METUtilities/METMaker.h"
+#include "METUtilities/METSignificance.h"
 #include "METUtilities/CutsMETMaker.h"
 #include "TauAnalysisTools/TauSelectionTool.h"
 
@@ -136,6 +137,13 @@ EL::StatusCode METConstructor :: initialize ()
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
+  // define m_isMC
+  const xAOD::EventInfo* eventInfo(nullptr);
+  ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
+
+  m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
+  ANA_MSG_DEBUG( "Is MC? " << m_isMC );
+
   //////////// IMETMaker ////////////////
   ASG_SET_ANA_TOOL_TYPE(m_metmaker_handle, met::METMaker);
   m_metmaker_handle.setName("METMaker");
@@ -154,6 +162,24 @@ EL::StatusCode METConstructor :: initialize ()
     ANA_MSG_ERROR( "Failed to properly initialize tau selection tool. Exiting." );
     return EL::StatusCode::FAILURE;
   }
+
+  //////////// IMETSignificance ////////////////
+  setToolName( m_metSignificance_handle );
+  ASG_SET_ANA_TOOL_TYPE( m_metSignificance_handle, met::METSignificance );
+  ANA_CHECK( m_metSignificance_handle.setProperty("TreatPUJets", m_significanceTreatPUJets) );
+  ANA_CHECK( m_metSignificance_handle.setProperty("SoftTermReso", static_cast<int>(m_significanceSoftTermReso)) ); // property is int for some reason
+  ANA_CHECK( m_metSignificance_handle.setProperty("IsData", !m_isMC) );
+  // For AFII samples
+  if ( m_isMC ) {
+    // Check simulation flavour for calibration config - cannot directly read metadata in xAOD otside of Athena!
+    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
+    if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ) {
+      ANA_MSG_INFO( "Setting simulation flavour to AFII");
+      ANA_CHECK( m_metSignificance_handle.setProperty("IsAFII", true));
+    }
+  }
+  ANA_CHECK( m_metSignificance_handle.retrieve());
+  ANA_MSG_DEBUG("Retrieved tool: " << m_metSignificance_handle);
 
   ANA_MSG_INFO( "METConstructor Interface " << m_name << " succesfully initialized!");
 
@@ -175,13 +201,6 @@ EL::StatusCode METConstructor :: initialize ()
   }
 
   m_numEvent = 0; //just as a check
-
-  // define m_isMC
-  const xAOD::EventInfo* eventInfo(nullptr);
-  ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
-
-  m_isMC = eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION );
-  ANA_MSG_DEBUG( "Is MC? " << static_cast<int>(m_isMC) );
 
   // Write output sys names
   if ( m_writeSystToMetadata ) {
@@ -489,6 +508,34 @@ EL::StatusCode METConstructor :: execute ()
 
      ANA_CHECK( m_metmaker_handle->buildMETSum("FinalClus", newMet, MissingETBase::Source::LCTopo));
      ANA_CHECK( m_metmaker_handle->buildMETSum("FinalTrk",  newMet, MissingETBase::Source::Track));
+
+     // Calculate MET significance if enabled
+     if ( m_calculateSignificance ) {
+       std::vector<std::string> totalMETNames = {"FinalTrk", "FinalClus"};
+
+       for ( const std::string &name : totalMETNames ) {
+         // Calculate MET significance
+         if ( !m_rebuildUsingTracksInJets ) {
+           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, "RefJet", "PVSoftTrk", name) );
+         } else {
+           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, "RefJetTrk", "PVSoftTrk", name) );
+         }
+
+         // Decorate MET object with results
+         const xAOD::MissingET *met = *(newMet->find(name));
+         if ( !met ) {
+           ANA_MSG_WARNING( "Cannot find MET object with name: " << name );
+         }
+
+         met->auxdecor<double>("METOverSqrtSumET") = m_metSignificance_handle->GetMETOverSqrtSumET();
+         met->auxdecor<double>("METOverSqrtHT") = m_metSignificance_handle->GetMETOverSqrtHT();
+         met->auxdecor<double>("Significance") = m_metSignificance_handle->GetSignificance();
+         met->auxdecor<double>("SigDirectional") = m_metSignificance_handle->GetSigDirectional();
+         met->auxdecor<double>("Rho") = m_metSignificance_handle->GetRho();
+         met->auxdecor<double>("VarL") = m_metSignificance_handle->GetVarL();
+         met->auxdecor<double>("VarT") = m_metSignificance_handle->GetVarT();
+       }
+     }
 
      ANA_CHECK( m_store->record(newMet, (m_outputContainer+sysListItr->name()).Data() ));
      ANA_CHECK( m_store->record(metAuxCont, (m_outputContainer+sysListItr->name() + "Aux.").Data()));

--- a/Root/MetContainer.cxx
+++ b/Root/MetContainer.cxx
@@ -17,18 +17,43 @@ MetContainer::~MetContainer()
 void MetContainer::setTree(TTree *tree)
 {
 
-
   connectBranch<float>(tree, "metFinalClus",         &m_metFinalClus     );
   connectBranch<float>(tree, "metFinalClusPx",       &m_metFinalClusPx	 );
   connectBranch<float>(tree, "metFinalClusPy",       &m_metFinalClusPy	 );
   connectBranch<float>(tree, "metFinalClusSumEt",    &m_metFinalClusSumEt);
   connectBranch<float>(tree, "metFinalClusPhi",      &m_metFinalClusPhi  );
 
+  if ( m_infoSwitch.m_sigClus ) {
+    connectBranch<float>(tree, "metFinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt );
+    connectBranch<float>(tree, "metFinalClusOverSqrtHt",     &m_metFinalClusOverSqrtHt    );
+    connectBranch<float>(tree, "metFinalClusSignificance",   &m_metFinalClusSignificance  );
+    connectBranch<float>(tree, "metFinalClusSigDirectional", &m_metFinalClusSigDirectional);
+  }
+
+  if ( m_infoSwitch.m_sigResolutionClus ) {
+    connectBranch<float>(tree, "metFinalClusRho",  &m_metFinalClusRho );
+    connectBranch<float>(tree, "metFinalClusVarL", &m_metFinalClusVarL);
+    connectBranch<float>(tree, "metFinalClusVarT", &m_metFinalClusVarT);
+  }
+
   connectBranch<float>(tree, "metFinalTrk",          &m_metFinalTrk      );
   connectBranch<float>(tree, "metFinalTrkPx",        &m_metFinalTrkPx	 );
   connectBranch<float>(tree, "metFinalTrkPy",        &m_metFinalTrkPy	 );
   connectBranch<float>(tree, "metFinalTrkSumEt",     &m_metFinalTrkSumEt );
   connectBranch<float>(tree, "metFinalTrkPhi",       &m_metFinalTrkPhi   );
+
+  if ( m_infoSwitch.m_sigTrk ) {
+    connectBranch<float>(tree, "metFinalTrkOverSqrtSumEt",  &m_metFinalTrkOverSqrtSumEt );
+    connectBranch<float>(tree, "metFinalTrkOverSqrtHt",     &m_metFinalTrkOverSqrtHt    );
+    connectBranch<float>(tree, "metFinalTrkSignificance",   &m_metFinalTrkSignificance  );
+    connectBranch<float>(tree, "metFinalTrkSigDirectional", &m_metFinalTrkSigDirectional);
+  }
+
+  if ( m_infoSwitch.m_sigResolutionTrk ) {
+    connectBranch<float>(tree, "metFinalTrkRho",  &m_metFinalTrkRho );
+    connectBranch<float>(tree, "metFinalTrkVarL", &m_metFinalTrkVarL);
+    connectBranch<float>(tree, "metFinalTrkVarT", &m_metFinalTrkVarT);
+  }
 
   if ( m_infoSwitch.m_refEle ) {
     connectBranch<float>(tree, "metEle",             &m_metEle       );
@@ -91,11 +116,37 @@ void MetContainer::setBranches(TTree *tree)
   tree->Branch("metFinalClusSumEt",    &m_metFinalClusSumEt, "metFinalClusSumEt/F");
   tree->Branch("metFinalClusPhi",      &m_metFinalClusPhi,   "metFinalClusPhi/F");
 
+  if ( m_infoSwitch.m_sigClus ) {
+    tree->Branch("metFinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt,  "metFinalClusOverSqrtSumEt/F" );
+    tree->Branch("metFinalClusOverSqrtHt",     &m_metFinalClusOverSqrtHt,     "metFinalClusOverSqrtHt/F"    );
+    tree->Branch("metFinalClusSignificance",   &m_metFinalClusSignificance,   "metFinalClusSignificance/F"  );
+    tree->Branch("metFinalClusSigDirectional", &m_metFinalClusSigDirectional, "metFinalClusSigDirectional/F");
+  }
+
+  if ( m_infoSwitch.m_sigResolutionClus ) {
+    tree->Branch("metFinalClusRho",  &m_metFinalClusRho,  "metFinalClusRho/F" );
+    tree->Branch("metFinalClusVarL", &m_metFinalClusVarL, "metFinalClusVarL/F");
+    tree->Branch("metFinalClusVarT", &m_metFinalClusVarT, "metFinalClusVarT/F");
+  }
+
   tree->Branch("metFinalTrk",          &m_metFinalTrk,       "metFinalTrk/F");
   tree->Branch("metFinalTrkPx",        &m_metFinalTrkPx,     "metFinalTrkPx/F");
   tree->Branch("metFinalTrkPy",        &m_metFinalTrkPy,     "metFinalTrkPy/F");
   tree->Branch("metFinalTrkSumEt",     &m_metFinalTrkSumEt,  "metFinalTrkSumEt/F");
   tree->Branch("metFinalTrkPhi",       &m_metFinalTrkPhi,    "metFinalTrkPhi/F");
+
+  if ( m_infoSwitch.m_sigTrk ) {
+    tree->Branch("metFinalTrkOverSqrtSumEt",  &m_metFinalTrkOverSqrtSumEt,  "metFinalTrkOverSqrtSumEt/F" );
+    tree->Branch("metFinalTrkOverSqrtHt",     &m_metFinalTrkOverSqrtHt,     "metFinalTrkOverSqrtHt/F"    );
+    tree->Branch("metFinalTrkSignificance",   &m_metFinalTrkSignificance,   "metFinalTrkSignificance/F"  );
+    tree->Branch("metFinalTrkSigDirectional", &m_metFinalTrkSigDirectional, "metFinalTrkSigDirectional/F");
+  }
+
+  if ( m_infoSwitch.m_sigResolutionTrk ) {
+    tree->Branch("metFinalTrkRho",  &m_metFinalTrkRho,  "metFinalTrkRho/F" );
+    tree->Branch("metFinalTrkVarL", &m_metFinalTrkVarL, "metFinalTrkVarL/F");
+    tree->Branch("metFinalTrkVarT", &m_metFinalTrkVarT, "metFinalTrkVarT/F");
+  }
 
   if ( m_infoSwitch.m_refEle ) {
     tree->Branch("metEle",             &m_metEle,            "metEle/F");
@@ -164,6 +215,29 @@ void MetContainer::clear()
   m_metFinalTrkSumEt  = -999;
   m_metFinalTrkPhi    = -999;
 
+  if ( m_infoSwitch.m_sigClus ) {
+    m_metFinalClusOverSqrtSumEt  = -999;
+    m_metFinalClusOverSqrtHt     = -999;
+    m_metFinalClusSignificance   = -999;
+    m_metFinalClusSigDirectional = -999;
+  }
+  if ( m_infoSwitch.m_sigTrk ) {
+    m_metFinalTrkOverSqrtSumEt  = -999;
+    m_metFinalTrkOverSqrtHt     = -999;
+    m_metFinalTrkSignificance   = -999;
+    m_metFinalTrkSigDirectional = -999;
+  }
+  if ( m_infoSwitch.m_sigResolutionClus ) {
+    m_metFinalClusRho  = -999;
+    m_metFinalClusVarL = -999;
+    m_metFinalClusVarT = -999;
+  }
+  if ( m_infoSwitch.m_sigResolutionTrk ) {
+    m_metFinalTrkRho  = -999;
+    m_metFinalTrkVarL = -999;
+    m_metFinalTrkVarT = -999;
+  }
+
   if ( m_infoSwitch.m_refEle ) {
     m_metEle = m_metEleSumEt = m_metElePhi = -999;
   }
@@ -207,6 +281,32 @@ void MetContainer::FillMET( const xAOD::MissingETContainer* met) {
   m_metFinalTrkPy     = final_trk->mpy() / m_units;
   m_metFinalTrkSumEt  = final_trk->sumet() / m_units;
   m_metFinalTrkPhi    = final_trk->phi();
+
+  if ( m_infoSwitch.m_sigClus ) {
+    m_metFinalClusOverSqrtSumEt  = final_clus->auxdecor<double>("METOverSqrtSumET");
+    m_metFinalClusOverSqrtHt     = final_clus->auxdecor<double>("METOverSqrtHT");
+    m_metFinalClusSignificance   = final_clus->auxdecor<double>("Significance");
+    m_metFinalClusSigDirectional = final_clus->auxdecor<double>("SigDirectional");
+  }
+
+  if ( m_infoSwitch.m_sigTrk ) {
+    m_metFinalTrkOverSqrtSumEt  = final_trk->auxdecor<double>("METOverSqrtSumET");
+    m_metFinalTrkOverSqrtHt     = final_trk->auxdecor<double>("METOverSqrtHT");
+    m_metFinalTrkSignificance   = final_trk->auxdecor<double>("Significance");
+    m_metFinalTrkSigDirectional = final_trk->auxdecor<double>("SigDirectional");
+  }
+
+  if ( m_infoSwitch.m_sigResolutionClus ) {
+    m_metFinalClusRho  = final_clus->auxdecor<double>("Rho");
+    m_metFinalClusVarL = final_clus->auxdecor<double>("VarL");
+    m_metFinalClusVarT = final_clus->auxdecor<double>("VarT");
+  }
+
+  if ( m_infoSwitch.m_sigResolutionTrk ) {
+    m_metFinalTrkRho  = final_trk->auxdecor<double>("Rho");
+    m_metFinalTrkVarL = final_trk->auxdecor<double>("VarL");
+    m_metFinalTrkVarT = final_trk->auxdecor<double>("VarT");
+  }
 
   if ( m_infoSwitch.m_refEle ) {
     const xAOD::MissingET* ref_ele       = *met->find("RefEle");
@@ -267,7 +367,3 @@ void MetContainer::FillMET( const xAOD::MissingETContainer* met) {
 
   return;
 }
-
-
-
-

--- a/Root/MetContainer.cxx
+++ b/Root/MetContainer.cxx
@@ -17,11 +17,13 @@ MetContainer::~MetContainer()
 void MetContainer::setTree(TTree *tree)
 {
 
-  connectBranch<float>(tree, "metFinalClus",         &m_metFinalClus     );
-  connectBranch<float>(tree, "metFinalClusPx",       &m_metFinalClusPx	 );
-  connectBranch<float>(tree, "metFinalClusPy",       &m_metFinalClusPy	 );
-  connectBranch<float>(tree, "metFinalClusSumEt",    &m_metFinalClusSumEt);
-  connectBranch<float>(tree, "metFinalClusPhi",      &m_metFinalClusPhi  );
+  if ( m_infoSwitch.m_metClus || !m_infoSwitch.m_metTrk ) {
+    connectBranch<float>(tree, "metFinalClus",         &m_metFinalClus     );
+    connectBranch<float>(tree, "metFinalClusPx",       &m_metFinalClusPx   );
+    connectBranch<float>(tree, "metFinalClusPy",       &m_metFinalClusPy   );
+    connectBranch<float>(tree, "metFinalClusSumEt",    &m_metFinalClusSumEt);
+    connectBranch<float>(tree, "metFinalClusPhi",      &m_metFinalClusPhi  );
+  }
 
   if ( m_infoSwitch.m_sigClus ) {
     connectBranch<float>(tree, "metFinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt );
@@ -36,11 +38,13 @@ void MetContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "metFinalClusVarT", &m_metFinalClusVarT);
   }
 
-  connectBranch<float>(tree, "metFinalTrk",          &m_metFinalTrk      );
-  connectBranch<float>(tree, "metFinalTrkPx",        &m_metFinalTrkPx	 );
-  connectBranch<float>(tree, "metFinalTrkPy",        &m_metFinalTrkPy	 );
-  connectBranch<float>(tree, "metFinalTrkSumEt",     &m_metFinalTrkSumEt );
-  connectBranch<float>(tree, "metFinalTrkPhi",       &m_metFinalTrkPhi   );
+  if ( m_infoSwitch.m_metTrk || !m_infoSwitch.m_metClus ) {
+    connectBranch<float>(tree, "metFinalTrk",          &m_metFinalTrk     );
+    connectBranch<float>(tree, "metFinalTrkPx",        &m_metFinalTrkPx   );
+    connectBranch<float>(tree, "metFinalTrkPy",        &m_metFinalTrkPy   );
+    connectBranch<float>(tree, "metFinalTrkSumEt",     &m_metFinalTrkSumEt);
+    connectBranch<float>(tree, "metFinalTrkPhi",       &m_metFinalTrkPhi  );
+  }
 
   if ( m_infoSwitch.m_sigTrk ) {
     connectBranch<float>(tree, "metFinalTrkOverSqrtSumEt",  &m_metFinalTrkOverSqrtSumEt );
@@ -109,12 +113,13 @@ void MetContainer::setTree(TTree *tree)
 void MetContainer::setBranches(TTree *tree)
 {
 
-
-  tree->Branch("metFinalClus",         &m_metFinalClus,      "metFinalClus/F");
-  tree->Branch("metFinalClusPx",       &m_metFinalClusPx,    "metFinalClusPx/F");
-  tree->Branch("metFinalClusPy",       &m_metFinalClusPy,    "metFinalClusPy/F");
-  tree->Branch("metFinalClusSumEt",    &m_metFinalClusSumEt, "metFinalClusSumEt/F");
-  tree->Branch("metFinalClusPhi",      &m_metFinalClusPhi,   "metFinalClusPhi/F");
+  if ( m_infoSwitch.m_metClus || !m_infoSwitch.m_metTrk ) {
+    tree->Branch("metFinalClus",         &m_metFinalClus,      "metFinalClus/F"     );
+    tree->Branch("metFinalClusPx",       &m_metFinalClusPx,    "metFinalClusPx/F"   );
+    tree->Branch("metFinalClusPy",       &m_metFinalClusPy,    "metFinalClusPy/F"   );
+    tree->Branch("metFinalClusSumEt",    &m_metFinalClusSumEt, "metFinalClusSumEt/F");
+    tree->Branch("metFinalClusPhi",      &m_metFinalClusPhi,   "metFinalClusPhi/F"  );
+  }
 
   if ( m_infoSwitch.m_sigClus ) {
     tree->Branch("metFinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt,  "metFinalClusOverSqrtSumEt/F" );
@@ -129,11 +134,13 @@ void MetContainer::setBranches(TTree *tree)
     tree->Branch("metFinalClusVarT", &m_metFinalClusVarT, "metFinalClusVarT/F");
   }
 
-  tree->Branch("metFinalTrk",          &m_metFinalTrk,       "metFinalTrk/F");
-  tree->Branch("metFinalTrkPx",        &m_metFinalTrkPx,     "metFinalTrkPx/F");
-  tree->Branch("metFinalTrkPy",        &m_metFinalTrkPy,     "metFinalTrkPy/F");
-  tree->Branch("metFinalTrkSumEt",     &m_metFinalTrkSumEt,  "metFinalTrkSumEt/F");
-  tree->Branch("metFinalTrkPhi",       &m_metFinalTrkPhi,    "metFinalTrkPhi/F");
+  if ( m_infoSwitch.m_metTrk || !m_infoSwitch.m_metClus ) {
+    tree->Branch("metFinalTrk",          &m_metFinalTrk,       "metFinalTrk/F"     );
+    tree->Branch("metFinalTrkPx",        &m_metFinalTrkPx,     "metFinalTrkPx/F"   );
+    tree->Branch("metFinalTrkPy",        &m_metFinalTrkPy,     "metFinalTrkPy/F"   );
+    tree->Branch("metFinalTrkSumEt",     &m_metFinalTrkSumEt,  "metFinalTrkSumEt/F");
+    tree->Branch("metFinalTrkPhi",       &m_metFinalTrkPhi,    "metFinalTrkPhi/F"  );
+  }
 
   if ( m_infoSwitch.m_sigTrk ) {
     tree->Branch("metFinalTrkOverSqrtSumEt",  &m_metFinalTrkOverSqrtSumEt,  "metFinalTrkOverSqrtSumEt/F" );
@@ -203,17 +210,21 @@ void MetContainer::setBranches(TTree *tree)
 
 void MetContainer::clear()
 {
-  m_metFinalClus      = -999;
-  m_metFinalClusPx    = -999;
-  m_metFinalClusPy    = -999;
-  m_metFinalClusSumEt = -999;
-  m_metFinalClusPhi   = -999;
+  if ( m_infoSwitch.m_metClus || !m_infoSwitch.m_metTrk ) {
+    m_metFinalClus      = -999;
+    m_metFinalClusPx    = -999;
+    m_metFinalClusPy    = -999;
+    m_metFinalClusSumEt = -999;
+    m_metFinalClusPhi   = -999;
+  }
 
-  m_metFinalTrk	      = -999;
-  m_metFinalTrkPx     = -999;
-  m_metFinalTrkPy     = -999;
-  m_metFinalTrkSumEt  = -999;
-  m_metFinalTrkPhi    = -999;
+  if ( m_infoSwitch.m_metTrk || !m_infoSwitch.m_metClus ) {
+    m_metFinalTrk	      = -999;
+    m_metFinalTrkPx     = -999;
+    m_metFinalTrkPy     = -999;
+    m_metFinalTrkSumEt  = -999;
+    m_metFinalTrkPhi    = -999;
+  }
 
   if ( m_infoSwitch.m_sigClus ) {
     m_metFinalClusOverSqrtSumEt  = -999;
@@ -268,44 +279,48 @@ void MetContainer::FillMET( const xAOD::MissingETContainer* met) {
 
   //if ( m_debug ) { Info("HelpTreeBase::FillMET()", "Filling MET info"); }
 
-  const xAOD::MissingET* final_clus = *met->find("FinalClus"); // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based onleares)
-  m_metFinalClus      = final_clus->met() / m_units;
-  m_metFinalClusPx    = final_clus->mpx() / m_units;
-  m_metFinalClusPy    = final_clus->mpy() / m_units;
-  m_metFinalClusSumEt = final_clus->sumet() / m_units;
-  m_metFinalClusPhi   = final_clus->phi();
-
-  const xAOD::MissingET* final_trk = *met->find("FinalTrk"); // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
-  m_metFinalTrk	      = final_trk->met() / m_units;
-  m_metFinalTrkPx     = final_trk->mpx() / m_units;
-  m_metFinalTrkPy     = final_trk->mpy() / m_units;
-  m_metFinalTrkSumEt  = final_trk->sumet() / m_units;
-  m_metFinalTrkPhi    = final_trk->phi();
-
-  if ( m_infoSwitch.m_sigClus ) {
-    m_metFinalClusOverSqrtSumEt  = final_clus->auxdecor<double>("METOverSqrtSumET");
-    m_metFinalClusOverSqrtHt     = final_clus->auxdecor<double>("METOverSqrtHT");
-    m_metFinalClusSignificance   = final_clus->auxdecor<double>("Significance");
-    m_metFinalClusSigDirectional = final_clus->auxdecor<double>("SigDirectional");
+  if ( m_infoSwitch.m_metClus || !m_infoSwitch.m_metTrk ) {
+    const xAOD::MissingET* final_clus = *met->find("FinalClus"); // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based onleares)
+    m_metFinalClus      = final_clus->met() / m_units;
+    m_metFinalClusPx    = final_clus->mpx() / m_units;
+    m_metFinalClusPy    = final_clus->mpy() / m_units;
+    m_metFinalClusSumEt = final_clus->sumet() / m_units;
+    m_metFinalClusPhi   = final_clus->phi();
+    
+    if ( m_infoSwitch.m_sigClus ) {
+      m_metFinalClusOverSqrtSumEt  = final_clus->auxdecor<double>("METOverSqrtSumET");
+      m_metFinalClusOverSqrtHt     = final_clus->auxdecor<double>("METOverSqrtHT");
+      m_metFinalClusSignificance   = final_clus->auxdecor<double>("Significance");
+      m_metFinalClusSigDirectional = final_clus->auxdecor<double>("SigDirectional");
+    }
+    
+    if ( m_infoSwitch.m_sigResolutionClus ) {
+      m_metFinalClusRho  = final_clus->auxdecor<double>("Rho");
+      m_metFinalClusVarL = final_clus->auxdecor<double>("VarL");
+      m_metFinalClusVarT = final_clus->auxdecor<double>("VarT");
+    }
   }
 
-  if ( m_infoSwitch.m_sigTrk ) {
-    m_metFinalTrkOverSqrtSumEt  = final_trk->auxdecor<double>("METOverSqrtSumET");
-    m_metFinalTrkOverSqrtHt     = final_trk->auxdecor<double>("METOverSqrtHT");
-    m_metFinalTrkSignificance   = final_trk->auxdecor<double>("Significance");
-    m_metFinalTrkSigDirectional = final_trk->auxdecor<double>("SigDirectional");
-  }
+  if ( m_infoSwitch.m_metTrk || !m_infoSwitch.m_metClus ) {
+    const xAOD::MissingET* final_trk = *met->find("FinalTrk"); // ("FinalClus" uses the calocluster-based soft terms, "FinalTrk" uses the track-based ones)
+    m_metFinalTrk       = final_trk->met() / m_units;
+    m_metFinalTrkPx     = final_trk->mpx() / m_units;
+    m_metFinalTrkPy     = final_trk->mpy() / m_units;
+    m_metFinalTrkSumEt  = final_trk->sumet() / m_units;
+    m_metFinalTrkPhi    = final_trk->phi();
 
-  if ( m_infoSwitch.m_sigResolutionClus ) {
-    m_metFinalClusRho  = final_clus->auxdecor<double>("Rho");
-    m_metFinalClusVarL = final_clus->auxdecor<double>("VarL");
-    m_metFinalClusVarT = final_clus->auxdecor<double>("VarT");
-  }
+    if ( m_infoSwitch.m_sigTrk ) {
+      m_metFinalTrkOverSqrtSumEt  = final_trk->auxdecor<double>("METOverSqrtSumET");
+      m_metFinalTrkOverSqrtHt     = final_trk->auxdecor<double>("METOverSqrtHT");
+      m_metFinalTrkSignificance   = final_trk->auxdecor<double>("Significance");
+      m_metFinalTrkSigDirectional = final_trk->auxdecor<double>("SigDirectional");
+    }
 
-  if ( m_infoSwitch.m_sigResolutionTrk ) {
-    m_metFinalTrkRho  = final_trk->auxdecor<double>("Rho");
-    m_metFinalTrkVarL = final_trk->auxdecor<double>("VarL");
-    m_metFinalTrkVarT = final_trk->auxdecor<double>("VarT");
+    if ( m_infoSwitch.m_sigResolutionTrk ) {
+      m_metFinalTrkRho  = final_trk->auxdecor<double>("Rho");
+      m_metFinalTrkVarL = final_trk->auxdecor<double>("VarL");
+      m_metFinalTrkVarT = final_trk->auxdecor<double>("VarT");
+    }
   }
 
   if ( m_infoSwitch.m_refEle ) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -586,6 +586,8 @@ namespace HelperClasses {
         ==================== ====================== =======
         Parameter            Pattern                Match
         ==================== ====================== =======
+        m_metClus            metClus                exact
+        m_metTrk             metTrk                 exact
         m_sigClus            sigClus|all            exact
         m_sigTrk             sigTrk|all             exact
         m_sigResolutionClus  sigResolutionClus|all  exact
@@ -601,12 +603,14 @@ namespace HelperClasses {
         ==================== ====================== =======
 
 
-        .. note:: For all except :cpp:member:`~HelperClasses::METInfoSwitch::m_refJetTrk`, you can pass in the string ``"all"`` to enable all information.
+        .. note:: For all except :cpp:member:`~HelperClasses::METInfoSwitch::m_refJetTrk`, you can pass in the string ``"all"`` to enable all information. You can force only calocluster- or track-based MET using :cpp:member:`~HelperClasses::METInfoSwitch::m_metClus` or :cpp:member:`~HelperClasses::METInfoSwitch::m_metTrk`.
 
     @endrst
    */
   class METInfoSwitch : public InfoSwitch {
   public:
+    bool m_metClus;
+    bool m_metTrk;
     bool m_sigClus;
     bool m_sigTrk;
     bool m_sigResolutionClus;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -583,18 +583,22 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::InfoSwitch` struct for Missing :math:`\text{E}_{\text{T}}` Information.
 
-        ================ ============== =======
-        Parameter        Pattern        Match
-        ================ ============== =======
-        m_refEle         refEle|all     exact
-        m_refGamma       refGamma|all   exact
-        m_refTau         refTau|all     exact
-        m_refMuons       refMuons|all   exact
-        m_refJet         refJet|all     exact
-        m_refJetTrk      refJetTrk      exact
-        m_softClus       softClus|all   exact
-        m_softTrk        softTrk|all    exact
-        ================ ============== =======
+        ==================== ====================== =======
+        Parameter            Pattern                Match
+        ==================== ====================== =======
+        m_sigClus            sigClus|all            exact
+        m_sigTrk             sigTrk|all             exact
+        m_sigResolutionClus  sigResolutionClus|all  exact
+        m_sigResolutionTrk   sigResolutionTrk|all   exact
+        m_refEle             refEle|all             exact
+        m_refGamma           refGamma|all           exact
+        m_refTau             refTau|all             exact
+        m_refMuons           refMuons|all           exact
+        m_refJet             refJet|all             exact
+        m_refJetTrk          refJetTrk              exact
+        m_softClus           softClus|all           exact
+        m_softTrk            softTrk|all            exact
+        ==================== ====================== =======
 
 
         .. note:: For all except :cpp:member:`~HelperClasses::METInfoSwitch::m_refJetTrk`, you can pass in the string ``"all"`` to enable all information.
@@ -603,6 +607,10 @@ namespace HelperClasses {
    */
   class METInfoSwitch : public InfoSwitch {
   public:
+    bool m_sigClus;
+    bool m_sigTrk;
+    bool m_sigResolutionClus;
+    bool m_sigResolutionTrk;
     bool m_refEle;
     bool m_refGamma;
     bool m_refTau;

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -9,7 +9,7 @@
 #include "xAODRootAccess/TStore.h"
 #include "AsgTools/AnaToolHandle.h"
 
-
+#include "METInterface/IMETSignificance.h"
 #include "PATInterfaces/SystematicRegistry.h"
 //look at https://twiki.cern.ch/twiki/bin/view/AtlasComputing/SoftwareTutorialxAODAnalysisInROOT
 
@@ -65,6 +65,16 @@ public:
     @endrst
   */
   bool    m_addSoftClusterTerms = false;
+  
+  // MET significance
+  /// @brief Force AFII flag in calculation, in case metadata is broken
+  bool m_setAFII = false;
+  /// @brief Enable MET significance calculation
+  bool m_calculateSignificance = false;
+  /// @brief Introduce "resolution" for jets with low JVT, if the analysis is sensitive to pileup jets
+  bool m_significanceTreatPUJets = true;
+  /// @brief Set soft term resolution
+  float m_significanceSoftTermReso = 10.0;
 
   // used for systematics
   /// @brief set to false if you want to run met systematics
@@ -110,8 +120,8 @@ private:
 
   // tools
   asg::AnaToolHandle<IMETMaker> m_metmaker_handle; //!
-
   asg::AnaToolHandle<IMETSystematicsTool> m_metSyst_handle; //!
+  asg::AnaToolHandle<IMETSignificance> m_metSignificance_handle; //!
 
   TauAnalysisTools::TauSelectionTool* m_tauSelTool; //!
 

--- a/xAODAnaHelpers/MetContainer.h
+++ b/xAODAnaHelpers/MetContainer.h
@@ -38,12 +38,28 @@ namespace xAH {
     float m_metFinalClusPy;
     float m_metFinalClusPhi;
     float m_metFinalClusSumEt;
+    
+    float m_metFinalClusOverSqrtSumEt;
+    float m_metFinalClusOverSqrtHt;
+    float m_metFinalClusSignificance;
+    float m_metFinalClusSigDirectional;
+    float m_metFinalClusRho;
+    float m_metFinalClusVarL;
+    float m_metFinalClusVarT;
 
     float m_metFinalTrk;
     float m_metFinalTrkPx;
     float m_metFinalTrkPy;
     float m_metFinalTrkPhi;
     float m_metFinalTrkSumEt;
+    
+    float m_metFinalTrkOverSqrtSumEt;
+    float m_metFinalTrkOverSqrtHt;
+    float m_metFinalTrkSignificance;
+    float m_metFinalTrkSigDirectional;
+    float m_metFinalTrkRho;
+    float m_metFinalTrkVarL;
+    float m_metFinalTrkVarT;
 
     float m_metEle;       float m_metEleSumEt;      float m_metElePhi;
     float m_metGamma;     float m_metGammaSumEt;    float m_metGammaPhi;


### PR DESCRIPTION
This adds optional MET significance calculation to METConstructor:
 - the outputs are grouped in 2 groups - one containing all different significances, the other resolution-related variables
 - significance can be only stored for "Clus" or "Trk" MET type
 - added ability to store only one type of MET (if `metTrk` is set, "Clus" type is disabled)

As always, I'm open to property name changes.