### PR TITLE
Algorithm::isMC now returns a boolean. If the type cannot be determin…

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -55,21 +55,19 @@ StatusCode xAH::Algorithm::parseSystValVector(){
     return StatusCode::SUCCESS;
 }
 
-int xAH::Algorithm::isMC(){
+bool xAH::Algorithm::isMC(){
   // first override if need to
   if(m_isMC == 0 || m_isMC == 1) return m_isMC;
 
   const xAOD::EventInfo* ei(nullptr);
   // couldn't retrieve it
   if(!HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store, msg()).isSuccess()){
-    ANA_MSG_DEBUG( "Could not retrieve eventInfo container: " << m_eventInfoContainerName);
-    return -1;
+    RCU_THROW_MSG( "Could not retrieve eventInfo container: " + m_eventInfoContainerName);
   }
 
   static SG::AuxElement::ConstAccessor<uint32_t> eventType("eventTypeBitmask");
   if(!eventType.isAvailable(*ei)){
-    ANA_MSG_DEBUG( "eventType is not available.");
-    return -1;
+    RCU_THROW_MSG( "eventType is not available.");
   }
 
   // reached here, return 0 or 1 since we have all we need

--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -62,12 +62,12 @@ bool xAH::Algorithm::isMC(){
   const xAOD::EventInfo* ei(nullptr);
   // couldn't retrieve it
   if(!HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store, msg()).isSuccess()){
-    RCU_THROW_MSG( "Could not retrieve eventInfo container: " + m_eventInfoContainerName);
+    RCU_THROW_MSG( "Could not retrieve eventInfo container (" + m_eventInfoContainerName+") for isMC() check.");
   }
 
   static SG::AuxElement::ConstAccessor<uint32_t> eventType("eventTypeBitmask");
   if(!eventType.isAvailable(*ei)){
-    RCU_THROW_MSG( "eventType is not available.");
+    RCU_THROW_MSG( "eventType is not available for isMC() check.");
   }
 
   // reached here, return 0 or 1 since we have all we need

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -160,7 +160,7 @@ namespace xAH {
                 Try to determine if we are running over data or MC. The :cpp:member:`xAH::Algorithm::m_isMC` can be used
 		to fix the return value. Otherwise the `EventInfo` object is queried.
 		
-		An exception is thrown if th type cannot be determined.
+		An exception is thrown if the type cannot be determined.
 
                 ============ =======
                 Return Value Meaning

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -154,22 +154,22 @@ namespace xAH {
         xAOD::TStore* m_store = nullptr; //!
 
         // will try to determine if data or if MC
-        // returns: -1=unknown (could not determine), 0=data, 1=mc
+        // returns: 0=data, 1=mc
         /**
             @rst
-                Try to determine if we are running over data or MC.
+                Try to determine if we are running over data or MC. Throws an exception if
+		it cannot determine the type.
 
                 ============ =======
                 Return Value Meaning
                 ============ =======
-                -1           Unknown
                 0            Data
                 1            MC
                 ============ =======
 
             @endrst
          */
-        int isMC();
+        bool isMC();
 
         /**
             @rst

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -157,8 +157,10 @@ namespace xAH {
         // returns: 0=data, 1=mc
         /**
             @rst
-                Try to determine if we are running over data or MC. Throws an exception if
-		it cannot determine the type.
+                Try to determine if we are running over data or MC. The :cpp:member:`xAH::Algorithm::m_isMC` can be used
+		to fix the return value. Otherwise the `EventInfo` object is queried.
+		
+		An exception is thrown if th type cannot be determined.
 
                 ============ =======
                 Return Value Meaning


### PR DESCRIPTION
isMC should be a yes/no answer. Or unknown, in which case the user should be told to provide the correct answer.

See #1072 for why this is needed.