### PR TITLE
Add support for multiple data unprescaling weights

### DIFF
--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -34,8 +34,6 @@ void EventInfo::setTree(TTree *tree)
     if ( m_infoSwitch.m_weightsSys ) {
       connectBranch< std::vector<float> >(tree, "mcEventWeights", &m_mcEventWeights);
     }
-  } else {
-    connectBranch<float   >(tree, "prescale_DataWeight",         &m_prescale_DataWeight);
   }
 
   if ( m_infoSwitch.m_bcidInfo && !m_mc ){
@@ -129,8 +127,6 @@ void EventInfo::setBranches(TTree *tree)
     if ( m_infoSwitch.m_weightsSys ) {
       tree->Branch("mcEventWeights",   &m_mcEventWeights);
     }
-  } else {
-    tree->Branch("prescale_DataWeight",       &m_prescale_DataWeight,  "prescale_DataWeight/F");
   }
 
   if ( m_infoSwitch.m_bcidInfo && !m_mc ){
@@ -212,7 +208,6 @@ void EventInfo::clear()
   m_TileFlags = 0;
   m_SCTFlags = 0;
   m_mcEventWeight = 1.;
-  m_prescale_DataWeight = 1.;
   m_DistEmptyBCID = -999;
   m_DistLastUnpairedBCID = -999;
   m_DistNextUnpairedBCID = -999;
@@ -270,10 +265,6 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo,  xAOD::TEvent* even
         m_mcEventWeights      = std::vector<float>{m_mcEventWeight};
       }
     }
-  }
-  if ( !m_mc ) {
-    static SG::AuxElement::ConstAccessor< float > prsc_DataWeight ("prescale_DataWeight");
-    if ( prsc_DataWeight.isAvailable( *eventInfo ) )	 { m_prescale_DataWeight = prsc_DataWeight( *eventInfo ); }	    else { m_prescale_DataWeight = 1.0; }
   }
 
   if ( m_infoSwitch.m_bcidInfo && !m_mc ){

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -167,7 +167,14 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
   if ( m_trigInfoSwitch->m_passTriggers ) {
     // vector of strings for trigger names which fired
     m_tree->Branch("passedTriggers",       &m_passTriggers        );
+  }
+
+  if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
     m_tree->Branch("triggerPrescales",     &m_triggerPrescales    );
+  }
+
+  if ( !m_isMC && m_trigInfoSwitch->m_prescalesLumi ) {
+    m_tree->Branch("triggerPrescalesLumi", &m_triggerPrescalesLumi);
   }
 
   if ( m_trigInfoSwitch->m_passTrigBits ) {
@@ -228,8 +235,23 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
     static SG::AuxElement::ConstAccessor< std::vector< std::string > > passTrigs("passTriggers");
     if( passTrigs.isAvailable( *eventInfo ) ) { m_passTriggers = passTrigs( *eventInfo ); }
 
+  }
+
+  if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
+
+    if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_prescales"); }
+
     static SG::AuxElement::ConstAccessor< std::vector< float > > trigPrescales("triggerPrescales");
     if( trigPrescales.isAvailable( *eventInfo ) ) { m_triggerPrescales = trigPrescales( *eventInfo ); }
+
+  }
+
+  if ( !m_isMC && m_trigInfoSwitch->m_prescalesLumi ) {
+
+    if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_prescalesLumi"); }
+
+    static SG::AuxElement::ConstAccessor< std::map< std::string, float > > trigPrescalesLumi("triggerPrescalesLumi");
+    if( trigPrescalesLumi.isAvailable( *eventInfo ) ) { m_triggerPrescalesLumi = trigPrescalesLumi( *eventInfo ); }
 
   }
 
@@ -257,6 +279,7 @@ void HelpTreeBase::ClearTrigger() {
 
   m_passTriggers.clear();
   m_triggerPrescales.clear();
+  m_triggerPrescalesLumi.clear();
   m_isPassBits.clear();
   m_isPassBitsNames.clear();
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -122,6 +122,8 @@ namespace HelperClasses{
     m_menuKeys          = has_exact("menuKeys");
     m_passTriggers      = has_exact("passTriggers");
     m_passTrigBits      = has_exact("passTrigBits");
+    m_prescales         = has_exact("prescales");
+    m_prescalesLumi     = has_exact("prescalesLumi");
   }
 
   void JetTriggerInfoSwitch::initialize(){

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -95,9 +95,6 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief The maximum threshold for <tt>EventInfo::actualInteractionsPerCrossing()</tt>
     int m_actualMuMax = -1; // Default to off
 
-    // Unprescaling data
-    bool m_savePrescaleDataWeight = false;
-
     /// @brief Calculate distance to nearest empty and unpaired BCIDs
     bool m_calcBCIDInfo = false;
 
@@ -126,6 +123,9 @@ class BasicEventSelection : public xAH::Algorithm
 
     /// @brief Decisions of triggers which are saved but not cut on
     std::string m_extraTriggerSelection = "";
+
+    /// @brief Comma-separated trigger chains to calculate lumi-based prescale data weights for
+    std::string m_triggerUnprescale = "";
 
     /**
       @rst
@@ -177,6 +177,8 @@ class BasicEventSelection : public xAH::Algorithm
   private:
 
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
+    // trigger unprescale chains
+    std::vector<std::string> m_triggerUnprescaleChainList; //!
 
     // tools
     asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -56,7 +56,6 @@ namespace xAH {
     int      m_rand_run_nr;
     int      m_rand_lumiblock_nr;
     int      m_bcid;
-    float    m_prescale_DataWeight;
     int      m_DistEmptyBCID;
     int      m_DistLastUnpairedBCID;
     int      m_DistNextUnpairedBCID;

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -319,6 +319,7 @@ protected:
   // jet trigger
   std::vector<std::string> m_passTriggers;
   std::vector<float> m_triggerPrescales;
+  std::map<std::string, float> m_triggerPrescalesLumi;
   std::vector<std::string>  m_isPassBitsNames;
   std::vector<unsigned int> m_isPassBits;
 

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -168,14 +168,19 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::InfoSwitch` struct for Trigger Information.
 
-        ============== ============ =======
-        Parameter      Pattern      Match
-        ============== ============ =======
-        m_basic        basic        exact
-        m_menuKeys     menuKeys     exact
-        m_passTriggers passTriggers exact
-        m_passTrigBits passTrigBits exact
-        ============== ============ =======
+        ================ ============== =======
+        Parameter        Pattern        Match
+        ================ ============== =======
+        m_basic          basic          exact
+        m_menuKeys       menuKeys       exact
+        m_passTriggers   passTriggers   exact
+        m_passTrigBits   passTrigBits   exact
+        m_prescales      prescales      exact
+        m_prescalesLumi  prescalesLumi  exact
+        ================ ============== =======
+
+        .. note::
+            ``m_prescales`` contains information from the ``TrigDecisionTool`` for every trigger used in event selection and event trigger-matching. ``m_prescalesLumi`` contains information retrieved from the pile-up reweighting tool based on the actual luminosities of triggers.
 
     @endrst
    */
@@ -185,6 +190,8 @@ namespace HelperClasses {
     bool m_menuKeys;
     bool m_passTriggers;
     bool m_passTrigBits;
+    bool m_prescales;
+    bool m_prescalesLumi;
     TriggerInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();


### PR DESCRIPTION
This add support for multiple data unprescaling weights. This is useful if you have same ntuples for different studies (different trigger selection).

Personally I would remove the old implementation which takes an OR of all triggers in `m_triggerSelection` but this is breaking. Let me know how to proceed.