### PR TITLE
A few more changes to autoconfigure PRW

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1015,12 +1015,13 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
   ANA_CHECK( m_event->retrieve( eventInfo, "EventInfo" ) );
 
   // Determine simulation flavour
-  const std::string SimulationFlavour = wk()->metaData()->castString("SimulationFlavour");
+  std::string SimulationFlavour;
+  if( m_setAFII )
+    SimulationFlavour="AFII";
+  else
+    SimulationFlavour = wk()->metaData()->castString("SimulationFlavour");
   if(SimulationFlavour.empty())
-    {
-      ANA_MSG_ERROR( "Need to set SimulationFlavour metaString of sample for BasicEventSelection::autoconfigurePileupRWTool to work. Aborting." );
-      return StatusCode::FAILURE;
-    }
+    SimulationFlavour="FS";
 
   // Extract campaign automatically from Run Number
   std::string mcCampaignMD = "";
@@ -1037,7 +1038,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
       mcCampaignMD="mc16d";
       break;
     default :
-      ANA_MSG_ERROR( "Could not determine mc campaign from run number! Impossible to autocongigure PRW. Aborting." );
+      ANA_MSG_ERROR( "Could not determine mc campaign from run number! Impossible to autoconfigure PRW. Aborting." );
       return StatusCode::FAILURE;
       break;
     }
@@ -1099,7 +1100,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
 	  std::string NoMetadataButPropertyOK("");
 	  NoMetadataButPropertyOK += "autoconfigurePileupRWTool(): access to FileMetaData succeeded, but the 'mcCampaign' property is passed to BasicEventSelection as '";
 	  NoMetadataButPropertyOK += m_mcCampaign;
-	  NoMetadataButPropertyOK += "'. Autocongiguring PRW accordingly.";
+	  NoMetadataButPropertyOK += "'. Autoconfiguring PRW accordingly.";
 	  ANA_MSG_WARNING( NoMetadataButPropertyOK );
 	  // ::
 	}

--- a/data/metadata/singletop.txt
+++ b/data/metadata/singletop.txt
@@ -1,0 +1,4 @@
+410646	PowhegPythia8EvtGen_A14_Wt_DR_inclusive_top	3.793700e+01	1.	1.000000e+00	1.
+410647	PowhegPythia8EvtGen_A14_Wt_DR_inclusive_antitop	3.790700e+01	1.	1.000000e+00	1.
+410658	PhPy8EG_A14_tchan_BW50_lept_top	3.699300e+01	1.	1.000000e+00	1.
+410659	PhPy8EG_A14_tchan_BW50_lept_antitop	2.217500e+01	1.	1.000000e+00	1.

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -48,8 +48,23 @@
 class BasicEventSelection : public xAH::Algorithm
 {
   public:
+  // Sample type settings
     /// @brief Protection when running on truth xAOD
     bool m_truthLevelOnly = false;
+
+  /** @rst
+      If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.
+
+      With SampleHandler, one can define sample metadata in job steering macro. You can do this with relevant samples doing something like:
+
+      .. code-block:: c++
+
+      // access a single sample
+      Sample *sample = sh.get ("mc14_13TeV.blahblahblah");
+      sample->setMetaString("SimulationFlavour", "AFII");
+
+      @endrst */
+    bool m_setAFII = false;
 
   // GRL
     /// @brief Apply GRL selection


### PR DESCRIPTION
One more change that did not make #1207 .
Added `m_setAFII` option to `BasicEventSelection`. Same functionality as `JetCalibrator`. The ability to manually set simulation type of the algorithm is needed, setting using `c.sample(...)` does not work. It is affected by the ["An Integer Is Required" submitting using GridDriver](https://groups.cern.ch/group/hn-atlas-dist-analysis-help/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2fhn-atlas-dist-analysis-help%2fLists%2fArchive%2fAn%20Integer%20Is%20Required%20submitting%20using%20GridDriver&FolderCTID=0x01200200FB8F64B0E343CB4680DEAC546A9DF813) bug.

Also sneaking in the single top cross-sections.