### PR TITLE
BasicEventSelection: Allow m_storeTrigDecisions even if no trigger selection is specified

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -879,7 +879,7 @@ EL::StatusCode BasicEventSelection :: execute ()
   // Trigger decision cut
   //---------------------
 
-  if ( !m_triggerSelection.empty() ) {
+  if ( !m_triggerSelection.empty() || m_storeTrigDecisions ) {
 
     auto triggerChainGroup = m_trigDecTool_handle->getChainGroup(m_triggerSelection);
 


### PR DESCRIPTION
In BasicEventSelection, it would be great to be able to get the list of passed triggers (if `m_storeTrigDecision` is true) written to the store even if there is no trigger selection is specified.

Is there any reason to not make the proposed change here?

Thanks!
-Larry