### PR TITLE
Adjust default jet calibration behavior, allow uncertainty configuration

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -179,6 +179,8 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
+  if(m_uncertMCType.empty()) m_uncertMCType = m_isFullSim ? "MC16" : "AFII";
+
   // initialize jet calibration tool
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("JetCollection",m_jetAlgo));

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -144,6 +144,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   if ( !isMC() ) {
+    m_isFullSim = false;
     // Insitu should not be applied to the trimmed jets, per Jet/Etmiss recommendation
     if ( m_forceInsitu && m_calibSequence.find("Insitu") == std::string::npos) m_calibSequence += "_Insitu";
 
@@ -180,6 +181,39 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
 
   if(m_uncertMCType.empty()) m_uncertMCType = m_isFullSim ? "MC16" : "AFII";
+
+  // Autoconfigure calibration sequence if the user didn't do it.
+  // Recommended strings taken from ApplyJetCalibrationR21 Twiki.
+  if(m_calibSequence.empty()){
+    // Standard R=0.4 jets
+    if(m_inContainerName.find("AntiKt4EM") != std::string::npos){
+      if(!isMC())          m_calibSequence = "JetArea_Residual_EtaJES_GSC_Insitu";
+      else if(m_isFullSim) m_calibSequence = "JetArea_Residual_EtaJES_GSC_Smear";
+      else /*AFII*/        m_calibSequence = "JetArea_Residual_EtaJES_GSC";
+    }
+    // R-scan jets
+    else if(m_inContainerName.find("AntiKt2LCTopo") != std::string::npos ||
+            m_inContainerName.find("AntiKt6LCTopo") != std::string::npos)
+      m_calibSequence = "JetArea_Residual_EtaJES_GSC";
+    // R=1.0 jets
+    else if(m_inContainerName.find("AntiKt10LCTopo")           != std::string::npos ||
+            m_inContainerName.find("AntiKt10TrackCaloCluster") != std::string::npos)
+      m_calibSequence = "EtaJES_JMS";
+    // Anything else is unrecognized
+    else{
+      ANA_MSG_ERROR( "Cannot autoconfigure jet calibration sequence for collection " << m_systName);
+      ANA_MSG_ERROR( "JetCalibrator::m_calibSequence needs to be set manually in configuration.");
+      return EL::StatusCode::FAILURE;
+    }
+  }
+
+  // Warn user if they're running standard jets without in-situ in data or smearing in MC
+  if(m_inContainerName.find("AntiKt4EM") != std::string::npos){
+    if(!isMC() && m_calibSequence.find("_Insitu") == std::string::npos)
+      ANA_MSG_WARNING("Calibrating AntiKt4EM jets in data without the in-situ step. This is not recommended, make sure it's really what you want!");
+    else if(m_isFullSim && m_calibSequence.find("_Smear") == std::string::npos)
+      ANA_MSG_WARNING("Calibrating AntiKt4EM jets in fullsim without the smearing step. This is not recommended, make sure it's really what you want!");
+  }
 
   // initialize jet calibration tool
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -143,8 +143,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
-  m_uncertMCType = "MC16";
-
   if ( !isMC() ) {
     // Insitu should not be applied to the trimmed jets, per Jet/Etmiss recommendation
     if ( m_forceInsitu && m_calibSequence.find("Insitu") == std::string::npos) m_calibSequence += "_Insitu";
@@ -175,7 +173,6 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
     if ( !m_isFullSim ) {
       m_calibConfig = m_calibConfigAFII;
-      m_uncertMCType = "AFII";
     } else {
       // Insitu should not be applied to the trimmed jets, per Jet/Etmiss recommendation
       if ( m_forceSmear && m_calibSequence.find("Smear") == std::string::npos) m_calibSequence += "_Smear";

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -69,7 +69,7 @@ public:
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
   /// @brief MC type for Jet Uncertainty Tool
-  std::string m_uncertMCType = "MC16";
+  std::string m_uncertMCType = "";
   /// @brief Override CalibArea tag (default recommended)
   std::string m_overrideCalibArea = "";
   /// @brief Override uncertainties CalibArea tag (default recommended)
@@ -89,7 +89,7 @@ public:
   @endrst */
   bool m_setAFII = false;
   /// @brief when running data "_Insitu" is appended to calibration sequence
-  bool m_forceInsitu = true;
+  bool m_forceInsitu = false;
   /// @brief when running FullSim "_Smear" is appended to calibration sequence
   bool m_forceSmear = false;
   /// @brief when using DEV mode of JetCalibTools

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -64,8 +64,8 @@ public:
   std::string m_calibConfigFullSim = "JES_data2017_2016_2015_Recommendation_Aug2018_rel21.config";
   /// @brief config for JetCalibrationTool for AFII MC
   std::string m_calibConfigAFII = "JES_MC16Recommendation_AFII_EMTopo_April2018_rel21.config";
-  /// @brief List of calibration steps. "Insitu" added automatically if running on data and "Smear" if running on FullSim MC
-  std::string m_calibSequence = "JetArea_Residual_EtaJES_GSC";
+  /// @brief List of calibration steps. Auto-configured to the Jet/Etmiss recommendation if left blank.
+  std::string m_calibSequence = "";
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
   /// @brief MC type for Jet Uncertainty Tool

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -68,6 +68,8 @@ public:
   std::string m_calibSequence = "JetArea_Residual_EtaJES_GSC";
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
+  /// @brief MC type for Jet Uncertainty Tool
+  std::string m_uncertMCType = "MC16";
   /// @brief Override CalibArea tag (default recommended)
   std::string m_overrideCalibArea = "";
   /// @brief Override uncertainties CalibArea tag (default recommended)
@@ -89,7 +91,7 @@ public:
   /// @brief when running data "_Insitu" is appended to calibration sequence
   bool m_forceInsitu = true;
   /// @brief when running FullSim "_Smear" is appended to calibration sequence
-  bool m_forceSmear = true;
+  bool m_forceSmear = false;
   /// @brief when using DEV mode of JetCalibTools
   bool m_jetCalibToolsDEV = false;
 
@@ -136,7 +138,6 @@ private:
   bool m_isFullSim;       //!
 
   std::string m_calibConfig; //!
-  std::string m_uncertMCType; //!
 
   std::vector<CP::SystematicSet> m_systList; //!
 


### PR DESCRIPTION
The last pull request for this (#1275) was reverted (#1277) after being merged, so I believe this new one is required to continue the discussion and get the changes back in. To recap, these changes are to `JetCalibrator` and are:
 - Allow the user to configure `m_uncertMCType` (which is required for fat jets, for example). If the user does not set this in their config, the default behavior is the same as it was before (`"MC16"` for fullsim and `"AFII"` for fastsim). This change is uncontroversial, since it just adds another option which the user is free to ignore.
 - Change the default values of `m_forceSmear` and `m_forceInsitu` to false. The smearing and in-situ calibration steps are (or should be, according to Jet/Etmiss recommendations) already included in the CalibSequence specified by the user. The purpose of this change is to avoid cases (of which at least 2 have already happened) of users explicitly excluding this step from their CalibSequence but the tool still mysteriously tries to apply it. Currently there's no way of knowing how to disable smearing/in-situ without reading the source code.

The only objection was from @mattleblanc, who made the point (which I agree with) that it should work out-of-the-box for R=0.4 EMTopo jets. But even in this case, the user has to specify a CalibSequence anyway, and if they use the recommended ones from the CP group, it will already include the smearing/in-situ step.

Personally I care more about making `m_uncertMCType` configurable because that's actually preventing my analysis code from working at the moment, so I'm OK with it if we insist on not changing the smearing/in-situ thing. But I do think it's confusing to have what are effectively manual overrides that default to "on" and are hidden from the user.