### PR TITLE
Tau tracks

### DIFF
--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -51,6 +51,7 @@
 #include <xAODAnaHelpers/HelperFunctions.h>
 #include <xAODAnaHelpers/OverlapRemover.h>
 #include <xAODAnaHelpers/TrigMatcher.h>
+#include <xAODAnaHelpers/TauJetMatching.h>
 #include <xAODAnaHelpers/Writer.h>
 #include <xAODAnaHelpers/MessagePrinterAlgo.h>
 
@@ -107,6 +108,7 @@
 
 #pragma link C++ class OverlapRemover+;
 #pragma link C++ class TrigMatcher+;
+#pragma link C++ class TauJetMatching+;
 #pragma link C++ class Writer+;
 #pragma link C++ class MessagePrinterAlgo+;
 #endif

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -41,12 +41,10 @@ TauContainer::TauContainer(const std::string& name, const std::string& detailStr
     m_EleBDTScore    = new  std::vector<float> ();
     m_passEleOLR     = new  std::vector<int>   ();
 
-    std::cout << "THIS IS A DEBUG STRING FROM TRKPARAMS" << m_infoSwitch.m_trackparams << std::endl;   
-
   }
 
   if( m_infoSwitch.m_trackparams) {
-    std::cout << "THIS IS A DEBUG STRING FROM TAUCONTAINER" << std::endl;   
+    
     m_tau_matchedJetWidth = new  std::vector<float>   ();
     m_tau_tracks_pt       = new  std::vector< std::vector<float> > ();
     m_tau_tracks_eta      = new  std::vector< std::vector<float> > ();

--- a/Root/TauContainer.cxx
+++ b/Root/TauContainer.cxx
@@ -40,6 +40,27 @@ TauContainer::TauContainer(const std::string& name, const std::string& detailStr
     
     m_EleBDTScore    = new  std::vector<float> ();
     m_passEleOLR     = new  std::vector<int>   ();
+
+    std::cout << "THIS IS A DEBUG STRING FROM TRKPARAMS" << m_infoSwitch.m_trackparams << std::endl;   
+
+  }
+
+  if( m_infoSwitch.m_trackparams) {
+    std::cout << "THIS IS A DEBUG STRING FROM TAUCONTAINER" << std::endl;   
+    m_tau_matchedJetWidth = new  std::vector<float>   ();
+    m_tau_tracks_pt       = new  std::vector< std::vector<float> > ();
+    m_tau_tracks_eta      = new  std::vector< std::vector<float> > ();
+    m_tau_tracks_phi      = new  std::vector< std::vector<float> > ();
+
+    m_tau_tracks_isCore          = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_isWide          = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_failTrackFilter = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_passTrkSel      = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_isClCharged     = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_isClIso         = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_isClConv        = new  std::vector< std::vector<int> > ();
+    m_tau_tracks_isClFake        = new  std::vector< std::vector<int> > ();
+  
   }
 
   // scale factors w/ sys
@@ -97,6 +118,25 @@ TauContainer::~TauContainer()
 
     delete m_passEleOLR;
   }
+
+  if( m_infoSwitch.m_trackparams) {
+    
+    delete m_tau_matchedJetWidth; 
+    delete m_tau_tracks_pt;
+    delete m_tau_tracks_eta;
+    delete m_tau_tracks_phi;
+
+    delete m_tau_tracks_isCore;
+    delete m_tau_tracks_isWide;
+    delete m_tau_tracks_failTrackFilter;
+    delete m_tau_tracks_passTrkSel;
+    delete m_tau_tracks_isClCharged;
+    delete m_tau_tracks_isClIso;
+    delete m_tau_tracks_isClConv;
+    delete m_tau_tracks_isClFake;
+  
+  }
+
 }
 
 void TauContainer::setTree(TTree *tree)
@@ -151,6 +191,46 @@ void TauContainer::setTree(TTree *tree)
     connectBranch<int>    (tree, "passEleOLR",     &m_passEleOLR);
   }
 
+
+  if( m_infoSwitch.m_trackparams) {
+
+    connectBranch<float>  (tree, "matchedJetWidth",    &m_tau_matchedJetWidth);
+    
+    tree->SetBranchStatus ( (m_name + "_tracks_pt").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_pt").c_str() , &m_tau_tracks_pt );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_eta").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_eta").c_str() , &m_tau_tracks_eta );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_phi").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_phi").c_str() , &m_tau_tracks_phi );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isCore").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isCore").c_str() , &m_tau_tracks_isCore );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isWide").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isWide").c_str() , &m_tau_tracks_isWide );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_failTrackFilter").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_failTrackFilter").c_str() , &m_tau_tracks_failTrackFilter );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_passTrkSel").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_passTrkSel").c_str() , &m_tau_tracks_passTrkSel );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isClCharged").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isClCharged").c_str() , &m_tau_tracks_isClCharged );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isClIso").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isClIso").c_str() , &m_tau_tracks_isClIso );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isClConv").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isClConv").c_str() , &m_tau_tracks_isClConv );
+
+    tree->SetBranchStatus ( (m_name + "_tracks_isClFake").c_str() , 1 );
+    tree->SetBranchAddress( (m_name + "_tracks_isClFake").c_str() , &m_tau_tracks_isClFake );
+
+  }
+
 }
 
 void TauContainer::updateParticle(uint idx, Tau& tau)
@@ -201,6 +281,25 @@ void TauContainer::updateParticle(uint idx, Tau& tau)
     tau.EleBDTScore     =  m_EleBDTScore     ->at(idx);
     
     tau.passEleOLR      =  m_passEleOLR      ->at(idx);
+  }
+
+  if( m_infoSwitch.m_trackparams) {
+
+    tau.matchedJetWidth  = m_tau_matchedJetWidth ->at(idx);
+    
+    tau.tracks_pt  = m_tau_tracks_pt  ->at(idx);
+    tau.tracks_eta = m_tau_tracks_eta ->at(idx);
+    tau.tracks_phi = m_tau_tracks_phi ->at(idx);
+
+    tau.tracks_isCore           = m_tau_tracks_isCore           ->at(idx);
+    tau.tracks_isWide           = m_tau_tracks_isWide           ->at(idx);
+    tau.tracks_failTrackFilter  = m_tau_tracks_failTrackFilter  ->at(idx);
+    tau.tracks_passTrkSel       = m_tau_tracks_passTrkSel       ->at(idx);
+    tau.tracks_isClCharged      = m_tau_tracks_isClCharged      ->at(idx);
+    tau.tracks_isClIso          = m_tau_tracks_isClIso          ->at(idx);
+    tau.tracks_isClConv         = m_tau_tracks_isClConv         ->at(idx);
+    tau.tracks_isClFake         = m_tau_tracks_isClFake         ->at(idx);
+
   }
 
 }
@@ -258,7 +357,26 @@ void TauContainer::setBranches(TTree *tree)
 
     setBranch<int>   (tree,"passEleOLR", m_passEleOLR);
   }
-  
+ 
+  if( m_infoSwitch.m_trackparams) {
+
+    setBranch<float>  (tree, "matchedJetWidth",    m_tau_matchedJetWidth);
+    
+    tree->Branch( (m_name + "_tracks_pt").c_str() , &m_tau_tracks_pt );
+    tree->Branch( (m_name + "_tracks_eta").c_str() , &m_tau_tracks_eta );
+    tree->Branch( (m_name + "_tracks_phi").c_str() , &m_tau_tracks_phi );
+    
+    tree->Branch( (m_name + "_tracks_isCore").c_str() , &m_tau_tracks_isCore );
+    tree->Branch( (m_name + "_tracks_isWide").c_str() , &m_tau_tracks_isWide );
+    tree->Branch( (m_name + "_tracks_failTrackFilter").c_str() , &m_tau_tracks_failTrackFilter );
+    tree->Branch( (m_name + "_tracks_passTrkSel").c_str() , &m_tau_tracks_passTrkSel );
+    tree->Branch( (m_name + "_tracks_isClCharged").c_str() , &m_tau_tracks_isClCharged );
+    tree->Branch( (m_name + "_tracks_isClIso").c_str() , &m_tau_tracks_isClIso );
+    tree->Branch( (m_name + "_tracks_isClConv").c_str() , &m_tau_tracks_isClConv );
+    tree->Branch( (m_name + "_tracks_isClFake").c_str() , &m_tau_tracks_isClFake );
+
+  }
+
   return;
 }
 
@@ -309,6 +427,25 @@ void TauContainer::clear()
     
     m_EleBDTScore->clear();
     m_passEleOLR->clear();
+  }
+
+  if( m_infoSwitch.m_trackparams) {
+
+    m_tau_matchedJetWidth->clear();
+    
+    m_tau_tracks_pt->clear();
+    m_tau_tracks_eta->clear();
+    m_tau_tracks_phi->clear();
+
+    m_tau_tracks_isCore->clear();
+    m_tau_tracks_isWide->clear();
+    m_tau_tracks_failTrackFilter->clear();
+    m_tau_tracks_passTrkSel->clear();
+    m_tau_tracks_isClCharged->clear();
+    m_tau_tracks_isClIso->clear();
+    m_tau_tracks_isClConv->clear();
+    m_tau_tracks_isClFake->clear();
+
   }
 
 }
@@ -418,6 +555,49 @@ void TauContainer::FillTau( const xAOD::IParticle* particle )
 
     static SG::AuxElement::Accessor<int> passEleOLRAcc ("passEleOLR");
     safeFill<int, int, xAOD::TauJet>(tau, passEleOLRAcc, m_passEleOLR, -1);
+  }
+
+
+  if( m_infoSwitch.m_trackparams) {
+
+    static SG::AuxElement::Accessor< float > jetWidthAcc("JetWidth");
+    safeFill<float, float, xAOD::TauJet>(tau, jetWidthAcc, m_tau_matchedJetWidth, -1.);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<float>   >   tauTrackPtAcc("trackPt");
+    safeVecFill<float, float, xAOD::TauJet>(tau, tauTrackPtAcc, m_tau_tracks_pt);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<float>   >   tauTrackEtaAcc("trackEta");
+    safeVecFill<float, float, xAOD::TauJet>(tau, tauTrackEtaAcc, m_tau_tracks_eta);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<float>   >   tauTrackPhiAcc("trackPhi");
+    safeVecFill<float, float, xAOD::TauJet>(tau, tauTrackPhiAcc, m_tau_tracks_phi);
+    
+    
+    // track classification
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsCoreAcc("trackIsCore");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsCoreAcc, m_tau_tracks_isCore);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsWideAcc("trackIsWide");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsWideAcc, m_tau_tracks_isWide);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackFailTrackFilterAcc("trackFailTrackFilter");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackFailTrackFilterAcc, m_tau_tracks_failTrackFilter);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackPassTrkSelAcc("trackPassTrkSel");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackPassTrkSelAcc, m_tau_tracks_passTrkSel);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsClChargedAcc("trackIsClCharged");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsClChargedAcc, m_tau_tracks_isClCharged);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsClIsoAcc("trackIsClIso");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsClIsoAcc, m_tau_tracks_isClIso);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsClConvAcc("trackIsClConv");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsClConvAcc, m_tau_tracks_isClConv);
+    
+    static SG::AuxElement::ConstAccessor< std::vector<int>   >   tauTrackIsClFakeAcc("trackIsClFake");
+    safeVecFill<int, int, xAOD::TauJet>(tau, tauTrackIsClFakeAcc, m_tau_tracks_isClFake);
+
   }
 
   return;

--- a/Root/TauJetMatching.cxx
+++ b/Root/TauJetMatching.cxx
@@ -223,7 +223,7 @@ EL::StatusCode TauJetMatching :: execute ()
 
 bool TauJetMatching :: executeDecoration ( std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > match_map, const xAOD::TauJetContainer* inTaus)
 {
-
+  std::cout << "THIS IS A DEBUG STRING FROM TAUJETMATCHING" << std::endl;
   static SG::AuxElement::Decorator< float > JetWidthDecor("JetWidth");
   static SG::AuxElement::ConstAccessor<float> jetWidthAcc("Width");
 

--- a/Root/TauJetMatching.cxx
+++ b/Root/TauJetMatching.cxx
@@ -1,0 +1,372 @@
+// c++ include(s):
+#include <iostream>
+#include <typeinfo>
+#include <map>
+
+// EL include(s):
+#include <EventLoop/Job.h>
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Worker.h>
+
+// EDM include(s):
+//#include "xAODCore/ShallowCopy.h"
+//#include "AthContainers/ConstDataVector.h"
+#include "xAODEventInfo/EventInfo.h"
+#include "xAODTau/TauJetContainer.h"
+#include "xAODJet/JetContainer.h"
+
+// package include(s):
+#include "xAODAnaHelpers/TauJetMatching.h"
+#include "xAODAnaHelpers/HelperClasses.h"
+#include "xAODAnaHelpers/HelperFunctions.h"
+
+// ROOT include(s):
+#include "TLorentzVector.h"
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(TauJetMatching)
+
+
+TauJetMatching :: TauJetMatching () :
+    Algorithm("TauJetMatching")
+{
+}
+
+TauJetMatching::~TauJetMatching() {}
+
+EL::StatusCode TauJetMatching :: setupJob (EL::Job& job)
+{
+  // Here you put code that sets up the job on the submission object
+  // so that it is ready to work with your algorithm, e.g. you can
+  // request the D3PDReader service or add output files.  Any code you
+  // put here could instead also go into the submission script.  The
+  // sole advantage of putting it here is that it gets automatically
+  // activated/deactivated when you add/remove the algorithm from your
+  // job, which may or may not be of value to you.
+
+  ANA_MSG_INFO( "Calling setupJob");
+
+  job.useXAOD ();
+  xAOD::Init( "TauJetMatching" ).ignore(); // call before opening first file
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: histInitialize ()
+{
+  // Here you do everything that needs to be done at the very
+  // beginning on each worker node, e.g. create histograms and output
+  // trees.  This method gets called before any input files are
+  // connected.
+
+  ANA_MSG_INFO( "Calling histInitialize");
+  ANA_CHECK( xAH::Algorithm::algInitialize());
+
+  //if ( this->numInstances() > 1 ) {
+  //  m_isUsedBefore = true;
+  //  ANA_MSG_INFO( "\t An algorithm of the same type has been already used " << numInstances() << " times" );
+  //}
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: fileExecute ()
+{
+  // Here you do everything that needs to be done exactly once for every
+  // single file, e.g. collect a list of all lumi-blocks processed
+
+  ANA_MSG_INFO( "Calling fileExecute");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: changeInput (bool /*firstFile*/)
+{
+  // Here you do everything you need to do when we change input files,
+  // e.g. resetting branch addresses on trees.  If you are using
+  // D3PDReader or a similar service this method is not needed.
+
+  ANA_MSG_INFO( "Calling changeInput");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: initialize ()
+{
+  // Here you do everything that you need to do after the first input
+  // file has been connected and before the first event is processed,
+  // e.g. create additional histograms based on which variables are
+  // available in the input files.  You can also create all of your
+  // histograms and trees in here, but be aware that this method
+  // doesn't get called if no events are processed.  So any objects
+  // you create here won't be available in the output if you have no
+  // input events.
+
+  ANA_MSG_INFO( "Initializing TauJetMatching Interface... ");
+
+  // Let's see if the algorithm has been already used before:
+  // if yes, will write object cutflow in a different histogram!
+  //
+  // This is the case when the selector algorithm is used for
+  // preselecting objects, and then again for the final selection
+  //
+  ANA_MSG_INFO( "Algorithm name: " << m_name << " - of type " << m_className );
+
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+
+  ANA_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
+
+  if ( m_inContainerName.empty() ){
+    ANA_MSG_ERROR( "InputContainer is empty!");
+    return EL::StatusCode::FAILURE;
+  }
+
+  if ( m_inJetContainerName.empty() ){
+    ANA_MSG_ERROR( "InputJetContainer is empty!");
+    return EL::StatusCode::FAILURE;
+  }
+
+  // ********************************
+  //
+  // Initialise TauJetMatchingTool
+  //
+  // ********************************
+
+  // IMPORTANT: if no working point is specified the one in this configuration will be used
+
+  ANA_MSG_INFO( "TauJetMatching Interface succesfully initialized!" );
+
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode TauJetMatching :: execute ()
+{
+  // Here you do everything that needs to be done on every single
+  // events, e.g. read input variables, apply cuts, and fill
+  // histograms and trees.  This is where most of your actual analysis
+  // code will go.
+
+  ANA_MSG_DEBUG( "Applying Tau Selection..." );
+
+  const xAOD::EventInfo* eventInfo(nullptr);
+  ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
+
+  const xAOD::TauJetContainer* inTaus(nullptr);
+
+  const xAOD::JetContainer* inJets(nullptr);
+  ANA_CHECK( HelperFunctions::retrieve(inJets, m_inJetContainerName, m_event, m_store, msg()) );
+
+
+  // if input comes from xAOD, or just running one collection,
+  // then get the one collection and be done with it
+  //
+  if ( m_inputAlgoSystNames.empty() ) {
+
+    // this will be the collection processed - no matter what!!
+    //
+    ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName, m_event, m_store, msg()) );
+
+    // fill truth-matching map
+    //
+    std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > match_map;
+    
+    match_map = findBestMatchDR( inJets, inTaus, m_DeltaR );
+    
+    executeDecoration(match_map, inTaus);
+
+  } else { // get the list of systematics to run over
+
+    // get vector of string giving the syst names of the upstream algo from TStore (rememeber: 1st element is a blank string: nominal case!)
+    //
+    std::vector< std::string >* systNames(nullptr);
+    ANA_CHECK( HelperFunctions::retrieve(systNames, m_inputAlgoSystNames, 0, m_store, msg()) );
+
+    // prepare a vector of the names of CDV containers for usage by downstream algos
+    // must be a pointer to be recorded in TStore
+    //
+    std::vector< std::string >* vecOutContainerNames = new std::vector< std::string >;
+    ANA_MSG_DEBUG( " input list of syst size: " << static_cast<int>(systNames->size()) );
+
+    // loop over systematic sets
+    //
+    for ( auto systName : *systNames ) {
+
+      ANA_MSG_DEBUG( " syst name: " << systName << "  input container name: " << m_inContainerName+systName );
+
+      ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName + systName, m_event, m_store, msg()) );
+      ANA_CHECK( HelperFunctions::retrieve(inJets, m_inJetContainerName, m_event, m_store, msg()) );
+
+      std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > match_map_sys;
+      
+      match_map_sys = findBestMatchDR( inJets, inTaus, m_DeltaR );
+      
+      executeDecoration(match_map_sys, inTaus);
+    }
+  }
+
+  // look what we have in TStore
+  //
+  if(msgLvl(MSG::VERBOSE)) m_store->print();
+
+  return EL::StatusCode::SUCCESS;
+
+}
+
+bool TauJetMatching :: executeDecoration ( std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > match_map, const xAOD::TauJetContainer* inTaus)
+{
+
+  static SG::AuxElement::Decorator< float > JetWidthDecor("JetWidth");
+  static SG::AuxElement::ConstAccessor<float> jetWidthAcc("Width");
+
+  ANA_MSG_DEBUG( "Initial Taus: " << static_cast<uint32_t>(inTaus->size()) );
+  
+  int iTau = -1;
+
+  for ( auto tau_itr : *inTaus ) { // duplicated of basic loop
+    iTau++;
+
+    std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > >::const_iterator it_map = match_map.find (iTau);
+
+    if (it_map != match_map.end()) {
+      
+      if (jetWidthAcc.isAvailable(*match_map[iTau].second)) {
+        JetWidthDecor(*tau_itr) = static_cast<float>( jetWidthAcc(*match_map[iTau].second) );
+      } else { 
+        JetWidthDecor(*tau_itr) = -1.;
+      } 
+    
+    } else {
+      JetWidthDecor(*tau_itr) = -1.;
+    }
+  }
+
+  ANA_MSG_DEBUG( "Left  executeDecoration..." );
+
+  return true;
+}
+
+EL::StatusCode TauJetMatching :: postExecute ()
+{
+  // Here you do everything that needs to be done after the main event
+  // processing.  This is typically very rare, particularly in user
+  // code.  It is mainly used in implementing the NTupleSvc.
+
+  ANA_MSG_DEBUG( "Calling postExecute");
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: finalize ()
+{
+  // This method is the mirror image of initialize(), meaning it gets
+  // called after the last event has been processed on the worker node
+  // and allows you to finish up any objects you created in
+  // initialize() before they are written to disk.  This is actually
+  // fairly rare, since this happens separately for each worker node.
+  // Most of the time you want to do your post-processing on the
+  // submission node after all your histogram outputs have been
+  // merged.  This is different from histFinalize() in that it only
+  // gets called on worker nodes that processed input events.
+
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode TauJetMatching :: histFinalize ()
+{
+  // This method is the mirror image of histInitialize(), meaning it
+  // gets called after the last event has been processed on the worker
+  // node and allows you to finish up any objects you created in
+  // histInitialize() before they are written to disk.  This is
+  // actually fairly rare, since this happens separately for each
+  // worker node.  Most of the time you want to do your
+  // post-processing on the submission node after all your histogram
+  // outputs have been merged.  This is different from finalize() in
+  // that it gets called on all worker nodes regardless of whether
+  // they processed input events.
+
+  ANA_MSG_INFO( "Calling histFinalize");
+  ANA_CHECK( xAH::Algorithm::algFinalize());
+  return EL::StatusCode::SUCCESS;
+}
+
+float TauJetMatching::getDR(float eta1, float eta2, float phi1, float phi2)
+{
+ float deta = std::abs(eta1-eta2);
+ float dphi = std::abs(phi1-phi2);
+ dphi = ( dphi <= TMath::Pi() ) ? dphi : ( 2 * TMath::Pi() - dphi );
+ return sqrt(deta*deta + dphi*dphi);
+}
+
+std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > TauJetMatching::findBestMatchDR(const xAOD::JetContainer* jetCont,
+                                                                                                            const xAOD::TauJetContainer* tauCont,
+                                                                                                            float best_DR=1.0)
+{ 
+  // Find tau that best matches a jet using DR.
+  // If matching is successful, returns a map where the key 
+  // is the  container index of the matched tau and the value
+  // is the pair of the matched tau and the corresponding jet
+  
+  float default_best_DR = best_DR;
+  int ijet = -1;
+  int best_ijet = -1;
+  const xAOD::Jet* best_jet = nullptr;
+
+  std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet*>> match_map;
+  
+  for (const auto jet : *jetCont) {
+      ++ijet;
+      
+      int itau = -1;
+      int best_itau = -1;
+      const xAOD::TauJet* best_tau = nullptr;
+      float DR = 0;
+      
+      for (const auto tau : *tauCont) {
+        ++itau;
+        
+        DR = this->getDR(tau->eta(),jet->eta(),tau->phi(),jet->phi());
+
+        if (DR < best_DR) {
+          best_DR = DR;
+          best_tau = tau;
+          best_jet = jet;
+          best_itau = itau;
+          best_ijet = ijet;
+        }
+      }
+      
+      std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > >::const_iterator got = match_map.find (best_itau);
+      
+      // if a new match is found for a previous 
+      // tau keep the new match if it is better 
+      
+      if (got == match_map.end() and best_itau != -1 and best_ijet != -1) {
+        match_map[best_itau] = std::pair<const xAOD::TauJet*, const xAOD::Jet*>(best_tau, best_jet);
+      }
+      else if (got != match_map.end() and best_itau != -1 and best_ijet != -1) {
+        float old_DR = this->getDR(match_map[best_itau].first->eta(), match_map[best_itau].second->eta(),match_map[best_itau].first->phi(), match_map[best_itau].second->phi());
+        if (old_DR > best_DR) {
+          match_map[best_itau] = std::pair<const xAOD::TauJet*, const xAOD::Jet*>(best_tau, best_jet);
+        }
+      }
+      
+      // reset the best_DR to the default value
+      best_DR = default_best_DR;
+  }
+
+  return match_map;
+
+}

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -721,7 +721,58 @@ int TauSelector :: passCuts( const xAOD::TauJet* tau ) {
   
   passEleOLR( *tau ) = static_cast<int>(tau->isTau(xAOD::TauJetParameters::PassEleOLR));
 
+  if (m_decorateWithTracks) {
 
+     // TauTracks decoration
+     // --------------------
+     SG::AuxElement::Decorator< std::vector<float> > tauTrackPt( "trackPt" );
+     SG::AuxElement::Decorator< std::vector<float> > tauTrackEta( "trackEta" );
+     SG::AuxElement::Decorator< std::vector<float> > tauTrackPhi( "trackPhi" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsCore( "trackIsCore" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsWide( "trackIsWide" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackFailTrackFilter( "trackFailTrackFilter" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackPassTrkSel( "trackPassTrkSel" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsClCharged( "trackIsClCharged" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsClIso( "trackIsClIso" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsClConv( "trackIsClConv" );
+     SG::AuxElement::Decorator< std::vector<int> > tauTrackIsClFake( "trackIsClFake" );
+     
+     
+     for (const xAOD::TauTrack* trk : tau->allTracks()){
+      
+        tauTrackPt( *tau ).push_back(trk->pt());
+        tauTrackEta( *tau ).push_back(trk->eta());
+        tauTrackPhi( *tau ).push_back(trk->phi());
+     
+     
+        if (!trk->flag(xAOD::TauJetParameters::coreTrack)) tauTrackIsCore(*tau).push_back(1);
+        else tauTrackIsCore(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::wideTrack)) tauTrackIsWide(*tau).push_back(1);
+        else tauTrackIsWide(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::failTrackFilter)) tauTrackFailTrackFilter(*tau).push_back(1);
+        else tauTrackFailTrackFilter(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::passTrkSelector)) tauTrackPassTrkSel(*tau).push_back(1);
+        else tauTrackPassTrkSel(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::classifiedCharged)) tauTrackIsClCharged(*tau).push_back(1);
+        else tauTrackIsClCharged(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::classifiedIsolation)) tauTrackIsClIso(*tau).push_back(1);
+        else tauTrackIsClIso(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::classifiedConversion)) tauTrackIsClConv(*tau).push_back(1);
+        else tauTrackIsClConv(*tau).push_back(0);
+     
+        if (!trk->flag(xAOD::TauJetParameters::classifiedFake)) tauTrackIsClFake(*tau).push_back(1);
+        else tauTrackIsClFake(*tau).push_back(0);
+     
+     }
+
+  } // if decorate with tracks
+  
   ANA_MSG_DEBUG( "Got decoration values" );
 
 

--- a/docs/Algorithms.rst
+++ b/docs/Algorithms.rst
@@ -211,6 +211,23 @@ TauSelector
 
 TauEfficiencyCorrector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The TauEfficientyCorrector provides one cumulative decoration with one SF corresponding to
+the combination of working points used for the tau selection/identification algorithms.
+Several initialisations of the algorithm are needed with different combinations in order 
+to dump in the ntuples different combined working points. Tau trigger SFs are saved separately
+and wrt said cumulative working point which has to be specified in the initialisation of a new
+instance of the algorithm together with the trigger menu.
+
+
+TauJetMatching
+~~~~~~~~~~~~~~
+This algorithm is introduced to match an arbitrary and configurable collection of jets 
+with the TauJet object. This is useful for cases where the tau seedJet (LC topo jet) 
+is not available in xAOD but one would need to get a handle on some original jet info. 
+The algorithm has a configurable DeltaR matching criterion and for now decorates taus 
+with the matched jet width. It should be executed before OLR. It can be used
+before tau selection and after tau calibration.
+
 
 HelperFunctions
 ---------------

--- a/docs/TauJetMatching.rst
+++ b/docs/TauJetMatching.rst
@@ -1,0 +1,8 @@
+:math:`\tau`
+============
+
+.. doxygenclass:: TauJetMatching
+   :members:
+   :undoc-members:
+   :protected-members:
+   :private-members:

--- a/xAODAnaHelpers/Tau.h
+++ b/xAODAnaHelpers/Tau.h
@@ -38,7 +38,7 @@ namespace xAH {
 
     int                 passEleOLR;
 
-    std::vector<float>  matchedJetWidth;
+    float               matchedJetWidth;
     
     std::vector<float>  tracks_pt;
     std::vector<float>  tracks_eta;
@@ -52,16 +52,6 @@ namespace xAH {
     std::vector< int >  tracks_isClIso;
     std::vector< int >  tracks_isClConv;
     std::vector< int >  tracks_isClFake;
-
-
-
-
-
-
-
-
-
-
 
   };
 

--- a/xAODAnaHelpers/Tau.h
+++ b/xAODAnaHelpers/Tau.h
@@ -11,32 +11,57 @@ namespace xAH {
   public:
 
     // trigger
-    int               isTrigMatched;
-    std::vector<int>  isTrigMatchedToChain;
-    std::string       listTrigChains;
+    int                 isTrigMatched;
+    std::vector<int>    isTrigMatchedToChain;
+    std::string         listTrigChains;
     
-    int               ntrk;
-    float             charge;
+    int                 ntrk;
+    float               charge;
     
     std::map< std::string, std::vector< float > > TauEff_SF;
     std::map< std::string, std::vector< float > > TauTrigEff_SF;
     
     // might need to delete these
-    int               isJetBDTSigVeryLoose;
-    int               isJetBDTSigLoose;
-    int               isJetBDTSigMedium;
-    int               isJetBDTSigTight;
+    int                 isJetBDTSigVeryLoose;
+    int                 isJetBDTSigLoose;
+    int                 isJetBDTSigMedium;
+    int                 isJetBDTSigTight;
 
-    float             JetBDTScore;
-    float             JetBDTScoreSigTrans;
+    float               JetBDTScore;
+    float               JetBDTScoreSigTrans;
 
-    int               isEleBDTLoose;
-    int               isEleBDTMedium;
-    int               isEleBDTTight;
+    int                 isEleBDTLoose;
+    int                 isEleBDTMedium;
+    int                 isEleBDTTight;
  
-    float             EleBDTScore;
+    float               EleBDTScore;
 
-    int               passEleOLR;
+    int                 passEleOLR;
+
+    std::vector<float>  matchedJetWidth;
+    
+    std::vector<float>  tracks_pt;
+    std::vector<float>  tracks_eta;
+    std::vector<float>  tracks_phi;
+
+    std::vector< int >  tracks_isCore;
+    std::vector< int >  tracks_isWide;
+    std::vector< int >  tracks_failTrackFilter;
+    std::vector< int >  tracks_passTrkSel;
+    std::vector< int >  tracks_isClCharged;
+    std::vector< int >  tracks_isClIso;
+    std::vector< int >  tracks_isClConv;
+    std::vector< int >  tracks_isClFake;
+
+
+
+
+
+
+
+
+
+
 
   };
 

--- a/xAODAnaHelpers/TauContainer.h
+++ b/xAODAnaHelpers/TauContainer.h
@@ -63,6 +63,22 @@ namespace xAH {
       std::vector<float>   *m_EleBDTScore;
 
       std::vector<int>   *m_passEleOLR;
+
+      std::vector< float > *m_tau_matchedJetWidth;
+      
+      std::vector< std::vector< float > > *m_tau_tracks_pt;
+      std::vector< std::vector< float > > *m_tau_tracks_eta;
+      std::vector< std::vector< float > > *m_tau_tracks_phi;
+  
+      std::vector< std::vector< int > > *m_tau_tracks_isCore;
+      std::vector< std::vector< int > > *m_tau_tracks_isWide;
+      std::vector< std::vector< int > > *m_tau_tracks_failTrackFilter;
+      std::vector< std::vector< int > > *m_tau_tracks_passTrkSel;
+      std::vector< std::vector< int > > *m_tau_tracks_isClCharged;
+      std::vector< std::vector< int > > *m_tau_tracks_isClIso;
+      std::vector< std::vector< int > > *m_tau_tracks_isClConv;
+      std::vector< std::vector< int > > *m_tau_tracks_isClFake;       
+
     };
 }
 #endif // xAODAnaHelpers_TauContainer_H

--- a/xAODAnaHelpers/TauJetMatching.h
+++ b/xAODAnaHelpers/TauJetMatching.h
@@ -1,0 +1,76 @@
+#ifndef xAODAnaHelpers_TauJetMatching_H
+#define xAODAnaHelpers_TauJetMatching_H
+
+// EDM include(s):
+#include "xAODTau/TauJet.h"
+#include "xAODTau/TauJetContainer.h"
+#include "xAODJet/JetContainer.h"
+#include "xAODJet/Jet.h"
+
+// algorithm wrapper
+#include "xAODAnaHelpers/Algorithm.h"
+
+class TauJetMatching : public xAH::Algorithm
+{
+  // put your configuration variables here as public variables.
+  // that way they can be set directly from CINT and python.
+
+public:
+
+  // configuration variables
+  /* input container name */
+  std::string    m_inContainerName = "";
+  /* output container name */
+  std::string    m_outContainerName;
+  /* output auxiliary container name */
+  std::string    m_outAuxContainerName;
+  std::string    m_inputAlgoSystNames = "";
+  std::string    m_outputAlgoSystNames = "TauJetMatching_Syst";
+
+  std::string    m_inJetContainerName = "";
+  float          m_DeltaR = 0.2;
+
+private:
+
+  int m_numEvent;           //!
+  int m_numObject;          //!
+
+  // variables that don't get filled at submission time should be
+  // protected from being send from the submission node to the worker
+  // node (done by the //!)
+
+public:
+  // Tree *myTree; //!
+  // TH1 *myHist; //!
+
+  // this is a standard constructor
+  TauJetMatching ();
+
+  ~TauJetMatching();
+
+  // these are the functions inherited from Algorithm
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+
+  // added functions not from Algorithm
+  bool executeDecoration( std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > >, const xAOD::TauJetContainer* tauCont);
+  float getDR(float eta1, float eta2, float phi1, float phi2);
+  std::unordered_map<int, std::pair<const xAOD::TauJet*, const xAOD::Jet* > > findBestMatchDR(const xAOD::JetContainer* jetCont,
+                                                                                              const xAOD::TauJetContainer* tauCont,
+                                                                                              float best_DR);
+
+  /// @cond
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(TauJetMatching, 1);
+  /// @endcond
+
+};
+
+#endif

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -4,6 +4,7 @@
 // EDM include(s):
 #include "xAODTau/TauJet.h"
 #include "xAODTau/TauJetContainer.h"
+#include "xAODTau/TauTrack.h"
 
 // ROOT include(s):
 #include "TH1D.h"
@@ -39,6 +40,8 @@ public:
   std::string    m_outAuxContainerName;
   std::string    m_inputAlgoSystNames = "";
   std::string    m_outputAlgoSystNames = "TauSelector_Syst";
+  /* decorate selected taus with tracks */
+  bool       	 m_decorateWithTracks = false;
   /* decorate selected objects - default "passSel" */
   bool       	 m_decorateSelectedObjects = true;
   /* fill using SG::VIEW_ELEMENTS to be light weight */


### PR DESCRIPTION
Updates for dumping tau tracks information in the ntuples. 

- A new algorithm is introduced to match an arbitrary and configurable collection of jets with the TauJet object. This is useful for cases where the tau seedJet (LC topo jet) is not available in xAOD but one would need to get a handle on some original jet info. The algorithm (TauJetMatching) has a configurable DR matching criterion and for now decorates taus with the matched jet width. It should be executed before OLR. I'm currently using it before tau selection and after tau calibration.

- tau tracks information is now decorated onto the tau in the TauSelector algorithm and retrieved when filling the tau container. This is optional and controlled by the HelperClasses flag trackparams. Performing the decoration is also optional and controlled by the flag m_decorateWithTracks in the TauSelector configuration.

 