### PR TITLE
Properly fail for muon efficiencies

### DIFF
--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -37,7 +37,8 @@ public:
   // configuration variables
   std::string   m_inContainerName = "";
 
-  std::string   m_calibRelease = "Data15_allPeriods_241115";
+  /// @brief Recommendations release (not recommended to change)
+  std::string   m_overrideCalibRelease = "";
 
   // Reco efficiency SF
   std::string   m_WorkingPointReco = "Loose";


### PR DESCRIPTION
Make calibration release non-hardcoded (as it is not recommended to change) - **breaking**.

Also the algorithm will now properly fail if the efficiencies/SF can not be retrieved.