### PR TITLE
Update JES uncertainties with the latest recommendations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.10
-    - RELEASE=AnalysisBase,21.2.12
-    - RELEASE=AnalysisTop,21.2.12
-    - RELEASE=AnalysisBase,21.2.13
-    - RELEASE=AnalysisTop,21.2.13
+    - RELEASE=AnalysisBase,21.2.18
+    - RELEASE=AnalysisTop,21.2.18
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -255,13 +255,14 @@ EL::StatusCode JetCalibrator :: initialize ()
   // initialize and configure the jet uncertainity tool
   // only initialize if a config file has been given
   //------------------------------------------------
-  if ( !m_JESUncertConfig.empty() && !m_systNameJES.empty()  && m_systNameJES != "None" ) {
+  if ( !m_JESUncertConfig.empty() && !m_systNameJES.empty() && m_systNameJES != "None" ) {
 
     ANA_MSG_INFO("Initialize JES UNCERT with " << m_JESUncertConfig);
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetUncertaintiesTool_handle, JetUncertaintiesTool));
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("JetDefinition",m_jetAlgo));
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("MCType",m_JESUncertMCType));
-    ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("ConfigFile", PathResolverFindCalibFile(m_JESUncertConfig)));
+    ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("ConfigFile", m_JESUncertConfig));
+    ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("CalibArea", m_JESCalibArea));
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JetUncertaintiesTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JetUncertaintiesTool_handle);

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -72,7 +72,9 @@ public:
   /// @brief config for JES Uncertainty Tool
   std::string m_JESUncertConfig = "";
   /// @brief JetUncertaintiesTool parameter
-  std::string m_JESUncertMCType = "MC15";
+  std::string m_JESUncertMCType = "MC16";
+  /// @brief JES CalibArea tag
+  std::string m_JESCalibArea = "CalibArea-02";
   /** @rst
     If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.
 


### PR DESCRIPTION
JES uncertainties also require CalibArea. Requires 21.2.18.