### PR TITLE
Properly fail for jet efficiencies

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -329,25 +329,20 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
 	// get the scale factor
 	float SF(-1.0);
-	// if only decorator with decision because OP is not calibrated, set SF to 1
-	if ( fabs(jet_itr->eta()) < 2.5 ) {
-
-	  CP::CorrectionCode BJetEffCode;
-	  // if passes cut take the efficiency scale factor
-	  // if failed cut take the inefficiency scale factor
-	  if( tagged ) {
-	    BJetEffCode = m_BJetEffSFTool_handle->getScaleFactor( *jet_itr, SF );
-	  } else {
-	    BJetEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, SF );
-	  }
-	  if (BJetEffCode == CP::CorrectionCode::Error){
-	    ANA_MSG_WARNING( "Error in getEfficiencyScaleFactor");
-	    SF = -1.0;
-	    //return EL::StatusCode::FAILURE;
-	  }
-	  // if it is out of validity range (jet pt > 1200 GeV), the tools just applies the SF at 200 GeV
-	  //if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange)
-	} // eta < 2.5
+  CP::CorrectionCode BJetEffCode;
+  // if passes cut take the efficiency scale factor
+  // if failed cut take the inefficiency scale factor
+  if( tagged ) {
+    BJetEffCode = m_BJetEffSFTool_handle->getScaleFactor( *jet_itr, SF );
+  } else {
+    BJetEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, SF );
+  }
+  if (BJetEffCode == CP::CorrectionCode::Error) {
+    ANA_MSG_ERROR( "Error in getEfficiencyScaleFactor");
+    return EL::StatusCode::FAILURE;
+  } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
+    ANA_MSG_DEBUG( "Jet is out of validity range");
+  }
 
 	// Add it to vector
 	sfVec.push_back(SF);

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -641,7 +641,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
             sfVecJVT( *jet ) = std::vector<float>();
           }
 
-          float jvtSF(-1.0);
+          float jvtSF(1.0);
           if ( m_JVT_tool_handle->isInRange(*jet) ) {
             // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
             if ( m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) {
@@ -649,16 +649,16 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
                 passedJVT( *jet ) = 0; // mark as not passed
               }
               if ( m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
-                ANA_MSG_WARNING( "Problem in JVT Tool getInefficiencyScaleFactor");
-                jvtSF = -1.0;
+                ANA_MSG_ERROR( "Error in JVT Tool getInefficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
               }
             } else { // otherwise classic efficiency scale factor
               if ( syst_it.name().empty() ) {
                 passedJVT( *jet ) = 1;
               }
               if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
-                ANA_MSG_WARNING( "Problem in JVT Tool getEfficiencyScaleFactor");
-                jvtSF = -1.0;
+                ANA_MSG_ERROR( "Error in JVT Tool getEfficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
               }
             }
           }
@@ -761,18 +761,18 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
             sfVecfJVT( *jet ) = std::vector<float>();
           }
 
-          float fjvtSF(-1.0);
+          float fjvtSF(1.0);
           if ( m_fJVT_eff_tool_handle->isInRange(*jet) ) {
             // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
             if ( !m_dofJVTVeto && jet->auxdata<char>("passFJVT") != 1 ) {
               if ( m_fJVT_eff_tool_handle->getInefficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
-                ANA_MSG_WARNING( "Problem in fJVT Tool getInefficiencyScaleFactor");
-                fjvtSF = -1.0;
+                ANA_MSG_ERROR( "Error in fJVT Tool getInefficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
               }
             } else { // otherwise classic efficiency scale factor
               if ( m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
-                ANA_MSG_WARNING( "Problem in fJVT Tool getEfficiencyScaleFactor");
-                fjvtSF = -1.0;
+                ANA_MSG_ERROR( "Error in fJVT Tool getEfficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
               }
             }
           }


### PR DESCRIPTION
Properly fail for JVT, fJVT and flavour tagging efficiencies.

Additionally, do not hardcode flavour tagging eta acceptance and leave it to the tool to decide.