### PR TITLE
Use Private Tools In Algorithms

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -36,10 +36,8 @@ using HelperClasses::ToolName;
 ClassImp(BJetEfficiencyCorrector)
 
 
-BJetEfficiencyCorrector :: BJetEfficiencyCorrector ()
-: Algorithm("BJetEfficiencyCorrector"),
-  m_BJetSelectTool_handle("BTaggingSelectionTool",this),
-  m_BJetEffSFTool_handle("BTaggingEfficiencyTool",this)
+BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
+    Algorithm("BJetEfficiencyCorrector")
 {
 }
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -162,6 +162,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   // initialize the BJetSelectionTool
   // A few which are not configurable as of yet....
   // is there a reason to have this configurable here??...I think no (GF to self)
+  setToolName(m_BJetSelectTool_handle);
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("MaxEta",2.5));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("MinPt",20000.));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("FlvTagCutDefinitionsFileName",m_corrFileName.c_str()));
@@ -177,6 +178,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if( m_getScaleFactors ) {
 
     // initialize the BJetEfficiencyCorrectionTool
+    setToolName(m_BJetEffSFTool_handle);
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("TaggerName",          m_taggerName));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("SystematicsStrategy", m_systematicsStrategy ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("OperatingPoint",      m_operatingPtCDI));

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -36,8 +36,10 @@ using HelperClasses::ToolName;
 ClassImp(BJetEfficiencyCorrector)
 
 
-BJetEfficiencyCorrector :: BJetEfficiencyCorrector () :
-    Algorithm("BJetEfficiencyCorrector")
+BJetEfficiencyCorrector :: BJetEfficiencyCorrector ()
+: Algorithm("BJetEfficiencyCorrector"),
+  m_BJetSelectTool_handle("BTaggingSelectionTool",this),
+  m_BJetEffSFTool_handle("BTaggingEfficiencyTool",this)
 {
 }
 
@@ -160,8 +162,6 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   }
 
   // initialize the BJetSelectionTool
-  setToolName(m_BJetSelectTool_handle);
-  //  Configure the BJetSelectionTool
   // A few which are not configurable as of yet....
   // is there a reason to have this configurable here??...I think no (GF to self)
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("MaxEta",2.5));
@@ -179,7 +179,6 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if( m_getScaleFactors ) {
 
     // initialize the BJetEfficiencyCorrectionTool
-    setToolName(m_BJetEffSFTool_handle);
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("TaggerName",          m_taggerName));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("SystematicsStrategy", m_systematicsStrategy ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("OperatingPoint",      m_operatingPtCDI));

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -325,6 +325,8 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
     //Initialize Tool
     if( m_reweightSherpa22 ){
+
+      setToolName(m_reweightSherpa22_tool_handle);
       ANA_CHECK( m_reweightSherpa22_tool_handle.setProperty( "TruthJetContainer", pmg_TruthJetContainer ));
       ANA_CHECK( m_reweightSherpa22_tool_handle.setProperty( "OutputLevel", msg().level() ));
       ANA_CHECK( m_reweightSherpa22_tool_handle.retrieve());
@@ -439,6 +441,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
         vecStringGRL.push_back(file);
     }
 
+    setToolName(m_grl_handle);
     ANA_CHECK( m_grl_handle.setProperty("GoodRunsListVec", vecStringGRL));
     ANA_CHECK( m_grl_handle.setProperty("PassThrough", false));
     ANA_CHECK( m_grl_handle.setProperty("OutputLevel", msg().level()));
@@ -491,6 +494,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
       printf( "\t %s \n", lumiCalcFiles.at(i).c_str() );
     }
 
+    setToolName(m_pileup_tool_handle, "Pileup");
     ANA_CHECK( m_pileup_tool_handle.setProperty("ConfigFiles", PRWFiles));
     ANA_CHECK( m_pileup_tool_handle.setProperty("LumiCalcFiles", lumiCalcFiles));
     ANA_CHECK( m_pileup_tool_handle.setProperty("DataScaleFactor", 1.0/1.09));
@@ -516,10 +520,12 @@ EL::StatusCode BasicEventSelection :: initialize ()
   if( !m_triggerSelection.empty() || !m_extraTriggerSelection.empty() ||
       m_applyTriggerCut || m_storeTrigDecisions || m_storePassL1 || m_storePassHLT || m_storeTrigKeys ) {
 
+    setToolName(m_trigConfTool_handle);
     ANA_CHECK( m_trigConfTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_trigConfTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigConfTool_handle);
 
+    setToolName(m_trigDecTool_handle, "TrigDecisionTool");
     ANA_CHECK( m_trigDecTool_handle.setProperty( "ConfigTool", m_trigConfTool_handle ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "TrigDecisionKey", "xTrigDecision" ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "OutputLevel", msg().level() ));

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -34,8 +34,13 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(BasicEventSelection)
 
-BasicEventSelection :: BasicEventSelection () :
-    Algorithm("BasicEventSelection")
+BasicEventSelection :: BasicEventSelection ()
+: Algorithm("BasicEventSelection"),
+  m_grl_handle("GoodRunsListSelectionTool/grl", this),
+  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup"),
+  m_trigConfTool_handle("TrigConf::xAODConfigTool/xAODConfigTool", this),
+  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
+  m_reweightSherpa22_tool_handle("PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool",this)
 {
 }
 
@@ -325,8 +330,6 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
     //Initialize Tool
     if( m_reweightSherpa22 ){
-
-      setToolName(m_reweightSherpa22_tool_handle);
       ANA_CHECK( m_reweightSherpa22_tool_handle.setProperty( "TruthJetContainer", pmg_TruthJetContainer ));
       ANA_CHECK( m_reweightSherpa22_tool_handle.setProperty( "OutputLevel", msg().level() ));
       ANA_CHECK( m_reweightSherpa22_tool_handle.retrieve());
@@ -441,8 +444,7 @@ EL::StatusCode BasicEventSelection :: initialize ()
         vecStringGRL.push_back(file);
     }
 
-    setToolName(m_grl_handle);
-    ANA_CHECK( m_grl_handle.setProperty( "GoodRunsListVec", vecStringGRL));
+    ANA_CHECK( m_grl_handle.setProperty("GoodRunsListVec", vecStringGRL));
     ANA_CHECK( m_grl_handle.setProperty("PassThrough", false));
     ANA_CHECK( m_grl_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_grl_handle.retrieve());
@@ -494,7 +496,6 @@ EL::StatusCode BasicEventSelection :: initialize ()
       printf( "\t %s \n", lumiCalcFiles.at(i).c_str() );
     }
 
-    setToolName(m_pileup_tool_handle, "Pileup");
     ANA_CHECK( m_pileup_tool_handle.setProperty("ConfigFiles", PRWFiles));
     ANA_CHECK( m_pileup_tool_handle.setProperty("LumiCalcFiles", lumiCalcFiles));
     ANA_CHECK( m_pileup_tool_handle.setProperty("DataScaleFactor", 1.0/1.09));
@@ -520,12 +521,10 @@ EL::StatusCode BasicEventSelection :: initialize ()
   if( !m_triggerSelection.empty() || !m_extraTriggerSelection.empty() ||
       m_applyTriggerCut || m_storeTrigDecisions || m_storePassL1 || m_storePassHLT || m_storeTrigKeys ) {
 
-    setToolName(m_trigConfTool_handle);
     ANA_CHECK( m_trigConfTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_trigConfTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigConfTool_handle);
 
-    setToolName(m_trigDecTool_handle, m_trigDecTool_name);
     ANA_CHECK( m_trigDecTool_handle.setProperty( "ConfigTool", m_trigConfTool_handle ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "TrigDecisionKey", "xTrigDecision" ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "OutputLevel", msg().level() ));

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -34,13 +34,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(BasicEventSelection)
 
-BasicEventSelection :: BasicEventSelection ()
-: Algorithm("BasicEventSelection"),
-  m_grl_handle("GoodRunsListSelectionTool/grl", this),
-  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup"),
-  m_trigConfTool_handle("TrigConf::xAODConfigTool/xAODConfigTool", this),
-  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
-  m_reweightSherpa22_tool_handle("PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool",this)
+BasicEventSelection :: BasicEventSelection () :
+    Algorithm("BasicEventSelection")
 {
 }
 

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -37,12 +37,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ElectronSelector)
 
-ElectronSelector :: ElectronSelector ()
-: Algorithm("ElectronSelector"),
-  m_isolationSelectionTool_handle("CP::IsolationSelectionTool/IsolationSelectionTool",this),
-  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
-  m_trigElectronMatchTool_handle("Trig::MatchingTool/MatchingTool",this)
-
+ElectronSelector :: ElectronSelector () :
+    Algorithm("ElectronSelector")
 {
 }
 

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -37,8 +37,12 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(ElectronSelector)
 
-ElectronSelector :: ElectronSelector () :
-    Algorithm("ElectronSelector")
+ElectronSelector :: ElectronSelector ()
+: Algorithm("ElectronSelector"),
+  m_isolationSelectionTool_handle("CP::IsolationSelectionTool/IsolationSelectionTool",this),
+  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
+  m_trigElectronMatchTool_handle("Trig::MatchingTool/MatchingTool",this)
+
 {
 }
 
@@ -298,7 +302,6 @@ EL::StatusCode ElectronSelector :: initialize ()
   //
   // *************************************
 
-  setToolName(m_isolationSelectionTool_handle);
   // Do this only for the first WP in the list
   ANA_MSG_DEBUG( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" );
   ANA_CHECK( m_isolationSelectionTool_handle.setProperty("ElectronWP", (m_IsoKeys.at(0)).c_str()));
@@ -345,7 +348,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   //     do not initialise if there are no input trigger chains
   if(  !( m_singleElTrigChains.empty() && m_diElTrigChains.empty() ) ) {
     // Grab the TrigDecTool from the ToolStore
-    if(!setToolName(m_trigDecTool_handle, m_trigDecTool_name)){
+    if(!m_trigDecTool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;
     }
@@ -353,7 +356,6 @@ EL::StatusCode ElectronSelector :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
     //  everything went fine, let's initialise the tool!
-    setToolName(m_trigElectronMatchTool_handle);
     ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
     ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
     ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -298,6 +298,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   //
   // *************************************
 
+  setToolName(m_isolationSelectionTool_handle);
   // Do this only for the first WP in the list
   ANA_MSG_DEBUG( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" );
   ANA_CHECK( m_isolationSelectionTool_handle.setProperty("ElectronWP", (m_IsoKeys.at(0)).c_str()));
@@ -344,6 +345,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   //     do not initialise if there are no input trigger chains
   if(  !( m_singleElTrigChains.empty() && m_diElTrigChains.empty() ) ) {
     // Grab the TrigDecTool from the ToolStore
+    setToolName(m_trigDecTool_handle, "TrigDecisionTool");
     if(!m_trigDecTool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;
@@ -352,6 +354,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
     //  everything went fine, let's initialise the tool!
+    setToolName(m_trigElectronMatchTool_handle);
     ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
     ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
     ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -38,9 +38,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetRoIBuilder)
 
-HLTJetRoIBuilder :: HLTJetRoIBuilder ()
-: Algorithm("HLTJetRoIBuilder"),
-  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool")
+HLTJetRoIBuilder :: HLTJetRoIBuilder () :
+  Algorithm("HLTJetRoIBuilder")
 {
 }
 

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -38,8 +38,9 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(HLTJetRoIBuilder)
 
-HLTJetRoIBuilder :: HLTJetRoIBuilder () :
-  Algorithm("HLTJetRoIBuilder")
+HLTJetRoIBuilder :: HLTJetRoIBuilder ()
+: Algorithm("HLTJetRoIBuilder"),
+  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool")
 {
 }
 
@@ -85,7 +86,7 @@ EL::StatusCode HLTJetRoIBuilder :: initialize ()
   m_store = wk()->xaodStore();
 
   // Grab the TrigDecTool from the ToolStore
-  if(!setToolName(m_trigDecTool_handle, m_trigDecTool_name)){
+  if(!m_trigDecTool_handle.isUserConfigured()){
     ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
     return EL::StatusCode::FAILURE;
   }

--- a/Root/HLTJetRoIBuilder.cxx
+++ b/Root/HLTJetRoIBuilder.cxx
@@ -85,6 +85,7 @@ EL::StatusCode HLTJetRoIBuilder :: initialize ()
   m_store = wk()->xaodStore();
 
   // Grab the TrigDecTool from the ToolStore
+  setToolName(m_trigDecTool_handle, "TrigDecisionTool");
   if(!m_trigDecTool_handle.isUserConfigured()){
     ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
     return EL::StatusCode::FAILURE;

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -44,16 +44,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetCalibrator)
 
-JetCalibrator :: JetCalibrator ()
-: Algorithm("JetCalibrator"),
-  m_JetCalibrationTool_handle("JetCalibrationTool",this),
-  m_JetUncertaintiesTool_handle("JetUncertaintiesTool",this),
-  m_JERTool_handle("JERTool",this),
-  m_JERSmearingTool_handle("JERSmearingTool",this),
-  m_JVTUpdateTool_handle("JetVertexTaggerTool",this),
-  m_fJVTTool_handle("JetForwardJvtTool",this),
-  m_JetCleaningTool_handle("JetCleaningTool",this),
-  m_JetTileCorrectionTool_handle("JetTileCorrectionTool",this)
+JetCalibrator :: JetCalibrator () :
+    Algorithm("JetCalibrator")
 {
 }
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -172,6 +172,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   // initialize jet calibration tool
+  setToolName(m_JetCalibrationTool_handle);
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("JetCollection",m_jetAlgo));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("ConfigFile",m_calibConfig));
@@ -189,6 +190,7 @@ EL::StatusCode JetCalibrator :: initialize ()
 
   // initialize jet tile correction tool
   if(m_doJetTileCorr && !isMC()){ // Jet Tile Correction should only be applied to data
+    setToolName(m_JetTileCorrectionTool_handle);
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetTileCorrectionTool_handle, CP::JetTileCorrectionTool));
     ANA_CHECK( m_JetTileCorrectionTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JetTileCorrectionTool_handle.retrieve());
@@ -199,6 +201,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     // initialize and configure the jet cleaning tool
     //------------------------------------------------
 
+    setToolName(m_JetCleaningTool_handle);
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "CutLevel", m_jetCleanCutLevel));
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "DoUgly", m_jetCleanUgly));
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "OutputLevel", msg().level() ));
@@ -212,7 +215,12 @@ EL::StatusCode JetCalibrator :: initialize ()
       m_decisionNames.push_back( "TightBadUgly" );
 
       for(unsigned int iD=0; iD < m_decisionNames.size() ; ++iD){
-        asg::AnaToolHandle<IJetSelector> this_JetCleaningTool_handle("JetCleaningTool/JetCleaningTool_"+m_decisionNames.at(iD), this);
+#ifdef USE_CMAKE
+	asg::AnaToolHandle<IJetSelector> this_JetCleaningTool_handle("JetCleaningTool/JetCleaningTool_"+m_decisionNames.at(iD), this);
+#else
+	asg::AnaToolHandle<IJetSelector> this_JetCleaningTool_handle{"JetCleaningTool"};
+        setToolName(this_JetCleaningTool_handle, "JetCleaningTool_"+m_decisionNames.at(iD)+"_"+m_name);
+#endif
         if( m_decisionNames.at(iD).find("Ugly") != std::string::npos ){
           ANA_CHECK( this_JetCleaningTool_handle.setProperty( "CutLevel", m_decisionNames.at(iD).substr(0,m_decisionNames.at(iD).size()-4) ));
           ANA_CHECK( this_JetCleaningTool_handle.setProperty( "DoUgly", true));
@@ -259,6 +267,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   //------------------------------------------------
   if ( !m_JESUncertConfig.empty() && !m_systNameJES.empty()  && m_systNameJES != "None" ) {
 
+    setToolName(m_JetUncertaintiesTool_handle);
     ANA_MSG_INFO("Initialize JES UNCERT with " << m_JESUncertConfig);
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetUncertaintiesTool_handle, JetUncertaintiesTool));
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("JetDefinition",m_jetAlgo));
@@ -310,6 +319,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   if ( !m_JERUncertConfig.empty() ) {
 
     // Instantiate the JER tool
+    setToolName(m_JERTool_handle);
     ANA_CHECK( m_JERTool_handle.setProperty("PlotFileName", m_JERUncertConfig.c_str()));
     ANA_CHECK( m_JERTool_handle.setProperty("CollectionName", m_jetAlgo));
     ANA_CHECK( m_JERTool_handle.setProperty("OutputLevel", msg().level() ));
@@ -317,6 +327,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_JERTool_handle);
 
     // Instantiate the JER Smearing tool
+    setToolName(m_JERSmearingTool_handle);
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("JERTool", m_JERTool_handle.getHandle()));
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("isMC", isMC()));
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("ApplyNominalSmearing", m_JERApplyNominal));
@@ -349,6 +360,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   // initialize and configure the JVT correction tool
 
   if( m_redoJVT ){
+    setToolName(m_JVTUpdateTool_handle);
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVTFileName", PathResolverFindCalibFile("JetMomentTools/JVTlikelihood_20140805.root")));
 
     if( ! m_JvtAuxName.empty() ){
@@ -360,6 +372,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   if ( m_calculatefJVT ) {
+    setToolName(m_fJVTTool_handle);
     ANA_CHECK(m_fJVTTool_handle.setProperty("CentralMaxPt", m_fJVTCentralMaxPt));
     if ( m_fJVTWorkingPoint == "Tight" ) {
       ANA_CHECK(m_fJVTTool_handle.setProperty("UseTightOP", true));

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -44,8 +44,16 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(JetCalibrator)
 
-JetCalibrator :: JetCalibrator () :
-    Algorithm("JetCalibrator")
+JetCalibrator :: JetCalibrator ()
+: Algorithm("JetCalibrator"),
+  m_JetCalibrationTool_handle("JetCalibrationTool",this),
+  m_JetUncertaintiesTool_handle("JetUncertaintiesTool",this),
+  m_JERTool_handle("JERTool",this),
+  m_JERSmearingTool_handle("JERSmearingTool",this),
+  m_JVTUpdateTool_handle("JetVertexTaggerTool",this),
+  m_fJVTTool_handle("JetForwardJvtTool",this),
+  m_JetCleaningTool_handle("JetCleaningTool",this),
+  m_JetTileCorrectionTool_handle("JetTileCorrectionTool",this)
 {
 }
 
@@ -172,7 +180,6 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   // initialize jet calibration tool
-  setToolName(m_JetCalibrationTool_handle);
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("JetCollection",m_jetAlgo));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("ConfigFile",m_calibConfig));
@@ -190,7 +197,6 @@ EL::StatusCode JetCalibrator :: initialize ()
 
   // initialize jet tile correction tool
   if(m_doJetTileCorr && !isMC()){ // Jet Tile Correction should only be applied to data
-    setToolName(m_JetTileCorrectionTool_handle);
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetTileCorrectionTool_handle, CP::JetTileCorrectionTool));
     ANA_CHECK( m_JetTileCorrectionTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JetTileCorrectionTool_handle.retrieve());
@@ -201,7 +207,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     // initialize and configure the jet cleaning tool
     //------------------------------------------------
 
-    setToolName(m_JetCleaningTool_handle);
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "CutLevel", m_jetCleanCutLevel));
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "DoUgly", m_jetCleanUgly));
     ANA_CHECK( m_JetCleaningTool_handle.setProperty( "OutputLevel", msg().level() ));
@@ -215,8 +220,7 @@ EL::StatusCode JetCalibrator :: initialize ()
       m_decisionNames.push_back( "TightBadUgly" );
 
       for(unsigned int iD=0; iD < m_decisionNames.size() ; ++iD){
-        asg::AnaToolHandle<IJetSelector> this_JetCleaningTool_handle{"JetCleaningTool"};
-        setToolName(this_JetCleaningTool_handle, "JetCleaningTool_"+m_decisionNames.at(iD)+"_"+m_name);
+        asg::AnaToolHandle<IJetSelector> this_JetCleaningTool_handle("JetCleaningTool/JetCleaningTool_"+m_decisionNames.at(iD), this);
         if( m_decisionNames.at(iD).find("Ugly") != std::string::npos ){
           ANA_CHECK( this_JetCleaningTool_handle.setProperty( "CutLevel", m_decisionNames.at(iD).substr(0,m_decisionNames.at(iD).size()-4) ));
           ANA_CHECK( this_JetCleaningTool_handle.setProperty( "DoUgly", true));
@@ -263,7 +267,6 @@ EL::StatusCode JetCalibrator :: initialize ()
   //------------------------------------------------
   if ( !m_JESUncertConfig.empty() && !m_systNameJES.empty()  && m_systNameJES != "None" ) {
 
-    setToolName(m_JetUncertaintiesTool_handle);
     ANA_MSG_INFO("Initialize JES UNCERT with " << m_JESUncertConfig);
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetUncertaintiesTool_handle, JetUncertaintiesTool));
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("JetDefinition",m_jetAlgo));
@@ -315,7 +318,6 @@ EL::StatusCode JetCalibrator :: initialize ()
   if ( !m_JERUncertConfig.empty() ) {
 
     // Instantiate the JER tool
-    setToolName(m_JERTool_handle);
     ANA_CHECK( m_JERTool_handle.setProperty("PlotFileName", m_JERUncertConfig.c_str()));
     ANA_CHECK( m_JERTool_handle.setProperty("CollectionName", m_jetAlgo));
     ANA_CHECK( m_JERTool_handle.setProperty("OutputLevel", msg().level() ));
@@ -323,7 +325,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_JERTool_handle);
 
     // Instantiate the JER Smearing tool
-    setToolName(m_JERSmearingTool_handle);
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("JERTool", m_JERTool_handle.getHandle()));
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("isMC", isMC()));
     ANA_CHECK( m_JERSmearingTool_handle.setProperty("ApplyNominalSmearing", m_JERApplyNominal));
@@ -356,7 +357,6 @@ EL::StatusCode JetCalibrator :: initialize ()
   // initialize and configure the JVT correction tool
 
   if( m_redoJVT ){
-    setToolName(m_JVTUpdateTool_handle);
     ANA_CHECK( m_JVTUpdateTool_handle.setProperty("JVTFileName", PathResolverFindCalibFile("JetMomentTools/JVTlikelihood_20140805.root")));
 
     if( ! m_JvtAuxName.empty() ){
@@ -368,7 +368,6 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   if ( m_calculatefJVT ) {
-    setToolName(m_fJVTTool_handle);
     ANA_CHECK(m_fJVTTool_handle.setProperty("CentralMaxPt", m_fJVTCentralMaxPt));
     if ( m_fJVTWorkingPoint == "Tight" ) {
       ANA_CHECK(m_fJVTTool_handle.setProperty("UseTightOP", true));

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -215,6 +215,7 @@ EL::StatusCode JetSelector :: initialize ()
   if ( m_doBTagCut ) {
 
     // initialize the BJetSelectionTool
+    setToolName(m_BJetSelectTool_handle);
     // A few which are not configurable as of yet....
     // is there a reason to have this configurable here??...I think no (GF to self)
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("MaxEta",m_b_eta_max));
@@ -233,6 +234,7 @@ EL::StatusCode JetSelector :: initialize ()
   //init fJVT
   if (m_dofJVT) {
     // initialize the CP::JetJvtEfficiency Tool for fJVT
+    setToolName(m_fJVT_eff_tool_handle, "fJVT_eff_tool");
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
@@ -266,6 +268,7 @@ EL::StatusCode JetSelector :: initialize ()
   }
 
   // initialize the CP::JetJvtEfficiency Tool for JVT
+  setToolName(m_JVT_tool_handle, "JVT_eff_tool");
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JVT_tool_handle, CP::JetJvtEfficiency));
   ANA_CHECK( m_JVT_tool_handle.setProperty("WorkingPoint", m_WorkingPointJVT ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("SFFile",       m_SFFileJVT ));

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -9,7 +9,7 @@
 #include <EventLoop/Worker.h>
 
 // EDM include(s):
-#include "xAODJet/JetContainer.h"
+#include <xAODJet/JetContainer.h>
 #include <xAODJet/JetAuxContainer.h>
 #include <xAODCore/AuxContainerBase.h>
 #include "xAODCore/ShallowCopy.h"
@@ -38,8 +38,11 @@
 ClassImp(JetSelector)
 
 
-JetSelector :: JetSelector () :
-    Algorithm("JetSelector")
+JetSelector :: JetSelector ()
+: Algorithm("JetSelector"),
+  m_JVT_tool_handle("CP::JetJvtEfficiency/JVT_eff_tool"),
+  m_fJVT_eff_tool_handle("CP::JetJvtEfficiency/fJVT_eff_tool"),
+  m_BJetSelectTool_handle("BTaggingSelectionTool",this)
 {
 }
 
@@ -215,7 +218,6 @@ EL::StatusCode JetSelector :: initialize ()
   if ( m_doBTagCut ) {
 
     // initialize the BJetSelectionTool
-    setToolName(m_BJetSelectTool_handle);
     // A few which are not configurable as of yet....
     // is there a reason to have this configurable here??...I think no (GF to self)
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("MaxEta",m_b_eta_max));
@@ -234,7 +236,6 @@ EL::StatusCode JetSelector :: initialize ()
   //init fJVT
   if (m_dofJVT) {
     // initialize the CP::JetJvtEfficiency Tool for fJVT
-    setToolName(m_fJVT_eff_tool_handle, "fJVT_eff_tool");
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
@@ -268,7 +269,6 @@ EL::StatusCode JetSelector :: initialize ()
   }
 
   // initialize the CP::JetJvtEfficiency Tool for JVT
-  setToolName(m_JVT_tool_handle, "JVT_eff_tool");
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JVT_tool_handle, CP::JetJvtEfficiency));
   ANA_CHECK( m_JVT_tool_handle.setProperty("WorkingPoint", m_WorkingPointJVT ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("SFFile",       m_SFFileJVT ));

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -38,11 +38,8 @@
 ClassImp(JetSelector)
 
 
-JetSelector :: JetSelector ()
-: Algorithm("JetSelector"),
-  m_JVT_tool_handle("CP::JetJvtEfficiency/JVT_eff_tool"),
-  m_fJVT_eff_tool_handle("CP::JetJvtEfficiency/fJVT_eff_tool"),
-  m_BJetSelectTool_handle("BTaggingSelectionTool",this)
+JetSelector :: JetSelector () :
+    Algorithm("JetSelector")
 {
 }
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -157,7 +157,6 @@ EL::StatusCode METConstructor :: initialize ()
   }
 
   //////////// IMETSignificance ////////////////
-  setToolName( m_metSignificance_handle );
   ASG_SET_ANA_TOOL_TYPE( m_metSignificance_handle, met::METSignificance );
   ANA_CHECK( m_metSignificance_handle.setProperty("TreatPUJets", m_significanceTreatPUJets) );
 #ifdef USE_CMAKE

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -157,6 +157,7 @@ EL::StatusCode METConstructor :: initialize ()
   }
 
   //////////// IMETSignificance ////////////////
+  setToolName( m_metSignificance_handle );
   ASG_SET_ANA_TOOL_TYPE( m_metSignificance_handle, met::METSignificance );
   ANA_CHECK( m_metSignificance_handle.setProperty("TreatPUJets", m_significanceTreatPUJets) );
 #ifdef USE_CMAKE

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -36,8 +36,9 @@ using HelperClasses::ToolName;
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonCalibrator)
 
-MuonCalibrator :: MuonCalibrator () :
-    Algorithm("MuonCalibrator")
+MuonCalibrator :: MuonCalibrator ()
+: Algorithm("MuonCalibrator"),
+  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup")
 {
 }
 
@@ -126,7 +127,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   // will be used.
   //
   if( isMC() ){
-    if(!setToolName(m_pileup_tool_handle, "Pileup")){
+    if(!m_pileup_tool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_pileup_tool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;
     }

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -36,9 +36,8 @@ using HelperClasses::ToolName;
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonCalibrator)
 
-MuonCalibrator :: MuonCalibrator ()
-: Algorithm("MuonCalibrator"),
-  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup")
+MuonCalibrator :: MuonCalibrator () :
+    Algorithm("MuonCalibrator")
 {
 }
 

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -126,6 +126,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   // will be used.
   //
   if( isMC() ){
+    setToolName(m_pileup_tool_handle, "Pileup");
     if(!m_pileup_tool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_pileup_tool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -34,8 +34,9 @@ using HelperClasses::ToolName;
 ClassImp(MuonEfficiencyCorrector)
 
 
-MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
-    Algorithm("MuonEfficiencyCorrector")
+MuonEfficiencyCorrector :: MuonEfficiencyCorrector ()
+: Algorithm("MuonEfficiencyCorrector"),
+  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup")
 {
 }
 
@@ -123,7 +124,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // Create a ToolHandle of the PRW tool which is passed to the MuonEfficiencyScaleFactors class later
   //
   if( isMC() ){
-    if(!setToolName(m_pileup_tool_handle, "Pileup")){
+    if(!m_pileup_tool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_pileup_tool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;
     }

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -34,9 +34,8 @@ using HelperClasses::ToolName;
 ClassImp(MuonEfficiencyCorrector)
 
 
-MuonEfficiencyCorrector :: MuonEfficiencyCorrector ()
-: Algorithm("MuonEfficiencyCorrector"),
-  m_pileup_tool_handle("CP::PileupReweightingTool/Pileup")
+MuonEfficiencyCorrector :: MuonEfficiencyCorrector () :
+    Algorithm("MuonEfficiencyCorrector")
 {
 }
 

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -123,6 +123,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // Create a ToolHandle of the PRW tool which is passed to the MuonEfficiencyScaleFactors class later
   //
   if( isMC() ){
+    setToolName(m_pileup_tool_handle, "Pileup");
     if(!m_pileup_tool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_pileup_tool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -35,12 +35,8 @@
 // this is needed to distribute the algorithm to the workers
 ClassImp(MuonSelector)
 
-MuonSelector :: MuonSelector ()
-: Algorithm("MuonSelector"),
-  m_isolationSelectionTool_handle("CP::IsolationSelectionTool/IsolationSelectionTool", this),
-  m_muonSelectionTool_handle("CP::MuonSelectionTool/MuonSelectionTool",this),
-  m_trigMuonMatchTool_handle("Trig::MatchingTool/MatchingTool",this),
-  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool")
+MuonSelector :: MuonSelector () :
+    Algorithm("MuonSelector")
 {
 }
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -240,6 +240,7 @@ EL::StatusCode MuonSelector :: initialize ()
   // Set eta and quality requirements in order to accept the muon - ID tracks required by default
   //
 
+  setToolName(m_muonSelectionTool_handle);
   ANA_CHECK( m_muonSelectionTool_handle.setProperty( "MaxEta", static_cast<double>(m_eta_max) ));
   ANA_CHECK( m_muonSelectionTool_handle.setProperty( "MuQuality", m_muonQuality ));
   ANA_CHECK( m_muonSelectionTool_handle.setProperty("OutputLevel", msg().level() ));
@@ -252,6 +253,7 @@ EL::StatusCode MuonSelector :: initialize ()
   //
   // *************************************
 
+  setToolName(m_isolationSelectionTool_handle);
   // Do this only for the first WP in the list
   ANA_MSG_DEBUG( "Adding isolation WP " << m_IsoKeys.at(0) << " to IsolationSelectionTool" );
   ANA_CHECK( m_isolationSelectionTool_handle.setProperty("MuonWP", (m_IsoKeys.at(0)).c_str()));
@@ -294,6 +296,7 @@ EL::StatusCode MuonSelector :: initialize ()
   // **************************************
   if( !( m_singleMuTrigChains.empty() && m_diMuTrigChains.empty() ) ) {
     // Grab the TrigDecTool from the ToolStore
+    setToolName(m_trigDecTool_handle, "TrigDecisionTool");
     if(!m_trigDecTool_handle.isUserConfigured()){
       ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
       return EL::StatusCode::FAILURE;
@@ -302,6 +305,7 @@ EL::StatusCode MuonSelector :: initialize ()
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
     //  everything went fine, let's initialise the tool!
+    setToolName(m_trigMuonMatchTool_handle);
     ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
     ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
     ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -256,6 +256,9 @@ EL::StatusCode PhotonCalibrator :: initialize ()
     // photon efficiency correction tool
     //----------------------------------
     //create the tools
+    setToolName(m_photonTightEffTool_handle);
+    setToolName(m_photonMediumEffTool_handle);
+    setToolName(m_photonLooseEffTool_handle);
 
     std::string conEffCalibPath  = PathResolverFindCalibFile(m_conEffCalibPath );
     std::string uncEffCalibPath  = PathResolverFindCalibFile(m_uncEffCalibPath );
@@ -295,6 +298,7 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   }
 
   //IsolationCorrectionTool
+  setToolName(m_isolationCorrectionTool_handle);
   ANA_CHECK(m_isolationCorrectionTool_handle.setProperty("OutputLevel", msg().level()));
   ANA_CHECK(m_isolationCorrectionTool_handle.retrieve());
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -53,8 +53,12 @@ using HelperClasses::ToolName;
 ClassImp(PhotonCalibrator)
 
 
-PhotonCalibrator :: PhotonCalibrator () :
-    Algorithm("PhotonCalibrator")
+PhotonCalibrator :: PhotonCalibrator ()
+: Algorithm("PhotonCalibrator"),
+  m_isolationCorrectionTool_handle("CP::IsolationCorrectionTool/IsolationCorrectionTool",this),
+  m_photonTightEffTool_handle("AsgPhotonEfficiencyCorrectionTool/tight",this),
+  m_photonMediumEffTool_handle("AsgPhotonEfficiencyCorrectionTool/medium",this),
+  m_photonLooseEffTool_handle("AsgPhotonEfficiencyCorrectionTool/loose",this)
 {
 }
 
@@ -256,9 +260,6 @@ EL::StatusCode PhotonCalibrator :: initialize ()
     // photon efficiency correction tool
     //----------------------------------
     //create the tools
-    setToolName(m_photonTightEffTool_handle);
-    setToolName(m_photonMediumEffTool_handle);
-    setToolName(m_photonLooseEffTool_handle);
 
     std::string conEffCalibPath  = PathResolverFindCalibFile(m_conEffCalibPath );
     std::string uncEffCalibPath  = PathResolverFindCalibFile(m_uncEffCalibPath );
@@ -298,7 +299,6 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   }
 
   //IsolationCorrectionTool
-  setToolName(m_isolationCorrectionTool_handle);
   ANA_CHECK(m_isolationCorrectionTool_handle.setProperty("OutputLevel", msg().level()));
   ANA_CHECK(m_isolationCorrectionTool_handle.retrieve());
 

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -53,12 +53,8 @@ using HelperClasses::ToolName;
 ClassImp(PhotonCalibrator)
 
 
-PhotonCalibrator :: PhotonCalibrator ()
-: Algorithm("PhotonCalibrator"),
-  m_isolationCorrectionTool_handle("CP::IsolationCorrectionTool/IsolationCorrectionTool",this),
-  m_photonTightEffTool_handle("AsgPhotonEfficiencyCorrectionTool/tight",this),
-  m_photonMediumEffTool_handle("AsgPhotonEfficiencyCorrectionTool/medium",this),
-  m_photonLooseEffTool_handle("AsgPhotonEfficiencyCorrectionTool/loose",this)
+PhotonCalibrator :: PhotonCalibrator () :
+    Algorithm("PhotonCalibrator")
 {
 }
 

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -30,9 +30,7 @@
 ClassImp(TrigMatcher)
 
 TrigMatcher :: TrigMatcher ()
-: Algorithm("TrigMatcher"),
-  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
-  m_trigMatchTool_handle("Trig::MatchingTool/MatchingTool", this)
+: Algorithm("TrigMatcher")
 {
 }
 

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -31,7 +31,8 @@ ClassImp(TrigMatcher)
 
 TrigMatcher :: TrigMatcher ()
 : Algorithm("TrigMatcher"),
-  m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool", this}
+  m_trigDecTool_handle("Trig::TrigDecisionTool/TrigDecisionTool"),
+  m_trigMatchTool_handle("Trig::MatchingTool/MatchingTool", this)
 {
 }
 
@@ -71,6 +72,14 @@ EL::StatusCode TrigMatcher :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
+  // Grab the TrigDecTool from the ToolStore
+  if(!m_trigDecTool_handle.isUserConfigured()){
+    ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
+    return EL::StatusCode::FAILURE;
+  }
+  ANA_CHECK( m_trigDecTool_handle.retrieve());
+  ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
+
   // ***************************************
   //
   // Initialise Trig::TrigMatchingTool
@@ -86,7 +95,7 @@ EL::StatusCode TrigMatcher :: initialize ()
 
   //  everything went fine, let's initialise the tool!
   //
-  ANA_CHECK( ASG_MAKE_ANA_TOOL(m_trigMatchTool_handle, Trig::MatchingTool) );
+  ANA_CHECK( m_trigMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
   ANA_CHECK( m_trigMatchTool_handle.retrieve() );
 
   // **********************************************************************************************

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -30,7 +30,8 @@
 ClassImp(TrigMatcher)
 
 TrigMatcher :: TrigMatcher ()
-: Algorithm("TrigMatcher")
+: Algorithm("TrigMatcher"),
+  m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool", this}
 {
 }
 
@@ -85,7 +86,6 @@ EL::StatusCode TrigMatcher :: initialize ()
 
   //  everything went fine, let's initialise the tool!
   //
-  setToolName(m_trigMatchTool_handle);
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_trigMatchTool_handle, Trig::MatchingTool) );
   ANA_CHECK( m_trigMatchTool_handle.retrieve() );
 

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -71,6 +71,7 @@ EL::StatusCode TrigMatcher :: initialize ()
   }
 
   // Grab the TrigDecTool from the ToolStore
+  setToolName(m_trigDecTool_handle, "TrigDecisionTool");
   if(!m_trigDecTool_handle.isUserConfigured()){
     ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
     return EL::StatusCode::FAILURE;
@@ -93,6 +94,7 @@ EL::StatusCode TrigMatcher :: initialize ()
 
   //  everything went fine, let's initialise the tool!
   //
+  setToolName(m_trigMatchTool_handle);
   ANA_CHECK( m_trigMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
   ANA_CHECK( m_trigMatchTool_handle.retrieve() );
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -239,6 +239,34 @@ namespace xAH {
            return ( m_toolAlreadyUsed.find(tool_name)->second );
         }
 
+
+        /**
+            @rst
+	        Note: This function does nothing in release 21.1! The native private tool mechanism is used instead.
+
+                Sets the name of a tool. If no name is needed, the tool will use the name of the algorithm plus a unique identifier (:cpp:func:`xAH::Algorithm::getAddress`) appended to ensure the tool is unique and effectively private.
+
+                The tool will not be guaranteed unique if two tools of the same type are created without a name passed in. But this is, at this point, up to the user and a more complex scenario than what this function tries to simplify on its own.
+
+            @endrst
+         */
+        template <typename T>
+        void setToolName(asg::AnaToolHandle<T>& handle, std::string name = "") const {
+#ifndef USE_CMAKE
+          if(name.empty()) name = handle.name() + "_" + m_name + "::" + getAddress();
+          handle.setName(name);
+          ANA_MSG_DEBUG("Trying to set-up tool: " << handle.typeAndName());
+#endif
+        }
+
+        /// @brief Return a ``std::string`` representation of ``this``
+        std::string getAddress() const {
+          const void * address = static_cast<const void*>(this);
+          std::stringstream ss;
+          ss << address;
+          return ss.str();
+        }
+
       private:
         /**
             @rst

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -25,6 +25,15 @@
 #include <AsgTools/MsgStreamMacros.h>
 #include <AsgTools/MessageCheck.h>
 
+//
+// Tools in R20.7 break if an algorithm parent is provided. Use the PRIVATETOOL define
+// to specify an algorithm parent when running in 21.2, but not in 20.7.
+#ifdef USE_CMAKE
+#define PRIVATETOOL this
+#else
+#define PRIVATETOOL 0
+#endif
+
 namespace xAH {
 
     /**

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -239,35 +239,6 @@ namespace xAH {
            return ( m_toolAlreadyUsed.find(tool_name)->second );
         }
 
-
-        /**
-            @rst
-                Sets the name of the tool and emits ``ANA_MSG_WARNING`` if the tool of given type/name has been configured previously.
-
-                The reason this exists is to unify setting the tool name correctly. |xAH| is choosing the convention that you always set the type of the tool in the header, but not the name. The name, if it needs to be configurable, will be set during algorithm execution, such as in ``histInitialize()``. If no name is needed, the tool will use the name of the algorithm plus a unique identifier (:cpp:func:`xAH::Algorithm::getAddress`) appended to ensure the tool is unique and effectively private.
-
-                The tool will not be guaranteed unique if two tools of the same type are created without a name passed in. But this is, at this point, up to the user and a more complex scenario than what this function tries to simplify on its own.
-
-            @endrst
-         */
-        template <typename T>
-        bool setToolName(asg::AnaToolHandle<T>& handle, std::string name = "") const {
-          if(name.empty()) name = handle.name() + "_" + m_name + "::" + getAddress();
-          handle.setName(name);
-          ANA_MSG_DEBUG("Trying to set-up tool: " << handle.typeAndName());
-          bool res = handle.isUserConfigured();
-          if (res) ANA_MSG_WARNING("note: handle " << handle.typeAndName() << " is user configured. If this is expected, ignore the message. If it is not expected, look into " << m_className + "::" << m_name << ", check documentation, or ask around.");
-          return res;
-        }
-
-        /// @brief Return a ``std::string`` representation of ``this``
-        std::string getAddress() const {
-          const void * address = static_cast<const void*>(this);
-          std::stringstream ss;
-          ss << address;
-          return ss.str();
-        }
-
       private:
         /**
             @rst

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -73,8 +73,8 @@ private:
   bool m_runAllSyst = false; //!
 
   // tools
-  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
-  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool"}; //!
+  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle;  //!
+  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle; //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -73,8 +73,8 @@ private:
   bool m_runAllSyst = false; //!
 
   // tools
-  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle;  //!
-  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle; //!
+  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool" , this}; //!
+  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool", this}; //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -73,13 +73,8 @@ private:
   bool m_runAllSyst = false; //!
 
   // tools
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool" , this}; //!
-  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool", this}; //!
-#else
-  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
-  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool"}; //!
-#endif
+  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool" , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool", PRIVATETOOL}; //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -73,8 +73,13 @@ private:
   bool m_runAllSyst = false; //!
 
   // tools
+#ifdef USE_CMAKE
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool" , this}; //!
   asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool", this}; //!
+#else
+  asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
+  asg::AnaToolHandle<IBTaggingEfficiencyTool> m_BJetEffSFTool_handle{"BTaggingEfficiencyTool"}; //!
+#endif
 
   std::vector<CP::SystematicSet> m_systList; //!
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -166,11 +166,19 @@ class BasicEventSelection : public xAH::Algorithm
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
 
     // tools
+#ifdef USE_CMAKE
     asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!
     asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle          {"CP::PileupReweightingTool/Pileup"                                     }; //!
     asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle         {"TrigConf::xAODConfigTool/xAODConfigTool"                        , this}; //!
     asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle          {"Trig::TrigDecisionTool/TrigDecisionTool"                              }; //!
     asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool", this}; //!
+#else
+    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle{"GoodRunsListSelectionTool"};                              //!
+    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"};                      //!
+    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle{"TrigConf::xAODConfigTool"};                      //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
+    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool"}; //!
+#endif
 
     int m_eventCounter;     //!
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -166,19 +166,11 @@ class BasicEventSelection : public xAH::Algorithm
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
 
     // tools
-#ifdef USE_CMAKE
-    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!
-    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle          {"CP::PileupReweightingTool/Pileup"                                     }; //!
-    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle         {"TrigConf::xAODConfigTool/xAODConfigTool"                        , this}; //!
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle          {"Trig::TrigDecisionTool/TrigDecisionTool"                              }; //!
-    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool", this}; //!
-#else
-    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle{"GoodRunsListSelectionTool"};                              //!
-    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"};                      //!
-    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle{"TrigConf::xAODConfigTool"};                      //!
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
-    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool"}; //!
-#endif
+    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , PRIVATETOOL}; //!
+    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle          {"CP::PileupReweightingTool/Pileup"                                            }; //!
+    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle         {"TrigConf::xAODConfigTool/xAODConfigTool"                        , PRIVATETOOL}; //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle          {"Trig::TrigDecisionTool/TrigDecisionTool"                                     }; //!
+    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool", PRIVATETOOL}; //!
 
     int m_eventCounter;     //!
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -161,24 +161,16 @@ class BasicEventSelection : public xAH::Algorithm
     /** Check for duplicated events in MC */
     bool m_checkDuplicatesMC = false;
 
-    /** @brief trigDecTool name for configurability if name is not default.  If empty, use the default name. If not empty, change the name. */
-    std::string m_trigDecTool_name{"xAH_TDT"};
-
   private:
 
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
 
     // tools
-    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle{"GoodRunsListSelectionTool"};                              //!
-    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"};                      //!
-    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle{"TrigConf::xAODConfigTool"};                      //!
-    /**
-      @rst
-        The name of this tool (if needs to be changed) can be set with :cpp:member:`BasicEventSelection::m_trigDecTool_name`.
-      @endrst
-    */
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
-    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool"}; //!
+    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle;                              //!
+    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                      //!
+    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle;                     //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle;                      //!
+    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle;            //!
 
     int m_eventCounter;     //!
 

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -166,11 +166,11 @@ class BasicEventSelection : public xAH::Algorithm
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
 
     // tools
-    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle;                              //!
-    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                      //!
-    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle;                     //!
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle;                      //!
-    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle;            //!
+    asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!
+    asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle          {"CP::PileupReweightingTool/Pileup"                                     }; //!
+    asg::AnaToolHandle<TrigConf::ITrigConfigTool>  m_trigConfTool_handle         {"TrigConf::xAODConfigTool/xAODConfigTool"                        , this}; //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle          {"Trig::TrigDecisionTool/TrigDecisionTool"                              }; //!
+    asg::AnaToolHandle<IWeightTool>                m_reweightSherpa22_tool_handle{"PMGTools::PMGSherpa22VJetsWeightTool/PMGSherpa22VJetsWeightTool", this}; //!
 
     int m_eventCounter;     //!
 

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -185,9 +185,6 @@ public:
   /// Recommended threshold for egamma triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.07;
 
-  /** @brief trigDecTool name for configurability if name is not default.  If empty, use the default name. If not empty, change the name. */
-  std::string m_trigDecTool_name{"xAH_TDT"};
-
 private:
 
   /**
@@ -251,16 +248,11 @@ private:
   /* tools */
 
   /// @brief MC15 ASG tool for isolation
-  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"}; //!
+  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
-  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                               //!
-  /**
-    @rst
-      The name of this tool (if needs to be changed) can be set with :cpp:member:`ElectronSelector::m_trigDecTool_name`.
-    @endrst
-  */
-  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle{"Trig::TrigDecisionTool"};                //!
-  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle{"Trig::MatchingTool"};          //!
+  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                          //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle {"Trig::MatchingTool/MatchingTool"                  , this}; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true;

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -248,11 +248,20 @@ private:
   /* tools */
 
   /// @brief MC15 ASG tool for isolation
+#ifdef USE_CMAKE
   asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
   CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                          //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
+
   asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle {"Trig::MatchingTool/MatchingTool"                  , this}; //!
+#else
+  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"}; //!
+  // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
+  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                               //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle{"Trig::TrigDecisionTool"};                //!
+  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle{"Trig::MatchingTool"};          //!
+#endif
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true;

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -248,20 +248,11 @@ private:
   /* tools */
 
   /// @brief MC15 ASG tool for isolation
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
+  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", PRIVATETOOL}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
-  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                          //!
-  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
-
-  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle {"Trig::MatchingTool/MatchingTool"                  , this}; //!
-#else
-  asg::AnaToolHandle<CP::IIsolationSelectionTool> m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"}; //!
-  // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
-  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                               //!
-  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle{"Trig::TrigDecisionTool"};                //!
-  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle{"Trig::MatchingTool"};          //!
-#endif
+  CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                                 //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                       }; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle {"Trig::MatchingTool/MatchingTool"                  , PRIVATETOOL}; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true;

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -57,17 +57,9 @@ class HLTJetRoIBuilder : public xAH::Algorithm
      */
     std::string m_outContainerName = "";
 
-    /** @brief trigDecTool name for configurability if name is not default.  If empty, use the default name. If not empty, change the name. */
-    std::string m_trigDecTool_name{"xAH_TDT"};
-
   private:
 
-    /**
-      @rst
-        The name of this tool (if needs to be changed) can be set with :cpp:member:`HLTJetRoIBuilder::m_trigDecTool_name`.
-      @endrst
-    */
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle;                    //!
     std::string                  m_jetName = "EFJet";       //!
     std::string                  m_trkName = "InDetTrigTrackingxAODCnv_Bjet_IDTrig";       //!
     std::string                  m_vtxName = "EFHistoPrmVtx";       //!

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -59,7 +59,11 @@ class HLTJetRoIBuilder : public xAH::Algorithm
 
   private:
 
+#ifdef USE_CMAKE
     asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"}; //!
+#else
+    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
+#endif
     std::string                  m_jetName = "EFJet";       //!
     std::string                  m_trkName = "InDetTrigTrackingxAODCnv_Bjet_IDTrig";       //!
     std::string                  m_vtxName = "EFHistoPrmVtx";       //!

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -59,11 +59,8 @@ class HLTJetRoIBuilder : public xAH::Algorithm
 
   private:
 
-#ifdef USE_CMAKE
     asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"}; //!
-#else
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle{"Trig::TrigDecisionTool"};                         //!
-#endif
+
     std::string                  m_jetName = "EFJet";       //!
     std::string                  m_trkName = "InDetTrigTrackingxAODCnv_Bjet_IDTrig";       //!
     std::string                  m_vtxName = "EFHistoPrmVtx";       //!

--- a/xAODAnaHelpers/HLTJetRoIBuilder.h
+++ b/xAODAnaHelpers/HLTJetRoIBuilder.h
@@ -59,7 +59,7 @@ class HLTJetRoIBuilder : public xAH::Algorithm
 
   private:
 
-    asg::AnaToolHandle<Trig::TrigDecisionTool>     m_trigDecTool_handle;                    //!
+    asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"}; //!
     std::string                  m_jetName = "EFJet";       //!
     std::string                  m_trkName = "InDetTrigTrackingxAODCnv_Bjet_IDTrig";       //!
     std::string                  m_vtxName = "EFHistoPrmVtx";       //!

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -155,16 +155,16 @@ private:
   std::vector<int> m_systType; //!
 
   // tools
-  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle{"JetCalibrationTool"};         //!
-  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle{"JetUncertaintiesTool"};     //!
-  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle{"JERTool"};                               //!
-  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle{"JERSmearingTool"};               //!
-  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle{"JetVertexTaggerTool"};             //!
-  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle{"JetForwardJvtTool"};                    //!
-  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle{"JetCleaningTool"};               //!
-  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool"};   //!
+  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle;      //!
+  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle;    //!
+  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle;                 //!
+  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle;         //!
+  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle;           //!
+  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle;                //!
+  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle;         //!
+  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle;   //!
 
-  std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles;                              //!
+  std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles;     //!
   std::vector<std::string>  m_decisionNames;    //!
 
 public:

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -155,16 +155,16 @@ private:
   std::vector<int> m_systType; //!
 
   // tools
-  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle;      //!
-  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle;    //!
-  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle;                 //!
-  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle;         //!
-  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle;           //!
-  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle;                //!
-  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle;         //!
-  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle;   //!
+  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle   {"JetCalibrationTool"   , this}; //!
+  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle {"JetUncertaintiesTool" , this}; //!
+  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle              {"JERTool"              , this}; //!
+  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle      {"JERSmearingTool"      , this}; //!
+  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle        {"JetVertexTaggerTool"  , this}; //!
+  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , this}; //!
+  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , this}; //!
+  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", this}; //!
 
-  std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles;     //!
+  std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles; //!
   std::vector<std::string>  m_decisionNames;    //!
 
 public:

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -155,6 +155,7 @@ private:
   std::vector<int> m_systType; //!
 
   // tools
+#ifdef USE_CMAKE
   asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle   {"JetCalibrationTool"   , this}; //!
   asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle {"JetUncertaintiesTool" , this}; //!
   asg::AnaToolHandle<IJERTool>                   m_JERTool_handle              {"JERTool"              , this}; //!
@@ -163,6 +164,16 @@ private:
   asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , this}; //!
   asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , this}; //!
   asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", this}; //!
+#else
+  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle{"JetCalibrationTool"};         //!
+  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle{"JetUncertaintiesTool"};     //!
+  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle{"JERTool"};                               //!
+  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle{"JERSmearingTool"};               //!
+  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle{"JetVertexTaggerTool"};             //!
+  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle{"JetForwardJvtTool"};                    //!
+  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle{"JetCleaningTool"};               //!
+  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool"};   //!
+#endif
 
   std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles; //!
   std::vector<std::string>  m_decisionNames;    //!

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -155,25 +155,14 @@ private:
   std::vector<int> m_systType; //!
 
   // tools
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle   {"JetCalibrationTool"   , this}; //!
-  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle {"JetUncertaintiesTool" , this}; //!
-  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle              {"JERTool"              , this}; //!
-  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle      {"JERSmearingTool"      , this}; //!
-  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle        {"JetVertexTaggerTool"  , this}; //!
-  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , this}; //!
-  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , this}; //!
-  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", this}; //!
-#else
-  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle{"JetCalibrationTool"};         //!
-  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle{"JetUncertaintiesTool"};     //!
-  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle{"JERTool"};                               //!
-  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle{"JERSmearingTool"};               //!
-  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle{"JetVertexTaggerTool"};             //!
-  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle{"JetForwardJvtTool"};                    //!
-  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle{"JetCleaningTool"};               //!
-  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool"};   //!
-#endif
+  asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle   {"JetCalibrationTool"   , PRIVATETOOL}; //!
+  asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle {"JetUncertaintiesTool" , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IJERTool>                   m_JERTool_handle              {"JERTool"              , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IJERSmearingTool>           m_JERSmearingTool_handle      {"JERSmearingTool"      , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle        {"JetVertexTaggerTool"  , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , PRIVATETOOL}; //!
+  asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", PRIVATETOOL}; //!
 
   std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles; //!
   std::vector<std::string>  m_decisionNames;    //!

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -66,11 +66,7 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-#ifdef USE_CMAKE
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool/Pileup"}; //!
-#else
-  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"}; //!
-#endif
   std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;           //!
   std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                               //!
   std::vector<std::string> m_YearsList;                                                                    //!

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -7,8 +7,9 @@
 #include "xAODAnaHelpers/Algorithm.h"
 
 // external tools include(s):
-#include "AsgTools/AnaToolHandle.h"
-#include "PileupReweighting/PileupReweightingTool.h"
+#include <AsgTools/AnaToolHandle.h>
+
+#include <AsgAnalysisInterfaces/IPileupReweightingTool.h>
 
 class MuonCalibrator : public xAH::Algorithm
 {
@@ -66,7 +67,7 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"}; //!
+  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                              //!
   std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;    //!
   std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                        //!
   std::vector<std::string> m_YearsList;                                                             //!

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -66,7 +66,11 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
+#ifdef USE_CMAKE
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool/Pileup"}; //!
+#else
+  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool"}; //!
+#endif
   std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;           //!
   std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                               //!
   std::vector<std::string> m_YearsList;                                                                    //!

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -8,7 +8,6 @@
 
 // external tools include(s):
 #include <AsgTools/AnaToolHandle.h>
-
 #include <AsgAnalysisInterfaces/IPileupReweightingTool.h>
 
 class MuonCalibrator : public xAH::Algorithm
@@ -67,10 +66,10 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle;                              //!
-  std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;    //!
-  std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                        //!
-  std::vector<std::string> m_YearsList;                                                             //!
+  asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool/Pileup"}; //!
+  std::map<std::string, CP::MuonCalibrationAndSmearingTool*>  m_muonCalibrationAndSmearingTools;           //!
+  std::map<std::string, std::string> m_muonCalibrationAndSmearingTool_names;                               //!
+  std::vector<std::string> m_YearsList;                                                                    //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -107,9 +107,6 @@ public:
   /// @brief Recommended threshold for muon triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.1;
 
-  /** @brief trigDecTool name for configurability if name is not default.  If empty, use the default name. If not empty, change the name. */
-  std::string m_trigDecTool_name{"xAH_TDT"};
-
 private:
 
   int            m_muonQuality; //!
@@ -150,17 +147,12 @@ private:
   std::vector<std::string>            m_diMuTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diMuTrigChains */
 
   // tools
-  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"};   //!
+  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle;   //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
   CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
-  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle{"CP::MuonSelectionTool"};             //!
-  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle{"Trig::MatchingTool"};                //!
-  /**
-    @rst
-      The name of this tool (if needs to be changed) can be set with :cpp:member:`MuonSelector::m_trigDecTool_name`.
-    @endrst
-  */
-  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle{"Trig::TrigDecisionTool"};                  //!
+  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle;        //!
+  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle;        //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle;              //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -147,12 +147,12 @@ private:
   std::vector<std::string>            m_diMuTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diMuTrigChains */
 
   // tools
-  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle;   //!
+  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
   CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
-  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle;        //!
-  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle;        //!
-  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle;              //!
+  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle     {"CP::MuonSelectionTool/MuonSelectionTool"          , this}; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle     {"Trig::MatchingTool/MatchingTool"                  , this}; //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -147,21 +147,12 @@ private:
   std::vector<std::string>            m_diMuTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diMuTrigChains */
 
   // tools
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
+  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", PRIVATETOOL}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
-  CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
-  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle     {"CP::MuonSelectionTool/MuonSelectionTool"          , this}; //!
-  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle     {"Trig::MatchingTool/MatchingTool"                  , this}; //!
-  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
-#else
-  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"};   //!
-  // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
-  CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
-  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle{"CP::MuonSelectionTool"};             //!
-  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle{"Trig::MatchingTool"};                //!
-  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle{"Trig::TrigDecisionTool"};                  //!
-#endif
+  CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr}; //!
+  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle     {"CP::MuonSelectionTool/MuonSelectionTool"          , PRIVATETOOL}; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle     {"Trig::MatchingTool/MatchingTool"                  , PRIVATETOOL}; //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                       }; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -147,12 +147,21 @@ private:
   std::vector<std::string>            m_diMuTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diMuTrigChains */
 
   // tools
+#ifdef USE_CMAKE
   asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool/IsolationSelectionTool", this}; //!
   // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
   CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
   asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle     {"CP::MuonSelectionTool/MuonSelectionTool"          , this}; //!
   asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle     {"Trig::MatchingTool/MatchingTool"                  , this}; //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                }; //!
+#else
+  asg::AnaToolHandle<CP::IIsolationSelectionTool>  m_isolationSelectionTool_handle{"CP::IsolationSelectionTool"};   //!
+  // this only exists because the interface needs to be updated, complain on pathelp, remove forward declaration for this when fixed
+  CP::IsolationSelectionTool*                      m_isolationSelectionTool{nullptr};                               //!
+  asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle{"CP::MuonSelectionTool"};             //!
+  asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle{"Trig::MatchingTool"};                //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle{"Trig::TrigDecisionTool"};                  //!
+#endif
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing 
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -83,14 +83,14 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
-  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
+  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle; //!
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/tight"}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/loose"}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle; //!
 
 public:
   // Tree *myTree; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -83,24 +83,16 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle  {"CP::IsolationCorrectionTool/IsolationCorrectionTool", this}; //!
-#else
-  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
-#endif
+  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle  {"CP::IsolationCorrectionTool/IsolationCorrectionTool", PRIVATETOOL}; //!
+
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/tight"            , this}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"           , this}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/loose"            , this}; //!
-#else
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/tight"}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"}; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/loose"}; //!
-#endif
+
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/tight"            , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"           , PRIVATETOOL}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/loose"            , PRIVATETOOL}; //!
 
 public:
   // Tree *myTree; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -83,14 +83,14 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
-  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle; //!
+  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle  {"CP::IsolationCorrectionTool/IsolationCorrectionTool", this}; //!
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle; //!
-  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/tight"            , this}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"           , this}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/loose"            , this}; //!
 
 public:
   // Tree *myTree; //!

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -83,14 +83,24 @@ private:
 
   // tools
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
+#ifdef USE_CMAKE
   asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle  {"CP::IsolationCorrectionTool/IsolationCorrectionTool", this}; //!
+#else
+  asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle{"CP::IsolationCorrectionTool"}; //!
+#endif
   ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!
+#ifdef USE_CMAKE
   asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/tight"            , this}; //!
   asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"           , this}; //!
   asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle {"AsgPhotonEfficiencyCorrectionTool/loose"            , this}; //!
+#else
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonTightEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/tight"}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonMediumEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/medium"}; //!
+  asg::AnaToolHandle<IAsgPhotonEfficiencyCorrectionTool> m_photonLooseEffTool_handle{"AsgPhotonEfficiencyCorrectionTool/loose"}; //!
+#endif
 
 public:
   // Tree *myTree; //!

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -74,7 +74,7 @@ public:
 private:
 
   /* tools */
-  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle{"Trig::MatchingTool"}; //!
+  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -11,7 +11,8 @@
 #include <xAODAnaHelpers/Algorithm.h>
 
 #include <AsgTools/AnaToolHandle.h>
-#include <TriggerMatchingTool/MatchingTool.h>
+#include <TrigDecisionTool/TrigDecisionTool.h>
+#include <TriggerMatchingTool/IMatchingTool.h>
 
 #include <TH1D.h>
 
@@ -74,7 +75,8 @@ public:
 private:
 
   /* tools */
-  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle; //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle;   //!
+  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -75,8 +75,8 @@ public:
 private:
 
   /* tools */
-  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle;   //!
-  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle; //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool/TrigDecisionTool"      }; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool"        , this}; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -75,8 +75,13 @@ public:
 private:
 
   /* tools */
+#ifdef USE_CMAKE
   asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool/TrigDecisionTool"      }; //!
   asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool"        , this}; //!
+#else
+  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool"}; //!
+  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle{"Trig::MatchingTool"}; //!
+#endif
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -75,13 +75,8 @@ public:
 private:
 
   /* tools */
-#ifdef USE_CMAKE
-  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool/TrigDecisionTool"      }; //!
-  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool"        , this}; //!
-#else
-  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool"}; //!
-  asg::AnaToolHandle<Trig::IMatchingTool> m_trigMatchTool_handle{"Trig::MatchingTool"}; //!
-#endif
+  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool/TrigDecisionTool"             }; //!
+  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle{"Trig::MatchingTool/MatchingTool"        , PRIVATETOOL}; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 


### PR DESCRIPTION
Uses the "private tool" functionality of the `asg::AnaToolHandle` to make unique tools per algorithm. This replaces adding the algorithm address to the end of the tool name, which seems to be broken starting in at least 21.1.11.