### PR TITLE
Keep OR of triggers together for extra chains

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -473,6 +473,13 @@ EL::StatusCode BasicEventSelection :: initialize ()
     ANA_CHECK( m_trigDecTool_handle.setProperty( "OutputLevel", msg().level() ));
     ANA_CHECK( m_trigDecTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
+
+    // parse extra triggers list and split by comma
+    std::string token;
+    std::istringstream ss(m_extraTriggerSelection);
+    while (std::getline(ss, token, ',')) {
+      m_extraTriggerSelectionList.push_back(token);
+    }
   }//end trigger configuration
 
   // 3.
@@ -618,10 +625,15 @@ EL::StatusCode BasicEventSelection :: execute ()
 
   if ( m_eventCounter == 0 && !m_extraTriggerSelection.empty() ) {
     ANA_MSG_INFO( "*** Extra Trigger Info Saved are :\n");
-    auto printingTriggerChainGroup = m_trigDecTool_handle->getChainGroup(m_extraTriggerSelection);
-    std::vector<std::string> triggersUsed = printingTriggerChainGroup->getListOfTriggers();
-    for ( unsigned int iTrigger = 0; iTrigger < triggersUsed.size(); ++iTrigger ) {
-      printf("    %s\n", triggersUsed.at(iTrigger).c_str());
+    for ( const std::string &trigName : m_extraTriggerSelectionList ) {
+      printf("    %s\n", trigName.c_str());
+
+      printf("      Evaluates to:\n");
+      auto printingTriggerChainGroup = m_trigDecTool_handle->getChainGroup(trigName);
+      std::vector<std::string> triggersUsed = printingTriggerChainGroup->getListOfTriggers();		 
+      for ( unsigned int iTrigger = 0; iTrigger < triggersUsed.size(); ++iTrigger ) {		
+        printf("        %s\n", triggersUsed.at(iTrigger).c_str());
+      }
     }
     printf("\n");
   }
@@ -888,7 +900,8 @@ EL::StatusCode BasicEventSelection :: execute ()
           passedTriggers.push_back( trigName );
           triggerPrescales.push_back( trigChain->getPrescale() );
 
-          if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end()) {
+          bool doLumiPrescale = std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end();
+          if ( doLumiPrescale ) {
             triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
           } else {
             triggerPrescalesLumi.push_back( -1 );
@@ -903,19 +916,21 @@ EL::StatusCode BasicEventSelection :: execute ()
       //
       if ( !m_extraTriggerSelection.empty() ) {
 
-	auto extraTriggerChainGroup = m_trigDecTool_handle->getChainGroup(m_extraTriggerSelection);
-
-	for ( auto &trigName : extraTriggerChainGroup->getListOfTriggers() ) {
+	for ( const std::string &trigName : m_extraTriggerSelectionList ) {
 	  auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
 	  if ( trigChain->isPassed() ) {
 	    passedTriggers.push_back( trigName );
 	    triggerPrescales.push_back( trigChain->getPrescale() );
 
-	    if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigName) != m_triggerUnprescaleList.end()) {
-	      triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
-	    } else {
-	      triggerPrescalesLumi.push_back( -1 );
-	    }
+      bool doLumiPrescale = true;
+      for ( const std::string &trigPart : trigChain->getListOfTriggers() ) {
+        if (std::find(m_triggerUnprescaleList.begin(), m_triggerUnprescaleList.end(), trigPart) == m_triggerUnprescaleList.end()) doLumiPrescale = false;
+      }
+      if ( doLumiPrescale ) {
+        triggerPrescalesLumi.push_back( m_pileup_tool_handle->getDataWeight( *eventInfo, trigName, true ) );
+      } else {
+        triggerPrescalesLumi.push_back( -1 );
+      }
 	  }
 	  isPassedBitsNames.push_back( trigName );
 	  isPassedBits     .push_back( m_trigDecTool_handle->isPassedBits(trigName) );

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -191,6 +191,8 @@ class BasicEventSelection : public xAH::Algorithm
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
     // trigger unprescale chains
     std::vector<std::string> m_triggerUnprescaleList; //!
+    // decisions of triggers which are saved but not cut on, converted into a list
+    std::vector<std::string> m_extraTriggerSelectionList; //!
 
     // tools
     asg::AnaToolHandle<IGoodRunsListSelectionTool> m_grl_handle                  {"GoodRunsListSelectionTool"                                      , this}; //!


### PR DESCRIPTION
We use trigger tool to split OR of triggers. For base triggers this is probably desirable, but sometimes one can also be interested in the actual OR of triggers (e.g. for prescale). This disables OR splitting of extra triggers.

In most cases this should not be breaking, except if one always passes OR of triggers instead of a comma separated list. If desired, I can add an extra configuration for this.