### PR TITLE
ElectronEfficiencyCorrector: assign false as default for m_setAFII

### DIFF
--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -55,7 +55,7 @@ public:
   bool m_writeSystToMetadata = false;
 
   /** @brief Force AFII flag in calibration, in case metadata is broken */
-  bool m_setAFII;
+  bool m_setAFII = false;
 
   float m_systValPID = 0.0;
   float m_systValIso = 0.0;


### PR DESCRIPTION
This variable has no default value and is set to true if not defined in the config files, which causes problems when running on fullsim.