### PR TITLE
Update MET significance interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,8 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.39
-    - RELEASE=AnalysisTop,21.2.39
-    - RELEASE=AnalysisBase,21.2.38
-    - RELEASE=AnalysisTop,21.2.38
-    - RELEASE=AnalysisBase,21.2.37
-    - RELEASE=AnalysisTop,21.2.37
-    - RELEASE=AnalysisBase,21.2.36
-    - RELEASE=AnalysisTop,21.2.36
-    - RELEASE=AnalysisBase,21.2.35
-    - RELEASE=AnalysisTop,21.2.35
-    - RELEASE=AnalysisBase,21.2.34
-    - RELEASE=AnalysisTop,21.2.34
+    - RELEASE=AnalysisBase,21.2.51
+    - RELEASE=AnalysisTop,21.2.51
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -9,6 +9,7 @@
 #include "METUtilities/CutsMETMaker.h"
 #include "PATInterfaces/SystematicVariation.h"
 
+#include "xAODEventInfo/EventInfo.h"
 #include "xAODEgamma/PhotonContainer.h"
 #include "xAODEgamma/ElectronContainer.h"
 #include "xAODMuon/MuonContainer.h"
@@ -185,6 +186,8 @@ EL::StatusCode METConstructor :: execute ()
    m_numEvent ++ ;
    //ANA_MSG_DEBUG("number of processed events now is : "<< m_numEvent);
 
+   const xAOD::EventInfo* eventInfo(nullptr);
+   ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()));
 
    const xAOD::MissingETContainer* coreMet(0);
    ANA_CHECK( HelperFunctions::retrieve(coreMet, m_coreName, m_event, m_store, msg()));
@@ -525,9 +528,9 @@ EL::StatusCode METConstructor :: execute ()
        for ( const std::string &name : totalMETNames ) {
          // Calculate MET significance
          if ( !m_rebuildUsingTracksInJets ) {
-           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, "RefJet", "PVSoftTrk", name) );
+           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, eventInfo->averageInteractionsPerCrossing(), "RefJet", "PVSoftTrk", name) );
          } else {
-           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, "RefJetTrk", "PVSoftTrk", name) );
+           ANA_CHECK( m_metSignificance_handle->varianceMET(newMet, eventInfo->averageInteractionsPerCrossing(), "RefJetTrk", "PVSoftTrk", name) );
          }
 
          // Decorate MET object with results


### PR DESCRIPTION
Update MET significance interface that changed in 21.2.50.

**Note: requires 21.2.50 (updated in travis)!**