### PR TITLE
WIP: making TTree memory flushing more frequent

### DIFF
--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -196,7 +196,6 @@ EL::StatusCode TreeAlgo :: execute ()
     if(systName.empty()) treeName = "nominal";
 
     ANA_MSG_INFO( "Making tree " << m_name << "/" << treeName );
-    std::cout << "Making tree " << m_name << "/" << treeName << std::endl;
     TTree * outTree = new TTree(treeName.c_str(),treeName.c_str());
     if ( !outTree ) {
       ANA_MSG_ERROR("Failed to instantiate output tree!");

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -196,6 +196,7 @@ EL::StatusCode TreeAlgo :: execute ()
     if(systName.empty()) treeName = "nominal";
 
     ANA_MSG_INFO( "Making tree " << m_name << "/" << treeName );
+    std::cout << "Making tree " << m_name << "/" << treeName << std::endl;
     TTree * outTree = new TTree(treeName.c_str(),treeName.c_str());
     if ( !outTree ) {
       ANA_MSG_ERROR("Failed to instantiate output tree!");
@@ -207,6 +208,11 @@ EL::StatusCode TreeAlgo :: execute ()
 
     // tell the tree to go into the file
     outTree->SetDirectory( treeFile->GetDirectory(m_name.c_str()) );
+    
+    // Ensure tree flushes memory after a reasonable amount of time
+    // Otherwise jobs with a lot of systematics use too much memory.
+    outTree->SetAutoFlush(-500000); // replace 5 with 10?
+    
     // choose if want to add tree to same directory as ouput histograms
     if ( m_outHistDir ) {
       if(m_trees.size() > 1) ANA_MSG_WARNING( "You're running systematics! You may find issues in writing all of the output TTrees to the output histogram file... Set `m_outHistDir = false` if you run into issues!");


### PR DESCRIPTION
WIP because I haven't tested that this consistently fixes my problem yet, it just looks promising from one job. Just want to get the discussion out there and collect ideas before going too much into it.

I found that when I added more systematics to my jobs they began to fail. The memory management plots showed the memory usage suddenly ballooning some time into the job: see [this one](https://bigpanda.cern.ch/memoryplot/?pandaid=3907846163) as a classic example. Even in cases where jobs succeeded the same behaviour was visible ([example](https://bigpanda.cern.ch/memoryplot/?pandaid=3907442946)). 

Someone helpfully forwarded a thread on the flavour tagging list looking at a very similar issue, which they found was due to TTree memory flushing intervals essentially being too long. (Sorry I'd link the mail archive here but it's protected for that list, for some reason...) I am trying the same fix here which they used, and on a test job it seemed improved. However, I feel like there's got to be a better way of dealing with this ... 

Tagging @kratsg and @kkrizka for thoughts!

Cheers,
Kate