### PR TITLE
Add configurable electron PID/isolation branches

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -21,16 +21,7 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_isolation ) {
-    m_isIsolated_LooseTrackOnly              = new std::vector<int>   ();
-    m_isIsolated_Loose                       = new std::vector<int>   ();
-    m_isIsolated_Tight                       = new std::vector<int>   ();
-    m_isIsolated_Gradient                    = new std::vector<int>   ();
-    m_isIsolated_GradientLoose               = new std::vector<int>   ();
-    m_isIsolated_FixedCutLoose               = new std::vector<int>   ();
-    m_isIsolated_FixedCutTight               = new std::vector<int>   ();
-    m_isIsolated_FixedCutTightTrackOnly      = new std::vector<int>   ();
-    m_isIsolated_UserDefinedFixEfficiency    = new std::vector<int>   ();
-    m_isIsolated_UserDefinedCut              = new std::vector<int>   ();
+    m_isIsolated = new std::map< std::string, std::vector< int > >();
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -47,41 +38,16 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_PID ) {
-    m_n_LHVeryLoose = 0;
-    m_LHVeryLoose = new std::vector<int>   ();
-
-    m_n_LHLoose = 0;
-    m_LHLoose = new std::vector<int>   ();
-
-    m_n_LHLooseBL = 0;
-    m_LHLooseBL = new std::vector<int>   ();
-
-    m_n_LHMedium = 0;
-    m_LHMedium = new std::vector<int>   ();
-
-    m_n_LHTight = 0;
-    m_LHTight = new std::vector<int>   ();
-
-    m_n_IsEMLoose = 0;
-    m_IsEMLoose = new std::vector<int>   ();
-
-    m_n_IsEMMedium = 0;
-    m_IsEMMedium = new std::vector<int>   ();
-
-    m_n_IsEMTight = 0;
-    m_IsEMTight = new std::vector<int>   ();
-
+    m_PID = new std::map< std::string, std::vector< int > >();
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-
     m_TrigEff_SF = new std::map< std::string, std::vector< std::vector< float > > >();
     m_TrigMCEff  = new std::map< std::string, std::vector< std::vector< float > > >();
     m_PIDEff_SF  = new std::map< std::string, std::vector< std::vector< float > > >();
     m_IsoEff_SF  = new std::map< std::string, std::vector< std::vector< float > > >();
 
     m_RecoEff_SF = new std::vector< std::vector< float > > ();
-
   }
 
   if ( m_infoSwitch.m_trackparams ) {
@@ -123,7 +89,10 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
     // default PID working points if no user input
-    if ( !m_infoSwitch.m_PIDWPs.size() ) m_infoSwitch.m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
+    if ( !m_infoSwitch.m_PIDWPs.size() ) m_infoSwitch.m_PIDWPs = {"LHLoose","LHLooseBL","LHMedium","LHTight"};
+
+    // default PID SF working points if no user input
+    if ( !m_infoSwitch.m_PIDSFWPs.size() ) m_infoSwitch.m_PIDSFWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
 
     // default isolation working points if no user input
     if ( !m_infoSwitch.m_isolWPs.size() ) m_infoSwitch.m_isolWPs = {"","Gradient","Loose","Tight"};
@@ -156,16 +125,7 @@ ElectronContainer::~ElectronContainer()
   }
 
   if ( m_infoSwitch.m_isolation ) {
-    delete m_isIsolated_LooseTrackOnly              ;
-    delete m_isIsolated_Loose                       ;
-    delete m_isIsolated_Tight                       ;
-    delete m_isIsolated_Gradient                    ;
-    delete m_isIsolated_GradientLoose               ;
-    delete m_isIsolated_FixedCutLoose               ;
-    delete m_isIsolated_FixedCutTight               ;
-    delete m_isIsolated_FixedCutTightTrackOnly      ;
-    delete m_isIsolated_UserDefinedFixEfficiency    ;
-    delete m_isIsolated_UserDefinedCut              ;
+    delete m_isIsolated;
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -182,14 +142,7 @@ ElectronContainer::~ElectronContainer()
   }
 
   if ( m_infoSwitch.m_PID ) {
-    delete m_LHVeryLoose;
-    delete m_LHLoose    ;
-    delete m_LHLooseBL  ;
-    delete m_LHMedium   ;
-    delete m_LHTight    ;
-    delete m_IsEMLoose  ;
-    delete m_IsEMMedium ;
-    delete m_IsEMTight  ;
+    delete m_PID;
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -255,16 +208,12 @@ void ElectronContainer::setTree(TTree *tree)
   }
 
   if ( m_infoSwitch.m_isolation ) {
-    connectBranch<int>(tree, "isIsolated_LooseTrackOnly",              &m_isIsolated_LooseTrackOnly);
-    connectBranch<int>(tree, "isIsolated_Loose",                       &m_isIsolated_Loose);
-    connectBranch<int>(tree, "isIsolated_Tight",                       &m_isIsolated_Tight);
-    connectBranch<int>(tree, "isIsolated_Gradient",                    &m_isIsolated_Gradient);
-    connectBranch<int>(tree, "isIsolated_GradientLoose",               &m_isIsolated_GradientLoose);
-    connectBranch<int>(tree, "isIsolated_FixedCutLoose",               &m_isIsolated_FixedCutLoose);
-    connectBranch<int>(tree, "isIsolated_FixedCutTight",               &m_isIsolated_FixedCutTight);
-    connectBranch<int>(tree, "isIsolated_FixedCutTightTrackOnly",      &m_isIsolated_FixedCutTightTrackOnly);
-    connectBranch<int>(tree, "isIsolated_UserDefinedFixEfficiency",    &m_isIsolated_UserDefinedFixEfficiency);
-    connectBranch<int>(tree, "isIsolated_UserDefinedCut",              &m_isIsolated_UserDefinedCut);
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        tree->SetBranchStatus ( (m_name + "_isIsolated_" + isol).c_str() , 1);
+        tree->SetBranchAddress( (m_name + "_isIsolated_" + isol).c_str() , & (*m_isIsolated)[ isol ] );
+      }
+    }
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -281,41 +230,16 @@ void ElectronContainer::setTree(TTree *tree)
   }
 
   if ( m_infoSwitch.m_PID ) {
-    tree->SetBranchStatus (("n"+m_name+"_LHVeryLoose").c_str(),     1);
-    tree->SetBranchAddress(("n"+m_name+"_LHVeryLoose").c_str(),     &m_n_LHVeryLoose);
-    connectBranch<int>(tree, "LHVeryLoose",         &m_LHVeryLoose);
-
-    tree->SetBranchStatus (("n"+m_name+"_LHLoose").c_str(),     1);
-    tree->SetBranchAddress(("n"+m_name+"_LHLoose").c_str(),     &m_n_LHLoose);
-    connectBranch<int>(tree, "LHLoose",         &m_LHLoose);
-
-    tree->SetBranchStatus (("n"+m_name+"_LHLooseBL").c_str(),   1);
-    tree->SetBranchAddress(("n"+m_name+"_LHLooseBL").c_str(),   &m_n_LHLooseBL);
-    connectBranch<int>(tree, "LHLooseBL",         &m_LHLooseBL);
-
-    tree->SetBranchStatus (("n"+m_name+"_LHMedium").c_str(),      1);
-    tree->SetBranchAddress(("n"+m_name+"_LHMedium").c_str(),      &m_n_LHMedium);
-    connectBranch<int>(tree, "LHMedium",      &m_LHMedium);
-
-    tree->SetBranchStatus (("n"+m_name+"_LHTight").c_str(),      1);
-    tree->SetBranchAddress(("n"+m_name+"_LHTight").c_str(),      &m_n_LHTight);
-    connectBranch<int>(tree, "LHTight",       &m_LHTight);
-
-    tree->SetBranchStatus (("n"+m_name+"_IsEMLoose").c_str(),      1);
-    tree->SetBranchAddress(("n"+m_name+"_IsEMLoose").c_str(),      &m_n_IsEMLoose);
-    connectBranch<int>(tree, "IsEMLoose",     &m_IsEMLoose);
-
-    tree->SetBranchStatus (("n"+m_name+"_IsEMMedium").c_str(),      1);
-    tree->SetBranchAddress(("n"+m_name+"_IsEMMedium").c_str(),      &m_n_IsEMMedium);
-    connectBranch<int>(tree, "IsEMMedium",    &m_IsEMMedium);
-
-    tree->SetBranchStatus (("n"+m_name+"_IsEMTight").c_str(),      1);
-    tree->SetBranchAddress(("n"+m_name+"_IsEMTight").c_str(),      &m_n_IsEMTight);
-    connectBranch<int>(tree, "IsEMTight",     &m_IsEMTight);
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      if (!PID.empty()) {
+        tree->SetBranchStatus ( (m_name + PID).c_str() , 1);
+        tree->SetBranchAddress( (m_name + PID).c_str() , & (*m_PID)[ PID ] );
+      }
+    }
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDSFWPs) {
       tree->SetBranchStatus ( (m_name+"_PIDEff_SF_" + PID).c_str() , 1);
       tree->SetBranchAddress( (m_name+"_PIDEff_SF_" + PID).c_str() , & (*m_PIDEff_SF)[ PID ] );
 
@@ -392,16 +316,11 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
 
   // isolation
   if ( m_infoSwitch.m_isolation ) {
-    elec.isIsolated_LooseTrackOnly                =     m_isIsolated_LooseTrackOnly                  ->at(idx);
-    elec.isIsolated_Loose                         =     m_isIsolated_Loose                           ->at(idx);
-    elec.isIsolated_Tight                         =     m_isIsolated_Tight                           ->at(idx);
-    elec.isIsolated_Gradient                      =     m_isIsolated_Gradient                        ->at(idx);
-    elec.isIsolated_GradientLoose                 =     m_isIsolated_GradientLoose                   ->at(idx);
-    elec.isIsolated_FixedCutLoose                 =     m_isIsolated_FixedCutLoose                   ->at(idx);
-    elec.isIsolated_FixedCutTight                 =     m_isIsolated_FixedCutTight                   ->at(idx);
-    elec.isIsolated_FixedCutTightTrackOnly        =     m_isIsolated_FixedCutTightTrackOnly          ->at(idx);
-    elec.isIsolated_UserDefinedFixEfficiency      =     m_isIsolated_UserDefinedFixEfficiency        ->at(idx);
-    elec.isIsolated_UserDefinedCut                =     m_isIsolated_UserDefinedCut                  ->at(idx);
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        elec.isIsolated[isol] = (*m_isIsolated)[ isol ].at(idx);
+      }
+    }
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -419,21 +338,18 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
 
   // quality
   if ( m_infoSwitch.m_PID ) {
-    elec.LHVeryLoose   = m_LHVeryLoose->at(idx);
-    elec.LHLoose       = m_LHLoose    ->at(idx);
-    elec.LHLooseBL     = m_LHLooseBL  ->at(idx);
-    elec.LHMedium      = m_LHMedium   ->at(idx);
-    elec.LHTight       = m_LHTight    ->at(idx);
-    elec.IsEMLoose     = m_IsEMLoose  ->at(idx);
-    elec.IsEMMedium    = m_IsEMMedium ->at(idx);
-    elec.IsEMTight     = m_IsEMTight  ->at(idx);
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      if (!PID.empty()) {
+        elec.PID[PID] = (*m_PID)[ PID ].at(idx);
+      }
+    }
   }
 
   // scale factors w/ sys
   // per object
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDSFWPs) {
       elec.PIDEff_SF[ PID ] = (*m_PIDEff_SF) [ PID ].at(idx);
       for (auto& iso : m_infoSwitch.m_isolWPs) {
         if(!iso.empty())
@@ -506,16 +422,11 @@ void ElectronContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_isolation ) {
-    setBranch<int>(tree, "isIsolated_LooseTrackOnly",              m_isIsolated_LooseTrackOnly);
-    setBranch<int>(tree, "isIsolated_Loose",                       m_isIsolated_Loose);
-    setBranch<int>(tree, "isIsolated_Tight",                       m_isIsolated_Tight);
-    setBranch<int>(tree, "isIsolated_Gradient",                    m_isIsolated_Gradient);
-    setBranch<int>(tree, "isIsolated_GradientLoose",               m_isIsolated_GradientLoose);
-    setBranch<int>(tree, "isIsolated_FixedCutLoose",               m_isIsolated_FixedCutLoose);
-    setBranch<int>(tree, "isIsolated_FixedCutTight",               m_isIsolated_FixedCutTight);
-    setBranch<int>(tree, "isIsolated_FixedCutTightTrackOnly",      m_isIsolated_FixedCutTightTrackOnly);
-    setBranch<int>(tree, "isIsolated_UserDefinedFixEfficiency",    m_isIsolated_UserDefinedFixEfficiency);
-    setBranch<int>(tree, "isIsolated_UserDefinedCut",              m_isIsolated_UserDefinedCut);
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        setBranch<int>(tree, "isIsolated_" + isol, &(*m_isIsolated)[isol]);
+      }
+    }
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -532,33 +443,15 @@ void ElectronContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_PID ) {
-    tree->Branch(("n"+m_name+"_LHVeryLoose").c_str(),      &m_n_LHVeryLoose);
-    setBranch<int>(tree, "LHVeryLoose",         m_LHVeryLoose);
-
-    tree->Branch(("n"+m_name+"_LHLoose").c_str(),      &m_n_LHLoose);
-    setBranch<int>(tree, "LHLoose",         m_LHLoose);
-
-    tree->Branch(("n"+m_name+"_LHLooseBL").c_str(),      &m_n_LHLooseBL);
-    setBranch<int>(tree, "LHLooseBL",         m_LHLooseBL);
-
-    tree->Branch(("n"+m_name+"_LHMedium").c_str(),      &m_n_LHMedium);
-    setBranch<int>(tree, "LHMedium",      m_LHMedium);
-
-    tree->Branch(("n"+m_name+"_LHTight").c_str(),      &m_n_LHTight);
-    setBranch<int>(tree, "LHTight",       m_LHTight);
-
-    tree->Branch(("n"+m_name+"_IsEMLoose").c_str(),      &m_n_IsEMLoose);
-    setBranch<int>(tree, "IsEMLoose",     m_IsEMLoose);
-
-    tree->Branch(("n"+m_name+"_IsEMMedium").c_str(),      &m_n_IsEMMedium);
-    setBranch<int>(tree, "IsEMMedium",    m_IsEMMedium);
-
-    tree->Branch(("n"+m_name+"_IsEMTight").c_str(),      &m_n_IsEMTight);
-    setBranch<int>(tree, "IsEMTight",     m_IsEMTight);
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      if (!PID.empty()) {
+        setBranch<int>(tree, PID, &(*m_PID)[PID]);
+      }
+    }
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDSFWPs) {
       tree->Branch( (m_name+"_PIDEff_SF_"  + PID).c_str() , & (*m_PIDEff_SF)[ PID ] );
       for (auto& isol : m_infoSwitch.m_isolWPs) {
         if(!isol.empty())
@@ -630,16 +523,9 @@ void ElectronContainer::clear()
   }
 
   if ( m_infoSwitch.m_isolation ) {
-    m_isIsolated_LooseTrackOnly              ->clear();
-    m_isIsolated_Loose                       ->clear();
-    m_isIsolated_Tight                       ->clear();
-    m_isIsolated_Gradient                    ->clear();
-    m_isIsolated_GradientLoose               ->clear();
-    m_isIsolated_FixedCutLoose               ->clear();
-    m_isIsolated_FixedCutTight               ->clear();
-    m_isIsolated_FixedCutTightTrackOnly      ->clear();
-    m_isIsolated_UserDefinedFixEfficiency    ->clear();
-    m_isIsolated_UserDefinedCut              ->clear();
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
+      (*m_isIsolated)[ isol ].clear();
+    }
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -656,35 +542,14 @@ void ElectronContainer::clear()
   }
 
   if ( m_infoSwitch.m_PID ) {
-    m_n_LHVeryLoose = 0;
-    m_LHVeryLoose   -> clear();
-
-    m_n_LHLoose = 0;
-    m_LHLoose   -> clear();
-
-    m_n_LHLooseBL = 0;
-    m_LHLooseBL   -> clear();
-
-    m_n_LHMedium = 0;
-    m_LHMedium   -> clear();
-
-    m_n_LHTight = 0;
-    m_LHTight   -> clear();
-
-    m_n_IsEMLoose = 0;
-    m_IsEMLoose   -> clear();
-
-    m_n_IsEMMedium = 0;
-    m_IsEMMedium   -> clear();
-
-    m_n_IsEMTight = 0;
-    m_IsEMTight   -> clear();
-
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      (*m_PID)[ PID ].clear();
+    }
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDSFWPs) {
       (*m_PIDEff_SF)[ PID ].clear();
       for (auto& isol : m_infoSwitch.m_isolWPs) {
         if(!isol.empty())
@@ -786,36 +651,15 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
   }
 
   if ( m_infoSwitch.m_isolation ) {
+    static std::map< std::string, SG::AuxElement::Accessor<char> > accIsol;
 
-    static SG::AuxElement::Accessor<char> isIsoLooseTrackOnlyAcc ("isIsolated_LooseTrackOnly");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoLooseTrackOnlyAcc, m_isIsolated_LooseTrackOnly, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoLooseAcc ("isIsolated_Loose");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoLooseAcc, m_isIsolated_Loose, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoTightAcc, m_isIsolated_Tight, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoGradientAcc ("isIsolated_Gradient");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoGradientAcc, m_isIsolated_Gradient, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoGradientLooseAcc ("isIsolated_GradientLoose");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoGradientLooseAcc, m_isIsolated_GradientLoose, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoFixedCutLooseAcc ("isIsolated_FixedCutLoose");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoFixedCutLooseAcc, m_isIsolated_FixedCutLoose, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightAcc ("isIsolated_FixedCutTight");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoFixedCutTightAcc, m_isIsolated_FixedCutTight, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightTrackOnlyAcc ("isIsolated_FixedCutTightTrackOnly");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoFixedCutTightTrackOnlyAcc, m_isIsolated_FixedCutTightTrackOnly, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedFixEfficiencyAcc ("isIsolated_UserDefinedFixEfficiency");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoUserDefinedFixEfficiencyAcc, m_isIsolated_UserDefinedFixEfficiency, -1);
-
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
-    safeFill<char, int, xAOD::Electron>(elec, isIsoUserDefinedCutAcc, m_isIsolated_UserDefinedCut, -1);
+    for (auto& isol : m_infoSwitch.m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        std::string isolWP = "isIsolated_" + isol;
+        accIsol.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( isol , SG::AuxElement::Accessor<char>( isolWP ) ) );
+        safeFill<char, int, xAOD::Electron>( elec, accIsol.at( isol ), &m_isIsolated->at( isol ), -1 );
+      }
+    }
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
@@ -832,56 +676,14 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
   }
 
   if ( m_infoSwitch.m_PID ) {
+    static std::map< std::string, SG::AuxElement::Accessor<char> > accPID;
 
-    static SG::AuxElement::Accessor<char> LHVeryLooseAcc ("LHVeryLoose");
-    if ( LHVeryLooseAcc.isAvailable( *elec ) ) {
-      m_LHVeryLoose->push_back( LHVeryLooseAcc( *elec ) );
-      if ( LHVeryLooseAcc( *elec ) == 1 ) { ++m_n_LHVeryLoose; }
-    }  else {  m_LHVeryLoose->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> LHLooseAcc ("LHLoose");
-    if ( LHLooseAcc.isAvailable( *elec ) ) {
-      m_LHLoose->push_back( LHLooseAcc( *elec ) );
-      if ( LHLooseAcc( *elec ) == 1 ) { ++m_n_LHLoose; }
-    }  else {  m_LHLoose->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> LHLooseBLAcc ("LHLooseBL");
-    if ( LHLooseBLAcc.isAvailable( *elec ) ) {
-      m_LHLooseBL->push_back( LHLooseBLAcc( *elec ) );
-      if ( LHLooseBLAcc( *elec ) == 1 ) { ++m_n_LHLooseBL; }
-    }  else { m_LHLooseBL->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> LHMediumAcc ("LHMedium");
-    if ( LHMediumAcc.isAvailable( *elec ) ) {
-      m_LHMedium->push_back( LHMediumAcc( *elec ) );
-      if ( LHMediumAcc( *elec ) == 1 ) { ++m_n_LHMedium; }
-    }  else { m_LHMedium->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> LHTightAcc ("LHTight");
-    if ( LHTightAcc.isAvailable( *elec ) ) {
-      m_LHTight->push_back( LHTightAcc( *elec ) );
-      if ( LHTightAcc( *elec ) == 1 ) { ++m_n_LHTight; }
-    } else { m_LHTight->push_back( -1 ); }
-
-
-    static SG::AuxElement::Accessor<char> EMLooseAcc ("IsEMLoose");
-    if ( EMLooseAcc.isAvailable( *elec ) ) {
-      m_IsEMLoose->push_back( EMLooseAcc( *elec ) );
-      if ( EMLooseAcc( *elec ) == 1 ) { ++m_n_IsEMLoose; }
-    } else { m_IsEMLoose->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> EMMediumAcc ("IsEMMedium");
-    if ( EMMediumAcc.isAvailable( *elec ) ) {
-      m_IsEMMedium->push_back( EMMediumAcc( *elec ) );
-      if ( EMMediumAcc( *elec ) == 1 ) { ++m_n_IsEMMedium; }
-    } else { m_IsEMMedium->push_back( -1 ); }
-
-    static SG::AuxElement::Accessor<char> EMTightAcc ("IsEMTight");
-    if ( EMTightAcc.isAvailable( *elec ) ) {
-      m_IsEMTight->push_back( EMTightAcc( *elec ) );
-      if ( EMTightAcc( *elec ) == 1 ) { ++m_n_IsEMTight; }
-    } else { m_IsEMTight->push_back( -1 ); }
-
+    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+      if (!PID.empty()) {
+        accPID.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( PID , SG::AuxElement::Accessor<char>( PID ) ) );
+        safeFill<char, int, xAOD::Electron>( elec, accPID.at( PID ), &m_PID->at( PID ), -1 );
+      }
+    }
   }
 
   if ( m_infoSwitch.m_trackparams ) {
@@ -981,7 +783,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigSF;
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigEFF;
 
-    for (auto& PID : m_infoSwitch.m_PIDWPs) {
+    for (auto& PID : m_infoSwitch.m_PIDSFWPs) {
       std::string PIDSF = "ElPIDEff_SF_syst_" + PID;
       accPIDSF.insert( std::pair<std::string, SG::AuxElement::Accessor< std::vector< float > > > ( PID , SG::AuxElement::Accessor< std::vector< float > >( PIDSF ) ) );
       safeSFVecFill<float, xAOD::Electron>( elec, accPIDSF.at( PID ), &m_PIDEff_SF->at( PID ), junkSF );

--- a/Root/ElectronHists.cxx
+++ b/Root/ElectronHists.cxx
@@ -173,7 +173,7 @@ StatusCode ElectronHists::execute( const xAH::Particle* particle, float eventWei
   }
 
 
-  if ( m_infoSwitch->m_quality ) {
+  if ( m_infoSwitch->m_PID || m_infoSwitch->m_quality ) {
     for (auto& PID : m_infoSwitch->m_PIDWPs) {
       if (PID.empty()) continue;
 

--- a/Root/ElectronHists.cxx
+++ b/Root/ElectronHists.cxx
@@ -22,17 +22,11 @@ StatusCode ElectronHists::initialize() {
   if( m_infoSwitch->m_isolation ) {
     if(m_debug) Info("ElectronHists::initialize()", "adding isolation plots");
 
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (isol.empty() && isol == "NONE") continue;
 
-    m_isIsolated_LooseTrackOnly           = book(m_name, "isIsolated_LooseTrackOnly"       ,   "isIsolated_LooseTrackOnly", 3, -1.5, 1.5);
-    m_isIsolated_Loose                    = book(m_name, "isIsolated_Loose"            ,       "isIsolated_Loose", 3, -1.5, 1.5);
-    m_isIsolated_Tight                    = book(m_name, "isIsolated_Tight"             ,      "isIsolated_Tight", 3, -1.5, 1.5);
-    m_isIsolated_Gradient                 = book(m_name, "isIsolated_Gradient"      ,          "isIsolated_Gradient", 3, -1.5, 1.5);
-    m_isIsolated_GradientLoose            = book(m_name, "isIsolated_GradientLoose",           "isIsolated_GradientLoose", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutLoose            = book(m_name, "isIsolated_FixedCutLoose",           "isIsolated_FixedCutLoose", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutTight            = book(m_name, "isIsolated_FixedCutTight",           "isIsolated_FixedCutTight", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutTightTrackOnly   = book(m_name, "isIsolated_FixedCutTightTrackOnly"  ,"isIsolated_FixedCutTightTrackOnly", 3, -1.5, 1.5);
-    m_isIsolated_UserDefinedFixEfficiency = book(m_name, "isIsolated_UserDefinedFixEfficiency","isIsolated_UserDefinedFixEfficiency", 3, -1.5, 1.5);
-    m_isIsolated_UserDefinedCut           = book(m_name, "isIsolated_UserDefinedCut",          "isIsolated_UserDefinedCut", 3, -1.5, 1.5);
+      m_isIsolated[isol] = book(m_name, "isIsolated_" + isol,   "isIsolated_" + isol, 3, -1.5, 1.5);
+    }
 
     m_ptcone20     = book(m_name, "ptcone20",     "ptcone20",     101, -0.2, 20);
     m_ptcone30     = book(m_name, "ptcone30",     "ptcone30",     101, -0.2, 20);
@@ -53,14 +47,15 @@ StatusCode ElectronHists::initialize() {
     m_topoetcone20_rel = book(m_name, "topoetcone20_rel", "topoetcone20_rel", 110, -0.2, 2);
     m_topoetcone30_rel = book(m_name, "topoetcone30_rel", "topoetcone30_rel", 110, -0.2, 2);
     m_topoetcone40_rel = book(m_name, "topoetcone40_rel", "topoetcone40_rel", 110, -0.2, 2);
-  }
+}
 
-  // quality
-  if(m_infoSwitch->m_quality){
-    //m_LHVeryLoose = book(m_name, "LHVeryLoose", "LHVeryLoose", 3, -1.5, 1.5);
-    m_LHLoose     = book(m_name, "LHLoose"    , "LHLoose"    , 3, -1.5, 1.5);
-    m_LHMedium    = book(m_name, "LHMedium"   , "LHMedium"   , 3, -1.5, 1.5);
-    m_LHTight     = book(m_name, "LHTight"    , "LHTight"    , 3, -1.5, 1.5);
+  // PID
+  if (m_infoSwitch->m_PID || m_infoSwitch->m_quality) {
+    for (auto& PID : m_infoSwitch->m_PIDWPs) {
+      if (PID.empty()) continue;
+
+      m_PID[PID] = book(m_name, PID, PID, 3, -1.5, 1.5);
+    }
   }
 
   return StatusCode::SUCCESS;
@@ -85,28 +80,20 @@ StatusCode ElectronHists::execute( const xAOD::IParticle* particle, float eventW
 
   // isolation
   if ( m_infoSwitch->m_isolation ) {
+    static std::map< std::string, SG::AuxElement::Accessor<char> > accIsol;
 
-    static SG::AuxElement::Accessor<char> isIsoLooseTrackOnlyAcc ("isIsolated_LooseTrackOnly");
-    static SG::AuxElement::Accessor<char> isIsoLooseAcc ("isIsolated_Loose");
-    static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
-    static SG::AuxElement::Accessor<char> isIsoGradientAcc ("isIsolated_Gradient");
-    static SG::AuxElement::Accessor<char> isIsoGradientLooseAcc ("isIsolated_GradientLoose");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutLooseAcc ("isIsolated_FixedCutLoose");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightAcc ("isIsolated_FixedCutTight");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightTrackOnlyAcc ("isIsolated_FixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedFixEfficiencyAcc ("isIsolated_UserDefinedFixEfficiency");
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
-
-    if (isIsoLooseTrackOnlyAcc.isAvailable(*electron)) {m_isIsolated_LooseTrackOnly->Fill(isIsoLooseTrackOnlyAcc(*electron), eventWeight);} else {m_isIsolated_LooseTrackOnly->Fill(-1,eventWeight);}
-    if (isIsoLooseAcc.isAvailable(*electron) )         {m_isIsolated_Loose->Fill( isIsoLooseAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_Loose->Fill( -1 ,  eventWeight ); }
-    if (isIsoTightAcc.isAvailable( *electron ) )       { m_isIsolated_Tight->Fill( isIsoTightAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_Tight->Fill( -1 ,  eventWeight ); }
-    if (isIsoGradientAcc.isAvailable( *electron ) )       { m_isIsolated_Gradient->Fill( isIsoGradientAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_Gradient->Fill( -1 ,  eventWeight ); }
-    if (isIsoGradientLooseAcc.isAvailable(*electron))  { m_isIsolated_GradientLoose->Fill( isIsoGradientLooseAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_GradientLoose->Fill( -1 ,  eventWeight ); }
-    if (isIsoFixedCutLooseAcc.isAvailable(*electron))          { m_isIsolated_FixedCutLoose->Fill( isIsoFixedCutLooseAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_FixedCutLoose->Fill( -1 ,  eventWeight ); }
-    if (isIsoFixedCutTightAcc.isAvailable(*electron))          { m_isIsolated_FixedCutTight->Fill( isIsoFixedCutTightAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_FixedCutTight->Fill( -1 ,  eventWeight ); }
-    if (isIsoFixedCutTightTrackOnlyAcc.isAvailable(*electron))          { m_isIsolated_FixedCutTightTrackOnly->Fill( isIsoFixedCutTightTrackOnlyAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_FixedCutTightTrackOnly->Fill( -1 ,  eventWeight ); }
-    if ( isIsoUserDefinedFixEfficiencyAcc.isAvailable(*electron)) {m_isIsolated_UserDefinedFixEfficiency->Fill(isIsoUserDefinedFixEfficiencyAcc(*electron), eventWeight);} else {m_isIsolated_UserDefinedFixEfficiency->Fill(-1,eventWeight);}
-    if ( isIsoUserDefinedCutAcc.isAvailable( *electron ) )           { m_isIsolated_UserDefinedCut->Fill( isIsoUserDefinedCutAcc( *electron ) ,  eventWeight ); } else { m_isIsolated_UserDefinedCut->Fill( -1 ,  eventWeight ); }
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        std::string isolWP = "isIsolated_" + isol;
+        accIsol.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( isol , SG::AuxElement::Accessor<char>( isolWP ) ) );
+        
+        if (accIsol.at(isol).isAvailable(*electron)) {
+            m_isIsolated[isol]->Fill(accIsol.at(isol)(*electron), eventWeight);
+        } else {
+            m_isIsolated[isol]->Fill(-1 , eventWeight);
+        }
+      }
+    }
 
     m_ptcone20    ->Fill( electron->isolation( xAOD::Iso::ptcone20    ) / 1e3, eventWeight );
     m_ptcone30    ->Fill( electron->isolation( xAOD::Iso::ptcone30    ) / 1e3, eventWeight );
@@ -154,23 +141,14 @@ StatusCode ElectronHists::execute( const xAH::Particle* particle, float eventWei
       return StatusCode::FAILURE;
     }
 
-  m_isIsolated_LooseTrackOnly           ->Fill( elec->isIsolated_LooseTrackOnly ,  eventWeight );
-  m_isIsolated_Loose                    ->Fill( elec->isIsolated_Loose ,  eventWeight );
-  m_isIsolated_Tight                    ->Fill( elec->isIsolated_Tight ,  eventWeight );
-  m_isIsolated_Gradient                 ->Fill( elec->isIsolated_Gradient ,  eventWeight );
-  m_isIsolated_GradientLoose            ->Fill( elec->isIsolated_GradientLoose ,  eventWeight );
-  //m_isIsolated_GradientT1               ->Fill( elec->isIsolated_GradientLoose ,  eventWeight );
-  //m_isIsolated_GradientT2               ->Fill( elec->isIsoGradientT2Acc ,  eventWeight );
-  //m_isIsolated_MU0p06                   ->Fill( elec->isIsoMU0p06Acc ,  eventWeight );
-  m_isIsolated_FixedCutLoose            ->Fill( elec->isIsolated_FixedCutLoose ,  eventWeight );
-  //m_isIsolated_FixedCutTight            ->Fill( elec->isIsolated_FixedCutTight ,  eventWeight );
-  m_isIsolated_FixedCutTightTrackOnly   ->Fill( elec->isIsolated_FixedCutTightTrackOnly ,  eventWeight );
-  m_isIsolated_UserDefinedFixEfficiency ->Fill( elec->isIsolated_UserDefinedFixEfficiency ,  eventWeight );
-  m_isIsolated_UserDefinedCut           ->Fill( elec->isIsolated_UserDefinedCut ,  eventWeight );
-
-
   // isolation
   if ( m_infoSwitch->m_isolation ) {
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (isol.empty() && isol == "NONE") continue;
+
+      m_isIsolated[isol]->Fill(elec->isIsolated.at(isol), eventWeight);
+    }
+
     m_ptcone20    ->Fill( elec->ptcone20    , eventWeight );
     m_ptcone30    ->Fill( elec->ptcone30    , eventWeight );
     m_ptcone40    ->Fill( elec->ptcone40    , eventWeight );
@@ -196,12 +174,11 @@ StatusCode ElectronHists::execute( const xAH::Particle* particle, float eventWei
 
 
   if ( m_infoSwitch->m_quality ) {
+    for (auto& PID : m_infoSwitch->m_PIDWPs) {
+      if (PID.empty()) continue;
 
-    //m_isVeryLoose->Fill( elec->  isVeryLoose,  eventWeight );
-    m_LHLoose    ->Fill( elec->  LHLoose    ,  eventWeight );
-    m_LHMedium   ->Fill( elec->  LHMedium   ,  eventWeight );
-    m_LHTight    ->Fill( elec->  LHTight    ,  eventWeight );
-
+      m_PID[PID]->Fill(elec->PID.at(PID), eventWeight);
+    }
   }
 
   return StatusCode::SUCCESS;

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -190,16 +190,20 @@ namespace HelperClasses{
     // working points combinations for trigger corrections
     std::string token;
     std::string pid_keyword = "PID_";
+    std::string pidsf_keyword = "PIDSF_";
     std::string isol_keyword = "ISOL_";
     std::string trig_keyword = "TRIG_";
 
     std::istringstream ss(m_configStr);
     while ( std::getline(ss, token, ' ') ) {
       auto pid_substr = token.find(pid_keyword);
+      auto pidsf_substr = token.find(pidsf_keyword);
       auto isol_substr = token.find(isol_keyword);
       auto trig_substr = token.find(trig_keyword);
       if( pid_substr != std::string::npos ){
         m_PIDWPs.push_back(token.substr(4));
+      } else if( pidsf_substr != std::string::npos ){
+        m_PIDSFWPs.push_back(token.substr(6));
       } else if(isol_substr != std::string::npos){
         if(token.substr(5) == "NONE" || token == isol_keyword) m_isolWPs.push_back("");
         else m_isolWPs.push_back(token.substr(5));

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -180,6 +180,9 @@ namespace HelperClasses{
     m_isolation     = has_exact("isolation");
     m_isolationKinematics = has_exact("isolationKinematics");
     m_quality       = has_exact("quality");
+    if (m_quality) {
+        std::cerr << "WARNING! The 'quality' option is deprecated in ElectronInfoSwitch. Use 'PID' instead." << std::endl;
+    }
     m_PID           = has_exact("PID");
     m_trackparams   = has_exact("trackparams");
     m_trackhitcont  = has_exact("trackhitcont");

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -5,30 +5,21 @@
 
 
 namespace xAH {
-  
+
   class Electron : public Particle
   {
   public:
 
     // kinematics
     float  caloCluster_eta;
- 
+
     // trigger
     int               isTrigMatched;
     std::vector<int>  isTrigMatchedToChain;
     std::string       listTrigChains;
 
     // isolation
-    int   isIsolated_LooseTrackOnly;
-    int   isIsolated_Loose;
-    int   isIsolated_Tight;
-    int   isIsolated_Gradient;
-    int   isIsolated_GradientLoose;
-    int   isIsolated_FixedCutLoose;
-    int   isIsolated_FixedCutTight;
-    int   isIsolated_FixedCutTightTrackOnly;
-    int   isIsolated_UserDefinedFixEfficiency;
-    int   isIsolated_UserDefinedCut;
+    std::map< std::string, int > isIsolated;
     float etcone20;
     float ptcone20;
     float ptcone30;
@@ -41,15 +32,8 @@ namespace xAH {
     float topoetcone40;
 
     // PID
-    int   LHVeryLoose;
-    int   LHLoose;
-    int   LHLooseBL;
-    int   LHMedium;
-    int   LHTight;
-    int   IsEMLoose;
-    int   IsEMMedium;
-    int   IsEMTight;
-    
+    std::map< std::string, int > PID;
+
     // scale factors w/ sys
     // per object
     std::vector< float > RecoEff_SF;
@@ -60,7 +44,7 @@ namespace xAH {
     std::map< std::string, std::vector< float > > TrigMCEff;
     //const std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
     //const std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
-    
+
     // track parameters
     float  trkd0;
     float  trkd0sig;
@@ -70,7 +54,7 @@ namespace xAH {
     float  trktheta;
     float  trkcharge;
     float  trkqOverP;
-    
+
     // track hit content
     int  trknSiHits;
     int  trknPixHits;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -21,7 +21,7 @@ namespace xAH {
     public:
       ElectronContainer(const std::string& name = "el", const std::string& detailStr="", float units = 1e3, bool mc = false, bool storeSystSFs = true);
       virtual ~ElectronContainer();
-    
+
       virtual void setTree(TTree *tree);
       virtual void setBranches(TTree *tree);
       virtual void clear();
@@ -31,28 +31,19 @@ namespace xAH {
 
     protected:
       virtual void updateParticle(uint idx, Electron& elec);
-    
+
     private:
 
       // kinematics
       std::vector<float>*  m_caloCluster_eta;
- 
+
       // trigger
       std::vector<int>*  m_isTrigMatched;
       std::vector<std::vector<int> >* m_isTrigMatchedToChain;
       std::vector<std::string>*       m_listTrigChains;
 
       // isolation
-      std::vector<int>*   m_isIsolated_LooseTrackOnly;
-      std::vector<int>*   m_isIsolated_Loose;
-      std::vector<int>*   m_isIsolated_Tight;
-      std::vector<int>*   m_isIsolated_Gradient;
-      std::vector<int>*   m_isIsolated_GradientLoose;
-      std::vector<int>*   m_isIsolated_FixedCutLoose;
-      std::vector<int>*   m_isIsolated_FixedCutTight;
-      std::vector<int>*   m_isIsolated_FixedCutTightTrackOnly;
-      std::vector<int>*   m_isIsolated_UserDefinedFixEfficiency;
-      std::vector<int>*   m_isIsolated_UserDefinedCut;
+      std::map< std::string, std::vector< int > >* m_isIsolated;
       std::vector<float>* m_etcone20;
       std::vector<float>* m_ptcone20;
       std::vector<float>* m_ptcone30;
@@ -65,23 +56,8 @@ namespace xAH {
       std::vector<float>* m_topoetcone40;
 
       // PID
-      int m_n_LHVeryLoose;
-      std::vector<int>*   m_LHVeryLoose;
-      int m_n_LHLoose;
-      std::vector<int>*   m_LHLoose;
-      int m_n_LHLooseBL;
-      std::vector<int>*   m_LHLooseBL;
-      int m_n_LHMedium;
-      std::vector<int>*   m_LHMedium;
-      int m_n_LHTight;
-      std::vector<int>*   m_LHTight;
-      int m_n_IsEMLoose;
-      std::vector<int>*   m_IsEMLoose;
-      int m_n_IsEMMedium;
-      std::vector<int>*   m_IsEMMedium;
-      int m_n_IsEMTight;
-      std::vector<int>*   m_IsEMTight;
-    
+      std::map< std::string, std::vector< int > >* m_PID;
+
       // scale factors w/ sys
       // per object
       std::vector< std::vector< float > >* m_RecoEff_SF;
@@ -90,7 +66,7 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
-      
+
       // track parameters
       std::vector<float>* m_trkd0;
       std::vector<float>* m_trkd0sig;
@@ -100,7 +76,7 @@ namespace xAH {
       std::vector<float>* m_trktheta;
       std::vector<float>* m_trkcharge;
       std::vector<float>* m_trkqOverP;
-    
+
       // track hit content
       std::vector<int>*   m_trknSiHits;
       std::vector<int>*   m_trknPixHits;
@@ -123,7 +99,7 @@ namespace xAH {
       std::vector<int>*   m_PromptLeptonIso_sv1_jf_ntrkv;
       std::vector<float>* m_PromptLeptonNoIso_TagWeight;
       std::vector<float>* m_PromptLepton_TagWeight;
-    
+
     };
 }
 #endif // xAODAnaHelpers_ElectronContainer_H

--- a/xAODAnaHelpers/ElectronHists.h
+++ b/xAODAnaHelpers/ElectronHists.h
@@ -34,26 +34,10 @@ class ElectronHists : public IParticleHists
   private:
 
     // Isolation
-    TH1F* m_isIsolated_LooseTrackOnly              ; //!
-    TH1F* m_isIsolated_Loose			   ; //!
-    TH1F* m_isIsolated_Tight			   ; //!
-    TH1F* m_isIsolated_Gradient			   ; //!
-    TH1F* m_isIsolated_GradientLoose		   ; //!
-    TH1F* m_isIsolated_GradientT1		   ; //!
-    TH1F* m_isIsolated_GradientT2		   ; //!
-    TH1F* m_isIsolated_MU0p06			   ; //!
-    TH1F* m_isIsolated_FixedCutLoose		   ; //!
-    TH1F* m_isIsolated_FixedCutTight		   ; //!
-    TH1F* m_isIsolated_FixedCutTightTrackOnly	   ; //!
-    TH1F* m_isIsolated_UserDefinedFixEfficiency	   ; //!
-    TH1F* m_isIsolated_UserDefinedCut		   ; //!
+    std::map<std::string, TH1F *> m_isIsolated; //!
 
-    //quality
-    //TH1F* m_LHVeryLoose   ; //!
-    TH1F* m_LHLoose       ; //!
-    TH1F* m_LHMedium      ; //!
-    TH1F* m_LHTight       ; //!
-
+    // PID
+    std::map<std::string, TH1F *> m_PID; //!
 
     // clean
     TH1F* m_ptcone20;                //!

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -303,7 +303,6 @@ namespace HelperClasses {
         m_trigger             trigger             exact
         m_isolation           isolation           exact
         m_isolationKinematics isolationKinematics exact
-        m_quality             quality             exact
         m_PID                 PID                 exact
         m_trackparams         trackparams         exact
         m_trackhitcont        trackhitcont        exact
@@ -315,6 +314,20 @@ namespace HelperClasses {
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern
         ===================== =================== =======
+
+        .. note::
+
+            ``PID``, ``isolation`` and ``effSF`` switches do not enable any additional output by themselves. They require additional working point pattern using ``PID_XYZ`` for PID working points, ``PIDSF_XYZ`` for PID scale factors, ``ISOL_XYZ`` for isolation working points and scale factors, and ``TRIG_XYZ`` for trigger scale factors. ``XYZ`` in the pattern should be replaced using the working point name, for example::
+
+                m_configStr = "... PID_LHMedium PIDSF_MediumLLH ..."
+
+            will define the ``LHMedium`` PID working point and the accompanying scale factors. Note that not all PID working points have scale factors available.
+            
+            Isolation supports ``NONE`` or empty option which will enable scale factors without additional isolation requirements, for example::
+
+                m_configStr = "... ISOL_NONE ISOL_Loose ..."
+
+            will define the ``Loose`` isolation working point status branch, and scale factors without isolation requirements and using the ``Loose`` WP.
 
     @endrst
    */

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -309,6 +309,7 @@ namespace HelperClasses {
         m_trackhitcont        trackhitcont        exact
         m_effSF               effSF               exact
         m_PIDWPs[XYZ]         PID_XYZ             pattern
+        m_PIDSFWPs[XYZ]       PIDSF_XYZ           pattern
         m_isolWPs[""]         ISOL_               exact
         m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
@@ -329,6 +330,7 @@ namespace HelperClasses {
     bool m_effSF;
     bool m_promptlepton;
     std::vector< std::string > m_PIDWPs;
+    std::vector< std::string > m_PIDSFWPs;
     std::vector< std::string > m_isolWPs;
     std::vector< std::string > m_trigWPs;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };


### PR DESCRIPTION
This is the first part of #1109 implementation.

What was changed:
 - added `PID_<wp>` switch token and renamed the existing one to `PIDSF_<wp>` as scale factors do not use all PID working points
 - used existing `ISOL_<wp>` for isolation branches
 - isolation counters were removed

This is breaking: branches names stayed the same but isolation ones will be removed. PID can get the same defaults as they were before. If you want also `ISOL` can be split into `ISOL` and `ISOLSF`, but I don't think it's necessary - one would need SFs anyway.

I plan to do the same thing for muons if this is reasonable.