### PR TITLE
Separate JES and JER systematics

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -238,11 +238,22 @@ EL::StatusCode JetCalibrator :: initialize ()
   const CP::SystematicSet recSyst = CP::SystematicSet();
   ANA_MSG_INFO(" Initializing Jet Calibrator Systematics :");
 
+  // Backwards compatibility
+  if ( !m_systName.empty() ) {
+    if ( m_systNameJES.empty() ) {
+        m_systNameJES = m_systName;
+        m_systValJES = m_systVal;
+    }
+    if ( m_systNameJER.empty() ) {
+        m_systNameJER = m_systName;
+    }
+  }
+
   //
   // Make a list of systematics to be used, based on configuration input
   // Use HelperFunctions::getListofSystematics() for this!
   //
-  m_systList = HelperFunctions::getListofSystematics( recSyst, m_systName, m_systVal, msg() );
+  m_systList = HelperFunctions::getListofSystematics( recSyst, "", 0, msg() ); // Generate nominal
   for(unsigned int i=0; i<m_systList.size(); i++)
     m_systType.insert(m_systType.begin(), 0); // Push systType nominal for this case
 
@@ -251,7 +262,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   // initialize and configure the jet uncertainity tool
   // only initialize if a config file has been given
   //------------------------------------------------
-  if ( !m_JESUncertConfig.empty() && !m_systName.empty()  && m_systName != "None" ) {
+  if ( !m_JESUncertConfig.empty() && !m_systNameJES.empty()  && m_systNameJES != "None" ) {
 
     setToolName(m_JetUncertaintiesTool_handle);
     ANA_MSG_INFO("Initialize JES UNCERT with " << m_JESUncertConfig);
@@ -269,13 +280,13 @@ EL::StatusCode JetCalibrator :: initialize ()
     //If just one systVal, then push it to the vector
     ANA_CHECK( this->parseSystValVector());
     if( m_systValVector.size() == 0) {
-      ANA_MSG_DEBUG("Pushing the following systVal to m_systValVector: " << m_systVal );
-      m_systValVector.push_back(m_systVal);
+      ANA_MSG_DEBUG("Pushing the following systVal to m_systValVector: " << m_systValJES );
+      m_systValVector.push_back(m_systValJES);
     }
 
     for(unsigned int iSyst=0; iSyst < m_systValVector.size(); ++iSyst){
       m_systVal = m_systValVector.at(iSyst);
-      std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, m_systVal, msg() );
+      std::vector<CP::SystematicSet> JESSysList = HelperFunctions::getListofSystematics( recSysts, m_systNameJES, m_systValJES, msg() );
 
       for(unsigned int i=0; i < JESSysList.size(); ++i){
         // do not add another nominal syst to the list!!
@@ -292,7 +303,7 @@ EL::StatusCode JetCalibrator :: initialize ()
       m_runSysts = true;
       // setup uncertainity tool for systematic evaluation
       if ( m_JetUncertaintiesTool_handle->applySystematicVariation(m_systList.at(0)) != CP::SystematicCode::Ok ) {
-        ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
+        ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systNameJES);
         return EL::StatusCode::FAILURE;
       }
     }
@@ -325,7 +336,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     const CP::SystematicSet recSysts = m_JERSmearingTool_handle->recommendedSystematics();
     ANA_MSG_INFO( " Initializing JER Systematics :");
 
-    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systName, 1, msg() ); //Only 1 sys allowed
+    std::vector<CP::SystematicSet> JERSysList = HelperFunctions::getListofSystematics( recSysts, m_systNameJER, 1, msg() ); //Only 1 sys allowed
     for(unsigned int i=0; i < JERSysList.size(); ++i){
       // do not add another nominal syst to the list!!
       // CP::SystematicSet() creates an empty systematic set, compared to the set at index i
@@ -370,7 +381,7 @@ EL::StatusCode JetCalibrator :: initialize ()
 
   std::vector< std::string >* SystJetsNames = new std::vector< std::string >;
   for ( const auto& syst_it : m_systList ) {
-    if ( m_systName.empty() ) {
+    if ( m_systName.empty() && m_systNameJES.empty() && m_systNameJER.empty() ) {
       ANA_MSG_INFO("\t Running w/ nominal configuration only!");
       break;
     }
@@ -483,7 +494,7 @@ EL::StatusCode JetCalibrator :: execute ()
         // JES Uncertainty Systematic
         ANA_MSG_DEBUG("Configure JES for systematic variation : " << syst_it.name());
         if ( m_JetUncertaintiesTool_handle->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
-          ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
+          ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systNameJES);
           return EL::StatusCode::FAILURE;
         }
 
@@ -506,12 +517,12 @@ EL::StatusCode JetCalibrator :: execute ()
         ANA_MSG_DEBUG("Configure JER for systematic variation : " << syst_it.name());
         if( thisSysType == 2){ //apply this systematic
           if ( m_JERSmearingTool_handle->applySystematicVariation(syst_it) != CP::SystematicCode::Ok ) {
-            ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
+            ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systNameJER);
             return EL::StatusCode::FAILURE;
           }
         }else{ //apply nominal, which is always first element of m_systList
           if ( m_JERSmearingTool_handle->applySystematicVariation(m_systList.at(0)) != CP::SystematicCode::Ok ) {
-            ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systName);
+            ANA_MSG_ERROR( "Cannot configure JetUncertaintiesTool for systematic " << m_systNameJER);
             return EL::StatusCode::FAILURE;
           }
         }

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -126,6 +126,18 @@ public:
   /// @brief jet tile correction
   bool m_doJetTileCorr = false;
 
+  /** If running systematics, the name of the systematic */
+  std::string m_systNameJES = "";
+  /** If running systematics, the value to set the systematic to
+      @rst
+          .. note:: This will set the systematic to the value :math:`\pm x`.
+      @endrst
+   */
+  float m_systValJES = 0.0;
+
+  /** If running systematics, the name of the systematic */
+  std::string m_systNameJER = "";
+
 private:
   /// @brief set to true if systematics asked for and exist
   bool m_runSysts = false; //!


### PR DESCRIPTION
Some JER systematics should also be applied on data. It would be nice to be able to only enable those. I've made a simple change that adds 3 new configuration properties to JetCalibrator:
 - `m_systNameJES`/`m_systValJES`
 - `m_systNameJER` (`m_systVal` is hardcoded for JER)

The usual `m_systVal` is still there for backwards compatibility or just to enable systematics globally.