### PR TITLE
Set missing scale factors to -1 (breaking)

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -328,7 +328,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 	ANA_MSG_DEBUG("Successfully configured BJetEfficiencyCorrections for systematic: " << syst_it.name());
 
 	// get the scale factor
-	float SF(1.0);
+	float SF(-1.0);
 	// if only decorator with decision because OP is not calibrated, set SF to 1
 	if ( fabs(jet_itr->eta()) < 2.5 ) {
 
@@ -342,7 +342,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 	  }
 	  if (BJetEffCode == CP::CorrectionCode::Error){
 	    ANA_MSG_WARNING( "Error in getEfficiencyScaleFactor");
-	    SF = -2;
+	    SF = -1.0;
 	    //return EL::StatusCode::FAILURE;
 	  }
 	  // if it is out of validity range (jet pt > 1200 GeV), the tools just applies the SF at 200 GeV

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -845,8 +845,8 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    std::vector<float> junkSF(1,1.0);
-    std::vector<float> junkEff(1,0.0);
+    std::vector<float> junkSF(1,-1.0);
+    std::vector<float> junkEff(1,-1.0);
 
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accPIDSF;
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accIsoSF;

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -657,10 +657,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // obtain efficiency SF's for PID
     	 //
-    	 double pidEffSF(1.0); // tool wants a double
+    	 double pidEffSF(-1.0); // tool wants a double
     	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_PID->getEfficiencyScaleFactor( *el_itr, pidEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in PID getEfficiencyScaleFactor Tool");
-  	   pidEffSF = 1.0;
+  	   pidEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -760,10 +760,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // obtain efficiency SF's for Iso
     	 //
-    	 double IsoEffSF(1.0); // tool wants a double
+    	 double IsoEffSF(-1.0); // tool wants a double
     	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_Iso->getEfficiencyScaleFactor( *el_itr, IsoEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in Iso getEfficiencyScaleFactor Tool");
-  	   IsoEffSF = 1.0;
+  	   IsoEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -863,10 +863,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // obtain efficiency SF's for Reco
     	 //
-    	 double recoEffSF(1.0); // tool wants a double
+    	 double recoEffSF(-1.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Reco->getEfficiencyScaleFactor( *el_itr, recoEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in Reco getEfficiencyScaleFactor Tool");
-  	   recoEffSF = 1.0;
+  	   recoEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -960,7 +960,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
-    	 if ( el_itr->pt() < m_ptThreshold ) {
+    	 if ( el_itr->pt() < m_ptThresholdTrigger ) {
     	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
   	   isBadElectron = true;
     	 }
@@ -972,11 +972,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // obtain efficiency SF for Trig
     	 //
-    	 double trigEffSF(1.0); // tool wants a double
+    	 double trigEffSF(-1.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Trig->getEfficiencyScaleFactor( *el_itr, trigEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in Trig getEfficiencyScaleFactor Tool");
   	   isBadElectron = true;
-  	   trigEffSF = 1.0;
+  	   trigEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -1067,7 +1067,7 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // skip electron if outside acceptance for SF calculation
     	 //
-    	 if ( el_itr->pt() < m_ptThreshold ) {
+    	 if ( el_itr->pt() < m_ptThresholdTrigger ) {
     	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
   	   isBadElectron = true;
     	 }
@@ -1079,11 +1079,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	 //
     	 // obtain Trig MC efficiency
     	 //
-    	 double trigMCEff(0.0); // tool wants a double
+    	 double trigMCEff(-1.0); // tool wants a double
     	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_TrigMCEff->getEfficiencyScaleFactor( *el_itr, trigMCEff ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in TrigMCEff getEfficiencyScaleFactor Tool");
   	   isBadElectron = true;
-  	   trigMCEff = 0.0;
+  	   trigMCEff = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -641,7 +641,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
             sfVecJVT( *jet ) = std::vector<float>();
           }
 
-          float jvtSF(1.0);
+          float jvtSF(-1.0);
           if ( m_JVT_tool_handle->isInRange(*jet) ) {
             // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
             if ( m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) {
@@ -650,7 +650,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               }
               if ( m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_WARNING( "Problem in JVT Tool getInefficiencyScaleFactor");
-                jvtSF = 1.0;
+                jvtSF = -1.0;
               }
             } else { // otherwise classic efficiency scale factor
               if ( syst_it.name().empty() ) {
@@ -658,7 +658,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               }
               if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_WARNING( "Problem in JVT Tool getEfficiencyScaleFactor");
-                jvtSF = 1.0;
+                jvtSF = -1.0;
               }
             }
           }
@@ -761,18 +761,18 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
             sfVecfJVT( *jet ) = std::vector<float>();
           }
 
-          float fjvtSF(1.0);
+          float fjvtSF(-1.0);
           if ( m_fJVT_eff_tool_handle->isInRange(*jet) ) {
             // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
             if ( !m_dofJVTVeto && jet->auxdata<char>("passFJVT") != 1 ) {
               if ( m_fJVT_eff_tool_handle->getInefficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_WARNING( "Problem in fJVT Tool getInefficiencyScaleFactor");
-                fjvtSF = 1.0;
+                fjvtSF = -1.0;
               }
             } else { // otherwise classic efficiency scale factor
               if ( m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_WARNING( "Problem in fJVT Tool getEfficiencyScaleFactor");
-                fjvtSF = 1.0;
+                fjvtSF = -1.0;
               }
             }
           }

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -834,8 +834,8 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    std::vector<float> junkSF(1,1.0);
-    std::vector<float> junkEff(1,0.0);
+    std::vector<float> junkSF(1,-1.0);
+    std::vector<float> junkEff(1,-1.0);
 
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accRecoSF;
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTrigSF;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -514,10 +514,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   sfVecReco( *mu_itr ) = std::vector<float>();
     	 }
 
-    	 float recoEffSF(1.0);
+    	 float recoEffSF(-1.0);
     	 if ( m_muRecoSF_tool->getEfficiencyScaleFactor( *mu_itr, recoEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in getEfficiencyScaleFactor");
-    	   recoEffSF = 1.0;
+    	   recoEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -613,10 +613,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   sfVecIso( *mu_itr ) = std::vector<float>();
     	 }
 
-    	 float IsoEffSF(1.0);
+    	 float IsoEffSF(-1.0);
     	 if ( m_muIsoSF_tool->getEfficiencyScaleFactor( *mu_itr, IsoEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in getEfficiencyScaleFactor");
-  	   IsoEffSF = 1.0;
+  	   IsoEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector
@@ -737,10 +737,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            //
            std::string full_scan_chain = "HLT_mu8noL1";
 
-           double triggerMCEff(0.0); // tool wants a double
+           double triggerMCEff(-1.0); // tool wants a double
            if ( m_muTrigSF_tool->getTriggerEfficiency( *mu_itr, triggerMCEff, trig_it, !isMC() ) != CP::CorrectionCode::Ok ) {
              ANA_MSG_WARNING( "Problem in getTriggerEfficiency - single muon trigger(s)");
-             triggerMCEff = 0.0;
+             triggerMCEff = -1.0;
            }
            // Add it to decoration vector
            //
@@ -748,11 +748,11 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
            // retrieve MC efficiency for full scan chain
            //
-           double triggerDataEff(0.0); // tool wants a double
+           double triggerDataEff(-1.0); // tool wants a double
            if ( trig_it == full_scan_chain ) {
              if ( m_muTrigSF_tool->getTriggerEfficiency( *mu_itr, triggerDataEff, trig_it, isMC() ) != CP::CorrectionCode::Ok ) {
                ANA_MSG_WARNING( "Problem in getTriggerEfficiency - single muon trigger(s)");
-               triggerDataEff = 0.0;
+               triggerDataEff = -1.0;
              }
            }
 
@@ -760,7 +760,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            if ( trig_it != full_scan_chain ) {
              if ( m_muTrigSF_tool->getTriggerScaleFactor( *mySingleMuonCont.asDataVector(), triggerEffSF, trig_it ) != CP::CorrectionCode::Ok ) {
                ANA_MSG_WARNING( "Problem in getTriggerScaleFactor - single muon trigger(s)");
-               triggerEffSF = 1.0;
+               triggerEffSF = -1.0;
              }
            } else {
              if ( triggerMCEff > 0.0 ) {
@@ -861,10 +861,10 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
   	   sfVecTTVA( *mu_itr ) = std::vector<float>();
     	 }
 
-    	 float TTVAEffSF(1.0);
+    	 float TTVAEffSF(-1.0);
     	 if ( m_muTTVASF_tool->getEfficiencyScaleFactor( *mu_itr, TTVAEffSF ) != CP::CorrectionCode::Ok ) {
     	   ANA_MSG_WARNING( "Problem in getEfficiencyScaleFactor");
-  	   TTVAEffSF = 1.0;
+  	   TTVAEffSF = -1.0;
     	 }
     	 //
     	 // Add it to decoration vector

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -361,7 +361,7 @@ void TauContainer::FillTau( const xAOD::IParticle* particle )
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
-    std::vector<float> junkSF(1,1.0);
+    std::vector<float> junkSF(1,-1.0);
 
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTauEffSF;
     static std::map< std::string, SG::AuxElement::Accessor< std::vector< float > > > accTauTrigSF;

--- a/Root/TauEfficiencyCorrector.cxx
+++ b/Root/TauEfficiencyCorrector.cxx
@@ -402,10 +402,10 @@ EL::StatusCode TauEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* /*ev
           sfVec( *tau_itr ) = std::vector<float>();
   	}
 
-  	double tauEffSF(1.0);
+  	double tauEffSF(-1.0);
   	if ( m_tauEffCorrTool_handle->getEfficiencyScaleFactor( *tau_itr, tauEffSF ) != CP::CorrectionCode::Ok ) {
   	  ANA_MSG_WARNING( "Problem in getEfficiencyScaleFactor");
-  	  tauEffSF = 1.0;
+  	  tauEffSF = -1.0;
   	}
   	//
   	// Add it to decoration vector

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -81,7 +81,8 @@ public:
   std::string m_corrFileNameTrigMCEff = "";
 
   /// @brief Defines the acceptance region for calculating scale factors
-  float m_ptThreshold = 15e3;
+  float m_ptThreshold = 4.5e3;
+  float m_ptThresholdTrigger = 7e3;
 
 private:
   int m_numEvent;         //!


### PR DESCRIPTION
Set missing scale factors to -1, to be sure that they are missing (being 1 is not completely clear, maybe just the SF is not needed).

Also lower the electron efficiencies threshold and add a separate trigger one (as they have it higher, but do not want to hardcode the value in).

I guess there is no need to say this is a breaking change, but it will probably avoid mistakes for many users.