### PR TITLE
Updates and corrections for bcid, rho, and PRW tool

### DIFF
--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -326,7 +326,11 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo,  xAOD::TEvent* even
 
   if ( m_infoSwitch.m_shapeLC && event ) {
     const xAOD::EventShape* evtShape(nullptr);
-    HelperFunctions::retrieve( evtShape, "Kt4LCTopoOriginEventShape", event, 0 );
+    #ifndef USE_CMAKE
+      HelperFunctions::retrieve( evtShape, "Kt4LCTopoEventShape", event, 0 );
+    #else
+      HelperFunctions::retrieve( evtShape, "Kt4LCTopoOriginEventShape", event, 0 );
+    #endif
     if ( !evtShape->getDensity( xAOD::EventShape::Density, m_rhoLC ) ) {
       Info("FillEvent()","Could not retrieve xAOD::EventShape::Density from xAOD::EventShape");
       m_rhoLC = -999;
@@ -335,7 +339,11 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo,  xAOD::TEvent* even
 
   if ( m_infoSwitch.m_shapeEM && event ) {
     const xAOD::EventShape* evtShape(nullptr);
-    HelperFunctions::retrieve( evtShape, "Kt4EMTopoOriginEventShape", event, 0 );
+    #ifndef USE_CMAKE
+      HelperFunctions::retrieve( evtShape, "Kt4EMTopoEventShape", event, 0 );
+    #else
+      HelperFunctions::retrieve( evtShape, "Kt4EMTopoOriginEventShape", event, 0 );
+    #endif
     if ( !evtShape->getDensity( xAOD::EventShape::Density, m_rhoEM ) ) {
       Info("FillEvent()","Could not retrieve xAOD::EventShape::Density from xAOD::EventShape");
       m_rhoEM = -999;

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -57,6 +57,7 @@ namespace xAH {
     int      m_rand_lumiblock_nr;
     int      m_bcid;
     float    m_prescale_DataWeight;
+    int      m_DistEmptyBCID;
 
     // event pileup
     int      m_npv;


### PR DESCRIPTION
Various corrections and updates.
1) Apply PRW to data, necessary for corrected average mu and data weight (see [twiki](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ExtendedPileupReweighting))
2) Add corrected average mu to data tree, remove prescale_DataWeight from pileup flag, and add bcid to MC tree
3) Add DistEmptyBCID calculation and to data tree.  This is the distance from this bcid to the previous empty bcid
4) Update Rho for R21, fix LCTopo version