### PR TITLE
Get rid of unused variable warning in empty Algorithm::setToolName in 21.2.

### DIFF
--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -263,7 +263,7 @@ namespace xAH {
 #ifdef USE_CMAKE
 	void setToolName(__attribute__((unused)) asg::AnaToolHandle<T>& handle, __attribute__((unused)) const std::string& name = "") const {
 #else
-        void setToolName(asg::AnaToolHandle<T>& handle, const std::string& name = "") const {
+        void setToolName(asg::AnaToolHandle<T>& handle, std::string name = "") const {
           if(name.empty()) name = handle.name() + "_" + m_name + "::" + getAddress();
           handle.setName(name);
           ANA_MSG_DEBUG("Trying to set-up tool: " << handle.typeAndName());

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -260,8 +260,10 @@ namespace xAH {
             @endrst
          */
         template <typename T>
-        void setToolName(asg::AnaToolHandle<T>& handle, std::string name = "") const {
-#ifndef USE_CMAKE
+#ifdef USE_CMAKE
+	void setToolName(__attribute__((unused)) asg::AnaToolHandle<T>& handle, __attribute__((unused)) const std::string& name = "") const {
+#else
+        void setToolName(asg::AnaToolHandle<T>& handle, const std::string& name = "") const {
           if(name.empty()) name = handle.name() + "_" + m_name + "::" + getAddress();
           handle.setName(name);
           ANA_MSG_DEBUG("Trying to set-up tool: " << handle.typeAndName());


### PR DESCRIPTION
Comes from empty Algorithm::setToolName in 21.2.