### PR TITLE
Rename JetInfoSwitch::m_flavTag to JetInfoSwitch::m_flavorTag.

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -279,7 +279,7 @@ void FatJetContainer::setTree(TTree *tree)
 
   for(const auto& kv : m_trkJets)
     {
-      m_trkJets[kv.first]->JetContainer::setTree(tree, "MV2c10");
+      m_trkJets[kv.first]->JetContainer::setTree(tree);
       if(tree->GetBranch(branchName("trkJetsIdx").c_str()))
 	connectBranch< std::vector<unsigned int> >(tree, "trkJetsIdx", &m_trkJetsIdx[kv.first]);
       else

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -242,8 +242,8 @@ namespace HelperClasses{
     }
     m_constituent       = has_exact("constituent");
     m_constituentAll    = has_exact("constituentAll");
-    m_flavTag           = has_exact("flavorTag");
-    m_flavTagHLT        = has_exact("flavorTagHLT");
+    m_flavorTag         = has_exact("flavorTag");
+    m_flavorTagHLT      = has_exact("flavorTagHLT");
     m_btag_jettrk       = has_exact("btag_jettrk");
     m_jetFitterDetails  = has_exact("jetFitterDetails");
     m_svDetails         = has_exact("svDetails");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -12,7 +12,7 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
 {
   // rapidity
   if(m_infoSwitch.m_rapidity) {
-    m_rapidity                    =new std::vector<float>();
+    m_rapidity                  =new std::vector<float>();
   }
 
   // clean
@@ -170,15 +170,14 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_constituent_e          = new  std::vector< std::vector<float> > ();
   }
 
-  // flavTag
-  if( m_infoSwitch.m_flavTag  || m_infoSwitch.m_flavTagHLT  ) {
+  // flavorTag
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
     //m_MV1                       =new std::vector<float>();
     m_MV2c00                    =new std::vector<float>();
     m_MV2c10                    =new std::vector<float>();
     m_MV2c20                    =new std::vector<float>();
     m_MV2c100                   =new std::vector<float>();
-    m_MV2                       =new std::vector<float>();
     m_HadronConeExclTruthLabelID=new std::vector<int>();
 
     // Jet Fitter
@@ -268,8 +267,8 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
 
   }
 
-  //  flavTagHLT
-  if( m_infoSwitch.m_flavTagHLT  ) {
+  //  flavorTagHLT
+  if( m_infoSwitch.m_flavorTagHLT  ) {
     m_vtxOnlineValid     = new  std::vector<float>();
     m_vtxHadDummy        = new  std::vector<float>();
 
@@ -556,12 +555,11 @@ JetContainer::~JetContainer()
   }
 
 
-  // flavTag
-  if( m_infoSwitch.m_flavTag  || m_infoSwitch.m_flavTagHLT  ) {
-    // flavTag
+  // flavorTag
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
+    // flavorTag
 
     //delete m_MV1;
-    delete m_MV2;
     delete m_MV2c00;
     delete m_MV2c10;
     delete m_MV2c20;
@@ -655,8 +653,8 @@ JetContainer::~JetContainer()
 
   }
 
-    //  flavTagHLT
-  if( m_infoSwitch.m_flavTagHLT  ) {
+    //  flavorTagHLT
+  if( m_infoSwitch.m_flavorTagHLT  ) {
     delete m_vtxOnlineValid     ;
     delete m_vtxHadDummy        ;
     delete m_bs_online_vx       ;
@@ -740,11 +738,6 @@ JetContainer::~JetContainer()
 
 void JetContainer::setTree(TTree *tree)
 {
-  JetContainer::setTree(tree, "");
-}
-
-void JetContainer::setTree(TTree *tree, const std::string& tagger)
-{
   //
   // Connect branches
   ParticleContainer::setTree(tree);
@@ -816,20 +809,16 @@ void JetContainer::setTree(TTree *tree, const std::string& tagger)
       connectBranch<double>(tree,"JetVertexCharge_discriminant", &m_JetVertexCharge_discriminant);
     }
 
-  if(m_infoSwitch.m_flavTag || m_infoSwitch.m_flavTagHLT)
+  if(m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT)
     {
       connectBranch<float>(tree,"MV2c00",               &m_MV2c00);
       connectBranch<float>(tree,"MV2c10",               &m_MV2c10);
       connectBranch<float>(tree,"MV2c20",               &m_MV2c20);
       connectBranch<float>(tree,"MV2c100",              &m_MV2c100);
       connectBranch<int>  (tree,"HadronConeExclTruthLabelID",&m_HadronConeExclTruthLabelID);
-
-      if(tagger == "MV2c20")  m_MV2 = m_MV2c20;
-      if(tagger == "MV2c10")  m_MV2 = m_MV2c10;
-
     }
 
-  if(m_infoSwitch.m_flavTagHLT)
+  if(m_infoSwitch.m_flavorTagHLT)
     {
       connectBranch<float>(tree,"vtxHadDummy",    &m_vtxHadDummy);
       connectBranch<float>(tree,"bs_online_vx",   &m_bs_online_vx);
@@ -1024,23 +1013,22 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
     jet.JVC = m_JetVertexCharge_discriminant->at(idx);
   }
 
-  if(m_infoSwitch.m_flavTag  || m_infoSwitch.m_flavTagHLT)
+  if(m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT)
     {
-      if(m_debug) std::cout << "updating flavTag " << std::endl;
+      if(m_debug) std::cout << "updating flavorTag " << std::endl;
       jet.MV2c00                    =m_MV2c00               ->at(idx);
       jet.MV2c10                    =m_MV2c10               ->at(idx);
       jet.MV2c20                    =m_MV2c20               ->at(idx);
       jet.MV2c100                   =m_MV2c100              ->at(idx);
-      jet.MV2                       =m_MV2                  ->at(idx);
       //std::cout << m_HadronConeExclTruthLabelID->size() << std::endl;
       jet.HadronConeExclTruthLabelID=m_HadronConeExclTruthLabelID->at(idx);
-      if(m_debug) std::cout << "leave flavTag " << std::endl;
+      if(m_debug) std::cout << "leave flavorTag " << std::endl;
     }
 
 
-  if(m_infoSwitch.m_flavTagHLT)
+  if(m_infoSwitch.m_flavorTagHLT)
     {
-      if(m_debug) std::cout << "updating flavTagHLT " << std::endl;
+      if(m_debug) std::cout << "updating flavorTagHLT " << std::endl;
       jet.bs_online_vx                      =m_bs_online_vx                  ->at(idx);
       jet.bs_online_vy                      =m_bs_online_vy                  ->at(idx);
       jet.bs_online_vz                      =m_bs_online_vz                  ->at(idx);
@@ -1568,15 +1556,14 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<std::vector<float> >(tree,"constituent_e",      m_constituent_e     );
   }
 
-  if( m_infoSwitch.m_flavTag  || m_infoSwitch.m_flavTagHLT  ) {
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
-    setBranch<float>(tree,"MV2c00",        m_MV2c00);
-    setBranch<float>(tree,"MV2c10",        m_MV2c10);
-    setBranch<float>(tree,"MV2c20",    m_MV2c20);
-    setBranch<float>(tree,"MV2c100",    m_MV2c100);
+    setBranch<float>(tree,"MV2c00",   m_MV2c00);
+    setBranch<float>(tree,"MV2c10",   m_MV2c10);
+    setBranch<float>(tree,"MV2c20",   m_MV2c20);
+    setBranch<float>(tree,"MV2c100",  m_MV2c100);
 
     setBranch<int  >(tree,"HadronConeExclTruthLabelID", m_HadronConeExclTruthLabelID);
-
 
     if( m_infoSwitch.m_jetFitterDetails){
 
@@ -1665,7 +1652,7 @@ void JetContainer::setBranches(TTree *tree)
     }
   }
 
-  if( m_infoSwitch.m_flavTagHLT  ) {
+  if( m_infoSwitch.m_flavorTagHLT  ) {
 
     setBranch<float>(tree,"vtxOnlineValid",m_vtxOnlineValid);
     setBranch<float>(tree,"vtxHadDummy"   ,m_vtxHadDummy   );
@@ -1910,13 +1897,12 @@ void JetContainer::clear()
   }
 
   // flavor tag
-  if ( m_infoSwitch.m_flavTag || m_infoSwitch.m_flavTagHLT  ) {
+  if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT  ) {
 
     m_MV2c00                    ->clear();
     m_MV2c10                    ->clear();
     m_MV2c20                    ->clear();
     m_MV2c100                   ->clear();
-    m_MV2                       ->clear();
     m_HadronConeExclTruthLabelID->clear();
 
 
@@ -2001,7 +1987,7 @@ void JetContainer::clear()
     }
   }
 
-  if ( m_infoSwitch.m_flavTagHLT  ) {
+  if ( m_infoSwitch.m_flavorTagHLT  ) {
     m_vtxOnlineValid->clear();
     m_vtxHadDummy->clear();
     m_bs_online_vx->clear();
@@ -2553,12 +2539,12 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_constituent_e->  push_back( e   );
   }
 
-  if ( m_infoSwitch.m_flavTag || m_infoSwitch.m_flavTagHLT ) {
+  if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT ) {
     const xAOD::BTagging * myBTag(0);
 
-    if(m_infoSwitch.m_flavTag){
+    if(m_infoSwitch.m_flavorTag){
       myBTag = jet->btagging();
-    }else if(m_infoSwitch.m_flavTagHLT){
+    }else if(m_infoSwitch.m_flavorTagHLT){
       myBTag = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
     }
 
@@ -2806,8 +2792,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
 
 
 
-    if(m_infoSwitch.m_flavTagHLT ) {
-      if(m_debug) std::cout << "Filling m_flavTagHLT " << std::endl;
+    if(m_infoSwitch.m_flavorTagHLT ) {
+      if(m_debug) std::cout << "Filling m_flavorTagHLT " << std::endl;
       const xAOD::Vertex *online_pvx       = jet->auxdata<const xAOD::Vertex*>("HLTBJetTracks_vtx");
       const xAOD::Vertex *online_pvx_bkg   = jet->auxdata<const xAOD::Vertex*>("HLTBJetTracks_vtx_bkg");
       const xAOD::Vertex *offline_pvx      = jet->auxdata<const xAOD::Vertex*>("offline_vtx");
@@ -2877,8 +2863,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
         m_vtx_online_bkg_z0->push_back( -999 );
       }
 
-    }// m_flavTagHLT
-    if(m_debug) std::cout << "Done m_flavTagHLT " << std::endl;
+    }// m_flavorTagHLT
+    if(m_debug) std::cout << "Done m_flavorTagHLT " << std::endl;
   }
 
 

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -204,7 +204,7 @@ StatusCode JetHists::initialize() {
     m_JVC = book(m_name, "JVC", m_titlePrefix+"JVC", 100, -5, 5);
   }
 
-  if( m_infoSwitch->m_flavTag || m_infoSwitch->m_flavTagHLT ) {
+  if( m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT ) {
     if(m_debug) Info("JetHists::initialize()", "adding btagging plots");
 
     m_MV2c00          = book(m_name, "MV2c00",            m_titlePrefix+"MV2c00" ,   100,    -1.1,   1.1);
@@ -955,12 +955,12 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
   //
   // BTagging
   //
-  if( m_infoSwitch->m_flavTag || m_infoSwitch->m_flavTagHLT ) {
-    if(m_debug) std::cout << "JetHists: m_flavTag " <<std::endl;
+  if( m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT ) {
+    if(m_debug) std::cout << "JetHists: m_flavorTag " <<std::endl;
     const xAOD::BTagging *btag_info(0);
-    if(m_infoSwitch->m_flavTag){
+    if(m_infoSwitch->m_flavorTag){
       btag_info = jet->btagging();
-    }else if(m_infoSwitch->m_flavTagHLT){
+    }else if(m_infoSwitch->m_flavorTagHLT){
       btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
     }
 
@@ -986,7 +986,7 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       bool passMV2c1085 = (MV2c10 > 0.11);
 
 
-      if(m_infoSwitch->m_flavTagHLT){
+      if(m_infoSwitch->m_flavorTagHLT){
 	passMV2c1040 = (MV2c10 >  0.978);
 	passMV2c1050 = (MV2c10 >  0.948);
 	passMV2c1060 = (MV2c10 >  0.847);
@@ -1700,7 +1700,7 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       m_JVC->Fill(jet->JVC, eventWeight);
     }
 
-  if(m_infoSwitch->m_flavTag || m_infoSwitch->m_flavTagHLT)
+  if(m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT)
     {
 //      h_SV0                       ->Fill(jet->SV0                  , eventWeight);
 //      h_SV1                       ->Fill(jet->SV1                  , eventWeight);
@@ -1724,14 +1724,13 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 	bool passMV2c1085 = (MV2c10 > 0.11);
 
 
-	if(m_infoSwitch->m_flavTagHLT){
+	if(m_infoSwitch->m_flavorTagHLT){
 	  passMV2c1040 = (MV2c10 >  0.978);
 	  passMV2c1050 = (MV2c10 >  0.948);
 	  passMV2c1060 = (MV2c10 >  0.847);
 	  passMV2c1070 = (MV2c10 >  0.580);
 	  passMV2c1077 = (MV2c10 >  0.162);
 	  passMV2c1085 = (MV2c10 > -0.494);
-	  
 	}
 
 	if(m_infoSwitch->m_vsLumiBlock){

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -394,8 +394,8 @@ namespace HelperClasses {
         m_allTrackDetail allTrackDetail exact
         m_constituent    constituent    exact
         m_constituentAll constituentAll exact
-        m_flavTag        flavorTag      exact
-        m_flavTagHLT     flavorTagHLT   exact
+        m_flavorTag      flavorTag      exact
+        m_flavorTagHLT   flavorTagHLT   exact
         m_sfFTagFix      sfFTagFix      partial
         m_sfFTagFlt      sfFTagFlt      partial
         m_sfFTagHyb      sfFTagHyb      partial
@@ -460,8 +460,8 @@ namespace HelperClasses {
     bool m_allTrackPVSel;
     bool m_constituent;
     bool m_constituentAll;
-    bool m_flavTag;
-    bool m_flavTagHLT;
+    bool m_flavorTag;
+    bool m_flavorTagHLT;
     bool m_btag_jettrk;
     bool m_jetFitterDetails;
     bool m_svDetails;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -90,7 +90,6 @@ namespace xAH {
       float MV2c10;
       float MV2c20;
       float MV2c100;
-      float MV2;
       int  HadronConeExclTruthLabelID;
 
       float vtxOnlineValid;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -27,7 +27,6 @@ namespace xAH {
       virtual ~JetContainer();
     
       virtual void setTree    (TTree *tree);
-      virtual void setTree    (TTree *tree, const std::string& tagger/*="MV2c10"*/);
       virtual void setBranches(TTree *tree);
       virtual void clear();
       virtual void FillJet( const xAOD::Jet* jet,            const xAOD::Vertex* pv, int pvLocation );
@@ -167,7 +166,6 @@ namespace xAH {
       std::vector<float> *m_MV2c10;
       std::vector<float> *m_MV2c20;
       std::vector<float> *m_MV2c100;
-      std::vector<float> *m_MV2;
       std::vector<int>   *m_HadronConeExclTruthLabelID;
     
       // Jet Fitter 


### PR DESCRIPTION
Renames `JetInfoSwitch::m_flavTag` to `JetInfoSwitch::m_flavorTag` to match with the string that sets it in the detailStr. It is more consistent and thus self-documenting. The setting remains the same, so any users having it in their config file won't see a silent failure. If they use the C++ code directly in the analysis package, they will get an explicit error that can be fixed easily.

Also I removed the tagger argument from `JetContainer::setTree` since I don't think anyone uses MV2c20 anymore. Also the discriminant value is still accessible through a dedicate property.