### PR TITLE
Fix jets output

### DIFF
--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -467,7 +467,6 @@ namespace HelperClasses {
    */
   class JetInfoSwitch : public IParticleInfoSwitch {
   public:
-    bool m_kinematic;
     bool m_trigger;
     bool m_substructure;
     bool m_bosonCount;


### PR DESCRIPTION
This fixes broken jet branches output after #1152 was merged. `m_kinematic` is already contained in `IParticleInfoSwitch` so it should not be added here.