### PR TITLE
bump up cmake release, interface chng, +egammaPIDs header in PhCalibtr

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,5 @@
 env:
-  - ABV_RC=2.4.37 ABV_CM=21.2.3
+  - ABV_RC=2.4.37 ABV_CM=21.2.4
 
 before_script:
   - ls

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -44,6 +44,9 @@
 
 #include <PATCore/PATCoreEnums.h>
 
+// apparently needed for egammaPIDs but was included in HelperClasses too?
+#include "ElectronPhotonSelectorTools/egammaPIDdefs.h"
+
 using HelperClasses::ToolName;
 
 // this is needed to distribute the algorithm to the workers

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -257,7 +257,7 @@ if __name__ == "__main__":
 
     # at this point, we should import ROOT and do stuff
     import ROOT
-    if int(os.environ.get('ROOTCORE_RELEASE_SERIES', 0)) < 25:
+    if xAODAnaHelpers.utils.is_release20():
       xAH_logger.info("loading packages")
       ROOT.gROOT.Macro("$ROOTCOREDIR/scripts/load_packages.C")
     else:
@@ -284,7 +284,7 @@ if __name__ == "__main__":
     elif args.driver == 'condor':
       if getattr(ROOT.EL, 'CondorDriver') is None:
         raise KeyError('Cannot load the Condor driver from EventLoop. Did you not compile it?')
-      if not os.path.isfile(os.path.expandvars('$ROOTCOREBIN/../RootCore.par')):
+      if not os.path.isfile(os.path.expandvars('$ROOTCOREBIN/../RootCore.par')) and xAODAnaHelpers.utils.is_release20():
         raise IOError('I cannot find RootCore.par. Make sure you run `rc make_par` before running xAH_run.py.')
     elif args.driver == 'lsf':
       if getattr(ROOT.EL, 'LSFDriver') is None:

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -283,7 +283,7 @@ namespace xAH {
 
             @endrst
          */
-        static std::map<std::string, int> m_instanceRegistry;
+        static std::map<std::string, int> m_instanceRegistry; //!
 
         /**
             @rst

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -11,7 +11,11 @@
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
+#ifndef USE_CMAKE
 #include "PhotonEfficiencyCorrection/IAsgPhotonEfficiencyCorrectionTool.h"
+#else
+#include "EgammaAnalysisInterfaces/IAsgPhotonEfficiencyCorrectionTool.h"
+#endif
 #include "IsolationCorrections/IIsolationCorrectionTool.h"
 
 class AsgPhotonIsEMSelector;


### PR DESCRIPTION
This closes #1024 . For some reason, I need to explicitly include 

```
#include "ElectronPhotonSelectorTools/egammaPIDdefs.h"
```

to make this work now. I wonder what happened, since we have it in `HelperClasses.h`, but it's ok now. I won't look too much into this.