### PR TITLE
Fix bugs in ElectronEfficiencyCorrector SFs decors not being correct

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -996,11 +996,11 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
         for (auto& trig : m_infoSwitch.m_trigWPs) {
 
-          std::string TrigSF = "ElTrigEff_SF_syst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
+          std::string TrigSF = "ElTrigEff_SF_syst_" + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "");
           accTrigSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigSF ) ) );
           safeSFVecFill<float, xAOD::Electron>( elec, accTrigSF.at( trig+PID+isol ), &m_TrigEff_SF->at( trig+PID+isol ), junkSF );
 
-          std::string TrigEFF = "ElTrigMCEff_syst_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "");
+          std::string TrigEFF = "ElTrigMCEff_syst_" + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "");
           accTrigEFF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( trig+PID+isol , SG::AuxElement::Accessor< std::vector< float > >( TrigEFF ) ) );
           safeSFVecFill<float, xAOD::Electron>( elec, accTrigEFF.at( trig+PID+isol ), &m_TrigMCEff->at( trig+PID+isol ), junkSF );
 

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -126,7 +126,7 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     if ( !m_infoSwitch.m_PIDWPs.size() ) m_infoSwitch.m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
 
     // default isolation working points if no user input
-    if ( !m_infoSwitch.m_isolWPs.size() ) m_infoSwitch.m_isolWPs = {"","isolGradient","isolLoose","isolTight"};
+    if ( !m_infoSwitch.m_isolWPs.size() ) m_infoSwitch.m_isolWPs = {"","Gradient","Loose","Tight"};
 
     // default trigger working points if no user input
     if ( !m_infoSwitch.m_trigWPs.size() ) m_infoSwitch.m_trigWPs = {"SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0"};
@@ -321,15 +321,15 @@ void ElectronContainer::setTree(TTree *tree)
 
       for (auto& isol : m_infoSwitch.m_isolWPs) {
         if(!isol.empty()) {
-          tree->SetBranchStatus ( (m_name+"_IsoEff_SF_" + PID + "_" + isol).c_str() , 1);
-          tree->SetBranchAddress( (m_name+"_IsoEff_SF_" + PID + "_" + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+          tree->SetBranchStatus ( (m_name+"_IsoEff_SF_" + PID + "_isol" + isol).c_str() , 1);
+          tree->SetBranchAddress( (m_name+"_IsoEff_SF_" + PID + "_isol" + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
         }
         for (auto& trig : m_infoSwitch.m_trigWPs) {
-          tree->SetBranchStatus ( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , 1 );
-          tree->SetBranchAddress( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
+          tree->SetBranchStatus ( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , 1 );
+          tree->SetBranchAddress( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
 
-          tree->SetBranchStatus ( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , 1 );
-          tree->SetBranchAddress( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
+          tree->SetBranchStatus ( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , 1 );
+          tree->SetBranchAddress( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
         }
       }
     }
@@ -562,10 +562,10 @@ void ElectronContainer::setBranches(TTree *tree)
       tree->Branch( (m_name+"_PIDEff_SF_"  + PID).c_str() , & (*m_PIDEff_SF)[ PID ] );
       for (auto& isol : m_infoSwitch.m_isolWPs) {
         if(!isol.empty())
-          tree->Branch( (m_name+"_IsoEff_SF_"  + PID + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
+          tree->Branch( (m_name+"_IsoEff_SF_"  + PID + "_isol" + isol).c_str() , & (*m_IsoEff_SF)[ PID+isol ] );
         for (auto& trig : m_infoSwitch.m_trigWPs) {
-          tree->Branch( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
-          tree->Branch( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
+          tree->Branch( (m_name+"_TrigEff_SF_" + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , & (*m_TrigEff_SF)[ trig+PID+isol ] );
+          tree->Branch( (m_name+"_TrigMCEff_"  + trig + "_" + PID + (!isol.empty() ? "_isol" + isol : "")).c_str() , & (*m_TrigMCEff) [ trig+PID+isol ] );
         }
       }
     }
@@ -989,7 +989,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       for (auto& isol : m_infoSwitch.m_isolWPs) {
 
         if(!isol.empty()) {
-          std::string IsoSF = "ElIsoEff_SF_syst_" + PID + "_" + isol;
+          std::string IsoSF = "ElIsoEff_SF_syst_" + PID + "_isol" + isol;
           accIsoSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( PID+isol , SG::AuxElement::Accessor< std::vector< float > >( IsoSF ) ) );
           safeSFVecFill<float, xAOD::Electron>( elec, accIsoSF.at( PID+isol ), &m_IsoEff_SF->at( PID+isol ), junkSF );
         }

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -205,7 +205,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       return EL::StatusCode::FAILURE;
     }
 
-    ANA_MSG_INFO("ISOLATION wp: " << m_Iso_WP << "\n ID wp (for isolation): " << m_IsoPID_WP);
+    ANA_MSG_INFO("Working Points");
+    ANA_MSG_INFO("\tISOLATION wp: " << m_Iso_WP);
+    ANA_MSG_INFO("\tID wp (for isolation): " << m_IsoPID_WP);
 
     m_IsoEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_Iso_" + m_IsoPID_WP + "_isol" + m_Iso_WP;
 
@@ -315,7 +317,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       return EL::StatusCode::FAILURE;
     }
 
-    ANA_MSG_INFO("Trigger ISOLATION wp: " << m_WorkingPointIsoTrig << "\n Trigger ID wp: " << m_WorkingPointIDTrig);
+    ANA_MSG_INFO("Working Points");
+    ANA_MSG_INFO("\tTrigger ISOLATION wp: " << m_WorkingPointIsoTrig);
+    ANA_MSG_INFO("\tTrigger ID wp: " << m_WorkingPointIDTrig);
+    ANA_MSG_INFO("\tTrigger TRIG wp: " << m_WorkingPointTrigTrig);
 
     m_TrigEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_Trig_" + m_WorkingPointTrigTrig + "_" + m_WorkingPointIDTrig;
     if ( !m_WorkingPointIsoTrig.empty() ) {
@@ -333,6 +338,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
       ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("CorrectionFileNameList",inputFilesTrig));
       ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("ForceDataType",sim_flav));
       ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("CorrelationModel",m_correlationModel));
+      ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("OutputLevel",msg().level()));
       ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->initialize());
     }
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -134,7 +134,7 @@ namespace HelperClasses{
     m_numLeading    = 0;
     for(auto configDetail : m_configDetails)
       {
-	if( configDetail.compare(0,8,"NLeading")==0) 
+	if( configDetail.compare(0,8,"NLeading")==0)
 	  {
 	    m_numLeading = std::atoi( configDetail.substr(8, std::string::npos).c_str() );
 	    break;
@@ -154,25 +154,25 @@ namespace HelperClasses{
     m_effSF         = has_exact("effSF");
     m_energyLoss    = has_exact("energyLoss");
     m_promptlepton  = has_exact("promptlepton");
-   
-    // working points combinations for trigger corrections 
+
+    // working points combinations for trigger corrections
     std::string token;
     std::string reco_prfx = "Reco";
     std::string isol_prfx = "Iso";
     std::string trig_prfx = "HLT";
-    
+
     std::istringstream ss(m_configStr);
     while ( std::getline(ss, token, ' ') ) {
       if ( token.compare( 0, reco_prfx.length(), reco_prfx ) == 0 ) { m_recoWPs.push_back(token); }
       if ( token.compare( 0, isol_prfx.length(), isol_prfx ) == 0 ) { m_isolWPs.push_back(token); }
       if ( token.compare( 0, trig_prfx.length(), trig_prfx ) == 0 ) { m_trigWPs.push_back(token); }
-    }  
-    
+    }
+
     m_recoEff_sysNames = has_exact("recoEff_sysNames");
     m_isoEff_sysNames  = has_exact("isoEff_sysNames");
-    m_trigEff_sysNames = has_exact("trigEff_sysNames"); 
-    m_ttvaEff_sysNames = has_exact("ttvaEff_sysNames"); 
-    
+    m_trigEff_sysNames = has_exact("trigEff_sysNames");
+    m_ttvaEff_sysNames = has_exact("ttvaEff_sysNames");
+
   }
 
   void ElectronInfoSwitch::initialize(){
@@ -187,28 +187,26 @@ namespace HelperClasses{
     m_promptlepton  = has_exact("promptlepton");
     // working points for scale-factors
 
-    // working points combinations for trigger corrections 
+    // working points combinations for trigger corrections
     std::string token;
-    std::string PID_keyword = "LLH";
-    std::string isol_keyword = "isol";
-    std::string trig_keyword1 = "DI_E_";
-    std::string trig_keyword2 = "MULTI_L_";
-    std::string trig_keyword3 = "SINGLE_E_";
-    std::string trig_keyword4 = "TRI_E_";
-    
+    std::string pid_keyword = "PID_";
+    std::string isol_keyword = "ISOL_";
+    std::string trig_keyword = "TRIG_";
+
     std::istringstream ss(m_configStr);
     while ( std::getline(ss, token, ' ') ) {
-     if ( token.find(PID_keyword ) != std::string::npos ) { m_PIDWPs.push_back(token); }
-     if ( token.find("isolNoRequirement") != std::string::npos ) { m_isolWPs.push_back(""); }
-     if ( (token.compare( 0, isol_keyword.length(), isol_keyword ) == 0) && 
-           token!="isolation" && 
-           token!="isolNoRequirement" ) { m_isolWPs.push_back(token); }
-     if ( (token.find(trig_keyword1 ) != std::string::npos) ||
-          (token.find(trig_keyword2 ) != std::string::npos) ||
-          (token.find(trig_keyword3 ) != std::string::npos) ||
-          (token.find(trig_keyword4 ) != std::string::npos)  ) { m_trigWPs.push_back(token); }
-   } 
-
+      auto pid_substr = token.find(pid_keyword);
+      auto isol_substr = token.find(isol_keyword);
+      auto trig_substr = token.find(trig_keyword);
+      if( pid_substr != std::string::npos ){
+        m_PIDWPs.push_back(token.substr(4));
+      } else if(isol_substr != std::string::npos){
+        if(token.substr(5) == "NONE" || token == isol_keyword) m_isolWPs.push_back("");
+        else if(token != "isolation") m_isolWPs.push_back(token.substr(5));
+      } else if(trig_substr != std::string::npos){
+        m_trigWPs.push_back(token.substr(5));
+      }
+    }
   }
 
   void PhotonInfoSwitch::initialize(){
@@ -286,11 +284,11 @@ namespace HelperClasses{
     }
 
 
-    m_hltVtxComp          = has_exact("hltVtxComp");    
-    m_onlineBS            = has_exact("onlineBS");    
+    m_hltVtxComp          = has_exact("hltVtxComp");
+    m_onlineBS            = has_exact("onlineBS");
     m_onlineBSTool        = has_exact("onlineBSTool");
 
-    
+
     m_charge              = has_exact("charge");
     m_etaPhiMap           = has_exact("etaPhiMap");
     m_byAverageMu         = has_exact("byAverageMu");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -202,7 +202,7 @@ namespace HelperClasses{
         m_PIDWPs.push_back(token.substr(4));
       } else if(isol_substr != std::string::npos){
         if(token.substr(5) == "NONE" || token == isol_keyword) m_isolWPs.push_back("");
-        else if(token != "isolation") m_isolWPs.push_back(token.substr(5));
+        else m_isolWPs.push_back(token.substr(5));
       } else if(trig_substr != std::string::npos){
         m_trigWPs.push_back(token.substr(5));
       }

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -310,7 +310,7 @@ namespace HelperClasses {
         m_effSF               effSF               exact
         m_PIDWPs[XYZ]         PID_XYZ             pattern
         m_isolWPs[""]         ISOL                exact
-        m_isolWPs[""]         ISOLNONE            exact
+        m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern
         ===================== =================== =======

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -309,7 +309,7 @@ namespace HelperClasses {
         m_trackhitcont        trackhitcont        exact
         m_effSF               effSF               exact
         m_PIDWPs[XYZ]         PID_XYZ             pattern
-        m_isolWPs[""]         ISOL                exact
+        m_isolWPs[""]         ISOL_               exact
         m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -297,44 +297,23 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::IParticleInfoSwitch` class for Electron Information.
 
-        =============================================================================================================================================================== =============================================================================================================================================== =======
-        Parameter                                                                                                                                                       Pattern                                                                                                                                         Match
-        =============================================================================================================================================================== =============================================================================================================================================== =======
-        m_trigger                                                                                                                                                       trigger                                                                                                                                         exact
-        m_isolation                                                                                                                                                     isolation                                                                                                                                       exact
-        m_isolationKinematics                                                                                                                                           isolationKinematics                                                                                                                             exact
-        m_quality                                                                                                                                                       quality                                                                                                                                         exact
-        m_PID                                                                                                                                                           PID                                                                                                                                             exact
-        m_trackparams                                                                                                                                                   trackparams                                                                                                                                     exact
-        m_trackhitcont                                                                                                                                                  trackhitcont                                                                                                                                    exact
-        m_effSF                                                                                                                                                         effSF                                                                                                                                           exact
-        m_PIDWPs["LooseAndBLayerLLH"]                                                                                                                                   LooseAndBLayerLLH                                                                                                                               exact
-        m_PIDWPs["MediumLLH"]                                                                                                                                           MediumLLH                                                                                                                                       exact
-        m_PIDWPs["TightLLH"]                                                                                                                                            TightLLH                                                                                                                                        exact
-        m_isolWPs["isolFixedCutLoose"]                                                                                                                                  isolFixedCutLoose                                                                                                                               exact
-        m_isolWPs["isolFixedCutTight"]                                                                                                                                  isolFixedCutTight                                                                                                                               exact
-        m_isolWPs["isolFixedCutTightTrackOnly"]                                                                                                                         isolFixedCutTightTrackOnly                                                                                                                      exact
-        m_isolWPs["isolGradient"]                                                                                                                                       isolGradient                                                                                                                                    exact
-        m_isolWPs["isolGradientLoose"]                                                                                                                                  isolGradientLoose                                                                                                                               exact
-        m_isolWPs["isolLoose"]                                                                                                                                          isolLoose                                                                                                                                       exact
-        m_isolWPs["isolLooseTrackOnly"]                                                                                                                                 isolLooseTrackOnly                                                                                                                              exact
-        m_isolWPs["isolTight"]                                                                                                                                          isolTight                                                                                                                                       exact
-        m_isolWPs[""]                                                                                                                                                   isolNoRequirement                                                                                                                               exact
-        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH]                                                                                       DI_E_2015_e12_lhloose_L1EM10VH_2016_e15_lhvloose_nod0_L1EM13VH                                                                                  exact
-        m_trigWPs[DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0]                                                                                                DI_E_2015_e12_lhloose_L1EM10VH_2016_e17_lhvloose_nod0                                                                                           exact
-        m_trigWPs[DI_E_2015_e17_lhloose_2016_e17_lhloose]                                                                                                               DI_E_2015_e17_lhloose_2016_e17_lhloose                                                                                                          exact
-        m_trigWPs[MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0]                                                                                                       MULTI_L_2015_e7_lhmedium_2016_e7_lhmedium_nod0                                                                                                  exact
-        m_trigWPs[MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0]                                                                                                       MULTI_L_2015_e12_lhloose_2016_e12_lhloose_nod0                                                                                                  exact
-        m_trigWPs[MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0]                                                                                                       MULTI_L_2015_e17_lhloose_2016_e17_lhloose_nod0                                                                                                  exact
-        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI]                                                                                 MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e24_lhmedium_nod0_L1EM20VHI                                                                            exact
-        m_trigWPs[MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI]                                                                                 MULTI_L_2015_e24_lhmedium_L1EM20VHI_2016_e26_lhmedium_nod0_L1EM22VHI                                                                            exact
-        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0]        SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e24_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
-        m_trigWPs[SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0]        SINGLE_E_2015_e24_lhmedium_L1EM20VH_OR_e60_lhmedium_OR_e120_lhloose_2016_e26_lhtight_nod0_ivarloose_OR_e60_lhmedium_nod0_OR_e140_lhloose_nod0   exact
-        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0]                                                                                                           TRI_E_2015_e9_lhloose_2016_e9_lhloose_nod0                                                                                                      exact
-        m_trigWPs[TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0]                                                                                                          TRI_E_2015_e9_lhloose_2016_e9_lhmedium_nod0                                                                                                     exact
-        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0]                                                                                                         TRI_E_2015_e17_lhloose_2016_e17_lhloose_nod0                                                                                                    exact
-        m_trigWPs[TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0]                                                                                                        TRI_E_2015_e17_lhloose_2016_e17_lhmedium_nod0                                                                                                   exact
-        =============================================================================================================================================================== =============================================================================================================================================== =======
+        ===================== =================== =======
+        Parameter             Pattern             Match
+        ===================== =================== =======
+        m_trigger             trigger             exact
+        m_isolation           isolation           exact
+        m_isolationKinematics isolationKinematics exact
+        m_quality             quality             exact
+        m_PID                 PID                 exact
+        m_trackparams         trackparams         exact
+        m_trackhitcont        trackhitcont        exact
+        m_effSF               effSF               exact
+        m_PIDWPs[XYZ]         PID_XYZ             pattern
+        m_isolWPs[""]         ISOL                exact
+        m_isolWPs[""]         ISOLNONE            exact
+        m_isolWPs[XYZ]        ISOL_XYZ            pattern
+        m_trigWPs[XYZ]        TRIG_XYZ            pattern
+        ===================== =================== =======
 
     @endrst
    */
@@ -454,7 +433,7 @@ namespace HelperClasses {
 
             will define ``std::map<std::vector<std::pair<std::string,uint>>> m_jetBTag["MV2c10"] = {std::make_pair("HybBEff",60), std::make_pair("HybBEff",70) ,std::make_pair("HybBEff",77), std::make_pair("HybBEff",85)}``.
 
-	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames`` 
+	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames``
 	    to ``{"GhostAntiKt2TrackJet", "GhostVR30Rmax4Rmin02TrackJet"}``.
 
     @endrst

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -65,7 +65,7 @@ namespace HelperFunctions {
 
     Source: http://stackoverflow.com/questions/18972258/index-of-nth-occurrence-of-the-string
   */
-  std::size_t string_pos( const std::string& inputstr, const char& occurence, int n_occurencies );
+  std::size_t string_pos( const std::string& haystack, const std::string& needle, unsigned int N );
 
   /**
     Function which returns the WP for ISO/ID from a config file.


### PR DESCRIPTION
This does a few things:

- fix `string_pos` because as the name implies, it's a p.o.s. (well, not really, but it had a logic bug that I just decided to rewrite the function entirely)
- fix `parse_wp` and update it to work correctly with the new `string_pos` but also use the dirname + basename of the config files given to it from `ElectronEfficiencyCorrector`
- fix `ElectronInfoSwitch` to parse things more correctly. Now, it uses `PID_XYZ`, `ISOL_XYZ`, and `TRIG_XYZ` to handle as a pattern to append to a list.

More specifically, I updated the table to look like this now for the `ElectronInfoSwitch` and this seems to make the most sense to me.

```
        ===================== =================== =======
        Parameter             Pattern             Match
        ===================== =================== =======
        m_PIDWPs[XYZ]         PID_XYZ             pattern
        m_isolWPs[""]         ISOL_               exact
        m_isolWPs[""]         ISOL_NONE           exact
        m_isolWPs[XYZ]        ISOL_XYZ            pattern
        m_trigWPs[XYZ]        TRIG_XYZ            pattern
        ===================== =================== =======
```

and the scale factors are written out by the TreeAlgo now correctly... Here's an example configuration:

```python
# RecoKey="", IdKey="Medium", IsoKey="", TriggerKey="2016_e24_lhmedium_nod0_L1EM15VH".
# see https://gitlab.cern.ch/akraszna/AnalysisAlgorithmExample/blob/master/ZAnalysis/python/ElectronEfficiencyAlg.py
el_eff_path = "ElectronEfficiencyCorrection/2015_2016/rel20.7/Moriond_February2017_v1/"
el_eff_trigger = "e24_lhmedium_nod0_L1EM15VH"
el_eff_id = "MediumLLH"
c.algorithm("ElectronEfficiencyCorrector", {
  "m_inContainerName": el_sel,
  "m_corrFileNamePID"       : el_eff_path+"offline/efficiencySF.offline."+el_eff_id+"_d0z0_v11.root",
  "m_corrFileNameTrig"      : el_eff_path+"trigger/efficiencySF."+el_eff_trigger+"."+el_eff_id+"_d0z0_v11.2016.root",
  "m_corrFileNameTrigMCEff" : el_eff_path+"trigger/efficiency."+el_eff_trigger+"."+el_eff_id+"_d0z0_v11.2016.root",
  "m_setAFII": False,
  "m_correlationModel": "SIMPLIFIED"
})

c.algorithm("TreeAlgo", {
  "m_name": "postsel",
  "m_evtContainerName": "EventInfo",
  "m_evtDetailStr": "",
  "m_elContainerName": el_sel,
  "m_elDetailStr": "kinematic effSF PID_MediumLLH ISOL_NONE TRIG_e24_lhmedium_nod0_L1EM15VH",
})
```