### PR TITLE
Add disabledTriggers List to Output Ntuples.

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -170,7 +170,8 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
   // Trigger Decision for each and every trigger in a vector
   if ( m_trigInfoSwitch->m_passTriggers ) {
     // vector of strings for trigger names which fired
-    m_tree->Branch("passedTriggers",       &m_passTriggers        );
+    m_tree->Branch("passedTriggers",       &m_passedTriggers      );
+    m_tree->Branch("disabledTriggers",     &m_disabledTriggers    );
   }
 
   if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
@@ -236,9 +237,10 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
   if ( m_trigInfoSwitch->m_passTriggers ) {
 
     if ( m_debug ) { Info("HelpTreeBase::FillTrigger()", "Switch: m_trigInfoSwitch->m_passTriggers"); }
-    static SG::AuxElement::ConstAccessor< std::vector< std::string > > passTrigs("passTriggers");
-    if( passTrigs.isAvailable( *eventInfo ) ) { m_passTriggers = passTrigs( *eventInfo ); }
-
+    static SG::AuxElement::ConstAccessor< std::vector< std::string > > acc_passedTriggers  ("passedTriggers");
+    if( acc_passedTriggers  .isAvailable( *eventInfo ) ) { m_passedTriggers   = acc_passedTriggers  ( *eventInfo ); }
+    static SG::AuxElement::ConstAccessor< std::vector< std::string > > acc_disabledTriggers("disabledTriggers");
+    if( acc_disabledTriggers.isAvailable( *eventInfo ) ) { m_disabledTriggers = acc_disabledTriggers( *eventInfo ); }
   }
 
   if ( !m_isMC && m_trigInfoSwitch->m_prescales ) {
@@ -281,7 +283,8 @@ void HelpTreeBase::ClearTrigger() {
   m_L1PSKey   = 0;
   m_HLTPSKey  = 0;
 
-  m_passTriggers.clear();
+  m_passedTriggers.clear();
+  m_disabledTriggers.clear();
   m_triggerPrescales.clear();
   m_triggerPrescalesLumi.clear();
   m_isPassBits.clear();

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -331,7 +331,8 @@ protected:
 						   */
 
   // jet trigger
-  std::vector<std::string> m_passTriggers;
+  std::vector<std::string> m_passedTriggers;
+  std::vector<std::string> m_disabledTriggers;
   std::vector<float> m_triggerPrescales;
   std::vector<float> m_triggerPrescalesLumi;
   std::vector<std::string>  m_isPassBitsNames;


### PR DESCRIPTION
This is a more backwards-compatible version of #1184 . It add a list of disabled status of the requested triggers by comparing against the prescale (<1 means disabled). This is needed for studying turn-on curves of triggers that are disabled for parts of a run.
https://groups.cern.ch/group/hn-atlas-TriggerHelp/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-TriggerHelp%2fLists%2fArchive%2fTurn-on%20Curves%20for%20Triggers%20Disabled%20For%20Parts%20Of%20Run&FolderCTID=0x012002001FA16C589111D24CA634A8138BBC0A5C

Changes:
* `BasicEventSelection` adds a `disabledTriggers` decorator (`std::vector<std::string>`) that contains all requested triggers that have perscale <1.
* The `disabledTriggers` list is then added to an output tree as a branch alongside `passedTriggers`.