### PR TITLE
Add minimum and maximum cuts on actual pileup

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -756,6 +756,22 @@ EL::StatusCode BasicEventSelection :: execute ()
       }
   }
 
+  if ( m_actualMuMin > 0 ) {
+      // apply minimum pile-up cut
+      if ( eventInfo->actualInteractionsPerCrossing() < m_actualMuMin ) { // veto event
+          wk()->skipEvent();
+          return EL::StatusCode::SUCCESS;
+      }
+  }
+
+  if ( m_actualMuMax > 0 ) {
+      // apply maximum pile-up cut
+      if ( eventInfo->actualInteractionsPerCrossing() > m_actualMuMax ) { // veto event
+          wk()->skipEvent();
+          return EL::StatusCode::SUCCESS;
+      }
+  }
+
 
   //------------------------------------------------------
   // If data, check if event passes GRL and event cleaning

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -80,6 +80,11 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Use Period Configuration or auto
     std::string m_periodConfig = "auto";
 
+    /// @brief The minimum pile-up allowed
+    int m_actualMuMin = -1; // Default to off
+    /// @brief The maximum pile-up allowed
+    int m_actualMuMax = -1; // Default to off
+
     // Unprescaling data
     bool m_savePrescaleDataWeight = false;
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -80,9 +80,9 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Use Period Configuration or auto
     std::string m_periodConfig = "auto";
 
-    /// @brief The minimum pile-up allowed
+    /// @brief The minimum threshold for <tt>EventInfo::actualInteractionsPerCrossing()</tt>
     int m_actualMuMin = -1; // Default to off
-    /// @brief The maximum pile-up allowed
+    /// @brief The maximum threshold for <tt>EventInfo::actualInteractionsPerCrossing()</tt>
     int m_actualMuMax = -1; // Default to off
 
     // Unprescaling data


### PR DESCRIPTION
The cuts on eventInfo->actualInteractionsPerCrossing() allow for
selection of specific pile-up values in a run. This is motivated by a
need case in StudyTrigTracks.