### PR TITLE
Update tool interfaces to be compatible with 21.2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
     - ABV_CM=21.2.7 ALLOWFAIL=true
     - ABV_CM=21.2.10 ALLOWFAIL=false
+    - ABV_CM=21.2.13 ALLOWFAIL=false
 script:
   - envsubst '\$ABV_CM \$TRAVIS_COMMIT \$TRAVIS_JOB_ID' < ci/Dockerfile > Dockerfile
   - docker build --build-arg ABV_CM=${ABV_CM}

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -995,7 +995,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       typedef std::multimap< std::string, AsgElectronLikelihoodTool* > LHToolsMap;
       LHToolsMap myLHTools = m_el_LH_PIDManager->getValidWPTools();
 
-      if ( m_doLHPIDcut && !( ( myLHTools.find( m_LHOperatingPoint )->second )->accept( *electron ) ) ) {
+      if ( m_doLHPIDcut && !( ( myLHTools.find( m_LHOperatingPoint )->second )->accept( electron ) ) ) {
         ANA_MSG_DEBUG( "Electron failed likelihood PID cut w/ operating point " << m_LHOperatingPoint );
         return 0;
       }
@@ -1004,8 +1004,8 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
         const std::string decorWP =  "LH" + it.first;
         ANA_MSG_DEBUG( "Decorating electron with decision for LH WP : " << decorWP );
-        ANA_MSG_DEBUG( "\t does electron pass " << decorWP << " ? " << static_cast<int>( it.second->accept( *electron ) ) );
-        electron->auxdecor<char>(decorWP) = static_cast<char>( it.second->accept( *electron ) );
+        ANA_MSG_DEBUG( "\t does electron pass " << decorWP << " ? " << static_cast<int>( it.second->accept( electron ) ) );
+        electron->auxdecor<char>(decorWP) = static_cast<char>( it.second->accept( electron ) );
 
       }
 

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -85,8 +85,9 @@ EL::StatusCode TrigMatcher :: initialize ()
 
   //  everything went fine, let's initialise the tool!
   //
-  m_trigMatchTool = new Trig::MatchingTool("TrigMatchTool_"+m_name);
-  ANA_CHECK( m_trigMatchTool->setProperty( "OutputLevel", msg().level()) );
+  setToolName(m_trigMatchTool_handle);
+  ANA_CHECK( ASG_MAKE_ANA_TOOL(m_trigMatchTool_handle, Trig::MatchingTool) );
+  ANA_CHECK( m_trigMatchTool_handle.retrieve() );
 
   // **********************************************************************************************
 
@@ -152,19 +153,11 @@ EL::StatusCode TrigMatcher :: executeMatching ( const xAOD::IParticleContainer* 
       for ( auto const &chain : m_trigChainsList ) {
 	ANA_MSG_DEBUG( "\t checking trigger chain " << chain);
 
-	bool matched = m_trigMatchTool->match( *particle, chain, 0.07 );
+	bool matched = m_trigMatchTool_handle->match( *particle, chain, 0.07 );
 	ANA_MSG_DEBUG( "\t\t result = " << matched );
 	if(matched) isTrigMatchedDecor( *particle ).push_back( chain );
       }
     }
-
-  return EL::StatusCode::SUCCESS;
-}
-
-EL::StatusCode TrigMatcher :: finalize ()
-{
-  ANA_MSG_INFO( "Cleaning up...");
-  if(m_trigMatchTool) { delete m_trigMatchTool; m_trigMatchTool=nullptr; }
 
   return EL::StatusCode::SUCCESS;
 }

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -74,7 +74,7 @@ public:
 private:
 
   /* tools */
-  Trig::MatchingTool* m_trigMatchTool = nullptr; //!
+  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle{"Trig::MatchingTool"}; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 
@@ -91,7 +91,6 @@ public:
   virtual EL::StatusCode setupJob (EL::Job& job);
   virtual EL::StatusCode initialize ();
   virtual EL::StatusCode execute ();
-  virtual EL::StatusCode finalize ();
 
   /* these are the functions not inherited from Algorithm */
   EL::StatusCode executeMatching( const xAOD::IParticleContainer* inParticles );


### PR DESCRIPTION
Updates to the tool interfaces to make them compatible with the latest AnalysisBase release:
* `ElectronSelection` tool only wants pointers to electrons, not references.
* Trig::MatchingTool has a new non-default option to [allow rerun decision](https://gitlab.cern.ch/atlas/athena/merge_requests/6515). This does have a default value if you use `Trig::IMatchingTool` and `asg::AnaToolHandle`. This updates `TrigMatcher` to use the `asg::AnaToolHandle` interface.

I am marking this as a WIP, because 21.2.13 does not like the way that we name our tools in BasicEventSelection: `<ToolType>/<ToolType>_<AlgorithmName>::<AlgorithmAddress>`. More speficially, the GRL tool hangs on retrieve if `::<AlgorithmAddress>` is included in the name. I reported it here:
https://groups.cern.ch/group/hn-atlas-PATHelp/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-PATHelp%2fLists%2fArchive%2fAnaToolHandleIGoodRunsListSelectionToolretrieve%20hangs%20in%2021%2e2%2e13&FolderCTID=0x0120020084D7E80CB0C3394A8D54EF07C309B044