### PR TITLE
Update interface paths and fix other warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,13 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
-set( release_libs xAODTriggerCnvLib FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib )
-set( release_depends PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces )
+set( release_libs xAODTriggerCnvLib )
 if( ${AnalysisBase_VERSION} VERSION_GREATER 21.0 )
   # 21.X
-  set( release_libs xAODTriggerCnvLib FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib )
-  set( release_depends PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces )
+  set( release_libs xAODTriggerCnvLib )
 else()
   # 2.6.X
   set( release_libs xAODTriggerCnv )
-  set( release_depends PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency PhysicsAnalysis/MuonID/MuonSelectorTools )
 endif()
 
 # Declare the package's dependencies:
@@ -54,6 +51,8 @@ atlas_depends_on_subdirs( PUBLIC
                           PhysicsAnalysis/ElectronPhotonID/ElectronPhotonShowerShapeFudgeTool
                           PhysicsAnalysis/ElectronPhotonID/PhotonEfficiencyCorrection
                           PhysicsAnalysis/JetMissingEtID/JetSelectorTools
+                          PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces
+                          PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonMomentumCorrections
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections
                           PhysicsAnalysis/TauID/TauAnalysisTools
@@ -96,6 +95,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    ElectronEfficiencyCorrectionLib ElectronPhotonSelectorToolsLib
                    IsolationSelectionLib IsolationCorrectionsLib
                    ElectronPhotonShowerShapeFudgeToolLib
+                   FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
                    TauAnalysisToolsLib AsgTools xAODMissingET JetResolutionLib
                    AssociationUtilsLib JetEDM JetUncertaintiesLib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,11 @@ atlas_depends_on_subdirs( PUBLIC
                           PhysicsAnalysis/ElectronPhotonID/IsolationCorrections
                           PhysicsAnalysis/ElectronPhotonID/ElectronPhotonShowerShapeFudgeTool
                           PhysicsAnalysis/ElectronPhotonID/PhotonEfficiencyCorrection
+                          PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces
+                          PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces
                           PhysicsAnalysis/JetMissingEtID/JetSelectorTools
-                          PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonMomentumCorrections
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections
-                          PhysicsAnalysis/MuonID/MuonSelectorTools
                           PhysicsAnalysis/TauID/TauAnalysisTools
                           Reconstruction/Jet/JetAnalysisTools/JetTileCorrection
                           Reconstruction/Jet/JetCalibTools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if( ${AnalysisBase_VERSION} VERSION_GREATER 21.0 )
   set( release_depends PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces )
 else()
   # 2.6.X
-  set( release_libs xAODTriggerCnv xAODBTaggingEfficiencyLib MuonSelectorToolsLib )
+  set( release_libs xAODTriggerCnv )
   set( release_depends PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency PhysicsAnalysis/MuonID/MuonSelectorTools )
 endif()
 
@@ -90,7 +90,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    xAODEventInfo GoodRunsListsLib PileupReweightingLib PATInterfaces
                    PathResolver xAODTau xAODJet xAODMuon xAODEgamma
                    xAODTracking xAODTruth MuonMomentumCorrectionsLib
-                   MuonEfficiencyCorrectionsLib JetCalibToolsLib
+                   MuonEfficiencyCorrectionsLib MuonSelectorToolsLib JetCalibToolsLib
                    JetSelectorToolsLib AthContainers
                    ElectronPhotonFourMomentumCorrectionLib
                    ElectronEfficiencyCorrectionLib ElectronPhotonSelectorToolsLib
@@ -99,7 +99,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
                    TauAnalysisToolsLib AsgTools xAODMissingET JetResolutionLib
                    AssociationUtilsLib JetEDM JetUncertaintiesLib
-                   JetCPInterfaces TrigConfxAODLib
+                   JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
                    TriggerMatchingToolLib xAODMetaDataCnv xAODMetaData
                    JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils JetTileCorrectionLib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,16 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
-set( release_libs xAODTriggerCnvLib )
+set( release_libs xAODTriggerCnvLib FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib )
+set( release_depends PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces )
 if( ${AnalysisBase_VERSION} VERSION_GREATER 21.0 )
   # 21.X
-  set( release_libs xAODTriggerCnvLib )
+  set( release_libs xAODTriggerCnvLib FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib )
+  set( release_depends PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces )
 else()
   # 2.6.X
-  set( release_libs xAODTriggerCnv )
+  set( release_libs xAODTriggerCnv xAODBTaggingEfficiencyLib MuonSelectorToolsLib )
+  set( release_depends PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency PhysicsAnalysis/MuonID/MuonSelectorTools )
 endif()
 
 # Declare the package's dependencies:
@@ -50,8 +53,6 @@ atlas_depends_on_subdirs( PUBLIC
                           PhysicsAnalysis/ElectronPhotonID/IsolationCorrections
                           PhysicsAnalysis/ElectronPhotonID/ElectronPhotonShowerShapeFudgeTool
                           PhysicsAnalysis/ElectronPhotonID/PhotonEfficiencyCorrection
-                          PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces
-                          PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces
                           PhysicsAnalysis/JetMissingEtID/JetSelectorTools
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonMomentumCorrections
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections
@@ -69,6 +70,7 @@ atlas_depends_on_subdirs( PUBLIC
                           Trigger/TrigAnalysis/TrigDecisionTool
                           Trigger/TrigAnalysis/TriggerMatchingTool
                           Trigger/TrigConfiguration/TrigConfxAOD
+                          ${release_depends}
 )
 
 # Find the needed external(s):
@@ -88,7 +90,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    xAODEventInfo GoodRunsListsLib PileupReweightingLib PATInterfaces
                    PathResolver xAODTau xAODJet xAODMuon xAODEgamma
                    xAODTracking xAODTruth MuonMomentumCorrectionsLib
-                   MuonEfficiencyCorrectionsLib MuonSelectorToolsLib JetCalibToolsLib
+                   MuonEfficiencyCorrectionsLib JetCalibToolsLib
                    JetSelectorToolsLib AthContainers
                    ElectronPhotonFourMomentumCorrectionLib
                    ElectronEfficiencyCorrectionLib ElectronPhotonSelectorToolsLib
@@ -97,7 +99,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
                    TauAnalysisToolsLib AsgTools xAODMissingET JetResolutionLib
                    AssociationUtilsLib JetEDM JetUncertaintiesLib
-                   JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
+                   JetCPInterfaces TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
                    TriggerMatchingToolLib xAODMetaDataCnv xAODMetaData
                    JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils JetTileCorrectionLib

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -309,7 +309,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
 
 
 EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD::JetContainer* inJets,
-								      const xAOD::EventInfo* eventInfo,
+								      const xAOD::EventInfo* /*eventInfo*/,
 								      bool doNominal)
 {
   ANA_MSG_DEBUG("Applying BJet Cuts and Efficiency Correction (when applicable...) ");

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -493,7 +493,7 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames )
+EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* /*eventInfo*/, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames )
 {
 
   //

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -493,7 +493,11 @@ EL::StatusCode MuonEfficiencyCorrector :: histFinalize ()
   return EL::StatusCode::SUCCESS;
 }
 
+#ifdef USE_CMAKE
 EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* /*eventInfo*/, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames )
+#else
+EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eventInfo, const xAOD::MuonContainer* inputMuons, bool nominal, bool writeSystNames )
+#endif
 {
 
   //

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -15,7 +15,7 @@
 #ifdef USE_CMAKE
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "FTagAnalysisInterfaces/IBTaggingEfficiencyTool.h"
-#else // RootCore back-compat
+#else
 #include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
 #include "xAODBTaggingEfficiency/IBTaggingEfficiencyTool.h"
 #endif

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -12,8 +12,13 @@
 #include "PATInterfaces/ISystematicsTool.h"
 
 // external tools include(s):
+#ifdef USE_CMAKE
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "FTagAnalysisInterfaces/IBTaggingEfficiencyTool.h"
+#else // RC back-compat
+#include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
+#include "xAODBTaggingEfficiency/IBTaggingEfficiencyTool.h"
+#endif
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -12,8 +12,8 @@
 #include "PATInterfaces/ISystematicsTool.h"
 
 // external tools include(s):
-#include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
-#include "xAODBTaggingEfficiency/IBTaggingEfficiencyTool.h"
+#include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
+#include "FTagAnalysisInterfaces/IBTaggingEfficiencyTool.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -15,7 +15,7 @@
 #ifdef USE_CMAKE
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "FTagAnalysisInterfaces/IBTaggingEfficiencyTool.h"
-#else // RC back-compat
+#else // RootCore back-compat
 #include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
 #include "xAODBTaggingEfficiency/IBTaggingEfficiencyTool.h"
 #endif

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -29,7 +29,7 @@
 #include "JetInterface/IJetModifier.h"
 #ifdef USE_CMAKE
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
-#else // RootCore back-compat
+#else
 #include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
 #endif
 

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -27,7 +27,7 @@
 #include "AsgTools/AnaToolHandle.h"
 #include "JetJvtEfficiency/IJetJvtEfficiency.h"
 #include "JetInterface/IJetModifier.h"
-#include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
+#include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 
 class JetSelector : public xAH::Algorithm
 {

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -27,7 +27,11 @@
 #include "AsgTools/AnaToolHandle.h"
 #include "JetJvtEfficiency/IJetJvtEfficiency.h"
 #include "JetInterface/IJetModifier.h"
+#ifdef USE_CMAKE
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
+#else // RootCore back-compat
+#include "xAODBTaggingEfficiency/IBTaggingSelectionTool.h"
+#endif
 
 class JetSelector : public xAH::Algorithm
 {

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -18,7 +18,7 @@
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
 #include "IsolationSelection/IIsolationSelectionTool.h"
-#include "MuonSelectorTools/IMuonSelectionTool.h"
+#include "MuonAnalysisInterfaces/IMuonSelectionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -20,7 +20,7 @@
 #include "IsolationSelection/IIsolationSelectionTool.h"
 #ifdef USE_CMAKE
 #include "MuonAnalysisInterfaces/IMuonSelectionTool.h"
-#else // RootCore back-compat
+#else
 #include "MuonSelectorTools/IMuonSelectionTool.h"
 #endif
 #include "TriggerMatchingTool/IMatchingTool.h"

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -18,7 +18,11 @@
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
 #include "IsolationSelection/IIsolationSelectionTool.h"
+#ifdef USE_CMAKE
 #include "MuonAnalysisInterfaces/IMuonSelectionTool.h"
+#else // RootCore back-compat
+#include "MuonSelectorTools/IMuonSelectionTool.h"
+#endif
 #include "TriggerMatchingTool/IMatchingTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 


### PR DESCRIPTION
Get rid of brutal warnings that flood the screen during compilation with this pull request.

`CMakeLists.txt`: add updated interface paths
`Root/BJetEfficiencyCorrector.cxx`: comment unused parameter
`Root/MuonEfficiencyCorrector.cxx`: comment unused parameter
`xAODAnaHelpers/BJetEfficiencyCorrector.h`: update interface paths
`xAODAnaHelpers/JetSelector.h`: update interface path
`xAODAnaHelpers/MuonSelector.h`: update interface path