### PR TITLE
Fixing compilation warning for deprecated jet jvt efficiency tool hea…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,10 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.22
-    - RELEASE=AnalysisTop,21.2.22
-    - RELEASE=AnalysisBase,21.2.21
-    - RELEASE=AnalysisTop,21.2.21
-    - RELEASE=AnalysisBase,21.2.20
-    - RELEASE=AnalysisTop,21.2.20
-    - RELEASE=AnalysisBase,21.2.19
-    - RELEASE=AnalysisTop,21.2.19
+    - RELEASE=AnalysisBase,21.2.39
+    - RELEASE=AnalysisTop,21.2.39
+    - RELEASE=AnalysisBase,21.2.33
+    - RELEASE=AnalysisTop,21.2.33
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,16 @@ env:
   matrix:
     - RELEASE=AnalysisBase,21.2.39
     - RELEASE=AnalysisTop,21.2.39
-    - RELEASE=AnalysisBase,21.2.33
-    - RELEASE=AnalysisTop,21.2.33
+    - RELEASE=AnalysisBase,21.2.38
+    - RELEASE=AnalysisTop,21.2.38
+    - RELEASE=AnalysisBase,21.2.37
+    - RELEASE=AnalysisTop,21.2.37
+    - RELEASE=AnalysisBase,21.2.36
+    - RELEASE=AnalysisTop,21.2.36
+    - RELEASE=AnalysisBase,21.2.35
+    - RELEASE=AnalysisTop,21.2.35
+    - RELEASE=AnalysisBase,21.2.34
+    - RELEASE=AnalysisTop,21.2.34
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ atlas_depends_on_subdirs( PUBLIC
                           PhysicsAnalysis/ElectronPhotonID/PhotonEfficiencyCorrection
                           PhysicsAnalysis/JetMissingEtID/JetSelectorTools
                           PhysicsAnalysis/Interfaces/FTagAnalysisInterfaces
+                          PhysicsAnalysis/Interfaces/JetAnalysisInterfaces
                           PhysicsAnalysis/Interfaces/MuonAnalysisInterfaces
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonMomentumCorrections
                           PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections
@@ -99,7 +100,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    ElectronEfficiencyCorrectionLib ElectronPhotonSelectorToolsLib
                    IsolationSelectionLib IsolationCorrectionsLib
                    ElectronPhotonShowerShapeFudgeToolLib
-                   FTagAnalysisInterfacesLib MuonAnalysisInterfacesLib
+                   FTagAnalysisInterfacesLib JetAnalysisInterfacesLib MuonAnalysisInterfacesLib
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
                    TauAnalysisToolsLib AsgTools xAODMissingET JetResolutionLib
                    AssociationUtilsLib JetEDM JetUncertaintiesLib

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -25,7 +25,7 @@
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
-#include "JetJvtEfficiency/IJetJvtEfficiency.h"
+#include "JetAnalysisInterfaces/IJetJvtEfficiency.h"
 #include "JetInterface/IJetModifier.h"
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"


### PR DESCRIPTION
…der, should now be used from JetAnalysisInterfaces. 

This was the warning I saw before the fix:

```
In file included from /afs/cern.ch/work/c/cohm/public/DV/FT/WorkArea/src/FactoryTools/dep/xAODAnaHelpers/xAODAnaHelpers/JetSelector.h:28:
/cvmfs/atlas.cern.ch/repo/sw/software/21.2/AnalysisBase/21.2.39/InstallArea/x86_64-slc6-gcc62-opt/src/Reconstruction/Jet/JetJvtEfficiency/JetJvtEfficiency/IJetJvtEfficiency.h:9:9: warning: This header has been moved to the JetAnalysisInterfaces package. Please update your includes to point here. [-W#pragma-messages]
#pragma message "This header has been moved to the JetAnalysisInterfaces package. Please update your includes to point here."
        ^
```

After this fix the warning is gone. The tests were done against the latest AnalysisBase (21.2.39).