### PR TITLE
Update settings in MuonCalibrator to R21.

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -176,13 +176,13 @@ EL::StatusCode MuonCalibrator :: initialize ()
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07" ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", true ));
-        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_02_08_17" )); 
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_25_07_17" )); 
       } else if ( yr == "Data16" || yr == "Data15" ) {
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", "Data16" ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07"));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", true ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ));
-        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_02_08_17" )); 
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_25_07_17" )); 
       } else if ( !yr.empty() ) {
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release ));

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -170,20 +170,47 @@ EL::StatusCode MuonCalibrator :: initialize ()
       m_muonCalibrationAndSmearingTools[yr] = new CP::MuonCalibrationAndSmearingTool( m_muonCalibrationAndSmearingTool_names[yr]);
       m_muonCalibrationAndSmearingTools[yr]->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
 
-      if ( yr == "Data16") {
+#ifdef USE_CMAKE
+      if ( yr == "Data17" ) {
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", "Data16" ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07" ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", true ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_02_08_17" )); 
+      } else if ( yr == "Data16" || yr == "Data15" ) {
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", "Data16" ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07"));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", true ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_02_08_17" )); 
+      } else if ( !yr.empty() ) {
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ));
+      }
+#else
+      if ( yr == "Data16") {
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", "Data16" ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_15_07" ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", true ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", true ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_06_02_17" )); 
       } else if (yr == "Data15") {
-        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_08_07"));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", "Data15" ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", "Recs2016_08_07" ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", false ));
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", false ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", "sagittaBiasDataAll_06_02_17" )); 
       } else if ( !yr.empty() ) {
         ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Year", yr ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaCorr", m_do_sagittaCorr ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("doSagittaMCDistortion", m_do_sagittaMCDistortion ));
+        ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("SagittaRelease", m_sagittaRelease ));
       }
-
-      if ( !m_release.empty() ) { ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->setProperty("Release", m_release)); }
+#endif // USE_CMAKE
 
       ANA_CHECK( m_muonCalibrationAndSmearingTools[yr]->initialize());
 
@@ -258,14 +285,15 @@ EL::StatusCode MuonCalibrator :: execute ()
     runNumber = m_pileup_tool_handle->getRandomRunNumber( *eventInfo, true );
   }
 
-  if (runNumber >= 266904 && runNumber <= 284484 ) {
+  if ( 266904 <= runNumber && runNumber <= 284484 ) {
+
     randYear = "Data15";
     if( ! (std::find(m_YearsList.begin(), m_YearsList.end(), randYear) != m_YearsList.end()) ) {
       ANA_MSG_ERROR( "Random runNumber is 2015 but no corresponding MuonCalibrationAndSmearingTool tool has been initialized. Check ilumicalc config or extend m_Years!");
       return EL::StatusCode::FAILURE;
     }
 
-  } else if (runNumber >= 296939 ) {
+  } else if ( 296939 <= runNumber && runNumber <= 311481 ) {
 
     randYear = "Data16";
     if( ! (std::find(m_YearsList.begin(), m_YearsList.end(), randYear) != m_YearsList.end()) ) {
@@ -273,7 +301,16 @@ EL::StatusCode MuonCalibrator :: execute ()
      return EL::StatusCode::FAILURE;
     }
 
+  } else if ( 324320 <= runNumber ) {
+
+    randYear = "Data17";
+    if( ! (std::find(m_YearsList.begin(), m_YearsList.end(), randYear) != m_YearsList.end()) ) {
+     ANA_MSG_ERROR( "Random runNumber is 2017 but no corresponding MuonCalibrationAndSmearingTool tool has been initialized. Check ilumicalc config or extend m_Years!");
+     return EL::StatusCode::FAILURE;
+    }
+
   }
+
 
 
 


### PR DESCRIPTION
This PR should update the settings in MuonCalibrator to work with R21 samples. Follows the recommendations from here:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC16#Momentum_corrections

Before I merge, I am still confused about several things as this is my first time using the tool. Can one of the muon experts ( @ntadej , @mmilesi , @fscutti , @johnda102 , tag anyone I missed ) comment?

1. What is the correct twiki page with R21 recommendations? I followed [MCPAnalysisGuidelinesMC16](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC16) (linked to as R21 recommendations), but [MCPAnalysisGuidelinesMC15](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC15) also has a paragraph on R21 and has a later date for the SagittaRelease setting.

2. What is the definition of the xAH settings for the calibration tool (`m_release`, `m_do_sagittaCorr`, `m_do_sagittaMCDistortion`, `m_sagittaRelease`)? Currently `m_release` applies to every year and the rest only apply to Data16 configuration with Data15 configuration being hard coded. What should they set for Data17? Note: Data16 and Data17 require different settings in R21.

3. Where can I find the documentation for applying the calibration to MC. I do not see any references to requiring a random run number in the twiki pages linked above.