### PR TITLE
Save DetectorEta and Light options for clean and energy

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -225,7 +225,9 @@ namespace HelperClasses{
     m_VTags         = has_exact("VTags");
     m_rapidity      = has_exact("rapidity");
     m_clean         = has_exact("clean");
+    m_cleanLight    = has_exact("cleanLight");
     m_energy        = has_exact("energy");
+    m_energyLight   = has_exact("energyLight");
     m_scales        = has_exact("scales");
     m_constscaleEta = has_exact("constscaleEta");
     m_detectorEta   = has_exact("detectorEta");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -228,6 +228,7 @@ namespace HelperClasses{
     m_energy        = has_exact("energy");
     m_scales        = has_exact("scales");
     m_constscaleEta = has_exact("constscaleEta");
+    m_detectorEta   = has_exact("detectorEta");
     m_resolution    = has_exact("resolution");
     m_truth         = has_exact("truth");
     m_truthDetails  = has_exact("truth_details");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -16,36 +16,40 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
   }
 
   // clean
-  if(m_infoSwitch.m_clean) {
-    m_Timing                    =new std::vector<float>();
-    m_LArQuality                =new std::vector<float>();
-    m_HECQuality                =new std::vector<float>();
-    m_NegativeE                 =new std::vector<float>();
-    m_AverageLArQF              =new std::vector<float>();
-    m_BchCorrCell               =new std::vector<float>();
-    m_N90Constituents           =new std::vector<float>();
-    m_LArBadHVEnergyFrac        =new std::vector<float>();
-    m_LArBadHVNCell             =new std::vector<int>();
-    m_OotFracClusters5          =new std::vector<float>();
-    m_OotFracClusters10         =new std::vector<float>();
-    m_LeadingClusterPt          =new std::vector<float>();
-    m_LeadingClusterSecondLambda=new std::vector<float>();
-    m_LeadingClusterCenterLambda=new std::vector<float>();
-    m_LeadingClusterSecondR     =new std::vector<float>();
+  if(m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight) {
+    if(m_infoSwitch.m_clean){
+      m_Timing                    =new std::vector<float>();
+      m_LArQuality                =new std::vector<float>();
+      m_HECQuality                =new std::vector<float>();
+      m_NegativeE                 =new std::vector<float>();
+      m_AverageLArQF              =new std::vector<float>();
+      m_BchCorrCell               =new std::vector<float>();
+      m_N90Constituents           =new std::vector<float>();
+      m_LArBadHVEnergyFrac        =new std::vector<float>();
+      m_LArBadHVNCell             =new std::vector<int>();
+      m_OotFracClusters5          =new std::vector<float>();
+      m_OotFracClusters10         =new std::vector<float>();
+      m_LeadingClusterPt          =new std::vector<float>();
+      m_LeadingClusterSecondLambda=new std::vector<float>();
+      m_LeadingClusterCenterLambda=new std::vector<float>();
+      m_LeadingClusterSecondR     =new std::vector<float>();
+      m_clean_passLooseBadUgly    =new std::vector<int>();
+      m_clean_passTightBadUgly    =new std::vector<int>();
+    }
     m_clean_passLooseBad        =new std::vector<int>();
-    m_clean_passLooseBadUgly    =new std::vector<int>();
     m_clean_passTightBad        =new std::vector<int>();
-    m_clean_passTightBadUgly    =new std::vector<int>();
   }
 
   // energy
-  if ( m_infoSwitch.m_energy ) {
-    m_HECFrac               = new std::vector<float>();
+  if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
+    if ( m_infoSwitch.m_energy )  {
+      m_HECFrac               = new std::vector<float>();
+      m_CentroidR             = new std::vector<float>();
+      m_LowEtConstituentsFrac = new std::vector<float>();
+    }
     m_EMFrac                = new std::vector<float>();
-    m_CentroidR             = new std::vector<float>();
     m_FracSamplingMax       = new std::vector<float>();
     m_FracSamplingMaxIndex  = new std::vector<float>();
-    m_LowEtConstituentsFrac = new std::vector<float>();
     m_GhostMuonSegmentCount = new std::vector<float>();
     m_Width                 = new std::vector<float>();
   }
@@ -404,36 +408,40 @@ JetContainer::~JetContainer()
   }
 
   // clean
-  if(m_infoSwitch.m_clean) {
-    delete m_Timing;
-    delete m_LArQuality;
-    delete m_HECQuality;
-    delete m_NegativeE;
-    delete m_AverageLArQF;
-    delete m_BchCorrCell;
-    delete m_N90Constituents;
-    delete m_LArBadHVEnergyFrac;
-    delete m_LArBadHVNCell;
-    delete m_OotFracClusters5;
-    delete m_OotFracClusters10;
-    delete m_LeadingClusterPt;
-    delete m_LeadingClusterSecondLambda;
-    delete m_LeadingClusterCenterLambda;
-    delete m_LeadingClusterSecondR;
+  if(m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight) {
+    if(m_infoSwitch.m_clean){
+      delete m_Timing;
+      delete m_LArQuality;
+      delete m_HECQuality;
+      delete m_NegativeE;
+      delete m_AverageLArQF;
+      delete m_BchCorrCell;
+      delete m_N90Constituents;
+      delete m_LArBadHVEnergyFrac;
+      delete m_LArBadHVNCell;
+      delete m_OotFracClusters5;
+      delete m_OotFracClusters10;
+      delete m_LeadingClusterPt;
+      delete m_LeadingClusterSecondLambda;
+      delete m_LeadingClusterCenterLambda;
+      delete m_LeadingClusterSecondR;
+      delete m_clean_passLooseBadUgly;
+      delete m_clean_passTightBadUgly;
+    }
     delete m_clean_passLooseBad;
-    delete m_clean_passLooseBadUgly;
     delete m_clean_passTightBad;
-    delete m_clean_passTightBadUgly;
   }
 
   // energy
-  if ( m_infoSwitch.m_energy ) {
-    delete m_HECFrac;
+  if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
+    if ( m_infoSwitch.m_energy ){
+      delete m_HECFrac;
+      delete m_CentroidR;
+      delete m_LowEtConstituentsFrac;
+    }
     delete m_EMFrac;
-    delete m_CentroidR;
     delete m_FracSamplingMax;
     delete m_FracSamplingMaxIndex;
-    delete m_LowEtConstituentsFrac;
     delete m_GhostMuonSegmentCount;
     delete m_Width;
   }
@@ -763,41 +771,42 @@ void JetContainer::setTree(TTree *tree, const std::string& tagger)
       connectBranch<float>(tree,"rapidity",                      &m_rapidity);
     }
 
-  if(m_infoSwitch.m_clean)
+  if(m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight)
     {
-      connectBranch<float>(tree,"Timing",                      &m_Timing);
-      connectBranch<float>(tree,"LArQuality",                  &m_LArQuality);
-
-
-      connectBranch<int>  (tree, "LArBadHVNCell",              &m_LArBadHVNCell);
-
-      connectBranch<float>(tree, "LArQuality",                 &m_LArQuality);
-      connectBranch<float>(tree, "HECQuality",                 &m_HECQuality);
-      connectBranch<float>(tree, "NegativeE",                  &m_NegativeE);
-      connectBranch<float>(tree, "AverageLArQF",               &m_AverageLArQF);
-      connectBranch<float>(tree, "BchCorrCell",                &m_BchCorrCell);
-      connectBranch<float>(tree, "N90Constituents",            &m_N90Constituents);
-      connectBranch<float>(tree, "LArBadHVEnergyFrac",         &m_LArBadHVEnergyFrac);
-      connectBranch<float>(tree, "OotFracClusters5",           &m_OotFracClusters5);
-      connectBranch<float>(tree, "OotFracClusters10",          &m_OotFracClusters10);
-      connectBranch<float>(tree, "LeadingClusterPt",           &m_LeadingClusterPt);
-      connectBranch<float>(tree, "LeadingClusterSecondLambda", &m_LeadingClusterSecondLambda);
-      connectBranch<float>(tree, "LeadingClusterCenterLambda", &m_LeadingClusterCenterLambda);
-      connectBranch<float>(tree, "LeadingClusterSecondR",      &m_LeadingClusterSecondR);
+      if(m_infoSwitch.m_clean){
+        connectBranch<float>(tree, "Timing",                     &m_Timing);
+        connectBranch<float>(tree, "LArQuality",                 &m_LArQuality);
+        connectBranch<int>  (tree, "LArBadHVNCell",              &m_LArBadHVNCell);
+        connectBranch<float>(tree, "LArQuality",                 &m_LArQuality);
+        connectBranch<float>(tree, "HECQuality",                 &m_HECQuality);
+        connectBranch<float>(tree, "NegativeE",                  &m_NegativeE);
+        connectBranch<float>(tree, "AverageLArQF",               &m_AverageLArQF);
+        connectBranch<float>(tree, "BchCorrCell",                &m_BchCorrCell);
+        connectBranch<float>(tree, "N90Constituents",            &m_N90Constituents);
+        connectBranch<float>(tree, "LArBadHVEnergyFrac",         &m_LArBadHVEnergyFrac);
+        connectBranch<float>(tree, "OotFracClusters5",           &m_OotFracClusters5);
+        connectBranch<float>(tree, "OotFracClusters10",          &m_OotFracClusters10);
+        connectBranch<float>(tree, "LeadingClusterPt",           &m_LeadingClusterPt);
+        connectBranch<float>(tree, "LeadingClusterSecondLambda", &m_LeadingClusterSecondLambda);
+        connectBranch<float>(tree, "LeadingClusterCenterLambda", &m_LeadingClusterCenterLambda);
+        connectBranch<float>(tree, "LeadingClusterSecondR",      &m_LeadingClusterSecondR);
+        connectBranch<int>  (tree, "clean_passLooseBadUgly",     &m_clean_passLooseBadUgly);
+        connectBranch<int>  (tree, "clean_passTightBadUgly",     &m_clean_passTightBadUgly);
+      }
       connectBranch<int>  (tree, "clean_passLooseBad",         &m_clean_passLooseBad);
-      connectBranch<int>  (tree, "clean_passLooseBadUgly",     &m_clean_passLooseBadUgly);
       connectBranch<int>  (tree, "clean_passTightBad",         &m_clean_passTightBad);
-      connectBranch<int>  (tree, "clean_passTightBadUgly",     &m_clean_passTightBadUgly);
     }
 
-  if(m_infoSwitch.m_energy)
+  if(m_infoSwitch.m_energy || m_infoSwitch.m_energyLight )
     {
-      connectBranch<float>(tree, "HECFrac",               &m_HECFrac);
+      if ( m_infoSwitch.m_energy ){
+        connectBranch<float>(tree, "HECFrac",               &m_HECFrac);
+        connectBranch<float>(tree, "CentroidR",             &m_CentroidR);
+        connectBranch<float>(tree, "LowEtConstituentsFrac", &m_LowEtConstituentsFrac);
+      }
       connectBranch<float>(tree, "EMFrac",                &m_EMFrac);
-      connectBranch<float>(tree, "CentroidR",             &m_CentroidR);
       connectBranch<float>(tree, "FracSamplingMax",       &m_FracSamplingMax);
       connectBranch<float>(tree, "FracSamplingMaxIndex",  &m_FracSamplingMaxIndex);
-      connectBranch<float>(tree, "LowEtConstituentsFrac", &m_LowEtConstituentsFrac);
       connectBranch<float>(tree, "GhostMuonSegmentCount", &m_GhostMuonSegmentCount);
       connectBranch<float>(tree, "Width",                 &m_Width);
     }
@@ -972,39 +981,43 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
       jet.rapidity                    =m_rapidity                    ->at(idx);
     }
 
-  if(m_infoSwitch.m_clean)
+  if(m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight)
     {
       if(m_debug) std::cout << "updating clean " << std::endl;
-      jet.Timing                    =m_Timing                    ->at(idx);
-      jet.LArQuality                =m_LArQuality                ->at(idx);
-      jet.HECQuality                =m_HECQuality                ->at(idx);
-      jet.NegativeE                 =m_NegativeE                 ->at(idx);
-      jet.AverageLArQF              =m_AverageLArQF              ->at(idx);
-      jet.BchCorrCell               =m_BchCorrCell               ->at(idx);
-      jet.N90Constituents           =m_N90Constituents           ->at(idx);
-      jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac       ->at(idx);
-      jet.LArBadHVNCell             =m_LArBadHVNCell             ->at(idx);
-      jet.OotFracClusters5          =m_OotFracClusters5          ->at(idx);
-      jet.OotFracClusters10         =m_OotFracClusters10         ->at(idx);
-      jet.LeadingClusterPt          =m_LeadingClusterPt          ->at(idx);
-      jet.LeadingClusterSecondLambda=m_LeadingClusterSecondLambda->at(idx);
-      jet.LeadingClusterCenterLambda=m_LeadingClusterCenterLambda->at(idx);
-      jet.LeadingClusterSecondR     =m_LeadingClusterSecondR     ->at(idx);
+      if(m_infoSwitch.m_clean){
+        jet.Timing                    =m_Timing                    ->at(idx);
+        jet.LArQuality                =m_LArQuality                ->at(idx);
+        jet.HECQuality                =m_HECQuality                ->at(idx);
+        jet.NegativeE                 =m_NegativeE                 ->at(idx);
+        jet.AverageLArQF              =m_AverageLArQF              ->at(idx);
+        jet.BchCorrCell               =m_BchCorrCell               ->at(idx);
+        jet.N90Constituents           =m_N90Constituents           ->at(idx);
+        jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac       ->at(idx);
+        jet.LArBadHVNCell             =m_LArBadHVNCell             ->at(idx);
+        jet.OotFracClusters5          =m_OotFracClusters5          ->at(idx);
+        jet.OotFracClusters10         =m_OotFracClusters10         ->at(idx);
+        jet.LeadingClusterPt          =m_LeadingClusterPt          ->at(idx);
+        jet.LeadingClusterSecondLambda=m_LeadingClusterSecondLambda->at(idx);
+        jet.LeadingClusterCenterLambda=m_LeadingClusterCenterLambda->at(idx);
+        jet.LeadingClusterSecondR     =m_LeadingClusterSecondR     ->at(idx);
+        jet.clean_passLooseBadUgly    =m_clean_passLooseBadUgly    ->at(idx);
+        jet.clean_passTightBadUgly    =m_clean_passTightBadUgly    ->at(idx);
+      }
       jet.clean_passLooseBad        =m_clean_passLooseBad        ->at(idx);
-      jet.clean_passLooseBadUgly    =m_clean_passLooseBadUgly    ->at(idx);
       jet.clean_passTightBad        =m_clean_passTightBad        ->at(idx);
-      jet.clean_passTightBadUgly    =m_clean_passTightBadUgly    ->at(idx);
     }
 
-  if(m_infoSwitch.m_energy)
+  if(m_infoSwitch.m_energy || m_infoSwitch.m_energyLight)
     {
       if(m_debug) std::cout << "updating energy " << std::endl;
-      jet.HECFrac              =m_HECFrac              ->at(idx);
+      if ( m_infoSwitch.m_energy ){
+        jet.HECFrac              =m_HECFrac              ->at(idx);
+        jet.CentroidR            =m_CentroidR            ->at(idx);
+        jet.LowEtConstituentsFrac=m_LowEtConstituentsFrac->at(idx);
+      }
       jet.EMFrac               =m_EMFrac               ->at(idx);
-      jet.CentroidR            =m_CentroidR            ->at(idx);
       jet.FracSamplingMax      =m_FracSamplingMax      ->at(idx);
       jet.FracSamplingMaxIndex =m_FracSamplingMaxIndex ->at(idx);
-      jet.LowEtConstituentsFrac=m_LowEtConstituentsFrac->at(idx);
       jet.GhostMuonSegmentCount=m_GhostMuonSegmentCount->at(idx);
       jet.Width                =m_Width                ->at(idx);
     }
@@ -1423,36 +1436,40 @@ void JetContainer::setBranches(TTree *tree)
   }
 
 
-  if( m_infoSwitch.m_clean ) {
-    setBranch<float>(tree,"Timing",                        m_Timing               );
-    setBranch<float>(tree,"LArQuality",                    m_LArQuality         );
-    setBranch<float>(tree,"HECQuality",                    m_HECQuality               );
-    setBranch<float>(tree,"NegativeE",                     m_NegativeE               );
-    setBranch<float>(tree,"AverageLArQF",                  m_AverageLArQF            );
-    setBranch<float>(tree,"BchCorrCell",                   m_BchCorrCell        );
-    setBranch<float>(tree,"N90Constituents",               m_N90Constituents           );
-    setBranch<float>(tree,"LArBadHVEnergyFrac",            m_LArBadHVEnergyFrac   );
-    setBranch<int>  (tree,"LArBadHVNCell",                 m_LArBadHVNCell  	  );
-    setBranch<float>(tree,"OotFracClusters5",              m_OotFracClusters5  	    );
-    setBranch<float>(tree,"OotFracClusters10",             m_OotFracClusters10  	  );
-    setBranch<float>(tree,"LeadingClusterPt",              m_LeadingClusterPt  	            );
-    setBranch<float>(tree,"LeadingClusterSecondLambda",    m_LeadingClusterSecondLambda  	  );
-    setBranch<float>(tree,"LeadingClusterCenterLambda",    m_LeadingClusterCenterLambda  	  );
-    setBranch<float>(tree,"LeadingClusterSecondR",         m_LeadingClusterSecondR  	      );
+  if( m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight ) {
+    if(m_infoSwitch.m_clean){
+      setBranch<float>(tree,"Timing",                        m_Timing               );
+      setBranch<float>(tree,"LArQuality",                    m_LArQuality         );
+      setBranch<float>(tree,"HECQuality",                    m_HECQuality               );
+      setBranch<float>(tree,"NegativeE",                     m_NegativeE               );
+      setBranch<float>(tree,"AverageLArQF",                  m_AverageLArQF            );
+      setBranch<float>(tree,"BchCorrCell",                   m_BchCorrCell        );
+      setBranch<float>(tree,"N90Constituents",               m_N90Constituents           );
+      setBranch<float>(tree,"LArBadHVEnergyFrac",            m_LArBadHVEnergyFrac   );
+      setBranch<int>  (tree,"LArBadHVNCell",                 m_LArBadHVNCell  	  );
+      setBranch<float>(tree,"OotFracClusters5",              m_OotFracClusters5  	    );
+      setBranch<float>(tree,"OotFracClusters10",             m_OotFracClusters10  	  );
+      setBranch<float>(tree,"LeadingClusterPt",              m_LeadingClusterPt  	            );
+      setBranch<float>(tree,"LeadingClusterSecondLambda",    m_LeadingClusterSecondLambda  	  );
+      setBranch<float>(tree,"LeadingClusterCenterLambda",    m_LeadingClusterCenterLambda  	  );
+      setBranch<float>(tree,"LeadingClusterSecondR",         m_LeadingClusterSecondR  	      );
+      setBranch<int>  (tree,"clean_passLooseBadUgly",        m_clean_passLooseBadUgly         );
+      setBranch<int>  (tree,"clean_passTightBadUgly",        m_clean_passTightBadUgly         );
+    }
     setBranch<int>  (tree,"clean_passLooseBad",            m_clean_passLooseBad             );
-    setBranch<int>  (tree,"clean_passLooseBadUgly",        m_clean_passLooseBadUgly         );
     setBranch<int>  (tree,"clean_passTightBad",            m_clean_passTightBad             );
-    setBranch<int>  (tree,"clean_passTightBadUgly",        m_clean_passTightBadUgly         );
   }
 
 
-  if ( m_infoSwitch.m_energy ) {
-    setBranch<float>(tree,"HECFrac",                   m_HECFrac            );
+  if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
+    if ( m_infoSwitch.m_energy ){
+      setBranch<float>(tree,"HECFrac",                   m_HECFrac            );
+      setBranch<float>(tree,"CentroidR",                 m_CentroidR      );
+      setBranch<float>(tree,"LowEtConstituentsFrac",     m_LowEtConstituentsFrac      );
+    }
     setBranch<float>(tree,"EMFrac",                    m_EMFrac     );
-    setBranch<float>(tree,"CentroidR",                 m_CentroidR      );
     setBranch<float>(tree,"FracSamplingMax",           m_FracSamplingMax    );
     setBranch<float>(tree,"FracSamplingMaxIndex",      m_FracSamplingMaxIndex );
-    setBranch<float>(tree,"LowEtConstituentsFrac",     m_LowEtConstituentsFrac      );
     setBranch<float>(tree,"GhostMuonSegmentCount",     m_GhostMuonSegmentCount   );
     setBranch<float>(tree,"Width",                     m_Width          );
   }
@@ -1772,37 +1789,41 @@ void JetContainer::clear()
   }
 
   // clean
-  if( m_infoSwitch.m_clean ) {
-    m_Timing                    ->clear();
-    m_LArQuality                ->clear();
-    m_HECQuality                ->clear();
-    m_NegativeE                 ->clear();
-    m_AverageLArQF              ->clear();
-    m_BchCorrCell               ->clear();
-    m_N90Constituents           ->clear();
-    m_LArBadHVEnergyFrac        ->clear();
-    m_LArBadHVNCell             ->clear();
-    m_OotFracClusters5          ->clear();
-    m_OotFracClusters10         ->clear();
-    m_LeadingClusterPt          ->clear();
-    m_LeadingClusterSecondLambda->clear();
-    m_LeadingClusterCenterLambda->clear();
-    m_LeadingClusterSecondR     ->clear();
+  if( m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight ) {
+    if(m_infoSwitch.m_clean){
+      m_Timing                    ->clear();
+      m_LArQuality                ->clear();
+      m_HECQuality                ->clear();
+      m_NegativeE                 ->clear();
+      m_AverageLArQF              ->clear();
+      m_BchCorrCell               ->clear();
+      m_N90Constituents           ->clear();
+      m_LArBadHVEnergyFrac        ->clear();
+      m_LArBadHVNCell             ->clear();
+      m_OotFracClusters5          ->clear();
+      m_OotFracClusters10         ->clear();
+      m_LeadingClusterPt          ->clear();
+      m_LeadingClusterSecondLambda->clear();
+      m_LeadingClusterCenterLambda->clear();
+      m_LeadingClusterSecondR     ->clear();
+      m_clean_passTightBadUgly    ->clear();
+      m_clean_passLooseBadUgly    ->clear();
+    }
     m_clean_passLooseBad        ->clear();
-    m_clean_passLooseBadUgly    ->clear();
     m_clean_passTightBad        ->clear();
-    m_clean_passTightBadUgly    ->clear();
   }
 
 
   // energy
-  if ( m_infoSwitch.m_energy ) {
-    m_HECFrac               ->clear();
+  if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
+    if ( m_infoSwitch.m_energy ){
+      m_HECFrac               ->clear();
+      m_CentroidR             ->clear();
+      m_LowEtConstituentsFrac ->clear();
+    }
     m_EMFrac                ->clear();
-    m_CentroidR             ->clear();
     m_FracSamplingMax       ->clear();
     m_FracSamplingMaxIndex  ->clear();
-    m_LowEtConstituentsFrac ->clear();
     m_GhostMuonSegmentCount ->clear();
     m_Width                 ->clear();
   }
@@ -2118,85 +2139,95 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_rapidity->push_back( jet->rapidity() );
   }
 
-  if (m_infoSwitch.m_clean) {
-    static SG::AuxElement::ConstAccessor<float> jetTime ("Timing");
-    safeFill<float, float, xAOD::Jet>(jet, jetTime, m_Timing, -999);
+  if (m_infoSwitch.m_clean || m_infoSwitch.m_cleanLight) {
 
-    static SG::AuxElement::ConstAccessor<float> LArQuality ("LArQuality");
-    safeFill<float, float, xAOD::Jet>(jet, LArQuality, m_LArQuality, -999);
+    if(m_infoSwitch.m_clean){
 
-    static SG::AuxElement::ConstAccessor<float> hecq ("HECQuality");
-    safeFill<float, float, xAOD::Jet>(jet, hecq, m_HECQuality, -999);
+      static SG::AuxElement::ConstAccessor<float> jetTime ("Timing");
+      safeFill<float, float, xAOD::Jet>(jet, jetTime, m_Timing, -999);
 
-    static SG::AuxElement::ConstAccessor<float> negE ("NegativeE");
-    safeFill<float, float, xAOD::Jet>(jet, negE, m_NegativeE, -999, m_units);
+      static SG::AuxElement::ConstAccessor<float> LArQuality ("LArQuality");
+      safeFill<float, float, xAOD::Jet>(jet, LArQuality, m_LArQuality, -999);
 
-    static SG::AuxElement::ConstAccessor<float> avLArQF ("AverageLArQF");
-    safeFill<float, float, xAOD::Jet>(jet, avLArQF, m_AverageLArQF, -999);
+      static SG::AuxElement::ConstAccessor<float> hecq ("HECQuality");
+      safeFill<float, float, xAOD::Jet>(jet, hecq, m_HECQuality, -999);
 
-    static SG::AuxElement::ConstAccessor<float> bchCorrCell ("BchCorrCell");
-    safeFill<float, float, xAOD::Jet>(jet, bchCorrCell, m_BchCorrCell, -999);
+      static SG::AuxElement::ConstAccessor<float> negE ("NegativeE");
+      safeFill<float, float, xAOD::Jet>(jet, negE, m_NegativeE, -999, m_units);
 
-    static SG::AuxElement::ConstAccessor<float> N90Const ("N90Constituents");
-    safeFill<float, float, xAOD::Jet>(jet, N90Const, m_N90Constituents, -999);
+      static SG::AuxElement::ConstAccessor<float> avLArQF ("AverageLArQF");
+      safeFill<float, float, xAOD::Jet>(jet, avLArQF, m_AverageLArQF, -999);
 
-    static SG::AuxElement::ConstAccessor<float> LArBadHVEFrac ("LArBadHVEnergyFrac");
-    safeFill<float, float, xAOD::Jet>(jet, LArBadHVEFrac, m_LArBadHVEnergyFrac, -999);
+      static SG::AuxElement::ConstAccessor<float> bchCorrCell ("BchCorrCell");
+      safeFill<float, float, xAOD::Jet>(jet, bchCorrCell, m_BchCorrCell, -999);
 
-    static SG::AuxElement::ConstAccessor<int> LArBadHVNCell ("LArBadHVNCell");
-    safeFill<int, int, xAOD::Jet>(jet, LArBadHVNCell, m_LArBadHVNCell, -999);
+      static SG::AuxElement::ConstAccessor<float> N90Const ("N90Constituents");
+      safeFill<float, float, xAOD::Jet>(jet, N90Const, m_N90Constituents, -999);
 
-    static SG::AuxElement::ConstAccessor<float> OotFracClus5 ("OotFracClusters5");
-    safeFill<float, float, xAOD::Jet>(jet, OotFracClus5, m_OotFracClusters5, -999);
+      static SG::AuxElement::ConstAccessor<float> LArBadHVEFrac ("LArBadHVEnergyFrac");
+      safeFill<float, float, xAOD::Jet>(jet, LArBadHVEFrac, m_LArBadHVEnergyFrac, -999);
 
-    static SG::AuxElement::ConstAccessor<float> OotFracClus10 ("OotFracClusters10");
-    safeFill<float, float, xAOD::Jet>(jet, OotFracClus10, m_OotFracClusters10, -999);
+      static SG::AuxElement::ConstAccessor<int> LArBadHVNCell ("LArBadHVNCell");
+      safeFill<int, int, xAOD::Jet>(jet, LArBadHVNCell, m_LArBadHVNCell, -999);
 
-    static SG::AuxElement::ConstAccessor<float> leadClusPt ("LeadingClusterPt");
-    safeFill<float, float, xAOD::Jet>(jet, leadClusPt, m_LeadingClusterPt, -999);
+      static SG::AuxElement::ConstAccessor<float> OotFracClus5 ("OotFracClusters5");
+      safeFill<float, float, xAOD::Jet>(jet, OotFracClus5, m_OotFracClusters5, -999);
 
-    static SG::AuxElement::ConstAccessor<float> leadClusSecondLambda ("LeadingClusterSecondLambda");
-    safeFill<float, float, xAOD::Jet>(jet, leadClusSecondLambda, m_LeadingClusterSecondLambda, -999);
+      static SG::AuxElement::ConstAccessor<float> OotFracClus10 ("OotFracClusters10");
+      safeFill<float, float, xAOD::Jet>(jet, OotFracClus10, m_OotFracClusters10, -999);
 
-    static SG::AuxElement::ConstAccessor<float> leadClusCenterLambda ("LeadingClusterCenterLambda");
-    safeFill<float, float, xAOD::Jet>(jet, leadClusCenterLambda, m_LeadingClusterCenterLambda, -999);
+      static SG::AuxElement::ConstAccessor<float> leadClusPt ("LeadingClusterPt");
+      safeFill<float, float, xAOD::Jet>(jet, leadClusPt, m_LeadingClusterPt, -999);
 
-    static SG::AuxElement::ConstAccessor<float> leadClusSecondR ("LeadingClusterSecondR");
-    safeFill<float, float, xAOD::Jet>(jet, leadClusSecondR, m_LeadingClusterSecondR, -999);
+      static SG::AuxElement::ConstAccessor<float> leadClusSecondLambda ("LeadingClusterSecondLambda");
+      safeFill<float, float, xAOD::Jet>(jet, leadClusSecondLambda, m_LeadingClusterSecondLambda, -999);
+
+      static SG::AuxElement::ConstAccessor<float> leadClusCenterLambda ("LeadingClusterCenterLambda");
+      safeFill<float, float, xAOD::Jet>(jet, leadClusCenterLambda, m_LeadingClusterCenterLambda, -999);
+
+      static SG::AuxElement::ConstAccessor<float> leadClusSecondR ("LeadingClusterSecondR");
+      safeFill<float, float, xAOD::Jet>(jet, leadClusSecondR, m_LeadingClusterSecondR, -999);
+
+      static SG::AuxElement::ConstAccessor<char> clean_passLooseBadUgly ("clean_passLooseBadUgly");
+      safeFill<char, int, xAOD::Jet>(jet, clean_passLooseBadUgly, m_clean_passLooseBadUgly, -999);
+
+      static SG::AuxElement::ConstAccessor<char> clean_passTightBadUgly ("clean_passTightBadUgly");
+      safeFill<char, int, xAOD::Jet>(jet, clean_passTightBadUgly, m_clean_passTightBadUgly, -999);
+
+    }
 
     static SG::AuxElement::ConstAccessor<char> clean_passLooseBad ("clean_passLooseBad");
     safeFill<char, int, xAOD::Jet>(jet, clean_passLooseBad, m_clean_passLooseBad, -999);
 
-    static SG::AuxElement::ConstAccessor<char> clean_passLooseBadUgly ("clean_passLooseBadUgly");
-    safeFill<char, int, xAOD::Jet>(jet, clean_passLooseBadUgly, m_clean_passLooseBadUgly, -999);
-
     static SG::AuxElement::ConstAccessor<char> clean_passTightBad ("clean_passTightBad");
     safeFill<char, int, xAOD::Jet>(jet, clean_passTightBad, m_clean_passTightBad, -999);
-
-    static SG::AuxElement::ConstAccessor<char> clean_passTightBadUgly ("clean_passTightBadUgly");
-    safeFill<char, int, xAOD::Jet>(jet, clean_passTightBadUgly, m_clean_passTightBadUgly, -999);
 
   } // clean
 
 
-  if ( m_infoSwitch.m_energy ) {
-    static SG::AuxElement::ConstAccessor<float> HECf ("HECFrac");
-    safeFill<float, float, xAOD::Jet>(jet, HECf, m_HECFrac, -999);
+  if ( m_infoSwitch.m_energy | m_infoSwitch.m_energyLight ) {
+
+    if ( m_infoSwitch.m_energy ){
+
+      static SG::AuxElement::ConstAccessor<float> HECf ("HECFrac");
+      safeFill<float, float, xAOD::Jet>(jet, HECf, m_HECFrac, -999);
+
+      static SG::AuxElement::ConstAccessor<float> centroidR ("CentroidR");
+      safeFill<float, float, xAOD::Jet>(jet, centroidR, m_CentroidR, -999);
+
+      static SG::AuxElement::ConstAccessor<float> lowEtFrac ("LowEtConstituentsFrac");
+      safeFill<float, float, xAOD::Jet>(jet, lowEtFrac, m_LowEtConstituentsFrac, -999);
+
+    }
 
     static SG::AuxElement::ConstAccessor<float> EMf ("EMFrac");
     safeFill<float, float, xAOD::Jet>(jet, EMf, m_EMFrac, -999);
-
-    static SG::AuxElement::ConstAccessor<float> centroidR ("CentroidR");
-    safeFill<float, float, xAOD::Jet>(jet, centroidR, m_CentroidR, -999);
 
     static SG::AuxElement::ConstAccessor<float> fracSampMax ("FracSamplingMax");
     safeFill<float, float, xAOD::Jet>(jet, fracSampMax, m_FracSamplingMax, -999);
 
     static SG::AuxElement::ConstAccessor<int> fracSampMaxIdx ("FracSamplingMaxIndex");
     safeFill<int, float, xAOD::Jet>(jet, fracSampMaxIdx, m_FracSamplingMaxIndex, -999);
-
-    static SG::AuxElement::ConstAccessor<float> lowEtFrac ("LowEtConstituentsFrac");
-    safeFill<float, float, xAOD::Jet>(jet, lowEtFrac, m_LowEtConstituentsFrac, -999);
 
     static SG::AuxElement::ConstAccessor<int> muonSegCount ("GhostMuonSegmentCount");
     safeFill<int, float, xAOD::Jet>(jet, muonSegCount, m_GhostMuonSegmentCount, -999);

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -66,6 +66,11 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_constScaleEta               = new std::vector<float>();
   }
 
+  // detector eta
+  if ( m_infoSwitch.m_detectorEta ) {
+    m_detectorEta               = new std::vector<float>();
+  }
+
   // layer
   if ( m_infoSwitch.m_layer ) {
     m_EnergyPerSampling       = new std::vector< std::vector<float> >();
@@ -449,6 +454,10 @@ JetContainer::~JetContainer()
     delete m_constScaleEta         ;
   }
 
+  // detector eta
+  if ( m_infoSwitch.m_detectorEta ) {
+    delete m_detectorEta;
+  }
 
   // layer
   if ( m_infoSwitch.m_layer ) {
@@ -1462,6 +1471,10 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"constScaleEta",              m_constScaleEta            );
   }
 
+  if ( m_infoSwitch.m_detectorEta ) {
+    setBranch<float>(tree,"detectorEta",              m_detectorEta            );
+  }
+
   if ( m_infoSwitch.m_layer ) {
     setBranch<std::vector<float> >(tree,"EnergyPerSampling",     m_EnergyPerSampling   );
   }
@@ -1808,6 +1821,11 @@ void JetContainer::clear()
   // eta at constScale
   if ( m_infoSwitch.m_constscaleEta ) {
     m_constScaleEta	    ->clear();
+  }
+
+  // detector eta
+  if ( m_infoSwitch.m_detectorEta ) {
+    m_detectorEta           ->clear();
   }
 
   // layer
@@ -2229,6 +2247,11 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     status = jet->getAttribute<xAOD::JetFourMom_t>( "JetConstitScaleMomentum", fourVec );
     if( status ) { m_constScaleEta->push_back( fourVec.Eta() ); }
     else { m_constScaleEta->push_back( -999 ); }
+  }
+
+  if ( m_infoSwitch.m_detectorEta ) {
+    static SG::AuxElement::ConstAccessor<float> DetEta ("DetectorEta");
+    safeFill<float, float, xAOD::Jet>(jet, DetEta, m_detectorEta, -999);
   }
 
   if ( m_infoSwitch.m_layer ) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -381,6 +381,7 @@ namespace HelperClasses {
         m_energy         energy         exact
         m_scales         scales         exact
         m_constscaleEta  constscaleEta  exact
+        m_detectorEta    detectorEta    exact
         m_resolution     resolution     exact
         m_truth          truth          exact
         m_truthDetails   truth_details  exact
@@ -449,6 +450,7 @@ namespace HelperClasses {
     bool m_energy;
     bool m_scales;
     bool m_constscaleEta;
+    bool m_detectorEta;
     bool m_resolution;
     bool m_truth;
     bool m_truthDetails;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -378,7 +378,9 @@ namespace HelperClasses {
         m_VTags          VTags          exact
         m_rapidity       rapidity       exact
         m_clean          clean          exact
+        m_cleanLight     cleanLight     exact
         m_energy         energy         exact
+        m_energyLight    energyLight    exact
         m_scales         scales         exact
         m_constscaleEta  constscaleEta  exact
         m_detectorEta    detectorEta    exact
@@ -447,7 +449,9 @@ namespace HelperClasses {
     bool m_VTags;
     bool m_rapidity;
     bool m_clean;
+    bool m_cleanLight;
     bool m_energy;
+    bool m_energyLight;
     bool m_scales;
     bool m_constscaleEta;
     bool m_detectorEta;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -90,7 +90,9 @@ namespace xAH {
 
       // constScale Eta
       std::vector<float> *m_constScaleEta;
-      
+
+      // detector Eta
+      std::vector<float> *m_detectorEta;
 
       // layer
       std::vector< std::vector<float> > *m_EnergyPerSampling;


### PR DESCRIPTION
Save DetectorEta in trees. ConstScaleEta can be already being saved, but this is equal to DetectorEta only in R20 and not in R21.
    
New equivalent clean and energy options but with less variables being saved (cleanLight and energyLight). This is helpful for SM analyses and JetEtmiss R-scan studies.