### PR TITLE
Fix xsec for private samples with existing DSIDs.

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -362,14 +362,10 @@ if __name__ == "__main__":
                 if len(parts)!=2: continue
                 config[parts[0].strip()]=parts[1].strip()
 
-          xsec   =float(config.get('xsec'   ,1))
-          filteff=float(config.get('filteff',1))
-          nEvents=float(config.get('nEvents',1))
-
           ROOT.SH.readFileList(sh_all, sname, fname)
-          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.crossSection    ,xsec)
-          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.filterEfficiency,filteff)
-          sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.numEvents       ,nEvents)
+          if 'xsec'    in config: sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.crossSection    ,float(config['xsec'   ]))
+          if 'filteff' in config: sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.filterEfficiency,float(config['filteff']))
+          if 'nEvents' in config: sh_all.get(sname).meta().setDouble(ROOT.SH.MetaFields.numEvents       ,float(config['nEvents']))
       else:
 
         if args.use_scanDQ2:


### PR DESCRIPTION
This bug affects reading datasets from txt files (rucio lists are ok) that have an DSID with an entry in the xsec database. A default value of 1 was set for cross-section. This is then added by EventLoop to any value read from the SUSY cross-section database, if an entry there already exists.

The fix sets the cross-section information only if the corresponding .config file exists. It is up to the user to make sure that there is no conflict with the SUSY database. All official samples should have an entry there. The only time a .config file should be present is if a new dataset is being created and then an existing DSID should not be reused.