### PR TITLE
Add functionality for pT-dependent HF-aware overlap removal scheme

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -325,7 +325,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
   SG::AuxElement::Decorator< char > dec_isBTag( m_decor );
   SG::AuxElement::Decorator< std::vector<float> > dec_sfBTag( m_decorSF );
-
   //
   // run the btagging decision and get scale factors
   //
@@ -379,7 +378,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
     ANA_MSG_DEBUG( "Jet is out of validity range");
   }
-
 	// Add it to vector
 	sfVec.push_back(SF);
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -402,6 +402,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -402,6 +402,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -403,7 +403,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -406,7 +406,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,6 +1,7 @@
 
 
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -406,6 +406,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -402,7 +402,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -403,6 +403,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,4 +1,3 @@
-
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.
@@ -54,6 +53,7 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
   return EL::StatusCode::SUCCESS;
 }
+
 
 
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -405,7 +405,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,7 +1,3 @@
-
-
-
-
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -56,7 +56,6 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
 
 
-
 EL::StatusCode BJetEfficiencyCorrector :: histInitialize ()
 {
   ANA_CHECK( xAH::Algorithm::algInitialize());
@@ -326,6 +325,8 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
   SG::AuxElement::Decorator< char > dec_isBTag( m_decor );
   SG::AuxElement::Decorator< std::vector<float> > dec_sfBTag( m_decorSF );
+
+  SG::AuxElement::Decorator< char > dec_isBTagOR( m_decor+"OR" );
   //
   // run the btagging decision and get scale factors
   //
@@ -341,6 +342,15 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     else {
       dec_isBTag( *jet_itr ) = 0;
       tagged = false;
+    }
+
+    // Add pT-dependent b-tag decision decorator (intended for use in OR)
+    if ((m_orBJetPtUpperThres < 0 || m_orBJetPtUpperThres > (*jet_itr).pt()/1000.) // passes pT criteria
+	&& m_BJetSelectTool_handle->accept( *jet_itr ) ) {
+      dec_isBTagOR( *jet_itr ) = 1;
+    }
+    else {
+      dec_isBTagOR( *jet_itr ) = 0;
     }
 
     // Create Scale Factor aux for all jets
@@ -379,6 +389,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
     ANA_MSG_DEBUG( "Jet is out of validity range");
   }
+
 	// Add it to vector
 	sfVec.push_back(SF);
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -405,6 +405,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,3 +1,4 @@
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,4 +1,5 @@
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -404,7 +404,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,5 +1,6 @@
 
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -402,7 +402,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -58,6 +58,9 @@ public:
   /// @brief The decoration key written to passing objects
   std::string m_decor = "BTag";
 
+  /// @brief upper pt threshold of b-jet in OR in unit of GeV, negative value means no pt threshold
+  float m_orBJetPtUpperThres=-1;
+
   /// @brief Calibration to use for MC (EfficiencyB/C/T/LightCalibrations), "auto" to determine from sample name
   std::string m_EfficiencyCalibration = "";
 


### PR DESCRIPTION
Some analyses (at least in the SUSY group) are testing a pT-dependent HF-aware OR scheme, where b-jets are favored over electrons in overlap removal *only* if the b-jet pT is below some threshold. See for example here https://indico.cern.ch/event/734312/contributions/3077972/attachments/1687953/2715012/BjetOR_MC16ad_Data151617_SummaryBkgF_July17.pdf (starting on slide 4)

This PR adds the same functionality to xAH by adding an extra decorator to the jet container which contains a pT-dependent b-tag decision. The name of the variable is identical to the standard decorator with "OR" at the end. This variable is the same as the standard b-tag decision if the jet pT is below the user-defined threshold, and it is 0 if the pT is above the threshold. If the threshold is negative, this variable will be identical to the standard regardless of the jet pT.

To use this scheme in overlap removal, the user simply needs to pass the "OR" b-tag decorator rather than the standard decorator as the `m_bTagWP` flag in the OverlapRemover.