### PR TITLE
Allow multiple trigger jet collections in treeAlgo and sort L1 RoIs

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -542,15 +542,34 @@ void HelpTreeBase::AddL1Jets()
 
 }
 
-void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets ) {
+void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, bool sortL1Jets ) {
 
   this->ClearL1Jets();
 
-  for( auto jet_itr : *jets ) {
-    m_l1Jet_et8x8.push_back ( jet_itr->et8x8() / m_units );
-    m_l1Jet_eta.push_back( jet_itr->eta() );
-    m_l1Jet_phi.push_back( jet_itr->phi() );
-    m_nL1Jet++;
+  if(!sortL1Jets) {
+    for( auto jet_itr : *jets ) {
+      m_l1Jet_et8x8.push_back ( jet_itr->et8x8() / m_units );
+      m_l1Jet_eta.push_back( jet_itr->eta() );
+      m_l1Jet_phi.push_back( jet_itr->phi() );
+      m_nL1Jet++;
+    }
+  }
+
+  else {
+    std::vector< float > L1jet_Et, L1jet_Et_sorted;
+    for( auto jet_itr : *jets ) {
+      L1jet_Et.push_back( jet_itr->et8x8() );
+      L1jet_Et_sorted.push_back( jet_itr->et8x8() );
+    }
+    std::sort(L1jet_Et_sorted.begin(), L1jet_Et_sorted.end(), std::greater<float>());
+
+    for( unsigned int i = 0; i < L1jet_Et.size(); i++) {
+      int index = std::find (L1jet_Et.begin(), L1jet_Et.end(), L1jet_Et_sorted.at(i)) - L1jet_Et.begin();
+      m_l1Jet_et8x8.push_back ( jets->at(index)->et8x8() / m_units );
+      m_l1Jet_eta.push_back( jets->at(index)->eta() );
+      m_l1Jet_phi.push_back( jets->at(index)->phi() );
+      m_nL1Jet++;
+    }
   }
 }
 

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -345,7 +345,7 @@ EL::StatusCode TreeAlgo :: execute ()
 
       const xAOD::JetRoIContainer* inL1Jets(nullptr);
       ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainerName, m_event, m_store, msg()) );
-      helpTree->FillL1Jets( inL1Jets);
+      helpTree->FillL1Jets( inL1Jets, m_sortL1Jets );
     }
 
     if ( !m_trigJetContainerName.empty() ) {

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -83,13 +83,21 @@ EL::StatusCode TreeAlgo :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-  // allow to store different variables for each jet collection (reco only, default: store the same)
+  // allow to store different variables for each jet collection (reco and trig only, default: store the same)
   std::istringstream ss(m_jetDetailStr);
   while ( std::getline(ss, token, '|') ){
     m_jetDetails.push_back(token);
   }
   if( m_jetDetails.size()!=1  && m_jetContainers.size()!=m_jetDetails.size()){
     ANA_MSG_ERROR( "The size of m_jetContainers should be equal to the size of m_jetDetailStr. Exiting");
+    return EL::StatusCode::FAILURE;
+  }
+  std::istringstream ss_trig_details(m_trigJetDetailStr);
+  while ( std::getline(ss_trig_details, token, '|') ){
+    m_trigJetDetails.push_back(token);
+  }
+  if( m_trigJetDetails.size()!=1  && m_trigJetContainers.size()!=m_trigJetDetails.size()){
+    ANA_MSG_ERROR( "The size of m_trigJetContainers should be equal to the size of m_trigJetDetailStr. Exiting");
     return EL::StatusCode::FAILURE;
   }
 
@@ -220,7 +228,9 @@ EL::StatusCode TreeAlgo :: execute ()
     // if (!m_trigJetContainerName.empty() )       { helpTree->AddJets(m_trigJetDetailStr, "trigJet");                }
     if (!m_trigJetContainerName.empty() )      {
       for(unsigned int ll=0; ll<m_trigJetContainers.size();++ll){
-        helpTree->AddJets       (m_trigJetDetailStr, m_trigJetBranches.at(ll).c_str());
+        // helpTree->AddJets       (m_trigJetDetailStr, m_trigJetBranches.at(ll).c_str());
+        if(m_trigJetDetails.size()==1) helpTree->AddJets       (m_trigJetDetailStr, m_trigJetBranches.at(ll).c_str());
+	else{ helpTree->AddJets       (m_trigJetDetails.at(ll), m_trigJetBranches.at(ll).c_str()); }
       }
     }
     if (!m_truthJetContainerName.empty() )      {

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -130,7 +130,7 @@ public:
 
   void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string jetName = "jet" );
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
-  void FillL1Jets( const xAOD::JetRoIContainer* jets );
+  void FillL1Jets( const xAOD::JetRoIContainer* jets, bool sortL1Jets = false );
 
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -40,6 +40,7 @@ public:
   std::string m_truthJetContainerName = "";
   std::string m_truthJetBranchName = "truthJet";
   std::string m_trigJetContainerName = "";
+  std::string m_trigJetBranchName = "trigJet";
   std::string m_fatJetContainerName = "";
   std::string m_truthFatJetContainerName = "";
   std::string m_tauContainerName = "";
@@ -65,9 +66,11 @@ protected:
 
   std::vector<std::string> m_jetContainers; //!
   std::vector<std::string> m_truthJetContainers; //!
+  std::vector<std::string> m_trigJetContainers; //!
 
   std::vector<std::string> m_jetBranches; //!
   std::vector<std::string> m_truthJetBranches; //!
+  std::vector<std::string> m_trigJetBranches; //!
 
   std::map<std::string, HelpTreeBase*> m_trees;            //!
 

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -49,6 +49,7 @@ public:
   std::string m_truthParticlesContainerName = "";
   std::string m_trackParticlesContainerName = "";
   std::string m_l1JetContainerName = "";
+  bool m_sortL1Jets = false;
 
   // if these are set, assume systematics are being processed over
   std::string m_muSystsVec = "";

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -19,10 +19,10 @@ public:
   // holds bools that control which branches are filled
   std::string m_evtDetailStr = "";
   std::string m_trigDetailStr = "";
-  std::string m_trigJetDetailStr = "";
   std::string m_muDetailStr = "";
   std::string m_elDetailStr = "";
   std::string m_jetDetailStr = "";
+  std::string m_trigJetDetailStr = "";
   std::string m_truthJetDetailStr = "";
   std::string m_fatJetDetailStr = "";
   std::string m_truthFatJetDetailStr = "";
@@ -63,6 +63,7 @@ public:
 
 protected:
   std::vector<std::string> m_jetDetails; //!
+  std::vector<std::string> m_trigJetDetails; //!
 
   std::vector<std::string> m_jetContainers; //!
   std::vector<std::string> m_truthJetContainers; //!


### PR DESCRIPTION
1. Based on the logic of truthJets, extend the triggerJets sections to allow multiple trigger jet collections to be run at once, each with its own detailStr.
2. Add an option to sort L1  jet RoIs by et8x8, since they are currently unsorted, leave default false so as to leave default behaviour unchanged

This should only be three commits, but ended up as 6 since I made a tiny extra one (ac4c701) and subsequently tried to squash it onto the former, which obviously didn't work...