### PR TITLE
Add MV2c10 as a valid HLTBTagTaggerName

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -973,6 +973,10 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
     const xAOD::BTagging *btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
 
     double tagValue = -99;
+    if(m_HLTBTagTaggerName=="MV2c10"){
+      btag_info->MVx_discriminant("MV2c10", tagValue);
+    }
+
     if(m_HLTBTagTaggerName=="MV2c20"){
       btag_info->MVx_discriminant("MV2c20", tagValue);
     }


### PR DESCRIPTION
Currently `JetSelector` only selects `MV2c20` and `COMB` as valid strings for `m_HLTBTagTaggerName` for HLT b-tagging. This adds `MV2c10`.