### PR TITLE
Migrate ElectronEfficiencyCorrector to use calibration maps

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -100,7 +100,7 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     if ( !m_infoSwitch.m_PIDWPs.size() ) m_infoSwitch.m_PIDWPs = {"LHLoose","LHLooseBL","LHMedium","LHTight"};
 
     // default PID SF working points if no user input
-    if ( !m_infoSwitch.m_PIDSFWPs.size() ) m_infoSwitch.m_PIDSFWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
+    if ( !m_infoSwitch.m_PIDSFWPs.size() ) m_infoSwitch.m_PIDSFWPs = {"LooseBLayer","Medium","Tight"};
 
     // default isolation working points if no user input
     if ( !m_infoSwitch.m_isolWPs.size() ) m_infoSwitch.m_isolWPs = {"","Gradient","Loose","Tight"};
@@ -881,7 +881,7 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       }
     }
 
-   static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElRecoEff_SF_syst");
+   static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElRecoEff_SF_syst_Reconstruction");
    safeSFVecFill<float, xAOD::Electron>( elec, accRecoSF, m_RecoEff_SF, junkSF );
  }
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -576,7 +576,12 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
     	 ANA_MSG_DEBUG( "Applying PID efficiency SF" );
 
-    	 bool isBadElectron(false);
+       // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
+       //
+       if ( !el_itr->caloCluster() ) {
+         ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster info");
+         continue;
+       }
 
     	 //
     	 // obtain PID efficiency SF as a float (to be stored away separately)
@@ -588,32 +593,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	   sfVecPID ( *el_itr ) = std::vector<float>();
     	 }
 
-    	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
-    	 //
-    	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
-    	   isBadElectron = true;
-    	 }
-    	 //
-    	 // skip electron if outside acceptance for SF calculation
-    	 //
-    	 if ( el_itr->pt() < m_ptThreshold ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
-    	   isBadElectron = true;
-    	 }
-    	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
-    	   isBadElectron = true;
-    	 }
-
     	 //
     	 // obtain efficiency SF's for PID
     	 //
     	 double pidEffSF(-1.0); // tool wants a double
-    	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_PID->getEfficiencyScaleFactor( *el_itr, pidEffSF ) != CP::CorrectionCode::Ok ) {
-    	   ANA_MSG_WARNING( "Problem in PID getEfficiencyScaleFactor Tool");
-  	   pidEffSF = -1.0;
-    	 }
+       CP::CorrectionCode::ErrorCode status = m_asgElEffCorrTool_elSF_PID->getEfficiencyScaleFactor( *el_itr, pidEffSF );
+    	 if ( status == CP::CorrectionCode::Error ) {
+    	   ANA_MSG_ERROR( "Problem in PID getEfficiencyScaleFactor Tool");
+         return EL::StatusCode::FAILURE;
+    	 } else if ( status == CP::CorrectionCode::OutOfValidityRange ) {
+         ANA_MSG_DEBUG( "Electron of of PID efficiency validity range");
+       }
     	 //
     	 // Add it to decoration vector
     	 //
@@ -679,7 +669,12 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
     	 ANA_MSG_DEBUG( "Applying Iso efficiency SF" );
 
-    	 bool isBadElectron(false);
+       // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
+       //
+       if ( !el_itr->caloCluster() ) {
+         ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster info");
+         continue;
+       }
 
     	 //
     	 // obtain Iso efficiency SF as a float (to be stored away separately)
@@ -691,32 +686,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	   sfVecIso ( *el_itr ) = std::vector<float>();
     	 }
 
-    	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
-    	 //
-    	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
-    	   isBadElectron = true;
-    	 }
-    	 //
-    	 // skip electron if outside acceptance for SF calculation
-    	 //
-    	 if ( el_itr->pt() < m_ptThreshold ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
-    	   isBadElectron = true;
-    	 }
-    	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
-    	   isBadElectron = true;
-    	 }
-
     	 //
     	 // obtain efficiency SF's for Iso
     	 //
     	 double IsoEffSF(-1.0); // tool wants a double
-    	 if ( !isBadElectron &&  m_asgElEffCorrTool_elSF_Iso->getEfficiencyScaleFactor( *el_itr, IsoEffSF ) != CP::CorrectionCode::Ok ) {
-    	   ANA_MSG_WARNING( "Problem in Iso getEfficiencyScaleFactor Tool");
-  	   IsoEffSF = -1.0;
-    	 }
+       CP::CorrectionCode::ErrorCode status = m_asgElEffCorrTool_elSF_Iso->getEfficiencyScaleFactor( *el_itr, IsoEffSF );
+    	 if ( status == CP::CorrectionCode::Error ) {
+    	   ANA_MSG_ERROR( "Problem in Iso getEfficiencyScaleFactor Tool");
+         return EL::StatusCode::FAILURE;
+    	 } else if ( status == CP::CorrectionCode::OutOfValidityRange ) {
+         ANA_MSG_DEBUG( "Electron of of Iso efficiency validity range");
+       }
     	 //
     	 // Add it to decoration vector
     	 //
@@ -782,7 +762,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
     	 ANA_MSG_DEBUG( "Applying Reco efficiency SF" );
 
-    	 bool isBadElectron(false);
+       // NB: derivations might remove CaloCluster for low pt electrons: add a safety check!
+       if ( !el_itr->caloCluster() ) {
+         ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster info");
+         continue;
+       }
 
     	 //
     	 // obtain Reco efficiency SF as a float (to be stored away separately)
@@ -794,32 +778,17 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
     	   sfVecReco ( *el_itr ) = std::vector<float>();
     	 }
 
-    	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
-    	 //
-    	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
-  	   isBadElectron = true;
-    	 }
-    	 //
-    	 // skip electron if outside acceptance for SF calculation
-    	 //
-    	 if ( el_itr->pt() < m_ptThreshold ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
-  	   isBadElectron = true;
-    	 }
-    	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
-  	   isBadElectron = true;
-    	 }
-
     	 //
     	 // obtain efficiency SF's for Reco
     	 //
     	 double recoEffSF(-1.0); // tool wants a double
-    	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Reco->getEfficiencyScaleFactor( *el_itr, recoEffSF ) != CP::CorrectionCode::Ok ) {
-    	   ANA_MSG_WARNING( "Problem in Reco getEfficiencyScaleFactor Tool");
-  	   recoEffSF = -1.0;
-    	 }
+       CP::CorrectionCode::ErrorCode status = m_asgElEffCorrTool_elSF_Reco->getEfficiencyScaleFactor( *el_itr, recoEffSF );
+    	 if ( status == CP::CorrectionCode::Error ) {
+    	   ANA_MSG_ERROR( "Problem in Reco getEfficiencyScaleFactor Tool");
+         return EL::StatusCode::FAILURE;
+    	 } else if ( status == CP::CorrectionCode::OutOfValidityRange ) {
+         ANA_MSG_DEBUG( "Electron of of Reco efficiency validity range");
+       }
     	 //
     	 // Add it to decoration vector
     	 //
@@ -901,7 +870,11 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
 
     	 ANA_MSG_DEBUG( "Applying Trigger efficiency SF" );
 
-    	 bool isBadElectron(false);
+       // NB: derivations might remove CaloCluster and tracks for low pt electrons: add a safety check!
+       if ( !el_itr->caloCluster() ) {
+         ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster info");
+         continue;
+       }
 
     	 //
     	 // obtain Trigger efficiency SF as a float (to be stored away separately)
@@ -923,42 +896,28 @@ EL::StatusCode ElectronEfficiencyCorrector :: executeSF ( const xAOD::ElectronCo
          effVecTrig ( *el_itr ) = std::vector<float>();
        }
 
-    	 // NB: derivations might remove CC and tracks for low pt electrons: add a safety check!
-    	 //
-    	 if ( !( el_itr->caloCluster() && el_itr->trackParticle() ) ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", it has no caloCluster or trackParticle info");
-  	   isBadElectron = true;
-    	 }
-    	 //
-    	 // skip electron if outside acceptance for SF calculation
-    	 //
-    	 if ( el_itr->pt() < m_ptThresholdTrigger ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside pT acceptance ( currently SF available for pT > 15 GeV )");
-  	   isBadElectron = true;
-    	 }
-    	 if ( fabs( el_itr->caloCluster()->eta() ) > 2.47 ) {
-    	   ANA_MSG_DEBUG( "Apply SF: skipping electron " << idx << ", is outside |eta| acceptance");
-  	   isBadElectron = true;
-    	 }
-
     	 //
     	 // obtain efficiency SF for Trig
     	 //
     	 double trigEffSF(-1.0); // tool wants a double
-    	 if ( !isBadElectron && m_asgElEffCorrTool_elSF_Trig->getEfficiencyScaleFactor( *el_itr, trigEffSF ) != CP::CorrectionCode::Ok ) {
-    	   ANA_MSG_WARNING( "Problem in Trig getEfficiencyScaleFactor Tool");
-  	   isBadElectron = true;
-  	   trigEffSF = -1.0;
-    	 }
+       CP::CorrectionCode::ErrorCode status = m_asgElEffCorrTool_elSF_Trig->getEfficiencyScaleFactor( *el_itr, trigEffSF );
+    	 if ( status == CP::CorrectionCode::Error ) {
+    	   ANA_MSG_ERROR( "Problem in Trig getEfficiencyScaleFactor Tool");
+         return EL::StatusCode::FAILURE;
+    	 } else if ( status == CP::CorrectionCode::OutOfValidityRange ) {
+         ANA_MSG_DEBUG( "Electron of of Trig efficiency validity range");
+       }
 
        //
        // obtain Trig MC efficiency
        //
        double trigMCEff(-1.0); // tool wants a double
-       if ( !isBadElectron && m_asgElEffCorrTool_elSF_TrigMCEff->getEfficiencyScaleFactor( *el_itr, trigMCEff ) != CP::CorrectionCode::Ok ) {
-         ANA_MSG_WARNING( "Problem in TrigMCEff getEfficiencyScaleFactor Tool");
-       isBadElectron = true;
-       trigMCEff = -1.0;
+       CP::CorrectionCode::ErrorCode statusEff = m_asgElEffCorrTool_elSF_TrigMCEff->getEfficiencyScaleFactor( *el_itr, trigMCEff );
+       if ( statusEff == CP::CorrectionCode::Error ) {
+         ANA_MSG_ERROR( "Problem in TrigMCEff getEfficiencyScaleFactor Tool");
+         return EL::StatusCode::FAILURE;
+       } else if ( statusEff == CP::CorrectionCode::OutOfValidityRange ) {
+         ANA_MSG_DEBUG( "Electron of of TrigMCEff efficiency validity range");
        }
 
     	 //

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -530,64 +530,6 @@ std::size_t HelperFunctions::string_pos( const std::string& haystack, const std:
   return pos;
 }
 
-
-std::string HelperFunctions::parse_wp( const std::string& type, const std::string& config_name, MsgStream& msg )
-{
-  std::string funcName{"in parse_wp(): "};
-  std::string wp("");
-  // let's split the path up into pieces we understand
-  std::size_t last_path = config_name.find_last_of("/\\");
-  std::string basename = config_name.substr(last_path + 1);
-  std::string dirpath = config_name.substr(0, last_path);
-  std::string dirname = dirpath.substr(dirpath.find_last_of("/\\") + 1);
-  // the path we search on
-  std::string path = dirname + "/" + basename;
-
-  std::size_t found_substr;
-  // for string_pos
-  std::string needle = ".";
-
-  msg << MSG::INFO << funcName << type << " " << path << endmsg;
-
-  std::size_t init;
-  std::size_t end;
-
-  if ( type.compare("ISO") == 0 ) {
-    found_substr = path.find("_isol");
-    if ( found_substr == std::string::npos ) { return wp; }
-
-    init = found_substr + 5;
-    end  = path.find(".root");
-
-  } else if ( type.compare("ID") == 0 ) {
-    found_substr = path.find("LLH");
-    if ( found_substr == std::string::npos ) { return wp; }
-
-    init = string_pos( path, needle, 2 ) + 1;
-    end  = found_substr + 3;
-
-  } else if ( type.compare("TRIG") == 0 ) {
-    found_substr = path.find("trigger");
-    if ( found_substr == std::string::npos ) { return wp; }
-
-    init = string_pos( path, needle, 1 ) + 1;
-    end  = string_pos( path, needle, 2 );
-
-  } else {
-    msg << MSG::WARNING << funcName << "WP type can be either 'ISO' or 'ID'. Please check passed parameters of this function. Returning empty WP." << endmsg;
-    return wp;
-  }
-
-  if(end == std::string::npos)
-    wp = path.substr( init );
-  else
-    wp = path.substr( init, (end - init) );
-
-  msg << MSG::INFO << funcName << type << " (init, end)=(" << init << "," << end << ") " << wp << endmsg;
-
-  return wp;
-}
-
 bool HelperFunctions::has_exact(const std::string input, const std::string flag)
 {
   std::set<std::string> inputSet;

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -88,12 +88,6 @@ public:
   /// @brief Override corrections map file (not recommended)
   std::string m_overrideMapFilePath = "";
 
-  /// @brief Defines the acceptance region for calculating scale factors
-  float m_ptThreshold = 4.5e3;
-
-  /// @brief Defines the acceptance region for calculating trigger scale factors
-  float m_ptThresholdTrigger = 7e3;
-
 private:
   int m_numEvent;         //!
   int m_numObject;        //!

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -61,46 +61,47 @@ public:
   float m_systValIso = 0.0;
   float m_systValReco = 0.0;
   float m_systValTrig = 0.0;
-  float m_systValTrigMCEff = 0.0;
   std::string m_systNamePID = "";
   std::string m_systNameIso = "";
   std::string m_systNameReco = "";
   std::string m_systNameTrig = "";
-  std::string m_systNameTrigMCEff = "";
   std::string m_outputSystNamesPID = "EleEffCorr_PIDSyst";
   std::string m_outputSystNamesIso = "EleEffCorr_IsoSyst";
   std::string m_outputSystNamesReco = "EleEffCorr_RecoSyst";
   std::string m_outputSystNamesTrig = "EleEffCorr_TrigSyst";
-  std::string m_outputSystNamesTrigMCEff = "EleEffCorr_TrigMCEffSyst";
+
+  /// @brief Systematic correlation model
   std::string m_correlationModel = "FULL";
 
-  std::string m_corrFileNamePID = "";
-  std::string m_corrFileNameIso = "";
-  std::string m_corrFileNameReco = "";
-  std::string m_corrFileNameTrig = "";
-  std::string m_corrFileNameTrigMCEff = "";
+  /// @brief PID working point (LooseBLayer, Medium, Tight)
+  std::string m_WorkingPointPID = "";
+
+  /// @brief Isolation working point
+  std::string m_WorkingPointIso = "";
+
+  /// @brief Reconstruction working point (Reconstruction only)
+  std::string m_WorkingPointReco = "";
+
+  /// @brief Trigger working point
+  std::string m_WorkingPointTrig = "";
+
+  /// @brief Override corrections map file (not recommended)
+  std::string m_overrideMapFilePath = "";
 
   /// @brief Defines the acceptance region for calculating scale factors
   float m_ptThreshold = 4.5e3;
+
+  /// @brief Defines the acceptance region for calculating trigger scale factors
   float m_ptThresholdTrigger = 7e3;
 
 private:
   int m_numEvent;         //!
   int m_numObject;        //!
 
-  std::string m_PID_WP;    //!
-  std::string m_Iso_WP;    //!
-  std::string m_IsoPID_WP; //!
-
-  std::string m_WorkingPointIDTrig;  //!
-  std::string m_WorkingPointIsoTrig; //!
-  std::string m_WorkingPointTrigTrig; //!
-
   std::vector<CP::SystematicSet> m_systListPID;  //!
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
-  std::vector<CP::SystematicSet> m_systListTrigMCEff; //!
 
   // tools
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID = nullptr;  //!

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -82,14 +82,6 @@ namespace HelperFunctions {
   */
   std::size_t string_pos( const std::string& haystack, const std::string& needle, unsigned int N );
 
-  /**
-    Function which returns the WP for ISO/ID from a config file.
-    Returns empty string if no WP is found.
-
-  */
-  std::string parse_wp( const std::string& type, const std::string& config_name, MsgStream& msg );
-  inline std::string parse_wp( const std::string& type, const std::string& config_name ) { return parse_wp(type, config_name, msg()); }
-
   /*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*\
   |                                                                            |
   |   Author  : Marco Milesi                                                   |


### PR DESCRIPTION
This migrates ElectronEfficiencyCorrector to use calibration maps. It is also recommended not to change the map as always the latest should be available.

E/gamma changed their WP names again so this also changes the output a little unfortunately so the change is **breaking**.

Also we now let the tool decide if we are in the acceptance range (if not, it will return 1).