### PR TITLE
Do not hardcode PRW scale factors

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -494,9 +494,6 @@ EL::StatusCode BasicEventSelection :: initialize ()
 
     ANA_CHECK( m_pileup_tool_handle.setProperty("ConfigFiles", PRWFiles));
     ANA_CHECK( m_pileup_tool_handle.setProperty("LumiCalcFiles", lumiCalcFiles));
-    ANA_CHECK( m_pileup_tool_handle.setProperty("DataScaleFactor", 1.0/1.09));
-    ANA_CHECK( m_pileup_tool_handle.setProperty("DataScaleFactorUP", 1.0));
-    ANA_CHECK( m_pileup_tool_handle.setProperty("DataScaleFactorDOWN", 1.0/1.18));
     ANA_CHECK( m_pileup_tool_handle.setProperty("UsePeriodConfig", m_periodConfig) );
     ANA_CHECK( m_pileup_tool_handle.setProperty("OutputLevel", msg().level() ));
     ANA_CHECK( m_pileup_tool_handle.retrieve());


### PR DESCRIPTION
Do not hardcode PRW scale factors. These are defined in the tool and currently there is no reason to edit them by hand.