### PR TITLE
Store systematic variations of mcEventWeight

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -39,6 +39,7 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   m_debug = debug;
   m_tree = tree;
   m_tree->SetDirectory( file );
+  m_nominalTree = strcmp(m_tree->GetName(), "nominal") == 0;
   m_event = event;
   m_store = store;
   Info("HelpTreeBase()", "HelpTreeBase setup");
@@ -123,7 +124,7 @@ void HelpTreeBase::AddEvent( const std::string detailStr ) {
 
   if(m_debug)  Info("AddEvent()", "Adding event variables: %s", detailStr.c_str());
 
-  m_eventInfo       = new xAH::EventInfo(detailStr, m_units, m_isMC);
+  m_eventInfo       = new xAH::EventInfo(detailStr, m_units, m_isMC, m_nominalTree);
   m_eventInfo -> setBranches(m_tree);
   this->AddEventUser();
 }
@@ -287,7 +288,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
 
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
-  m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC, strcmp(m_tree->GetName(), "nominal") == 0);
+  m_muons[muonName] = new xAH::MuonContainer(muonName, detailStr, m_units, m_isMC, m_nominalTree);
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = thisMuon->m_infoSwitch;
 
@@ -437,7 +438,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr, const std::string e
 
   if(m_debug)  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
 
-  m_elecs[elecName] = new xAH::ElectronContainer(elecName, detailStr, m_units, m_isMC, strcmp(m_tree->GetName(), "nominal") == 0);
+  m_elecs[elecName] = new xAH::ElectronContainer(elecName, detailStr, m_units, m_isMC, m_nominalTree);
 
   xAH::ElectronContainer* thisElec = m_elecs[elecName];
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -113,6 +113,7 @@ namespace HelperClasses{
     m_shapeLC       = has_exact("shapeLC");
     m_truth         = has_exact("truth");
     m_caloClus      = has_exact("caloClusters");
+    m_weightsSys    = has_exact("weightsSys");
   }
 
   void TriggerInfoSwitch::initialize(){

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -13,7 +13,7 @@ namespace xAH {
   class EventInfo
   {
   public:
-    EventInfo(const std::string& detailStr="", float units = 1e3, bool mc = false);
+    EventInfo(const std::string& detailStr="", float units = 1e3, bool mc = false, bool storeSyst = true);
     ~EventInfo();
 
     void setTree    (TTree *tree);
@@ -28,6 +28,7 @@ namespace xAH {
     HelperClasses::EventInfoSwitch  m_infoSwitch;
     bool m_mc;
     bool m_debug;
+    bool m_storeSyst;
     float m_units;
 
   public:
@@ -47,6 +48,7 @@ namespace xAH {
     int      m_mcEventNumber;
     int      m_mcChannelNumber;
     float    m_mcEventWeight;
+    std::vector<float> m_mcEventWeights;
     float    m_weight_pileup;
     float    m_weight_pileup_up;
     float    m_weight_pileup_down;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -301,6 +301,7 @@ protected:
 
   bool m_debug;
   bool m_isMC;
+  bool m_nominalTree;
 
   // event
   xAH::EventInfo*      m_eventInfo;
@@ -412,4 +413,3 @@ void HelpTreeBase::setBranch(std::string prefix, std::string varName, std::vecto
 
 
 #endif
-

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -142,6 +142,7 @@ namespace HelperClasses {
         m_shapeLC        shapeLC        exact
         m_truth          truth          exact
         m_caloClus       caloClusters   exact
+        m_weightsSys     weightsSys     exact
         ================ ============== =======
 
     @endrst
@@ -155,6 +156,7 @@ namespace HelperClasses {
     bool m_shapeLC;
     bool m_truth;
     bool m_caloClus;
+    bool m_weightsSys;
     EventInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();


### PR DESCRIPTION
It can be useful to have systematic variations of mcEventWeight stored - they contain theoretical/generator uncertainties.

A summary of changes:
 - new `weightsSys` flag for `EventInfo` output
 - only stored for nominal tree (we always have to care about the output size ...)

Unfortunately it's impossible to read the actual names of the systematic variations using RootCore/AnalysisBase.