### PR TITLE
Sort track jets associated to a fat jet. Fix b-jet systematics filtering

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -232,7 +232,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
       std::vector<CP::SystematicSet>::iterator syst_it = m_systList.begin();
       while( syst_it != m_systList.end() ) {
         if( syst_it->name().empty() ) { syst_it++; }
-        syst_it = m_systList.erase(syst_it);
+        else { syst_it = m_systList.erase(syst_it); }
       }
     }
 

--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -773,6 +773,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
       {
 	try{
 	  assotrkjets = fatjet_parent->getAssociatedObjects<xAOD::Jet>(trackJetName);
+	  std::sort( assotrkjets.begin(), assotrkjets.end(), HelperFunctions::sort_pt );
 	}
 	catch (...){
 	  //Warning("execute()", "Unable to fetch \"%s\" link from leading calo-jet", trackJetName.data());

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -344,8 +344,7 @@ float HelperFunctions::getPrimaryVertexZ(const xAOD::Vertex* pvx)
   return pvx_z;
 }
 
-
-bool HelperFunctions::sort_pt(xAOD::IParticle* partA, xAOD::IParticle* partB){
+bool HelperFunctions::sort_pt(const xAOD::IParticle* partA, const xAOD::IParticle* partB){
   return partA->pt() > partB->pt();
 }
 

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -142,7 +142,7 @@ namespace HelperFunctions {
 
 
   // miscellaneous
-  bool sort_pt(xAOD::IParticle* partA, xAOD::IParticle* partB);
+  bool sort_pt(const xAOD::IParticle* partA, const xAOD::IParticle* partB);
 
   /**
     @brief Get a list of systematics


### PR DESCRIPTION
* The associated track jets are now sorted by pT.
* There was missing else in the systematics list filter loop that crashed if the systematics list on contained the nominal.
