### PR TITLE
Modify minor JES uncertainty and smearing changes

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -179,6 +179,8 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
+  if(m_uncertMCType.empty()) m_uncertMCType = m_isFullSim ? "MC16" : "AFII";
+
   // initialize jet calibration tool
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("JetCollection",m_jetAlgo));

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -143,8 +143,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-  m_uncertMCType = "MC16";
-
   if ( !isMC() ) {
     // Insitu should not be applied to the trimmed jets, per Jet/Etmiss recommendation
     if ( m_forceInsitu && m_calibSequence.find("Insitu") == std::string::npos) m_calibSequence += "_Insitu";
@@ -175,7 +173,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
     if ( !m_isFullSim ) {
       m_calibConfig = m_calibConfigAFII;
-      m_uncertMCType = "AFII";
     } else {
       // Insitu should not be applied to the trimmed jets, per Jet/Etmiss recommendation
       if ( m_forceSmear && m_calibSequence.find("Smear") == std::string::npos) m_calibSequence += "_Smear";

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -69,7 +69,7 @@ public:
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
   /// @brief MC type for Jet Uncertainty Tool
-  std::string m_uncertMCType = "MC16";
+  std::string m_uncertMCType = "";
   /// @brief Override CalibArea tag (default recommended)
   std::string m_overrideCalibArea = "";
   /// @brief Override uncertainties CalibArea tag (default recommended)
@@ -89,7 +89,7 @@ public:
   @endrst */
   bool m_setAFII = false;
   /// @brief when running data "_Insitu" is appended to calibration sequence
-  bool m_forceInsitu = true;
+  bool m_forceInsitu = false;
   /// @brief when running FullSim "_Smear" is appended to calibration sequence
   bool m_forceSmear = false;
   /// @brief when using DEV mode of JetCalibTools

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -68,6 +68,8 @@ public:
   std::string m_calibSequence = "JetArea_Residual_EtaJES_GSC";
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
+  /// @brief MC type for Jet Uncertainty Tool
+  std::string m_uncertMCType = "MC16";
   /// @brief Override CalibArea tag (default recommended)
   std::string m_overrideCalibArea = "";
   /// @brief Override uncertainties CalibArea tag (default recommended)
@@ -89,7 +91,7 @@ public:
   /// @brief when running data "_Insitu" is appended to calibration sequence
   bool m_forceInsitu = true;
   /// @brief when running FullSim "_Smear" is appended to calibration sequence
-  bool m_forceSmear = true;
+  bool m_forceSmear = false;
   /// @brief when using DEV mode of JetCalibTools
   bool m_jetCalibToolsDEV = false;
 
@@ -136,7 +138,6 @@ private:
   bool m_isFullSim;       //!
 
   std::string m_calibConfig; //!
-  std::string m_uncertMCType; //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 


### PR DESCRIPTION
This is a super simple request which changes 2 things that were recently done in JetCalibrator (in #1272 ):

- Revert `m_uncertMCType` to be configurable. It was recently changed to automatically be set to `MC16` or `AFII` depending on the type of simulation, but this breaks compatibility with existing fat jet calibrations for example.
- Change the default value of `m_forceSmear` to false. This is to avoid confusing default behavior that people have no way of knowing about without reading through the source code (I for one spent a fair amount of time trying to figure out why the tool was attempting to smear my fat jets when I didn't didn't configure it to). Anyone who wants this feature should turn it on in their configuration, or simply include smearing in their CalibSequence.