### PR TITLE
Electrons do not need isolation correction

### DIFF
--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -73,8 +73,8 @@ public:
   /** @brief Force AFII flag in calibration, in case metadata is broken */
   bool m_setAFII = false;
 
-  // for calo based isolation vars leakage correction
-  bool        m_useDataDrivenLeakageCorr = false;
+  /** @brief Apply isolation correction, not needed by default */
+  bool m_applyIsolationCorrection = false;
 
 private:
   int m_numEvent;         //!


### PR DESCRIPTION
As per discussion [here](https://groups.cern.ch/group/hn-atlas-EGammaWG/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fhn%2Datlas%2DEGammaWG%2FLists%2FArchive%2FElectron%20isolation%20corrections&FolderCTID=0x01200200D17DAC8476E41D4F8451088E75A5CE34), electrons do not need isolation correction in R21 as it is applied at the DAOD level.