### PR TITLE
Minor cleanup of BJetEfficiencyCorrector

### DIFF
--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -24,10 +24,12 @@ class BJetEfficiencyCorrector : public xAH::Algorithm
   // that way they can be set directly from CINT and python.
 public:
   std::string m_inContainerName = "";
+  /**
+    @brief The name of the vector containing the names of the systematically-varied jet-related containers from the upstream algorithm, which will be processed by this algorithm.
+
+    Only jet calibration systematics or any other that create shallow copies of jet containers should be passed to this tool. It is advised to run this algorithm before running algorithms combining multiple calibration systematics (e.g. overlap removal).
+  */
   std::string m_inputAlgo = "";
-  std::string m_outputAlgo = "";
-  std::string m_sysNamesForParCont = ""; 
-  // this is the name of the vector of names for the systematics to be used for the creation of a parallel container. This will be just a copy of the nominal one with the sys name appended. Use cases: MET-specific systematics.
 
   // systematics
   std::string m_systName = "";


### PR DESCRIPTION
@kkrizka already fixed most of my mistakes. Again sorry for that, that was one of my first PRs. This additionally cleans-up BJetEfficiencyCorrector:
 - Use common code with or without SYS.
 - Check the existence of input container - just in case.
 - Is `m_outputAlgo` needed? I removed it for now as this algorithm doesn't change any systematics but I can add it back.

I also added the disclaimer for `m_inputAlgo` that only jet systematics with separate trees should be used. I kept the same name for now (although I renamed it for electrons and muons to be more clear e.g. to `m_inputSystNamesElectrons`).

It would be nice if @kkrizka can review this.