### PR TITLE
Add MC/MC scale factors to b-tagging.

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -189,21 +189,21 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	  {
 	    std::string sampleName=wk()->metaData()->castString(SH::MetaFields::sampleName);
 
-	    switch(getMCShowerType(sampleName))
+	    switch(HelperFunctions::getMCShowerType(sampleName))
 	      {
-	      case Pythia8:
+	      case HelperFunctions::Pythia8:
 		calibration="410501";
 		break;
-	      case Herwig7:
+	      case HelperFunctions::Herwig7:
 		calibration="410558";
 		break;
-	      case Sherpa21:
+	      case HelperFunctions::Sherpa21:
 		calibration="426131";
 		break;
-	      case Sherpa22:
+	      case HelperFunctions::Sherpa22:
 		calibration="410250";
 	      break;
-	      case Unknown:
+	      case HelperFunctions::Unknown:
 		ANA_MSG_WARNING("Cannot determine MC shower type for sample " << sampleName << ", assuming Pythia8 (default).");
 		calibration="410501";
 		break;
@@ -448,24 +448,4 @@ EL::StatusCode BJetEfficiencyCorrector :: histFinalize ()
   ANA_CHECK( xAH::Algorithm::algFinalize());
 
   return EL::StatusCode::SUCCESS;
-}
-
-BJetEfficiencyCorrector::ShowerType BJetEfficiencyCorrector :: getMCShowerType(const std::string& sample_name) const
-{
-  //
-  //pre-process sample name
-  TString tmp_name(sample_name);
-  tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
-  if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
-  if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
-  //capitalize the entire sample name
-  tmp_name.ToUpper();
-
-  //
-  // Determine shower type by looking for keywords in name
-  if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
-  else if(tmp_name.Contains("HERWIG")) return Herwig7;
-  else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
-  else if(tmp_name.Contains("SHERPA")) return Sherpa22;
-  else return Unknown;
 }

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -543,3 +543,23 @@ bool HelperFunctions::has_exact(const std::string input, const std::string flag)
 
   return inputSet.find(flag) != inputSet.end();
 }
+
+HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& sample_name)
+{
+  //
+  //pre-process sample name
+  TString tmp_name(sample_name);
+  tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
+  if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
+  if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
+  //capitalize the entire sample name
+  tmp_name.ToUpper();
+
+  //
+  // Determine shower type by looking for keywords in name
+  if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
+  else if(tmp_name.Contains("HERWIG")) return Herwig7;
+  else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
+  else if(tmp_name.Contains("SHERPA")) return Sherpa22;
+  else return Unknown;
+}

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -62,10 +62,6 @@ public:
   std::string m_EfficiencyCalibration = "";
 
 private:
-  /// @brief The different supported shower types
-  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22};
-
-  ShowerType getMCShowerType(const std::string& sample_name) const;
 
   /// @brief The decoration key written to passing objects
   std::string m_decorSF = "";

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -58,7 +58,14 @@ public:
   /// @brief The decoration key written to passing objects
   std::string m_decor = "BTag";
 
+  /// @brief Calibration to use for MC (EfficiencyB/C/T/LightCalibrations), "auto" to determine from sample name
+  std::string m_EfficiencyCalibration = "";
+
 private:
+  /// @brief The different supported shower types
+  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22};
+
+  ShowerType getMCShowerType(const std::string& sample_name) const;
 
   /// @brief The decoration key written to passing objects
   std::string m_decorSF = "";

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -519,6 +519,25 @@ namespace HelperFunctions {
     vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
   }
 
+  /// @brief The different supported shower types
+  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22};
+
+  /**
+    @brief Determines the type of generator used for the shower from the sample name
+    @param sample_name      The name of the sample, usualy the dataset name
+
+    @rst
+    The name of the generator is determined using some common definitions in the ATLAS MC dataset naming scheme. The 
+    case independent strings that are searched for are:
+     * PYTHIA8EVTGEN or Py8EG or PYTHIA : Pythia8
+     * HERWIG : Herwig7
+     * SHERPA_CT : Sherpa21
+     * SHERPA : Sherpa22 (if not Sherpa 21)
+    @endrst
+   */
+  ShowerType getMCShowerType(const std::string& sample_name);
+
+
 } // close namespace HelperFunctions
 
 # endif


### PR DESCRIPTION
Added support for [MC/MC scale factors for b-tagging](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/BTagCalib2017#MC_MC_Scale_Factors_for_Analysis). The MC type can be set via the `m_EfficiencyCalibration`, with `auto` guessing the type from the sample name. The latter was [inspired via SUSYTools](https://gitlab.cern.ch/atlas/athena/blob/c5869763675d1bd421853a58031788c10e9e981e/PhysicsAnalysis/SUSYPhys/SUSYTools/SUSYTools/ISUSYObjDef_xAODTool.h#L157).