### PR TITLE
Make `m_significanceSoftTermReso` a `double` instead of `float`

### DIFF
--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -74,7 +74,7 @@ public:
   /// @brief Introduce "resolution" for jets with low JVT, if the analysis is sensitive to pileup jets
   bool m_significanceTreatPUJets = true;
   /// @brief Set soft term resolution
-  float m_significanceSoftTermReso = 10.0;
+  double m_significanceSoftTermReso = 10.0;
 
   // used for systematics
   /// @brief set to false if you want to run met systematics


### PR DESCRIPTION
In `METUtilities::METSignificance` the varible `m_softTermReso` that
is assigned through xAH's `METConstructor` is a `double`. Need
consistent typing for property-setting, otherwise crash.