### PR TITLE
Support for several track jet container associated to a fat jet.

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -280,7 +280,10 @@ void FatJetContainer::setTree(TTree *tree)
   for(const auto& kv : m_trkJets)
     {
       m_trkJets[kv.first]->JetContainer::setTree(tree, "MV2c10");
-      connectBranch< std::vector<unsigned int> >(tree, "trkJetsIdx_"+kv.first, &m_trkJetsIdx[kv.first]);
+      if(tree->GetBranch(branchName("trkJetsIdx").c_str()))
+	connectBranch< std::vector<unsigned int> >(tree, "trkJetsIdx", &m_trkJetsIdx[kv.first]);
+      else
+	connectBranch< std::vector<unsigned int> >(tree, "trkJetsIdx_"+kv.first, &m_trkJetsIdx[kv.first]);
     }
 }
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -220,6 +220,8 @@ namespace HelperClasses{
   }
 
   void JetInfoSwitch::initialize(){
+    std::string tmpConfigStr; // temporary config string used to extract multiple values
+
     m_substructure  = has_exact("substructure");
     m_bosonCount    = has_exact("bosonCount");
     m_VTags         = has_exact("VTags");
@@ -269,23 +271,19 @@ namespace HelperClasses{
     }
 
 
+    m_trackJetNames.clear();
     if(has_match("trackJetName")){
-      m_trackJets       = true;
       std::string input(m_configStr);
       // erase everything before the interesting string
-      input.erase( 0, input.find("trackJetName_") );
-      // erase everything after the interesting string
-      // only if there is something after the string
-      if( input.find(" ") != std::string::npos ) {
-        input.erase( input.find_first_of(" "), input.size() );
-      }
-      // remove trackJetName_ to just leave the tack name
-      input.erase(0,13);
+      input.erase( 0, input.find("trackJetName") );
+      input.erase( input.find(" "), std::string::npos );
+      input.erase( 0, 13 );
+      std::cout << "INPUT " << input << std::endl;
 
-      m_trackJetName = input;
-    }else{
-      m_trackJets            = false;
-      m_trackJetName         = "";
+      std::stringstream ss(input);
+      std::string s;
+      while(std::getline(ss, s, '_'))
+	m_trackJetNames.push_back(s);
     }
 
 
@@ -375,7 +373,7 @@ namespace HelperClasses{
     } // sfFTagHyb
 
     m_jetBTag.clear();
-    std::string tmpConfigStr(m_configStr);
+    tmpConfigStr=std::string(m_configStr);
     while( tmpConfigStr.find("jetBTag") != std::string::npos ) { // jetBTag
       // erase everything before the interesting string
       tmpConfigStr.erase( 0, tmpConfigStr.find("jetBTag") );

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -278,7 +278,6 @@ namespace HelperClasses{
       input.erase( 0, input.find("trackJetName") );
       input.erase( input.find(" "), std::string::npos );
       input.erase( 0, 13 );
-      std::cout << "INPUT " << input << std::endl;
 
       std::stringstream ss(input);
       std::string s;

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2686,7 +2686,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       float sv1_dR;         myBTag->variable<float>("SV1", "deltaR"      , sv1_dR );
 
       m_sv1_Lxy        ->push_back(sv1_Lxy        );
-      m_sv1_sig3d      ->push_back(sv1_sig3d        );
+      m_sv1_sig3d      ->push_back(sv1_sig3d      );
       m_sv1_L3d        ->push_back(sv1_L3d        );
       m_sv1_distmatlay ->push_back(sv1_distmatlay );
       m_sv1_dR         ->push_back(sv1_dR         );

--- a/xAODAnaHelpers/FatJet.h
+++ b/xAODAnaHelpers/FatJet.h
@@ -71,7 +71,7 @@ namespace xAH {
       int Wtag_tight;
       int Ztag_tight;
 
-      std::vector<xAH::Jet> trkJets;
+      std::unordered_map<std::string, std::vector<xAH::Jet>> trkJets;
       
     };
 

--- a/xAODAnaHelpers/FatJetContainer.h
+++ b/xAODAnaHelpers/FatJetContainer.h
@@ -40,7 +40,6 @@ namespace xAH {
 
       float       m_trackJetPtCut;
       float       m_trackJetEtaCut;
-      std::string m_trackJetName;
 
     protected:
 
@@ -127,8 +126,8 @@ namespace xAH {
 #endif
 
       // Assocated Track Jets
-      std::vector< std::vector<unsigned int> >* m_trkJetsIdx;
-      xAH::JetContainer*  m_trkJets;
+      std::unordered_map<std::string, xAH::JetContainer*> m_trkJets;
+      std::unordered_map<std::string, std::vector<std::vector<unsigned int>>* > m_trkJetsIdx;
 
     };
 }

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -454,6 +454,9 @@ namespace HelperClasses {
 
             will define ``std::map<std::vector<std::pair<std::string,uint>>> m_jetBTag["MV2c10"] = {std::make_pair("HybBEff",60), std::make_pair("HybBEff",70) ,std::make_pair("HybBEff",77), std::make_pair("HybBEff",85)}``.
 
+	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames`` 
+	    to ``{"GhostAntiKt2TrackJet", "GhostVR30Rmax4Rmin02TrackJet"}``.
+
     @endrst
    */
   class JetInfoSwitch : public IParticleInfoSwitch {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -484,7 +484,6 @@ namespace HelperClasses {
     bool m_svDetails;
     bool m_ipDetails;
     bool m_tracksInJet;
-    bool m_trackJets;
     bool m_hltVtxComp;
     bool m_onlineBS;
     bool m_onlineBSTool;
@@ -496,13 +495,13 @@ namespace HelperClasses {
     bool m_byAverageMu;
     bool m_area;
     bool m_JVC;
-    std::string      m_trackName;
-    std::string      m_trackJetName;
-    std::string      m_sfJVTName;
-    std::string      m_sffJVTName;
-    std::vector<int> m_sfFTagFix;
-    std::vector<int> m_sfFTagFlt;
-    std::vector<int> m_sfFTagHyb;
+    std::string              m_trackName;
+    std::vector<std::string> m_trackJetNames;
+    std::string              m_sfJVTName;
+    std::string              m_sffJVTName;
+    std::vector<int>         m_sfFTagFix;
+    std::vector<int>         m_sfFTagFlt;
+    std::vector<int>         m_sfFTagHyb;
     std::map<std::string,std::vector<std::pair<std::string,uint>>> m_jetBTag;
     JetInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~JetInfoSwitch() {}


### PR DESCRIPTION
The purpose is to have support for fixed radius and variable radius track jets in the same container.

The following user-facing changes are included in this commit.
* The ``JetInfoSwitch::trackJetName`` is now a ``std::vector<std::string>`` called ``JetInfoSwitch::trackJetNames``.
* ``JetInfoSwitch::trackJetNames`` is filled by splitting "trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet" on an underscore.
* The ``fatjet_trkJetsIdx`` branch in the ntuple is now renamed to ``fatjet_trkJetsIdx_TRKJETCOLLECTION`. Support is kept for reading existing ntuples.
* ``FatJet::trkJets`` is now a ``std::unordered_map<std::string, std::vector<xAH::Jet>>`` instead of ``std::vector<xAH::Jet>``. The key is the collection name.