### PR TITLE
Trigger matching for jets

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -230,7 +230,6 @@ namespace HelperClasses{
   void JetInfoSwitch::initialize(){
     std::string tmpConfigStr; // temporary config string used to extract multiple values
 
-    m_kinematic     = has_exact("kinematic");
     m_trigger       = has_exact("trigger");
     m_substructure  = has_exact("substructure");
     m_bosonCount    = has_exact("bosonCount");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -123,10 +123,10 @@ namespace HelperClasses{
     m_passTrigBits      = has_exact("passTrigBits");
   }
 
-  void JetTriggerInfoSwitch::initialize(){
-    m_kinematic     = has_exact("kinematic");
-    m_clean         = has_exact("clean");
-  }
+  //void JetTriggerInfoSwitch::initialize(){
+  //  m_kinematic     = has_exact("kinematic");
+  //  m_clean         = has_exact("clean");
+  //}
 
   void IParticleInfoSwitch::initialize(){
     m_kinematic     = has_exact("kinematic");
@@ -235,6 +235,8 @@ namespace HelperClasses{
   void JetInfoSwitch::initialize(){
     std::string tmpConfigStr; // temporary config string used to extract multiple values
 
+    m_kinematic     = has_exact("kinematic");
+    m_trigger       = has_exact("trigger");
     m_substructure  = has_exact("substructure");
     m_bosonCount    = has_exact("bosonCount");
     m_VTags         = has_exact("VTags");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -123,11 +123,6 @@ namespace HelperClasses{
     m_passTrigBits      = has_exact("passTrigBits");
   }
 
-  //void JetTriggerInfoSwitch::initialize(){
-  //  m_kinematic     = has_exact("kinematic");
-  //  m_clean         = has_exact("clean");
-  //}
-
   void IParticleInfoSwitch::initialize(){
     m_kinematic     = has_exact("kinematic");
 

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -514,7 +514,9 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
             isTrigMatchedMapTauDecor( *tau ) = std::map<std::string,char>();
           }
 
-          char matched = ( m_trigTauMatchTool_handle->match( *tau, chain, m_minDeltaR ) );
+          // check whether the tau is matched (NOTE: no DR is required for taus)
+          //
+          char matched = ( m_trigTauMatchTool_handle->match( *tau, chain ) );
 
           ANA_MSG_DEBUG( "\t\t is tau trigger matched? " << matched);
 
@@ -569,9 +571,9 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
       	    myTaus.push_back( selectedTaus->at(itau) );
       	    myTaus.push_back( selectedTaus->at(jtau) );
 
-            // check whether the pair is matched
+            // check whether the pair is matched (NOTE: no DR is required for taus)
             //
-      	    char matched = m_trigTauMatchTool_handle->match( myTaus, chain, m_minDeltaR );
+      	    char matched = m_trigTauMatchTool_handle->match( myTaus, chain  );
 
       	    ANA_MSG_DEBUG( "\t\t is the tau pair ("<<itau<<","<<jtau<<") trigger matched? " << matched);
 

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -190,29 +190,6 @@ namespace HelperClasses {
 
   /**
     @rst
-        The :cpp:class:`HelperClasses::InfoSwitch` struct for Jet Trigger Information.
-
-        ============== ============ =======
-        Parameter      Pattern      Match
-        ============== ============ =======
-        m_kinematic    kinematic    exact
-        m_clean        clean        exact
-        ============== ============ =======
-
-    @endrst
-   */
-
-  //class JetTriggerInfoSwitch : public InfoSwitch {
-  //public:
-  //  bool m_kinematic;
-  //  bool m_clean;
-  //  JetTriggerInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
-  //protected:
-  //  void initialize();
-  //};
-
-  /**
-    @rst
         The :cpp:class:`HelperClasses::InfoSwitch` struct for IParticle Information.
 
         ============== ============ =======

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -202,14 +202,14 @@ namespace HelperClasses {
     @endrst
    */
 
-  class JetTriggerInfoSwitch : public InfoSwitch {
-  public:
-    bool m_kinematic;
-    bool m_clean;
-    JetTriggerInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
-  protected:
-    void initialize();
-  };
+  //class JetTriggerInfoSwitch : public InfoSwitch {
+  //public:
+  //  bool m_kinematic;
+  //  bool m_clean;
+  //  JetTriggerInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
+  //protected:
+  //  void initialize();
+  //};
 
   /**
     @rst
@@ -407,6 +407,8 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
+        m_kinematic      kinematic      exact
+        m_trigger        trigger        exact
         m_substructure   substructure   exact
         m_bosonCount     bosonCount     exact
         m_VTags          VTags          exact
@@ -479,6 +481,8 @@ namespace HelperClasses {
    */
   class JetInfoSwitch : public IParticleInfoSwitch {
   public:
+    bool m_kinematic;
+    bool m_trigger;
     bool m_substructure;
     bool m_bosonCount;
     bool m_VTags;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -31,6 +31,11 @@ namespace xAH {
       Jet();
       float rapidity;
 
+      // trigger
+      int               isTrigMatched;
+      std::vector<int>  isTrigMatchedToChain;
+      std::string       listTrigChains;
+      
       // clean
       float Timing;
       float LArQuality;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -47,6 +47,11 @@ namespace xAH {
       // rapidity
       std::vector<float> *m_rapidity;
 
+      // trigger
+      std::vector<int>               *m_isTrigMatched;
+      std::vector<std::vector<int> > *m_isTrigMatchedToChain;
+      std::vector<std::string>       *m_listTrigChains;
+      
       // clean
       std::vector<float> *m_Timing;
       std::vector<float> *m_LArQuality;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -28,6 +28,8 @@
 #include "JetJvtEfficiency/IJetJvtEfficiency.h"
 #include "JetInterface/IJetModifier.h"
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
+#include "TriggerMatchingTool/IMatchingTool.h"
+#include "TrigDecisionTool/TrigDecisionTool.h"
 
 class JetSelector : public xAH::Algorithm
 {
@@ -223,6 +225,12 @@ public:
   std::string              m_passAuxDecorKeys = "";
   std::string              m_failAuxDecorKeys = "";
 
+  /* trigger matching */
+  /** A comma-separated string w/ alll the HLT single jet trigger chains for which you want to perform the matching. If left empty (as it is by default), no trigger matching will be attempted at all */
+  std::string    m_singleJetTrigChains = "";
+  /** A comma-separated string w/ all the HLT dijet trigger chains for which you want to perform the matching.  If left empty (as it is by default), no trigger matching will be attempted at all */
+  std::string    m_diJetTrigChains = "";
+
 private:
   int m_numEvent;         //!
   int m_numObject;        //!
@@ -257,9 +265,18 @@ private:
   std::vector<CP::SystematicSet> m_systListJVT; //!
   std::vector<CP::SystematicSet> m_systListfJVT; //!
 
+  std::vector<std::string>            m_singleJetTrigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_singleJetTrigChains */
+  std::vector<std::string>            m_diJetTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diJetTrigChains */
+  
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::JetJvtEfficiency/JVT"}; //!
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency/fJVT"}; //!
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
+
+  asg::AnaToolHandle<Trig::IMatchingTool>    m_trigJetMatchTool_handle{"Trig::MatchingTool/MatchingTool", this}; //!
+  asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"}; //!
+
+  /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
+  bool m_doTrigMatch = true; //!
 
   std::string m_outputJVTPassed = "JetJVT_Passed"; //!
   std::string m_outputfJVTPassed = "JetfJVT_Passed"; //!

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -75,10 +75,6 @@ public:
   
   std::string    m_diTauTrigChains = "";
 
-  //@brief Recommended threshold for muon triggers: 
-  //see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
-  double         m_minDeltaR = 0.1; // This DeltaR will probably need an update
-  
 private:
 
   int m_numEvent;           //!


### PR DESCRIPTION
This PR introduces trigger matching for jets and corrects the trigger match setting for taus. 
No DR info is provided for jets or for taus as opposed to say muons and electrons. The class JetTriggerInfoSwitch has been removed as all jet info has been transferred to JetInfoSwitch, like is done for leptons