### PR TITLE
Custom sample configuration by pattern

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -14,6 +14,7 @@ from .utils import NameGenerator
 class Config(object):
   def __init__(self):
     self._algorithms = []
+    self._samples    = {}
     self._log        = []
 
   def setalg(self, className, options):
@@ -77,3 +78,10 @@ class Config(object):
 
     # Add the constructed algo to the list of algorithms to run
     self._algorithms.append(alg_obj)
+
+
+  def samplemetadata(self, dsid, **kwargs):
+    try:
+      self._samples[dsid].update(kwargs)
+    except KeyError:
+      self._samples[dsid] = {}

--- a/python/config.py
+++ b/python/config.py
@@ -18,6 +18,13 @@ class Config(object):
     self._log        = []
 
   def setalg(self, className, options):
+    logger.warning("Config::setalg is being renamed to Config::algorithm.")
+    import inspect
+    frame, path, lineno, source, lines, _ = inspect.stack()[1]
+    logger.warning("\tPossible call stack: {0:s}({1:d}): {2:s}".format(path, lineno, lines[0].strip()))
+    return self.algorithm(className, options)
+
+  def algorithm(self, className, options):
     # check first argument
     if isinstance(className, unicode): className = className.encode('utf-8')
     if not isinstance(className, str):
@@ -79,9 +86,10 @@ class Config(object):
     # Add the constructed algo to the list of algorithms to run
     self._algorithms.append(alg_obj)
 
-
-  def samplemetadata(self, dsid, **kwargs):
+  # set based on patterns
+  def sample(self, pattern, **kwargs):
+    pattern = str(pattern)
     try:
-      self._samples[dsid].update(kwargs)
+      self._samples[pattern].update(kwargs)
     except KeyError:
-      self._samples[dsid] = {}
+      self._samples[pattern] = kwargs

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# PYTHON_ARGCOMPLETE_OK
 # @file:    xAH_run.py
 # @purpose: run the analysis
 # @author:  Giordon Stark <gstark@cern.ch>
@@ -474,6 +474,27 @@ if __name__ == "__main__":
           configurator = v
           break
 
+    # setting sample metadata
+    for dsid, metadata in configurator._samples.iteritems():
+      found_matching_sample = False
+      xAH_logger.debug("Looking for sample that matches DSID {0}".format(dsid))
+      for sample in sh_all:
+        if dsid in sample.name():
+          found_matching_sample = True
+          xAH_logger.debug("Found matching sample {0:s}".format(sample.name()))
+          for k,t,v in ((k, type(v), v) for k,v in metadata.iteritems()):
+            if t in [float]:
+              setter = 'setDouble'
+            elif t in [int]:
+              setter = 'setInteger'
+            elif t in [bool]:
+              setter = 'setBool'
+            else:
+              setter = 'setString'
+            getattr(sample.meta(), setter)(k, v)
+            xAH_logger.info("\t - sample.meta().{0:s}({1:s}, {2})".format(setter, k, v))
+        if not found_matching_sample:
+          xAH_logger.warning("No matching sample found for DSID {0}".format(dsid))
 
     # If we wish to add an NTupleSvc, make sure an output stream (NB: must have the same name of the service itself!)
     # is created and added to the job *before* the service

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -475,13 +475,13 @@ if __name__ == "__main__":
           break
 
     # setting sample metadata
-    for dsid, metadata in configurator._samples.iteritems():
+    for pattern, metadata in configurator._samples.iteritems():
       found_matching_sample = False
-      xAH_logger.debug("Looking for sample that matches DSID {0}".format(dsid))
+      xAH_logger.debug("Looking for sample(s) that matches pattern {0}".format(pattern))
       for sample in sh_all:
-        if dsid in sample.name():
+        if pattern in sample.name():
           found_matching_sample = True
-          xAH_logger.debug("Found matching sample {0:s}".format(sample.name()))
+          xAH_logger.info("Setting sample metadata for {0:s}".format(sample.name()))
           for k,t,v in ((k, type(v), v) for k,v in metadata.iteritems()):
             if t in [float]:
               setter = 'setDouble'
@@ -494,7 +494,7 @@ if __name__ == "__main__":
             getattr(sample.meta(), setter)(k, v)
             xAH_logger.info("\t - sample.meta().{0:s}({1:s}, {2})".format(setter, k, v))
         if not found_matching_sample:
-          xAH_logger.warning("No matching sample found for DSID {0}".format(dsid))
+          xAH_logger.warning("No matching sample found for pattern {0}".format(pattern))
 
     # If we wish to add an NTupleSvc, make sure an output stream (NB: must have the same name of the service itself!)
     # is created and added to the job *before* the service


### PR DESCRIPTION
There are two features in this PR:

- `Config.setalg` is being renamed to `Config.algorithm` which looks cleaner and more intuitive
- `Config.sample` is being added to allow the user to set custom metadata on various samples based on the pattern the user specifies

The user could do something like this:

```python
from xAODAnaHelpers import Config
c = Config()

c.sample(410000, foo='bar', hello='world')
c.sample("p9495", foo='bar', hello='world', b=1, c=2.0, d=True)
```
and would set the sample metadata correctly:

```
[2017-10-18 14:14:26,411][WARNING]  No matching sample found for pattern 410000 (xAH_run.py:497)
[2017-10-18 14:14:26,412][INFO   ]  Setting sample metadata for p9495 (xAH_run.py:484)
[2017-10-18 14:14:26,414][INFO   ]  	 - sample.meta().setDouble(c, 2.0) (xAH_run.py:495)
[2017-10-18 14:14:26,414][INFO   ]  	 - sample.meta().setString(foo, bar) (xAH_run.py:495)
[2017-10-18 14:14:26,415][INFO   ]  	 - sample.meta().setInteger(b, 1) (xAH_run.py:495)
[2017-10-18 14:14:26,416][INFO   ]  	 - sample.meta().setString(hello, world) (xAH_run.py:495)
[2017-10-18 14:14:26,417][INFO   ]  	 - sample.meta().setBool(d, True) (xAH_run.py:495)
```

which should hopefully be clear enough to whomever is using the code.

This should also get documented in our docs -- where should the documentation go?