### PR TITLE
allow for multiple variations on slc6 in lsb_release

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -247,11 +247,12 @@ if __name__ == "__main__":
         xAH_logger.debug('Running lsb_release -d.')
         lsb_release = subprocess.check_output(["lsb_release", "-d"], cwd=os.path.dirname(os.path.realpath(__file__)), stderr=subprocess.STDOUT).strip()
         xAH_logger.debug('  - command output: {}'.format(lsb_release))
-        if 'Scientific Linux release 6' not in lsb_release:
-          xAH_logger.debug('  - did not find "Scientific Linux release 6" in output.')
+        slc6_release_names = ['Scientific Linux release 6', 'Scientific Linux CERN SLC release 6']
+        if not any(name in lsb_release for name in slc6_release_names):
+          xAH_logger.debug('  - did not find SLC6 in output.')
           isSLC6 = False
         else:
-          xAH_logger.debug('  - found "Scientific Linux release 6" in output.')
+          xAH_logger.debug('  - found SLC6 in output.')
 
       except:
         xAH_logger.debug('Previous command could not run correctly. Searching through env. variables.')


### PR DESCRIPTION
SLC6 is reported in `lsb_release -d` as one of two possible variations atm:

```

Description:	Scientific Linux release 6.9 (Carbon)
Description:    Scientific Linux CERN SLC release 6.9 (Carbon)

```

this patch allows both to be recognized/identified as SLC6.