### PR TITLE
Add m_actualMu histogram and expand mu histograms to 100

### DIFF
--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -523,7 +523,7 @@ StatusCode JetHists::initialize() {
 
   // Average Mu
   if(m_infoSwitch->m_byAverageMu){
-    m_avgMu               = book(m_name, "avgMu",  "Average Mu", 51, -0.5, 50);
+    m_avgMu               = book(m_name, "avgMu",  "Average Mu", 101, -0.5, 100);
     m_jetPt_avgMu_00_15   = book(m_name, "jetPt_avgMu_00_15",  "jet p_{T} [GeV]", 120, 0, 600);
     m_jetPt_avgMu_15_25   = book(m_name, "jetPt_avgMu_15_25",  "jet p_{T} [GeV]", 120, 0, 600);
     m_jetPt_avgMu_25      = book(m_name, "jetPt_avgMu_25",     "jet p_{T} [GeV]", 120, 0, 600);
@@ -954,12 +954,6 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
   //   if(m_debug) std::cout << "JetHists: m_JVC " << std::endl;
   //   m_JVC->Fill(jet->JVC, eventWeight);
   // }
-
-// Pileup
-if (m_infoSwitch->m_vsActualMu) {
-  float actualMu = eventInfo->actualInteractionsPerCrossing();
-  m_actualMu->Fill(actualMu, eventWeight);
-}
 
   //
   // BTagging
@@ -2108,6 +2102,13 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       m_avgMu_vs_jetPt->Fill(jet->p4.Pt(), avg_mu, eventWeight);
 
     }
+
+    if (m_infoSwitch->m_vsActualMu) 
+      {
+	float actualMu = eventInfo->actualInteractionsPerCrossing();
+	m_actualMu->Fill(actualMu, eventWeight);
+      }
+
 
   if(m_infoSwitch->m_etaPhiMap)
     {

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -625,6 +625,12 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
 
   } // fillClean
 
+  // Pileup
+  if(m_infoSwitch->m_vsActualMu){
+    float actualMu = eventInfo->actualInteractionsPerCrossing();
+    m_actualMu->Fill(actualMu, eventWeight);
+  }
+
   // energy
   if( m_infoSwitch->m_energy ) {
     if(m_debug) std::cout << "JetHists: m_energy " <<std::endl;
@@ -1707,13 +1713,6 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       m_JVC->Fill(jet->JVC, eventWeight);
     }
 
-    // Pileup
-    if (m_infoSwitch->m_vsActualMu) {
-      float actualMu = eventInfo->m_lumiBlock;
-      m_actualMu->Fill(actualMu, eventWeight);
-    }
-
-
 
   if(m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT)
     {
@@ -2103,11 +2102,11 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 
     }
 
-    if (m_infoSwitch->m_vsActualMu) 
-      {
-	float actualMu = eventInfo->m_actualMu;
-	m_actualMu->Fill(actualMu, eventWeight);
-      }
+  if (m_infoSwitch->m_vsActualMu)
+    {
+	     float actualMu = eventInfo->m_actualMu;
+	      m_actualMu->Fill(actualMu, eventWeight);
+    }
 
 
   if(m_infoSwitch->m_etaPhiMap)

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -217,15 +217,15 @@ StatusCode JetHists::initialize() {
     //m_IP3DvsMV2c20  = book(m_name, "IP3DvsMV2c20",      m_titlePrefix+" jet MV2c20"       , 100,   -1  ,  1,
 
     if(m_infoSwitch->m_vsActualMu){
-      m_frac_MV240_vs_actMu  = book(m_name, "frac_MV2c1040_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1040", 0, 1);
-      m_frac_MV250_vs_actMu  = book(m_name, "frac_MV2c1050_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1050", 0, 1);
-      m_frac_MV260_vs_actMu  = book(m_name, "frac_MV2c1060_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1060", 0, 1);
-      m_frac_MV270_vs_actMu  = book(m_name, "frac_MV2c1070_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1070", 0, 1);
-      m_frac_MV277_vs_actMu  = book(m_name, "frac_MV2c1077_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1077", 0, 1);
-      m_frac_MV285_vs_actMu  = book(m_name, "frac_MV2c1085_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1085", 0, 1);
+      m_frac_MV240_vs_actMu  = book(m_name, "frac_MV2c1040_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1040", 0, 1);
+      m_frac_MV250_vs_actMu  = book(m_name, "frac_MV2c1050_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1050", 0, 1);
+      m_frac_MV260_vs_actMu  = book(m_name, "frac_MV2c1060_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1060", 0, 1);
+      m_frac_MV270_vs_actMu  = book(m_name, "frac_MV2c1070_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1070", 0, 1);
+      m_frac_MV277_vs_actMu  = book(m_name, "frac_MV2c1077_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1077", 0, 1);
+      m_frac_MV285_vs_actMu  = book(m_name, "frac_MV2c1085_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1085", 0, 1);
 
       // counts (e.g. numbers of jets) vs. proton-proton Interactions
-      m_actualMu = book(m_name, "actualMu", "number vs. actual #mu", 80, 0, 80);
+      m_actualMu = book(m_name, "actualMu", "number vs. actual #mu", 50, 0, 100);
 
     }
 
@@ -2105,7 +2105,7 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 
     if (m_infoSwitch->m_vsActualMu) 
       {
-	float actualMu = eventInfo->actualInteractionsPerCrossing();
+	float actualMu = eventInfo->m_actualMu;
 	m_actualMu->Fill(actualMu, eventWeight);
       }
 

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -631,6 +631,12 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
     m_actualMu->Fill(actualMu, eventWeight);
   }
 
+  if (m_infoSwitch->m_byAverageMu)
+  {
+    float averageMu = eventInfo->averageInteractionsPerCrossing();
+    m_avgMu->Fill(averageMu, eventWeight);
+  }
+
   // energy
   if( m_infoSwitch->m_energy ) {
     if(m_debug) std::cout << "JetHists: m_energy " <<std::endl;

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -224,6 +224,9 @@ StatusCode JetHists::initialize() {
       m_frac_MV277_vs_actMu  = book(m_name, "frac_MV2c1077_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1077", 0, 1);
       m_frac_MV285_vs_actMu  = book(m_name, "frac_MV2c1085_vs_actMu",  "actualMu",  40, 0, 80, "frac. pass MV2c1085", 0, 1);
 
+      // counts (e.g. numbers of jets) vs. proton-proton Interactions
+      m_actualMu = book(m_name, "actualMu", "number vs. actual #mu", 80, 0, 80);
+
     }
 
     if(m_infoSwitch->m_vsLumiBlock){
@@ -951,6 +954,12 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
   //   if(m_debug) std::cout << "JetHists: m_JVC " << std::endl;
   //   m_JVC->Fill(jet->JVC, eventWeight);
   // }
+
+// Pileup
+if (m_infoSwitch->m_vsActualMu) {
+  float actualMu = eventInfo->actualInteractionsPerCrossing();
+  m_actualMu->Fill(actualMu, eventWeight);
+}
 
   //
   // BTagging
@@ -1703,6 +1712,14 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
     {
       m_JVC->Fill(jet->JVC, eventWeight);
     }
+
+    // Pileup
+    if (m_infoSwitch->m_vsActualMu) {
+      float actualMu = eventInfo->m_lumiBlock;
+      m_actualMu->Fill(actualMu, eventWeight);
+    }
+
+
 
   if(m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT)
     {

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -171,6 +171,7 @@ class JetHists : public IParticleHists
     TProfile* m_vtxEff1_raw_vs_lBlock; //!
     TProfile* m_vtxEff10_noDummy_vs_lBlock; //!
     TProfile* m_vtxEff1_noDummy_vs_lBlock; //!
+    TH1F     *m_actualMu;                   // !
     TProfile* m_frac_MV240_vs_actMu; //!
     TProfile* m_frac_MV250_vs_actMu; //!
     TProfile* m_frac_MV260_vs_actMu; //!

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -171,7 +171,6 @@ class JetHists : public IParticleHists
     TProfile* m_vtxEff1_raw_vs_lBlock; //!
     TProfile* m_vtxEff10_noDummy_vs_lBlock; //!
     TProfile* m_vtxEff1_noDummy_vs_lBlock; //!
-    TH1F     *m_actualMu;                   // !
     TProfile* m_frac_MV240_vs_actMu; //!
     TProfile* m_frac_MV250_vs_actMu; //!
     TProfile* m_frac_MV260_vs_actMu; //!
@@ -372,6 +371,7 @@ class JetHists : public IParticleHists
     // charge
     //TH1F *m_charge;
 
+    TH1F* m_actualMu;                   // !
     TH1F* m_avgMu;
     TH1F* m_jetPt_avgMu_00_15;
     TH1F* m_jetPt_avgMu_15_25;


### PR DESCRIPTION
Motivated by work on StudyTrigTracks, which utilizes xAH, I propose to add a histogram to the `JetHists.{cxx,h}` code:

- m_actualMu, filled by xAOD::EventInfo::actualInteractionsPerCrossing() or xAH::EventInfo::m_actualMu

Also, expand the mu histograms to mu=100, to allow for more pileup to populate these distributions.