### PR TITLE
change to <release>-<hash>-<date> and add <release>-latest tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
   - docker build --build-arg ABV_CM=${ABV_CM}
                  --build-arg TRAVIS_COMMIT=${TRAVIS_COMMIT}
                  --build-arg TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
-                 -t ucatlas/xah .
-  - docker run --rm ucatlas/xah
-  - docker run --rm ucatlas/xah /bin/bash -c 'source xAODAnaHelpers_setup.sh; xAH_run.py -h'
+                 -t ucatlas/xah:${ABV_CM}-latest .
+  - docker run --rm ucatlas/xah:${ABV_CM}-latest
+  - docker run --rm ucatlas/xah:${ABV_CM}-latest /bin/bash -c 'source xAODAnaHelpers_setup.sh; xAH_run.py -h'
 # travis does not deploy on PRs, but we don't want to deploy images that could potentially break ;)
 deploy:
   provider: script

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 docker login -u $DOCKERLOGIN -p $DOCKERPW
-docker tag ucatlas/xah ucatlas/xah:$(date +%Y%M%d)-${ABV_CM}-${TRAVIS_COMMIT::6}
-docker push ucatlas/xah:$(date +%Y%M%d)-${ABV_CM}-${TRAVIS_COMMIT::6}
+docker tag  ucatlas/xah:${ABV_CM}-latest ucatlas/xah:${ABV_CM}-${TRAVIS_COMMIT::6}-$(date +%Y%M%d)
+docker push ucatlas/xah:${ABV_CM}-${TRAVIS_COMMIT::6}-$(date +%Y%M%d)
+docker push ucatlas/xah:${ABV_CM}-latest


### PR DESCRIPTION
This is a change to docker tagging to what looks nicer to read for people. Most folks who will want a docker tag will look for the release version first, then find the hash associated with it, and they can check the time if they care about the specific version of the software used.