### PR TITLE
Data unprescaling improvements (closes #1171)

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -250,7 +250,7 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_prescalesLumi"); }
 
-    static SG::AuxElement::ConstAccessor< std::map< std::string, float > > trigPrescalesLumi("triggerPrescalesLumi");
+    static SG::AuxElement::ConstAccessor< std::vector< float > > trigPrescalesLumi("triggerPrescalesLumi");
     if( trigPrescalesLumi.isAvailable( *eventInfo ) ) { m_triggerPrescalesLumi = trigPrescalesLumi( *eventInfo ); }
 
   }

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -124,9 +124,6 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Decisions of triggers which are saved but not cut on
     std::string m_extraTriggerSelection = "";
 
-    /// @brief Comma-separated trigger chains to calculate lumi-based prescale data weights for
-    std::string m_triggerUnprescale = "";
-
     /**
       @rst
         Skip events in which the trigger string :cpp:member:`~BasicEventSelection::m_triggerSelection` does not fire
@@ -178,7 +175,7 @@ class BasicEventSelection : public xAH::Algorithm
 
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
     // trigger unprescale chains
-    std::vector<std::string> m_triggerUnprescaleChainList; //!
+    std::vector<std::string> m_triggerUnprescaleList; //!
 
     // tools
     asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -319,7 +319,7 @@ protected:
   // jet trigger
   std::vector<std::string> m_passTriggers;
   std::vector<float> m_triggerPrescales;
-  std::map<std::string, float> m_triggerPrescalesLumi;
+  std::vector<float> m_triggerPrescalesLumi;
   std::vector<std::string>  m_isPassBitsNames;
   std::vector<unsigned int> m_isPassBits;
 


### PR DESCRIPTION
This PR makes data unprescaling consistent to what we have now:
 - triggers for unprescaling are extracted from lumicalc files
 - for backwards compatibility, PRW files are not loaded for data (upstream bugs)
 - -1 is set if trigger is not found
 - `TrigDecisionTool` is loaded into PRW
 - prescales are stored as vector of floats