### PR TITLE
xAH and submission of multiple datasets

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -3,6 +3,11 @@
 
 #include "xAODBase/IParticleContainer.h"
 
+// samples
+#include <SampleHandler/SampleGrid.h>
+#include <SampleHandler/MetaFields.h>
+#include <SampleHandler/MetaObject.h>
+
 // jet reclustering
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/ClusterSequence.hh>
@@ -11,6 +16,13 @@
 #include <fastjet/tools/Filter.hh>
 #include <JetEDM/JetConstituentFiller.h>
 
+void xAH::addRucio(SH::SampleHandler& sh, const std::string& name, const std::string& dslist)
+{
+  std::unique_ptr<SH::SampleGrid> sample(new SH::SampleGrid(name));
+  sample->meta()->setString(SH::MetaFields::gridName, dslist);
+  sample->meta()->setString(SH::MetaFields::gridFilter, SH::MetaFields::gridFilter_default);
+  sh.add(sample.release());
+}
 
 MsgStream& HelperFunctions::msg( MSG::Level lvl ) {
   static MsgStream msgStream( "HelperFunctions" );

--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -47,6 +47,7 @@
 #include <xAODAnaHelpers/MinixAOD.h>
 
 /* Other */
+#include <xAODAnaHelpers/HelperFunctions.h>
 #include <xAODAnaHelpers/OverlapRemover.h>
 #include <xAODAnaHelpers/TrigMatcher.h>
 #include <xAODAnaHelpers/Writer.h>
@@ -58,6 +59,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ nestedclass;
+
+#pragma link C++ namespace xAH;
+#pragma link C++ function xAH::addRucio;
 
 #pragma link C++ class xAH::Algorithm+;
 

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -259,6 +259,10 @@ if __name__ == "__main__":
 
     use_scanEOS = (args.use_scanEOS)
 
+    # singleTask is only supported with rucio and input filelists
+    if args.singleTask and (not args.use_inputFileList and not args.use_scanRucio):
+      xAH_logger.warning("--singleTask requires both --inputList and --inputRucio to have an effect")
+
 
     # at this point, we should import ROOT and do stuff
     import ROOT

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         raise OSError('Output directory {0:s} already exists. Either re-run with -f/--force, choose a different --submitDir, or rm -rf it yourself. Just deal with it, dang it.'.format(args.submit_dir))
 
     # they will need it to get it working for rel 20
-    needXRD = ( args.use_scanRucio ) & (args.driver!='prun')
+    needXRD = ( args.use_scanRucio ) and (args.driver!='prun')
     if needXRD:
       if os.getenv('XRDSYS') is None and os.getenv('RUCIO_HOME') is None:
         raise EnvironmentError('xrootd client is not setup. Run localSetupFAX or equivalent.')
@@ -260,7 +260,8 @@ if __name__ == "__main__":
     use_scanEOS = (args.use_scanEOS)
 
     # singleTask is only supported with rucio and input filelists
-    if args.singleTask and (not args.use_inputFileList and not args.use_scanRucio):
+    singleTask = (args.driver=='prun') and (args.singleTask)
+    if singleTask and (not args.use_inputFileList and not args.use_scanRucio):
       xAH_logger.warning("--singleTask requires both --inputList and --inputRucio to have an effect")
 
 
@@ -339,7 +340,7 @@ if __name__ == "__main__":
             line = line.strip()
             filelist.append(line)
         # Iterate over the filelist and add each item to the SampleHandler
-        if use_scanEOS or args.use_scanXRD or (args.use_scanRucio and not args.singleTask):
+        if use_scanEOS or args.use_scanXRD or (args.use_scanRucio and not singleTask):
           for line in filelist:
             if args.use_scanRucio:
               ROOT.SH.scanRucio(sh_all, line)
@@ -354,7 +355,7 @@ if __name__ == "__main__":
               ROOT.SH.ScanDir().scan(sh_all, sh_list)
             else:
               raise Exception("What just happened?")
-        elif args.use_scanRucio and args.singleTask:
+        elif args.use_scanRucio and singleTask:
           ROOT.xAH.addRucio(sh_all,os.path.basename(fname),
                             ','.join(filelist))
         else:

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -11,6 +11,8 @@
 #include "AsgTools/StatusCode.h"
 #include <AsgTools/MessageCheck.h>
 
+#include <SampleHandler/SampleHandler.h>
+
 // jet reclustering and trimming
 #include <fastjet/JetDefinition.hh>
 #include "xAODJet/JetContainer.h"
@@ -36,8 +38,21 @@
 // messaging includes
 #include <AsgTools/MsgStream.h>
 
-namespace HelperFunctions {
+// Functions that need to have a dictionary built. PyROOT does not
+// seem to like the HelperFunctions namespace for some reason.
+namespace xAH {
 
+  /**
+   * @brief Directly add a SampleGrid to a SamplerHandler listing several datasets.
+   * @param sh SampleHander to which the sample will be added to
+   * @param name Name of the sample
+   * @param list List of datasets to be included in the sample
+   */
+  void addRucio(SH::SampleHandler& sh, const std::string& name, const std::string& dslist);
+
+} // close namespace xAH
+
+namespace HelperFunctions {
   /**
     Static object that provides athena-based message logging functionality
   */


### PR DESCRIPTION
Implements submitting several datasets to the grid in a single JEDI task. Should address #837.
https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/EventLoop#Processing_multiple_datasets_in

If you use `--singleTask` with `--inputList` option, the datasets in each filelist are grouped into one sample. The name of the input filelist is used as the sample name. Also `--singleTask` only works with rucio.

There are two hacks in this commit. 
* Adding `SampleGrid` does not seem to work in Python and throws the error below. Unclear why. I added a `xAH::addRucio` function that implements creating and adding the `SampleGrid` to `SampleHandler`.
> TypeError: vars() argument must have __dict__ attribute TypeError: an integer is required
* Adding `addRucio` to `HelperFunctions` does not seem to generate the dictionary correctly. Also unclear why. I added it to the `xAH` namespace instead.

Also removes `--inputDQ2`, since DQ2 does not exist anymore.