### PR TITLE
Muon eff corr updates

### DIFF
--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -55,7 +55,7 @@ public:
   bool m_writeSystToMetadata = false;
 
   /** @brief Force AFII flag in calibration, in case metadata is broken */
-  bool m_setAFII = false;
+  bool m_setAFII;
 
   float m_systValPID = 0.0;
   float m_systValIso = 0.0;

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -55,7 +55,7 @@ public:
   bool m_writeSystToMetadata = false;
 
   /** @brief Force AFII flag in calibration, in case metadata is broken */
-  bool m_setAFII;
+  bool m_setAFII = false;
 
   float m_systValPID = 0.0;
   float m_systValIso = 0.0;

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -99,7 +99,7 @@ private:
   std::string m_trigEffSF_tool_name;                                       //!
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool = nullptr;               //!
   std::string m_TTVAEffSF_tool_name;                                       //!
-  std::vector<std::string> m_SingleMuTriggers;                             //!
+  std::map<std::string, std::string> m_SingleMuTriggerMap; //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
Currently the MuonEfficiencyCorrector flag `m_AllowZeroSF` must be True to avoid WARNINGs and ERRORs from the CP tool when running in mc16a (because of the different trigger menus in 2015 and 2016), but setting this flag to true comes with a list of its own warnings. I propose a quick check of the run number so that `m_AllowZeroSF` can be false without printing these WARNINGs and ERRORs.

In the `m_MuTrigLegs` option of the config, the user can add for example "2015:" or "2016:" before the trigger string (for example I plan to use "2015:HLT_mu20_iloose_L1MU15_OR_HLT_mu50,2016:HLT_mu26_ivarmedium_OR_HLT_mu50"), and the source code will create a corresponding map of years and trigger strings, then check the random run number of the event against the year before attempting to retrieve the trigger efficiency. 

If the user does not specify a year in the config, both entries in the map will be filled with the trigger string. So this does not change the current functionality of the algorithm.