### PR TITLE
Save Trigger Prescales Independent Of Decision

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -901,26 +901,27 @@ EL::StatusCode BasicEventSelection :: execute ()
     if ( m_storeTrigDecisions ) {
 
       std::vector<std::string>  passTriggers;
+      std::vector<std::string>  triggerNames;
       std::vector<float>        triggerPrescales;
       std::vector<float>        triggerPrescalesLumi;
-      std::vector<std::string>  isPassedBitsNames;
       std::vector<unsigned int> isPassedBits;
 
       // Save info for the triggers used to skim events
       //
       for ( auto &trigName : triggerChainGroup->getListOfTriggers() ) {
         auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
-        if ( trigChain->isPassed() ) {
+        if ( trigChain->isPassed() )
           passTriggers.push_back( trigName );
-          triggerPrescales.push_back( trigChain->getPrescale() );
 
-          if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end()) {
-            triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
-          } else {
-            triggerPrescalesLumi.push_back( -1 );
-          }
-        }
-        isPassedBitsNames.push_back( trigName );
+	triggerNames.push_back( trigName );
+
+	triggerPrescales.push_back( trigChain->getPrescale() );
+
+	if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end())
+	  triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
+	else
+	  triggerPrescalesLumi.push_back( -1 );
+
         isPassedBits     .push_back( m_trigDecTool_handle->isPassedBits(trigName) );
       }
 
@@ -928,35 +929,36 @@ EL::StatusCode BasicEventSelection :: execute ()
       //
       if ( !m_extraTriggerSelection.empty() ) {
 
-	      auto extraTriggerChainGroup = m_trigDecTool_handle->getChainGroup(m_extraTriggerSelection);
+	auto extraTriggerChainGroup = m_trigDecTool_handle->getChainGroup(m_extraTriggerSelection);
 
-	      for ( auto &trigName : extraTriggerChainGroup->getListOfTriggers() ) {
-	        auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
-	        if ( trigChain->isPassed() ) {
-	          passTriggers.push_back( trigName );
-	          triggerPrescales.push_back( trigChain->getPrescale() );
+	for ( auto &trigName : extraTriggerChainGroup->getListOfTriggers() ) {
+	  auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
+	  if ( trigChain->isPassed() )
+	    passTriggers.push_back( trigName );
 
-              if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end()) {
-                triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
-              } else {
-                triggerPrescalesLumi.push_back( -1 );
-              }
-	        }
-	        isPassedBitsNames.push_back( trigName );
-	        isPassedBits     .push_back( m_trigDecTool_handle->isPassedBits(trigName) );
-	      }
+	  triggerNames.push_back( trigName );
+	
+	  triggerPrescales.push_back( trigChain->getPrescale() );
+
+	  if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end())
+	    triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
+	  else
+	    triggerPrescalesLumi.push_back( -1 );
+
+	  isPassedBits     .push_back( m_trigDecTool_handle->isPassedBits(trigName) );
+	}
       }
 
-      static SG::AuxElement::Decorator< std::vector< std::string > >  passTrigs("passTriggers");
-      passTrigs( *eventInfo ) = passTriggers;
-      static SG::AuxElement::Decorator< std::vector< float > >        trigPrescales("triggerPrescales");
-      trigPrescales( *eventInfo ) = triggerPrescales;
-      static SG::AuxElement::Decorator< std::vector< float > >        trigPrescalesLumi("triggerPrescalesLumi");
-      trigPrescalesLumi( *eventInfo ) = triggerPrescalesLumi;
-      static SG::AuxElement::Decorator< std::vector< unsigned int > > isPassBits("isPassedBits");
-      isPassBits( *eventInfo ) = isPassedBits;
-      static SG::AuxElement::Decorator< std::vector< std::string > >  isPassBitsNames("isPassedBitsNames");
-      isPassBitsNames( *eventInfo ) = isPassedBitsNames;
+      static SG::AuxElement::Decorator< std::vector< std::string > >  dec_passTriggers        ("passTriggers");
+      dec_passTriggers        ( *eventInfo ) = passTriggers;
+      static SG::AuxElement::Decorator< std::vector< std::string > >  dec_triggerNames        ("triggerNames");
+      dec_triggerNames        ( *eventInfo ) = triggerNames;
+      static SG::AuxElement::Decorator< std::vector< float > >        dec_triggerPrescales    ("triggerPrescales");
+      dec_triggerPrescales    ( *eventInfo ) = triggerPrescales;
+      static SG::AuxElement::Decorator< std::vector< float > >        dec_triggerPrescalesLumi("triggerPrescalesLumi");
+      dec_triggerPrescalesLumi( *eventInfo ) = triggerPrescalesLumi;
+      static SG::AuxElement::Decorator< std::vector< unsigned int > > dec_isPassedBits        ("isPassedBits");
+      dec_isPassedBits        ( *eventInfo ) = isPassedBits;
 
     }
 

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -169,18 +169,17 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
     m_tree->Branch("passedTriggers",       &m_passTriggers        );
   }
 
-  if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
+  if(m_trigInfoSwitch->m_passTrigBits || (!m_isMC && (m_trigInfoSwitch->m_prescalesLumi || m_trigInfoSwitch->m_prescales)))
+    m_tree->Branch("triggerNames",         &m_triggerNames        );
+
+  if ( !m_isMC && m_trigInfoSwitch->m_prescales )
     m_tree->Branch("triggerPrescales",     &m_triggerPrescales    );
-  }
 
-  if ( !m_isMC && m_trigInfoSwitch->m_prescalesLumi ) {
+  if ( !m_isMC && m_trigInfoSwitch->m_prescalesLumi )
     m_tree->Branch("triggerPrescalesLumi", &m_triggerPrescalesLumi);
-  }
 
-  if ( m_trigInfoSwitch->m_passTrigBits ) {
+  if ( m_trigInfoSwitch->m_passTrigBits )
     m_tree->Branch("isPassBits",           &m_isPassBits          );
-    m_tree->Branch("isPassBitsNames",      &m_isPassBitsNames     );
-  }
 
   //this->AddTriggerUser();
 }
@@ -237,6 +236,12 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
 
   }
 
+  if(m_trigInfoSwitch->m_passTrigBits || (!m_isMC && (m_trigInfoSwitch->m_prescalesLumi || m_trigInfoSwitch->m_prescales)))
+    {
+      static SG::AuxElement::ConstAccessor< std::vector< std::string > > triggerNames("triggerNames");
+      if( triggerNames.isAvailable( *eventInfo ) ) { m_triggerNames = triggerNames( *eventInfo ); }
+    }
+
   if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_prescales"); }
@@ -260,9 +265,6 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
     static SG::AuxElement::ConstAccessor< std::vector< unsigned int > > isPassBits("isPassedBits");
     if( isPassBits.isAvailable( *eventInfo ) ) { m_isPassBits = isPassBits( *eventInfo ); }
 
-    static SG::AuxElement::ConstAccessor< std::vector< std::string > > isPassBitsNames("isPassedBitsNames");
-    if( isPassBitsNames.isAvailable( *eventInfo ) ) { m_isPassBitsNames = isPassBitsNames( *eventInfo ); }
-
   }
 
 }
@@ -277,11 +279,11 @@ void HelpTreeBase::ClearTrigger() {
   m_L1PSKey   = 0;
   m_HLTPSKey  = 0;
 
-  m_passTriggers.clear();
-  m_triggerPrescales.clear();
+  m_passTriggers        .clear();
+  m_triggerNames        .clear();
+  m_triggerPrescales    .clear();
   m_triggerPrescalesLumi.clear();
-  m_isPassBits.clear();
-  m_isPassBitsNames.clear();
+  m_isPassBits          .clear();
 
 }
 

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -317,10 +317,10 @@ protected:
 						   */
 
   // jet trigger
-  std::vector<std::string> m_passTriggers;
-  std::vector<float> m_triggerPrescales;
-  std::vector<float> m_triggerPrescalesLumi;
-  std::vector<std::string>  m_isPassBitsNames;
+  std::vector<std::string>  m_passTriggers;
+  std::vector<std::string>  m_triggerNames;
+  std::vector<float>        m_triggerPrescales;
+  std::vector<float>        m_triggerPrescalesLumi;
   std::vector<unsigned int> m_isPassBits;
 
   //


### PR DESCRIPTION
This changes how trigger prescales are saved in an output ntuple. Instead of being saved for only triggers that passed, they are now saved for all triggers whose status is checked. This is needed for studying turn-on curves of triggers that are disabled for parts of a run. See:
https://groups.cern.ch/group/hn-atlas-TriggerHelp/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-TriggerHelp%2fLists%2fArchive%2fTurn-on%20Curves%20for%20Triggers%20Disabled%20For%20Parts%20Of%20Run&FolderCTID=0x012002001FA16C589111D24CA634A8138BBC0A5C

Changes:
* `isPassedBitsNames` is replaced by `triggerNames` 
* `isPassedBits`, `triggerPrescalesLumi` and `triggerPrescales` now reference `triggerNames` instead of `passedTriggers`

Tagging @ntadej, since you seem to care about prescales.