### PR TITLE
Update CMakeList & xAH_run to allow for AnalysisTop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,19 @@
 atlas_subdir( xAODAnaHelpers )
 
 set( release_libs xAODTriggerCnvLib )
-if( ${AnalysisBase_VERSION} VERSION_GREATER 21.0 )
+
+if( AnalysisBase_VERSION AND AnalysisBase_VERSION VERSION_GREATER 21.0 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
+  MESSAGE("YES")
+elseif( AnalysisTop_VERSION AND AnalysisTop_VERSION VERSION_GREATER 21.0 )
+  # AnalysisTop 21.X
+  set( release_libs xAODTriggerCnvLib )
+  MESSAGE("YESTop")
 else()
   # 2.6.X
   set( release_libs xAODTriggerCnv )
+  MESSAGE("NO!!!")
 endif()
 
 # Declare the package's dependencies:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,15 +10,12 @@ set( release_libs xAODTriggerCnvLib )
 if( AnalysisBase_VERSION AND AnalysisBase_VERSION VERSION_GREATER 21.0 )
   # 21.X
   set( release_libs xAODTriggerCnvLib )
-  MESSAGE("YES")
 elseif( AnalysisTop_VERSION AND AnalysisTop_VERSION VERSION_GREATER 21.0 )
   # AnalysisTop 21.X
   set( release_libs xAODTriggerCnvLib )
-  MESSAGE("YESTop")
 else()
   # 2.6.X
   set( release_libs xAODTriggerCnv )
-  MESSAGE("NO!!!")
 endif()
 
 # Declare the package's dependencies:

--- a/python/utils.py
+++ b/python/utils.py
@@ -33,6 +33,14 @@ def is_release20():
 def is_release21():
   return not is_release20()
 
+## Find ASG analysis type (e.g. Base, Top) from a given list.  Return first option, or else None
+def findFrameworkTypeFromList(ASG_framework_list):
+  ASG_framework_types = [ ASGtype for ASGtype in ASG_framework_list if int( os.environ.get('Analysis'+ASGtype+'_SET_UP', 0) ) ]
+
+  if len(ASG_framework_types) == 0:
+    return None
+  else:
+    return ASG_framework_types[0]
 
 class ColoredFormatter(logging.Formatter):
   RESET_SEQ = "\033[0m"

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -258,18 +258,22 @@ if __name__ == "__main__":
 
     use_scanEOS = (args.use_scanEOS)
 
+
     # at this point, we should import ROOT and do stuff
     import ROOT
     if xAODAnaHelpers.utils.is_release20():
       xAH_logger.info("loading packages")
       ROOT.gROOT.Macro("$ROOTCOREDIR/scripts/load_packages.C")
     else:
-      # env var that tells us if CMAKE was setup
-      cmake_setup = 'AnalysisBase_SET_UP'
-      # architecture used for CMake
-      arch = os.environ.get('AnalysisBase_PLATFORM', os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>')))
-      if not int(os.environ.get(cmake_setup, 0)):
+      ## Determine which ASG framework using env var for CMAKE setup
+      ASG_framework_list = ['Base', 'Top']
+      try:
+        ASG_framework_type = next( ASGtype for ASGtype in ASG_framework_list if int( os.environ.get('Analysis'+ASGtype+'_SET_UP', 0) ) )
+      except:
         raise OSError("It doesn't seem like '{0:s}' exists. Did you set up your CMake environment correctly? (Hint: source 'build/{1:s}/setup.sh)".format(cmake_setup, arch))
+      # architecture used for CMake
+      arch = os.environ.get('Analysis'+ASG_framework_type+'_PLATFORM', os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>')))
+
     # Set up the job for xAOD access:
     ROOT.xAOD.Init("xAH_run").ignore()
 
@@ -410,8 +414,8 @@ if __name__ == "__main__":
 
     # This is a fix for running on the grid with release 21.2.X
     if int(os.environ.get('ROOTCORE_RELEASE_SERIES', 0)) >= 25:
-      xAH_logger.info("Setting nc_cmtConfig to {0:s}".format(os.getenv("AnalysisBase_PLATFORM")))
-      sh_all.setMetaString("nc_cmtConfig", os.getenv("AnalysisBase_PLATFORM"))
+      xAH_logger.info("Setting nc_cmtConfig to {0:s}".format(os.getenv('Analysis'+ASG_framework_type+'_PLATFORM')))
+      sh_all.setMetaString("nc_cmtConfig", os.getenv('Analysis'+ASG_framework_type+'_PLATFORM'))
 
     # read susy meta data (should be configurable)
     path_metadata=ROOT.PathResolverFindCalibDirectory("xAODAnaHelpers/metadata")

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -267,10 +267,10 @@ if __name__ == "__main__":
     else:
       ## Determine which ASG framework using env var for CMAKE setup
       ASG_framework_list = ['Base', 'Top']
-      try:
-        ASG_framework_type = next( ASGtype for ASGtype in ASG_framework_list if int( os.environ.get('Analysis'+ASGtype+'_SET_UP', 0) ) )
-      except:
+      ASG_framework_type = xAODAnaHelpers.utils.findFrameworkTypeFromList(ASG_framework_list)
+      if( ASG_framework_type == None ):
         raise OSError("It doesn't seem like '{0:s}' exists. Did you set up your CMake environment correctly? (Hint: source 'build/{1:s}/setup.sh)".format(cmake_setup, arch))
+
       # architecture used for CMake
       arch = os.environ.get('Analysis'+ASG_framework_type+'_PLATFORM', os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>')))
 

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -269,10 +269,11 @@ if __name__ == "__main__":
       ASG_framework_list = ['Base', 'Top']
       ASG_framework_type = xAODAnaHelpers.utils.findFrameworkTypeFromList(ASG_framework_list)
       if( ASG_framework_type == None ):
-        raise OSError("It doesn't seem like '{0:s}' exists. Did you set up your CMake environment correctly? (Hint: source 'build/{1:s}/setup.sh)".format(cmake_setup, arch))
+        arch = os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>'))
+        raise OSError("It doesn't seem like the CMake environment is setup correctly. (Hint: source 'build/{0:s}/setup.sh)".format(arch))
 
       # architecture used for CMake
-      arch = os.environ.get('Analysis'+ASG_framework_type+'_PLATFORM', os.environ.get('CMTCONFIG', os.environ.get('BINARY_TYPE', '<arch>')))
+      arch = os.environ.get('Analysis'+ASG_framework_type+'_PLATFORM')
 
     # Set up the job for xAOD access:
     ROOT.xAOD.Init("xAH_run").ignore()


### PR DESCRIPTION
Our CMakeList & xAH_run.py files currently require AnalysisBase environmental variables to be set, excluding the possibility to run in other ASG analysis frameworks.  These changes would allow AnalysisTop to be used (perhaps others can be added in the future if needed). 

This also swaps the environmental variable ${AnalysisBase_VERSION} for the cmake variable AnalysisBase_VERSION in CMakeList.txt, which seems cleaner.