### PR TITLE
Store basic trigger matching information also for dilepton triggers

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -692,6 +692,11 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
 
             ANA_MSG_DEBUG( "\t\t is the electron pair ("<<iel<<","<<jel<<") trigger matched? " << matched);
 
+            // set basic matching information
+            ( isTrigMatchedMapElDecor( *myElectrons[0] ) )[chain] = matched;
+            ( isTrigMatchedMapElDecor( *myElectrons[1] ) )[chain] = matched;
+
+            // set pair decision information
             std::pair <unsigned int, unsigned int>  chain_idxs = std::make_pair(iel,jel);
             dielectron_trigmatch_pair                   chain_decision = std::make_pair(chain_idxs,matched);
             diElectronTrigMatchPairMapDecor( *eventInfo ).insert( std::pair< std::string, dielectron_trigmatch_pair >(chain,chain_decision) );
@@ -1112,5 +1117,3 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
   return 1;
 }
-
-

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -661,6 +661,11 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
 
       	    ANA_MSG_DEBUG( "\t\t is the muon pair ("<<imu<<","<<jmu<<") trigger matched? " << matched);
 
+            // set basic matching information
+            ( isTrigMatchedMapMuDecor( *myMuons[0] ) )[chain] = matched;
+            ( isTrigMatchedMapMuDecor( *myMuons[1] ) )[chain] = matched;
+
+            // set pair decision information
       	    std::pair <unsigned int, unsigned int>  chain_idxs = std::make_pair(imu,jmu);
             dimuon_trigmatch_pair  chain_decision = std::make_pair(chain_idxs,matched);
             diMuonTrigMatchPairMapDecor( *eventInfo ).insert( std::pair< std::string, dimuon_trigmatch_pair >(chain,chain_decision) );
@@ -925,4 +930,3 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   ANA_MSG_DEBUG( "Leave passCuts... pass" );
   return 1;
 }
-


### PR DESCRIPTION
Decorate electron and muons with basic trigger matching information also for dilepton triggers. Useful for cases when you accept only two leptons.