### PR TITLE
 Add configurable muon quality/isolation branches

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -157,15 +157,23 @@ namespace HelperClasses{
 
     // working points combinations for trigger corrections
     std::string token;
-    std::string reco_prfx = "Reco";
-    std::string isol_prfx = "Iso";
-    std::string trig_prfx = "HLT";
+    std::string reco_keyword = "RECO_";
+    std::string isol_keyword = "ISOL_";
+    std::string trig_keyword = "TRIG_";
 
     std::istringstream ss(m_configStr);
     while ( std::getline(ss, token, ' ') ) {
-      if ( token.compare( 0, reco_prfx.length(), reco_prfx ) == 0 ) { m_recoWPs.push_back(token); }
-      if ( token.compare( 0, isol_prfx.length(), isol_prfx ) == 0 ) { m_isolWPs.push_back(token); }
-      if ( token.compare( 0, trig_prfx.length(), trig_prfx ) == 0 ) { m_trigWPs.push_back(token); }
+      auto reco_substr = token.find(reco_keyword);
+      auto isol_substr = token.find(isol_keyword);
+      auto trig_substr = token.find(trig_keyword);
+      if( reco_substr != std::string::npos ){
+        m_recoWPs.push_back(token.substr(5));
+      } else if(isol_substr != std::string::npos){
+        if(token.substr(5) == "NONE" || token == isol_keyword) m_isolWPs.push_back("");
+        else m_isolWPs.push_back(token.substr(5));
+      } else if(trig_substr != std::string::npos){
+        m_trigWPs.push_back(token.substr(5));
+      }
     }
 
     m_recoEff_sysNames = has_exact("recoEff_sysNames");

--- a/Root/Jet.cxx
+++ b/Root/Jet.cxx
@@ -339,7 +339,7 @@ void Jet::muonInJetCorrection(const xAH::MuonContainer* muons){
     const TLorentzVector& muonVec = thisMuon->p4;
     
     if(muonVec.Pt()  < 4)                       continue;
-    if(!thisMuon->isMedium && !thisMuon->isTight) continue;
+    if(!(thisMuon->quality.find("Medium") != thisMuon->quality.end() && thisMuon->quality.at("Medium"))) continue;
     
     float thisDr = jetVec.DeltaR(muonVec);
     if(thisDr < minDr){
@@ -366,5 +366,3 @@ void Jet::muonInJetCorrection(const xAH::MuonContainer* muons){
   
   return;
 }
-
-

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -216,9 +216,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // Initialise the CP::MuonTriggerScaleFactors tool
   //
 
-  m_trigEffSF_tool_name = "MuonTriggerScaleFactors_effSF_Trig_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-
-  std::string iso_trig_WP = "Iso" + m_WorkingPointIsoTrig;
+  m_trigEffSF_tool_name = "MuonTriggerScaleFactors_effSF_Trig_Reco" + m_WorkingPointReco;
 
   ANA_MSG_INFO( " Initialising CP::MuonTriggerScaleFactors for TRIGGER efficiency SF..." );
 
@@ -233,7 +231,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
       ANA_CHECK( m_muTrigSF_tool->setProperty("AllowZeroSF", m_AllowZeroSF ));
     }
 
-    ANA_CHECK( m_muTrigSF_tool->setProperty("MuonQuality", m_WorkingPointRecoTrig ));
+    ANA_CHECK( m_muTrigSF_tool->setProperty("MuonQuality", m_WorkingPointReco ));
     ANA_CHECK( m_muTrigSF_tool->initialize());
   }
 
@@ -246,7 +244,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   // Remember base output syst. names container
   m_outputSystNamesTrigBase = m_outputSystNamesTrig;
   // Add the chosen WP to the string labelling the output syst. names container
-  m_outputSystNamesTrig = m_outputSystNamesTrig + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+  m_outputSystNamesTrig = m_outputSystNamesTrig + "_Reco" + m_WorkingPointReco;
 
   CP::SystematicSet affectSystsTrig = m_muTrigSF_tool->affectingSystematics();
   for ( const auto& syst_it : affectSystsTrig ) { ANA_MSG_DEBUG("MuonEfficiencyScaleFactors tool can be affected by trigger efficiency systematic: " << syst_it.name()); }
@@ -685,8 +683,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* /*e
         if ( !syst_it.name().empty() && !nominal ) continue;
 
         // Create the name of the SF weight to be recorded
-        std::string sfName = "MuTrigEff_SF_syst_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
-        std::string effName = "MuTrigMCEff_syst_" + trig_it + "_Reco" + m_WorkingPointRecoTrig + "_Iso" + m_WorkingPointIsoTrig;
+        std::string sfName = "MuTrigEff_SF_syst_" + trig_it + "_Reco" + m_WorkingPointReco;
+        std::string effName = "MuTrigMCEff_syst_" + trig_it + "_Reco" + m_WorkingPointReco;
 
         ANA_MSG_DEBUG( "Trigger efficiency SF sys name (to be recorded in xAOD::TStore) is: " << syst_it.name() );
         if ( writeSystNames ) sysVariationNamesTrig->push_back(syst_it.name());

--- a/Root/MuonHists.cxx
+++ b/Root/MuonHists.cxx
@@ -29,19 +29,11 @@ StatusCode MuonHists::initialize() {
 
   // Isolation
   if(m_infoSwitch->m_isolation){
-    m_isIsolated_LooseTrackOnly           = book(m_name, "isIsolated_LooseTrackOnly"       ,   "isIsolated_LooseTrackOnly", 3, -1.5, 1.5);
-    m_isIsolated_Loose                    = book(m_name, "isIsolated_Loose"            ,       "isIsolated_Loose", 3, -1.5, 1.5);
-    m_isIsolated_Tight                    = book(m_name, "isIsolated_Tight"             ,      "isIsolated_Tight", 3, -1.5, 1.5);
-    m_isIsolated_Gradient                 = book(m_name, "isIsolated_Gradient"      ,          "isIsolated_Gradient", 3, -1.5, 1.5);
-    m_isIsolated_GradientLoose            = book(m_name, "isIsolated_GradientLoose",           "isIsolated_GradientLoose", 3, -1.5, 1.5);
-    m_isIsolated_GradientT1               = book(m_name, "isIsolated_GradientT1",              "isIsolated_GradientT1", 3, -1.5, 1.5);
-    m_isIsolated_GradientT2               = book(m_name, "isIsolated_GradientT2",              "isIsolated_GradientT2", 3, -1.5, 1.5);
-    m_isIsolated_MU0p06                   = book(m_name, "isIsolated_MU0p06",                  "isIsolated_MU0p06", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutLoose            = book(m_name, "isIsolated_FixedCutLoose",           "isIsolated_FixedCutLoose", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutTight            = book(m_name, "isIsolated_FixedCutTight",           "isIsolated_FixedCutTight", 3, -1.5, 1.5);
-    m_isIsolated_FixedCutTightTrackOnly   = book(m_name, "isIsolated_FixedCutTightTrackOnly"  ,"isIsolated_FixedCutTightTrackOnly", 3, -1.5, 1.5);
-    m_isIsolated_UserDefinedFixEfficiency = book(m_name, "isIsolated_UserDefinedFixEfficiency","isIsolated_UserDefinedFixEfficiency", 3, -1.5, 1.5);
-    m_isIsolated_UserDefinedCut           = book(m_name, "isIsolated_UserDefinedCut",          "isIsolated_UserDefinedCut", 3, -1.5, 1.5);
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (isol.empty()) continue;
+
+      m_isIsolated[isol] = book(m_name, "isIsolated_" + isol, "isIsolated_" + isol, 3, -1.5, 1.5);
+    }
 
     m_ptcone20     = book(m_name, "ptcone20",     "ptcone20",     101, -0.2, 20);
     m_ptcone30     = book(m_name, "ptcone30",     "ptcone30",     101, -0.2, 20);
@@ -68,10 +60,11 @@ StatusCode MuonHists::initialize() {
 
   // quality
   if(m_infoSwitch->m_quality){
-    m_isVeryLoose = book(m_name, "isVeryLoose", "isVeryLoose", 3, -1.5, 1.5);
-    m_isLoose     = book(m_name, "isLoose"    , "isLoose"    , 3, -1.5, 1.5);
-    m_isMedium    = book(m_name, "isMedium"   , "isMedium"   , 3, -1.5, 1.5);
-    m_isTight     = book(m_name, "isTight"    , "isTight"    , 3, -1.5, 1.5);
+    for (auto& quality : m_infoSwitch->m_recoWPs) {
+      if (quality.empty()) continue;
+
+      m_quality[quality] = book(m_name, "is" + quality, "is" + quality, 3, -1.5, 1.5);
+    }
   }
 
 
@@ -96,34 +89,20 @@ StatusCode MuonHists::execute( const xAOD::IParticle* particle, float eventWeigh
     }
 
   if ( m_infoSwitch->m_isolation ) {
+    static std::map< std::string, SG::AuxElement::Accessor<char> > accIsol;
 
-    static SG::AuxElement::Accessor<char> isIsoLooseTrackOnlyAcc ("isIsolated_LooseTrackOnly");
-    static SG::AuxElement::Accessor<char> isIsoLooseAcc ("isIsolated_Loose");
-    static SG::AuxElement::Accessor<char> isIsoTightAcc ("isIsolated_Tight");
-    static SG::AuxElement::Accessor<char> isIsoGradientAcc ("isIsolated_Gradient");
-    static SG::AuxElement::Accessor<char> isIsoGradientLooseAcc ("isIsolated_GradientLoose");
-    static SG::AuxElement::Accessor<char> isIsoGradientT1Acc ("isIsolated_GradientT1");
-    static SG::AuxElement::Accessor<char> isIsoGradientT2Acc ("isIsolated_GradientT2");
-    static SG::AuxElement::Accessor<char> isIsoMU0p06Acc ("isIsolated_MU0p06");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutLooseAcc ("isIsolated_FixedCutLoose");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightAcc ("isIsolated_FixedCutTight");
-    static SG::AuxElement::Accessor<char> isIsoFixedCutTightTrackOnlyAcc ("isIsolated_FixedCutTightTrackOnly");
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedFixEfficiencyAcc ("isIsolated_UserDefinedFixEfficiency");
-    static SG::AuxElement::Accessor<char> isIsoUserDefinedCutAcc ("isIsolated_UserDefinedCut");
-
-    if ( isIsoLooseTrackOnlyAcc.isAvailable( *muon ) ) { m_isIsolated_LooseTrackOnly->Fill( isIsoLooseTrackOnlyAcc( *muon ) ,  eventWeight ); } else {m_isIsolated_LooseTrackOnly->Fill( -1 ,  eventWeight );}
-    if ( isIsoLooseAcc.isAvailable( *muon ) )          { m_isIsolated_Loose->Fill( isIsoLooseAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_Loose->Fill( -1 ,  eventWeight ); }
-    if ( isIsoTightAcc.isAvailable( *muon ) )          { m_isIsolated_Tight->Fill( isIsoTightAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_Tight->Fill( -1 ,  eventWeight ); }
-    if ( isIsoGradientAcc.isAvailable( *muon ) )       { m_isIsolated_Gradient->Fill( isIsoGradientAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_Gradient->Fill( -1 ,  eventWeight ); }
-    if ( isIsoGradientLooseAcc.isAvailable( *muon ) )  { m_isIsolated_GradientLoose->Fill( isIsoGradientLooseAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_GradientLoose->Fill( -1 ,  eventWeight ); }
-    if ( isIsoGradientT1Acc.isAvailable( *muon ) )     { m_isIsolated_GradientT1->Fill( isIsoGradientT1Acc( *muon ) ,  eventWeight ); } else { m_isIsolated_GradientT1->Fill( -1 ,  eventWeight ); }
-    if ( isIsoGradientT2Acc.isAvailable( *muon ) )     { m_isIsolated_GradientT2->Fill( isIsoGradientT2Acc( *muon ) ,  eventWeight ); } else { m_isIsolated_GradientT2->Fill( -1 ,  eventWeight ); }
-    if ( isIsoMU0p06Acc.isAvailable( *muon ) )          { m_isIsolated_MU0p06->Fill( isIsoMU0p06Acc( *muon ) ,  eventWeight ); } else { m_isIsolated_MU0p06->Fill( -1 ,  eventWeight ); }
-    if ( isIsoFixedCutLooseAcc.isAvailable( *muon ) )          { m_isIsolated_FixedCutLoose->Fill( isIsoFixedCutLooseAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_FixedCutLoose->Fill( -1 ,  eventWeight ); }
-    if ( isIsoFixedCutTightAcc.isAvailable( *muon ) )          { m_isIsolated_FixedCutTight->Fill( isIsoFixedCutTightAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_FixedCutTight->Fill( -1 ,  eventWeight ); }
-    if ( isIsoFixedCutTightTrackOnlyAcc.isAvailable( *muon ) )          { m_isIsolated_FixedCutTightTrackOnly->Fill( isIsoFixedCutTightTrackOnlyAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_FixedCutTightTrackOnly->Fill( -1 ,  eventWeight ); }
-    if ( isIsoUserDefinedFixEfficiencyAcc.isAvailable( *muon ) ) { m_isIsolated_UserDefinedFixEfficiency->Fill( isIsoUserDefinedFixEfficiencyAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_UserDefinedFixEfficiency->Fill( -1 ,  eventWeight ); }
-    if ( isIsoUserDefinedCutAcc.isAvailable( *muon ) )           { m_isIsolated_UserDefinedCut->Fill( isIsoUserDefinedCutAcc( *muon ) ,  eventWeight ); } else { m_isIsolated_UserDefinedCut->Fill( -1 ,  eventWeight ); }
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (!isol.empty() && isol != "NONE") {
+        std::string isolWP = "isIsolated_" + isol;
+        accIsol.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( isol , SG::AuxElement::Accessor<char>( isolWP ) ) );
+          
+        if (accIsol.at(isol).isAvailable(*muon)) {
+          m_isIsolated[isol]->Fill(accIsol.at(isol)(*muon), eventWeight);
+        } else {
+          m_isIsolated[isol]->Fill(-1, eventWeight);
+        }
+      }
+    }
 
     m_ptcone20     ->Fill( muon->isolation( xAOD::Iso::ptcone20 )     ,  eventWeight );
     m_ptcone30     ->Fill( muon->isolation( xAOD::Iso::ptcone30 )     ,  eventWeight );
@@ -151,16 +130,19 @@ StatusCode MuonHists::execute( const xAOD::IParticle* particle, float eventWeigh
 
 
   if ( m_infoSwitch->m_quality ) {
-    static SG::AuxElement::Accessor<char> isVeryLooseQAcc ("isVeryLooseQ");
-    static SG::AuxElement::Accessor<char> isLooseQAcc ("isLooseQ");
-    static SG::AuxElement::Accessor<char> isMediumQAcc ("isMediumQ");
-    static SG::AuxElement::Accessor<char> isTightQAcc ("isTightQ");
+    static std::map< std::string, SG::AuxElement::Accessor<char> > accQuality;
 
-    if( isVeryLooseQAcc.isAvailable( *muon ) ) { m_isVeryLoose->Fill( static_cast<int>(isVeryLooseQAcc( *muon )),  eventWeight ); } else { m_isVeryLoose->Fill( -1 ,  eventWeight ); }
-    if( isLooseQAcc.isAvailable( *muon ) )     { m_isLoose    ->Fill( static_cast<int>(isLooseQAcc    ( *muon )),  eventWeight ); }         else { m_isLoose->Fill( -1 ,  eventWeight ); }
-    if( isMediumQAcc.isAvailable( *muon ) )    { m_isMedium   ->Fill( static_cast<int>(isMediumQAcc   ( *muon )),  eventWeight ); }       else { m_isMedium->Fill( -1 ,  eventWeight ); }
-    if( isTightQAcc.isAvailable( *muon ) )     { m_isTight    ->Fill( static_cast<int>(isTightQAcc    ( *muon )),  eventWeight ); }         else { m_isTight->Fill( -1 ,  eventWeight ); }
-
+    for (auto& quality : m_infoSwitch->m_recoWPs) {
+      if (!quality.empty()) {
+        accQuality.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( quality , SG::AuxElement::Accessor<char>( quality ) ) );
+        
+        if (accQuality.at(quality).isAvailable(*muon)) {
+          m_quality[quality]->Fill(accQuality.at(quality)(*muon), eventWeight);
+        } else {
+          m_quality[quality]->Fill(-1, eventWeight);
+        }
+      }
+    }
   }
 
 
@@ -187,21 +169,11 @@ StatusCode MuonHists::execute( const xAH::Particle* particle, float eventWeight,
     }
 
   if ( m_infoSwitch->m_isolation ) {
+    for (auto& isol : m_infoSwitch->m_isolWPs) {
+      if (isol.empty()) continue;
 
-
-    m_isIsolated_LooseTrackOnly           ->Fill( muon->isIsolated_LooseTrackOnly ,  eventWeight );
-    m_isIsolated_Loose                    ->Fill( muon->isIsolated_Loose ,  eventWeight );
-    m_isIsolated_Tight                    ->Fill( muon->isIsolated_Tight ,  eventWeight );
-    m_isIsolated_Gradient                 ->Fill( muon->isIsolated_Gradient ,  eventWeight );
-    m_isIsolated_GradientLoose            ->Fill( muon->isIsolated_GradientLoose ,  eventWeight );
-    //m_isIsolated_GradientT1               ->Fill( muon->isIsolated_GradientLoose ,  eventWeight );
-    //m_isIsolated_GradientT2               ->Fill( muon->isIsoGradientT2Acc ,  eventWeight );
-    //m_isIsolated_MU0p06                   ->Fill( muon->isIsoMU0p06Acc ,  eventWeight );
-    m_isIsolated_FixedCutLoose            ->Fill( muon->isIsolated_FixedCutLoose ,  eventWeight );
-    //m_isIsolated_FixedCutTight            ->Fill( muon->isIsolated_FixedCutTight ,  eventWeight );
-    m_isIsolated_FixedCutTightTrackOnly   ->Fill( muon->isIsolated_FixedCutTightTrackOnly ,  eventWeight );
-    m_isIsolated_UserDefinedFixEfficiency ->Fill( muon->isIsolated_UserDefinedFixEfficiency ,  eventWeight );
-    m_isIsolated_UserDefinedCut           ->Fill( muon->isIsolated_UserDefinedCut ,  eventWeight );
+      m_isIsolated[isol]->Fill(muon->isIsolated.at(isol), eventWeight);
+    }
 
     m_ptcone20     ->Fill( muon->ptcone20      ,  eventWeight );
     m_ptcone30     ->Fill( muon->ptcone30      ,  eventWeight );
@@ -228,12 +200,11 @@ StatusCode MuonHists::execute( const xAH::Particle* particle, float eventWeight,
 
 
   if ( m_infoSwitch->m_quality ) {
+    for (auto& quality : m_infoSwitch->m_recoWPs) {
+      if (quality.empty()) continue;
 
-    m_isVeryLoose->Fill( muon->  isVeryLoose,  eventWeight );
-    m_isLoose    ->Fill( muon->  isLoose    ,  eventWeight );
-    m_isMedium   ->Fill( (muon->isMedium + muon->isTight)  ,  eventWeight );
-    m_isTight    ->Fill( muon->  isTight    ,  eventWeight );
-
+      m_quality[quality]->Fill(muon->quality.at(quality), eventWeight);
+    }
   }
 
   return StatusCode::SUCCESS;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -261,6 +261,11 @@ namespace HelperClasses {
         m_trackhitcont         trackhitcont         exact
         m_effSF                effSF                exact
         m_energyLoss           energyLoss           exact
+        m_recoWPs[XYZ]         RECO_XYZ             pattern
+        m_isolWPs[""]          ISOL_                exact
+        m_isolWPs[""]          ISOL_NONE            exact
+        m_isolWPs[XYZ]         ISOL_XYZ             pattern
+        m_trigWPs[XYZ]         TRIG_XYZ             pattern
         ====================== ==================== =======
 
     @endrst

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -268,6 +268,20 @@ namespace HelperClasses {
         m_trigWPs[XYZ]         TRIG_XYZ             pattern
         ====================== ==================== =======
 
+        .. note::
+ 
+             ``quality``, ``isolation`` and ``effSF`` switches do not enable any additional output by themselves. They require additional working point pattern using ``RECO_XYZ`` for quality working points and scale factors, ``ISOL_XYZ`` for isolation working points and scale factors, and ``TRIG_XYZ`` for trigger scale factors. ``XYZ`` in the pattern should be replaced using the working point name, for example::
+ 
+                 m_configStr = "... RECO_Medium ..."
+ 
+             will define the ``Medium`` quality working point and the accompanying scale factors.
+             
+             Isolation supports ``NONE`` or empty option which will enable scale factors without additional isolation requirements, for example::
+ 
+                 m_configStr = "... ISOL_NONE ISOL_Loose ..."
+ 
+             will define the ``Loose`` isolation working point status branch, and scale factors without isolation requirements and using the ``Loose`` WP.
+ 
     @endrst
    */
   class MuonInfoSwitch : public IParticleInfoSwitch {

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -19,15 +19,7 @@ namespace xAH {
     std::string       listTrigChains;
     
       // isolation
-    int   isIsolated_LooseTrackOnly;
-    int   isIsolated_Loose;
-    int   isIsolated_Tight;
-    int   isIsolated_Gradient;
-    int   isIsolated_GradientLoose;
-    int   isIsolated_FixedCutLoose;
-    int   isIsolated_FixedCutTightTrackOnly;
-    int   isIsolated_UserDefinedFixEfficiency;
-    int   isIsolated_UserDefinedCut;
+    std::map< std::string, int > isIsolated;
     float ptcone20;
     float ptcone30;
     float ptcone40;
@@ -39,11 +31,8 @@ namespace xAH {
     float topoetcone40;
     
     // quality
-    int   isVeryLoose;
-    int   isLoose;
-    int   isMedium;
-    int   isTight;
-    
+    std::map< std::string, int > quality;
+
     // scale factors w/ sys
     // per object
     std::map< std::string, std::vector< float > > RecoEff_SF;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -40,15 +40,7 @@ namespace xAH {
       std::vector<std::string>       *m_listTrigChains;
     
       // isolation
-      std::vector<int>   *m_isIsolated_LooseTrackOnly;
-      std::vector<int>   *m_isIsolated_Loose;
-      std::vector<int>   *m_isIsolated_Tight;
-      std::vector<int>   *m_isIsolated_Gradient;
-      std::vector<int>   *m_isIsolated_GradientLoose;
-      std::vector<int>   *m_isIsolated_FixedCutLoose;
-      std::vector<int>   *m_isIsolated_FixedCutTightTrackOnly;
-      std::vector<int>   *m_isIsolated_UserDefinedFixEfficiency;
-      std::vector<int>   *m_isIsolated_UserDefinedCut;
+      std::map< std::string, std::vector< int > >* m_isIsolated;
       std::vector<float> *m_ptcone20;
       std::vector<float> *m_ptcone30;
       std::vector<float> *m_ptcone40;
@@ -58,13 +50,10 @@ namespace xAH {
       std::vector<float> *m_topoetcone20;
       std::vector<float> *m_topoetcone30;
       std::vector<float> *m_topoetcone40;
-    
+
       // quality
-      std::vector<int>   *m_isVeryLoose;
-      std::vector<int>   *m_isLoose;
-      std::vector<int>   *m_isMedium;
-      std::vector<int>   *m_isTight;
-    
+      std::map< std::string, std::vector< int > >* m_quality;
+
       // scale factors w/ sys
       // per object
       std::vector< std::vector< float > > *m_TTVAEff_SF;

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -47,8 +47,7 @@ public:
 
   /// @brief Use with caution!!!
   bool          m_AllowZeroSF = false;
-  std::string   m_WorkingPointRecoTrig = "Loose";
-  std::string   m_WorkingPointIsoTrig = "LooseTrackOnly";
+
   /// @brief list of comma-separated single-mu trigger corrections. Individual legs of di-mu menus can be parsed
   std::string   m_MuTrigLegs = "HLT_mu26_imedium";
 

--- a/xAODAnaHelpers/MuonHists.h
+++ b/xAODAnaHelpers/MuonHists.h
@@ -33,19 +33,7 @@ class MuonHists : public IParticleHists
   private:
 
     // Isolation
-    TH1F* m_isIsolated_LooseTrackOnly              ; //!
-    TH1F* m_isIsolated_Loose			   ; //!
-    TH1F* m_isIsolated_Tight			   ; //!
-    TH1F* m_isIsolated_Gradient			   ; //!
-    TH1F* m_isIsolated_GradientLoose		   ; //!
-    TH1F* m_isIsolated_GradientT1		   ; //!
-    TH1F* m_isIsolated_GradientT2		   ; //!
-    TH1F* m_isIsolated_MU0p06			   ; //!
-    TH1F* m_isIsolated_FixedCutLoose		   ; //!
-    TH1F* m_isIsolated_FixedCutTight		   ; //!
-    TH1F* m_isIsolated_FixedCutTightTrackOnly	   ; //!
-    TH1F* m_isIsolated_UserDefinedFixEfficiency	   ; //!
-    TH1F* m_isIsolated_UserDefinedCut		   ; //!
+    std::map<std::string, TH1F *> m_isIsolated; //!
 
     TH1F* m_ptcone20				   ; //!
     TH1F* m_ptcone30				   ; //!
@@ -69,10 +57,7 @@ class MuonHists : public IParticleHists
 
 
     // quality
-    TH1F* m_isVeryLoose				   ; //!
-    TH1F* m_isLoose				   ; //!
-    TH1F* m_isMedium				   ; //!
-    TH1F* m_isTight                                ; //!
+    std::map<std::string, TH1F *> m_quality; //!
 
 };
 


### PR DESCRIPTION
This is the second part of #1109 implementation.

This is breaking: info switches were changed to be unified with electrons. Also closes #1010. Muon quality and isolation branches are now configurable.