### PR TITLE
Add new egamma charge-flip support

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -94,6 +94,11 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     m_PromptLeptonIso                   = new std::vector<float> ();
     m_PromptLeptonVeto                  = new std::vector<float> ();
   }
+  
+  if ( m_infoSwitch.m_chflipBDT ) {
+    m_ECIDSPassed = new std::vector<int> ();
+    m_ECIDSResult = new std::vector<float> ();
+  }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
 
@@ -205,6 +210,11 @@ ElectronContainer::~ElectronContainer()
     delete m_PromptLeptonInput_sv1_jf_ntrkv    ;
     delete m_PromptLeptonIso                   ;
     delete m_PromptLeptonVeto                  ;
+  }
+
+  if ( m_infoSwitch.m_chflipBDT ) {
+    delete m_ECIDSPassed;
+    delete m_ECIDSResult;
   }
 
 }
@@ -327,6 +337,10 @@ void ElectronContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "PromptLeptonVeto",                 &m_PromptLeptonVeto);
   }
 
+  if ( m_infoSwitch.m_chflipBDT ) {
+    connectBranch<int>  (tree, "ECIDSPassed", &m_ECIDSPassed);
+    connectBranch<float>(tree, "ECIDSResult", &m_ECIDSResult);
+  }
 }
 
 void ElectronContainer::updateParticle(uint idx, Electron& elec)
@@ -445,6 +459,11 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
     elec.PromptLeptonVeto                  = m_PromptLeptonVeto                  ->at(idx);
   }
 
+  // charge-flip BDT
+  if ( m_infoSwitch.m_chflipBDT ) {
+    elec.ECIDSPassed = m_ECIDSPassed->at(idx);
+    elec.ECIDSResult = m_ECIDSResult->at(idx);
+  }
 }
 
 
@@ -551,6 +570,11 @@ void ElectronContainer::setBranches(TTree *tree)
     setBranch<int>  (tree, "PromptLeptonInput_sv1_jf_ntrkv",    m_PromptLeptonInput_sv1_jf_ntrkv);
     setBranch<float>(tree, "PromptLeptonIso",                   m_PromptLeptonIso);
     setBranch<float>(tree, "PromptLeptonVeto",                  m_PromptLeptonVeto);
+  }
+
+  if ( m_infoSwitch.m_chflipBDT ) {
+    setBranch<int>  (tree, "ECIDSPassed", m_ECIDSPassed);
+    setBranch<float>(tree, "ECIDSResult", m_ECIDSResult);
   }
 
   return;
@@ -660,6 +684,11 @@ void ElectronContainer::clear()
     m_PromptLeptonInput_sv1_jf_ntrkv     -> clear();
     m_PromptLeptonIso                    -> clear();
     m_PromptLeptonVeto                   -> clear();
+  }
+
+  if ( m_infoSwitch.m_chflipBDT ) {
+    m_ECIDSPassed->clear();
+    m_ECIDSResult->clear();
   }
 
 }
@@ -853,6 +882,14 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
     m_PromptLeptonInput_sv1_jf_ntrkv   ->push_back( acc_sv1_jf_ntrkv   .isAvailable(*elec) ? acc_sv1_jf_ntrkv(*elec)   : -100);
     m_PromptLeptonIso                  ->push_back( acc_Iso            .isAvailable(*elec) ? acc_Iso(*elec)            : -100);
     m_PromptLeptonVeto                 ->push_back( acc_Veto           .isAvailable(*elec) ? acc_Veto(*elec)           : -100);
+  }
+
+  if ( m_infoSwitch.m_chflipBDT ) {
+    static SG::AuxElement::ConstAccessor<char>  acc_ECIDSPassed("DFCommonElectronsECIDS");
+    static SG::AuxElement::ConstAccessor<float> acc_ECIDSResult("DFCommonElectronsECIDSResult");
+
+    safeFill<char,  int,   xAOD::Electron>( elec, acc_ECIDSPassed, m_ECIDSPassed, -1    );
+    safeFill<float, float, xAOD::Electron>( elec, acc_ECIDSResult, m_ECIDSResult, -9999 );
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -207,6 +207,7 @@ namespace HelperClasses{
     m_trackparams   = has_exact("trackparams");
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
+    m_chflipSF      = has_exact("chflipSF");
     m_promptlepton  = has_exact("promptlepton");
     // working points for scale-factors
 

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -208,6 +208,7 @@ namespace HelperClasses{
     m_trackhitcont  = has_exact("trackhitcont");
     m_effSF         = has_exact("effSF");
     m_chflipSF      = has_exact("chflipSF");
+    m_chflipBDT     = has_exact("chflipBDT");
     m_promptlepton  = has_exact("promptlepton");
     // working points for scale-factors
 

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -42,6 +42,7 @@ namespace xAH {
     std::map< std::string, std::vector< float > > IsoEff_SF;
     std::map< std::string, std::vector< float > > TrigEff_SF;
     std::map< std::string, std::vector< float > > TrigMCEff;
+    std::map< std::string, std::vector< float > > ChflipEff_SF;
     //const std::vector< std::string > m_PIDWPs = {"LooseAndBLayerLLH","MediumLLH","TightLLH"};
     //const std::vector< std::string > m_isolWPs = {"","_isolFixedCutLoose","_isolFixedCutTight","_isolFixedCutTightTrackOnly","_isolGradient","_isolGradientLoose","_isolLoose","_isolLooseTrackOnly","_isolTight"};
 

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -86,6 +86,9 @@ namespace xAH {
     float PromptLeptonIso;
     float PromptLeptonVeto;
 
+    // charge-flip BDT
+    int   ECIDSPassed;
+    float ECIDSResult;
   };
 
 }//xAH

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -66,6 +66,7 @@ namespace xAH {
       std::map< std::string, std::vector< std::vector< float > > >* m_IsoEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigEff_SF;
       std::map< std::string, std::vector< std::vector< float > > >* m_TrigMCEff;
+      std::map< std::string, std::vector< std::vector< float > > >* m_ChflipEff_SF;
 
       // reco parameters
       std::vector<int>* m_author;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -108,6 +108,9 @@ namespace xAH {
       std::vector<float>* m_PromptLeptonIso;
       std::vector<float>* m_PromptLeptonVeto;
 
+      // charge-flip BDT
+      std::vector<int>*   m_ECIDSPassed;
+      std::vector<float>* m_ECIDSResult;
     };
 }
 #endif // xAODAnaHelpers_ElectronContainer_H

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -19,6 +19,7 @@
 
 // external tools include(s):
 #include "ElectronEfficiencyCorrection/AsgElectronEfficiencyCorrectionTool.h"
+#include "ElectronEfficiencyCorrection/ElectronChargeEfficiencyCorrectionTool.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -61,14 +62,17 @@ public:
   float m_systValIso = 0.0;
   float m_systValReco = 0.0;
   float m_systValTrig = 0.0;
+  float m_systValChflip = 0.0;
   std::string m_systNamePID = "";
   std::string m_systNameIso = "";
   std::string m_systNameReco = "";
   std::string m_systNameTrig = "";
+  std::string m_systNameChflip = "";
   std::string m_outputSystNamesPID = "EleEffCorr_PIDSyst";
   std::string m_outputSystNamesIso = "EleEffCorr_IsoSyst";
   std::string m_outputSystNamesReco = "EleEffCorr_RecoSyst";
   std::string m_outputSystNamesTrig = "EleEffCorr_TrigSyst";
+  std::string m_outputSystNamesChflip = "EleEffCorr_ChflipSyst";
 
   /// @brief Systematic correlation model
   std::string m_correlationModel = "FULL";
@@ -85,6 +89,9 @@ public:
   /// @brief Trigger working point
   std::string m_WorkingPointTrig = "";
 
+  /// @brief Charge-flip efficiency path (currently not in the map file)
+  std::string m_ChflipCorrectionPath = "";
+
   /// @brief Override corrections map file (not recommended)
   std::string m_overrideMapFilePath = "";
 
@@ -96,6 +103,7 @@ private:
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListTrig; //!
+  std::vector<CP::SystematicSet> m_systListChflip; //!
 
   // tools
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_PID = nullptr;  //!
@@ -108,6 +116,8 @@ private:
   std::string m_TrigEffSF_tool_name;                                  //!
   AsgElectronEfficiencyCorrectionTool  *m_asgElEffCorrTool_elSF_TrigMCEff = nullptr; //!
   std::string m_TrigMCEff_tool_name;                                  //!
+  CP::ElectronChargeEfficiencyCorrectionTool *m_elChflipEffCorrTool = nullptr; //!
+  std::string m_ChflipEffSF_tool_name;                                //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -20,6 +20,7 @@
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
+#include "EgammaAnalysisInterfaces/IAsgElectronLikelihoodTool.h"
 #include "IsolationSelection/IIsolationSelectionTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
@@ -185,6 +186,12 @@ public:
   /// Recommended threshold for egamma triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.07;
 
+/* charge-flip */
+  /** @brief Recalculate charge-flip ECIDS BDT, not needed by default */
+  bool m_recalculateECIDS = false;
+  /** @brief ECIDS training file */
+  std::string m_ECIDSTrainingFile = "";
+
 private:
 
   /**
@@ -253,6 +260,7 @@ private:
   CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                                 //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                       }; //!
   asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle {"Trig::MatchingTool/MatchingTool"                  , this}; //!
+  asg::AnaToolHandle<IAsgElectronLikelihoodTool> m_electronChargeIDSelectorTool_handle{"AsgElectronChargeIDSelectorTool/AsgElectronChargeIDSelectorTool", this}; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
   bool m_doTrigMatch = true;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -319,6 +319,7 @@ namespace HelperClasses {
         m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern
+        m_chflipSF            chflipSF            exact
         ===================== =================== =======
 
         .. note::
@@ -348,6 +349,7 @@ namespace HelperClasses {
     bool m_trackparams;
     bool m_trackhitcont;
     bool m_effSF;
+    bool m_chflipSF;
     bool m_promptlepton;
     std::vector< std::string > m_PIDWPs;
     std::vector< std::string > m_PIDSFWPs;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -319,6 +319,7 @@ namespace HelperClasses {
         m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern
+        m_chflipBDT           chflipBDT           exact
         m_chflipSF            chflipSF            exact
         ===================== =================== =======
 
@@ -350,6 +351,7 @@ namespace HelperClasses {
     bool m_trackhitcont;
     bool m_effSF;
     bool m_chflipSF;
+    bool m_chflipBDT;
     bool m_promptlepton;
     std::vector< std::string > m_PIDWPs;
     std::vector< std::string > m_PIDSFWPs;


### PR DESCRIPTION
This MR adds support to:
 - central charge-flip SFs
 - charge-flip killer variables and recalculation

Note that charge-flip SFs for some reason use a different tool and need a file explicitly set. I try to autogenerate the filename for now and one only needs to specify the path but this introduces some hardcoded stuff - let me know if this is acceptable.