### PR TITLE
Overlap removal b/w taus and electrons + bugfixes

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -471,6 +471,7 @@ namespace HelperClasses{
   void TauInfoSwitch::initialize(){
     m_trigger        = has_exact("trigger");
     m_JetID          = has_exact("JetID");
+    m_EleVeto        = has_exact("EleVeto");
     m_effSF          = has_exact("effSF");
     m_trackparams    = has_exact("trackparams");
     m_trackhitcont   = has_exact("trackhitcont");

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -33,6 +33,15 @@ TauContainer::TauContainer(const std::string& name, const std::string& detailStr
     m_JetBDTScoreSigTrans  = new  std::vector<float>   ();
   }
 
+  if( m_infoSwitch.m_EleVeto) {
+    m_isEleBDTLoose  = new  std::vector<int>   ();
+    m_isEleBDTMedium = new  std::vector<int>   ();
+    m_isEleBDTTight  = new  std::vector<int>   ();
+    
+    m_EleBDTScore    = new  std::vector<float> ();
+    m_passEleOLR     = new  std::vector<int>   ();
+  }
+
   // scale factors w/ sys
   // per object
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -79,6 +88,15 @@ TauContainer::~TauContainer()
     delete m_JetBDTScoreSigTrans;
   }
 
+  if( m_infoSwitch.m_EleVeto) {
+    delete m_isEleBDTLoose;
+    delete m_isEleBDTMedium;
+    delete m_isEleBDTTight;
+    
+    delete m_EleBDTScore;
+
+    delete m_passEleOLR;
+  }
 }
 
 void TauContainer::setTree(TTree *tree)
@@ -123,6 +141,14 @@ void TauContainer::setTree(TTree *tree)
     connectBranch<float>  (tree, "JetBDTScore",         &m_JetBDTScore);
     connectBranch<float>  (tree, "JetBDTScoreSigTrans", &m_JetBDTScoreSigTrans);
   }
+
+  if ( m_infoSwitch.m_EleVeto ){
+    connectBranch<int>    (tree, "isEleBDLoose",   &m_isEleBDTLoose);
+    
+    connectBranch<float>  (tree, "EleBDTScore",    &m_EleBDTScore);
+    connectBranch<int>    (tree, "passEleOLR",     &m_passEleOLR);
+  }
+
 }
 
 void TauContainer::updateParticle(uint idx, Tau& tau)
@@ -164,6 +190,16 @@ void TauContainer::updateParticle(uint idx, Tau& tau)
     
     tau.JetBDTScore         =   m_JetBDTScore         ->at(idx);
     tau.JetBDTScoreSigTrans =   m_JetBDTScoreSigTrans ->at(idx);
+  }
+
+  if ( m_infoSwitch.m_EleVeto ) {
+    tau.isEleBDTLoose   =  m_isEleBDTLoose   ->at(idx);
+    tau.isEleBDTMedium  =  m_isEleBDTMedium  ->at(idx);
+    tau.isEleBDTTight   =  m_isEleBDTTight   ->at(idx);
+    
+    tau.EleBDTScore     =  m_EleBDTScore     ->at(idx);
+    
+    tau.passEleOLR      =  m_passEleOLR      ->at(idx);
   }
 
 }
@@ -214,6 +250,16 @@ void TauContainer::setBranches(TTree *tree)
 
   }
   
+  if ( m_infoSwitch.m_EleVeto ){
+    setBranch<int>   (tree,"isEleBDTLoose", m_isEleBDTLoose);
+    setBranch<int>   (tree,"isEleBDTMedium", m_isEleBDTMedium);
+    setBranch<int>   (tree,"isEleBDTTight", m_isEleBDTTight);
+    
+    setBranch<float> (tree,"EleBDTScore", m_EleBDTScore);
+
+    setBranch<int>   (tree,"passEleOLR", m_passEleOLR);
+  }
+  
   return;
 }
 
@@ -256,6 +302,15 @@ void TauContainer::clear()
     
     m_JetBDTScore->clear();
     m_JetBDTScoreSigTrans->clear();
+  }
+
+  if ( m_infoSwitch.m_EleVeto ) {
+    m_isEleBDTLoose->clear();
+    m_isEleBDTMedium->clear();
+    m_isEleBDTTight->clear();
+    
+    m_EleBDTScore->clear();
+    m_passEleOLR->clear();
   }
 
 }
@@ -348,6 +403,24 @@ void TauContainer::FillTau( const xAOD::IParticle* particle )
     static SG::AuxElement::Accessor<float> JetBDTScoreSigTransAcc ("JetBDTScoreSigTrans");
     safeFill<float, float, xAOD::TauJet>(tau, JetBDTScoreSigTransAcc, m_JetBDTScoreSigTrans, -999.);
   }
-  
+
+  if ( m_infoSwitch.m_EleVeto ) {
+    
+    static SG::AuxElement::Accessor<int> isEleBDTLooseAcc ("isEleBDTLoose");
+    safeFill<int, int, xAOD::TauJet>(tau, isEleBDTLooseAcc, m_isEleBDTLoose, -1);
+
+    static SG::AuxElement::Accessor<int> isEleBDTMediumAcc ("isEleBDTMedium");
+    safeFill<int, int, xAOD::TauJet>(tau, isEleBDTMediumAcc, m_isEleBDTMedium, -1);
+
+    static SG::AuxElement::Accessor<int> isEleBDTTightAcc ("isEleBDTTight");
+    safeFill<int, int, xAOD::TauJet>(tau, isEleBDTTightAcc, m_isEleBDTTight, -1);
+
+    static SG::AuxElement::Accessor<float> EleBDTScoreAcc ("EleBDTScore");
+    safeFill<float, float, xAOD::TauJet>(tau, EleBDTScoreAcc, m_EleBDTScore, -999.);
+
+    static SG::AuxElement::Accessor<int> passEleOLRAcc ("passEleOLR");
+    safeFill<int, int, xAOD::TauJet>(tau, passEleOLRAcc, m_passEleOLR, -1);
+  }
+
   return;
 }

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -122,13 +122,13 @@ void TauContainer::setTree(TTree *tree)
       tree->SetBranchStatus ( (m_name + "_TauEff_SF_" + taueff).c_str() , 1);
       tree->SetBranchAddress( (m_name + "_TauEff_SF_" + taueff).c_str() , & (*m_TauEff_SF)[ taueff ] );
 
-      for (auto& trig : m_infoSwitch.m_trigWPs) {
-        tree->SetBranchStatus ( (m_name + "_TauTrigEff_SF_" + trig + "_" + taueff).c_str() , 1 );
-        tree->SetBranchAddress( (m_name + "_TauTrigEff_SF_" + trig + "_" + taueff).c_str() , & (*m_TauTrigEff_SF)[ trig+taueff ] );
-
-      }
     }
-    
+
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
+      tree->SetBranchStatus ( (m_name + "_TauTrigEff_SF_" + trig).c_str() , 1 );
+      tree->SetBranchAddress( (m_name + "_TauTrigEff_SF_" + trig).c_str() , & (*m_TauTrigEff_SF)[ trig ] );
+
+    }
   }
 
   // might need to delete these 
@@ -173,12 +173,11 @@ void TauContainer::updateParticle(uint idx, Tau& tau)
     
     for (auto& taueff : m_infoSwitch.m_tauEffWPs) {
       tau.TauEff_SF[ taueff ] = (*m_TauEff_SF)[ taueff ].at(idx);
-
-      for (auto& trig : m_infoSwitch.m_trigWPs) {
-        tau.TauTrigEff_SF[ trig+taueff ] = (*m_TauTrigEff_SF)[ trig+taueff ].at(idx);
-      }
     }
     
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
+      tau.TauTrigEff_SF[ trig ] = (*m_TauTrigEff_SF)[ trig ].at(idx);
+    }
   }
 
   //  might need to delete these
@@ -229,13 +228,11 @@ void TauContainer::setBranches(TTree *tree)
     
     for (auto& taueff : m_infoSwitch.m_tauEffWPs) {
       tree->Branch( (m_name + "_TauEff_SF_" + taueff).c_str() , & (*m_TauEff_SF)[ taueff ] );
-      
-      for (auto& trig : m_infoSwitch.m_trigWPs) {
-        tree->Branch( (m_name + "_TauTrigEff_SF_" + trig + "_" + taueff).c_str() , & (*m_TauTrigEff_SF)[ trig+taueff ] );
-      }
     }
     
-    
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
+      tree->Branch( (m_name + "_TauTrigEff_SF_" + trig).c_str() , & (*m_TauTrigEff_SF)[ trig ] );
+    }
   }
 
   // might need to delete these
@@ -285,12 +282,11 @@ void TauContainer::clear()
     
     for (auto& taueff : m_infoSwitch.m_tauEffWPs) {
       (*m_TauEff_SF)[ taueff ].clear();
-
-      for (auto& trig : m_infoSwitch.m_trigWPs) {
-        (*m_TauTrigEff_SF)[ trig+taueff ].clear();
-      }
     }
 
+    for (auto& trig : m_infoSwitch.m_trigWPs) {
+      (*m_TauTrigEff_SF)[ trig ].clear();
+    }
   }
 
   // might need to delete these

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -143,7 +143,9 @@ void TauContainer::setTree(TTree *tree)
   }
 
   if ( m_infoSwitch.m_EleVeto ){
-    connectBranch<int>    (tree, "isEleBDLoose",   &m_isEleBDTLoose);
+    connectBranch<int>    (tree, "isEleBDTLoose",    &m_isEleBDTLoose);
+    connectBranch<int>    (tree, "isEleBDTMedium",   &m_isEleBDTMedium);
+    connectBranch<int>    (tree, "isEleBDTTight",    &m_isEleBDTTight);
     
     connectBranch<float>  (tree, "EleBDTScore",    &m_EleBDTScore);
     connectBranch<int>    (tree, "passEleOLR",     &m_passEleOLR);

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -188,6 +188,7 @@ EL::StatusCode TauSelector :: initialize ()
   //
   // ********************************
 
+  // IMPORTANT: if no working point is specified the one in this configuration will be used
   ANA_CHECK( m_tauSelTool_handle.setProperty("ConfigPath",PathResolverFindDataFile(m_ConfigPath).c_str()));
   if (!m_JetIDWP.empty()) {
     

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -211,6 +211,25 @@ EL::StatusCode TauSelector :: initialize ()
     }
   }
 
+  if (!m_EleBDTWP.empty()) {
+    
+    std::map <std::string, int> elebdt_wp_map;
+    
+    elebdt_wp_map["ELEIDNONE"] = int(TauAnalysisTools::ELEIDNONE);
+    elebdt_wp_map["ELEIDBDTLOOSE"] = int(TauAnalysisTools::ELEIDBDTLOOSE);
+    elebdt_wp_map["ELEIDBDTMEDIUM"] = int(TauAnalysisTools::ELEIDBDTMEDIUM);
+    elebdt_wp_map["ELEIDBDTTIGHT"] = int(TauAnalysisTools::ELEIDBDTTIGHT);
+    
+    if (elebdt_wp_map.count(m_EleBDTWP) != 0 ) {
+      ANA_CHECK( m_tauSelTool_handle.setProperty("EleBDTWP", elebdt_wp_map[m_EleBDTWP]));
+    } else {
+      ANA_MSG_ERROR( "Unknown requested tau EleBDTWP " << m_EleBDTWP);
+      return EL::StatusCode::FAILURE; 
+    }
+  }
+
+  ANA_CHECK( m_tauSelTool_handle.setProperty("EleOLR", m_EleOLR));
+
   ANA_CHECK(m_tauSelTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_tauSelTool_handle);
 
@@ -661,6 +680,7 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
   //
 
   // JetBDTSigID decoration
+  // ----------------------
   static SG::AuxElement::Decorator< int > isJetBDTSigVeryLoose("isJetBDTSigVeryLoose");
   static SG::AuxElement::Decorator< int > isJetBDTSigLoose("isJetBDTSigLoose");
   static SG::AuxElement::Decorator< int > isJetBDTSigMedium("isJetBDTSigMedium");
@@ -669,7 +689,6 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
   static SG::AuxElement::Decorator< float > JetBDTScore("JetBDTScore");
   static SG::AuxElement::Decorator< float > JetBDTScoreSigTrans("JetBDTScoreSigTrans");
   
-  ANA_MSG_DEBUG( "Got the decors" );
 
   isJetBDTSigVeryLoose( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::JetBDTSigVeryLoose));
   isJetBDTSigLoose( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::JetBDTSigLoose));
@@ -678,6 +697,29 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
 
   JetBDTScore( *tau ) = static_cast<float>(tau->discriminant(xAOD::TauJetParameters::BDTJetScore));
   JetBDTScoreSigTrans( *tau ) = static_cast<float>(tau->discriminant(xAOD::TauJetParameters::BDTJetScoreSigTrans));
+
+  // EleBDT decoration
+  // -----------------
+  static SG::AuxElement::Decorator< int > isEleBDTLoose("isEleBDTLoose");
+  static SG::AuxElement::Decorator< int > isEleBDTMedium("isEleBDTMedium");
+  static SG::AuxElement::Decorator< int > isEleBDTTight("isEleBDTTight");
+
+  static SG::AuxElement::Decorator< float > EleBDTScore("EleBDTScore");
+  
+
+  isEleBDTLoose( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::EleBDTLoose));
+  isEleBDTMedium( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::EleBDTMedium));
+  isEleBDTTight( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::EleBDTTight));
+
+  EleBDTScore( *tau ) = static_cast<float>(tau->discriminant(xAOD::TauJetParameters::BDTEleScore));
+
+
+  // EleOLR decoration
+  // -----------------
+  static SG::AuxElement::Decorator< int > passEleOLR("passEleOLR");
+  
+  passEleOLR( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::PassEleOLR));
+
 
   ANA_MSG_DEBUG( "Got decoration values" );
 

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -602,6 +602,7 @@ namespace HelperClasses {
         m_trigger          trigger          exact
         m_effSF            effSF            exact
         m_JetID            JetID            exact
+        m_EleVeto          EleVeto          exact
         m_trackparams      trackparams      exact
         m_trackhitcont     trackhitcont     exact
         m_tauEffWP         TAUEFF_XYZ       pattern
@@ -625,6 +626,7 @@ namespace HelperClasses {
   public:
     bool m_trigger;
     bool m_JetID;
+    bool m_EleVeto;
     bool m_trackparams;
     bool m_trackhitcont;
     bool m_effSF;

--- a/xAODAnaHelpers/Tau.h
+++ b/xAODAnaHelpers/Tau.h
@@ -29,6 +29,15 @@ namespace xAH {
 
     float             JetBDTScore;
     float             JetBDTScoreSigTrans;
+
+    int               isEleBDTLoose;
+    int               isEleBDTMedium;
+    int               isEleBDTTight;
+ 
+    float             EleBDTScore;
+
+    int               passEleOLR;
+
   };
 
 }//xAH

--- a/xAODAnaHelpers/TauContainer.h
+++ b/xAODAnaHelpers/TauContainer.h
@@ -47,7 +47,6 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_TauEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TauTrigEff_SF;
       
-      
       // might need to delete these
       std::vector<int>   *m_isJetBDTSigVeryLoose;
       std::vector<int>   *m_isJetBDTSigLoose;
@@ -57,6 +56,13 @@ namespace xAH {
       std::vector<float>   *m_JetBDTScore;
       std::vector<float>   *m_JetBDTScoreSigTrans;
 
+      std::vector<int>   *m_isEleBDTLoose;
+      std::vector<int>   *m_isEleBDTMedium;
+      std::vector<int>   *m_isEleBDTTight;
+
+      std::vector<float>   *m_EleBDTScore;
+
+      std::vector<int>   *m_passEleOLR;
     };
 }
 #endif // xAODAnaHelpers_TauContainer_H

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -54,6 +54,8 @@ public:
   /* a minimal pT threshold b/c some derivations may apply a thinning on tau tracks' features needed by the TauSelectionTool, which would cause a crash at runtime */
   float          m_minPtDAOD = 15e3;
   std::string    m_JetIDWP = "";
+  std::string    m_EleBDTWP = "";
+  bool           m_EleOLR = false;
 
   /* trigger matching */
   

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -50,12 +50,14 @@ public:
   /* maximum number of objects passing cuts */
   int            m_pass_max = -1;
   /* path to config file for the TauSelectionTool */
+
+  // IMPORTANT: if no working point is specified the one in this configuration will be used
   std::string    m_ConfigPath = "xAODAnaHelpers/TauConf/00-01-19/Selection/recommended_selection_mc15.conf";
   /* a minimal pT threshold b/c some derivations may apply a thinning on tau tracks' features needed by the TauSelectionTool, which would cause a crash at runtime */
   float          m_minPtDAOD = 15e3;
   std::string    m_JetIDWP = "";
   std::string    m_EleBDTWP = "";
-  bool           m_EleOLR = false;
+  bool           m_EleOLR = true;
 
   /* trigger matching */
   


### PR DESCRIPTION
Introduce possibility to write out bits for tau eVeto (ele vs tau overlap removal with or without additional EleBDT identification). Add tight working point of the EleBDT as well. In addition to this a bugfix was required to write out tau trigger corrections.