### PR TITLE
Add support for actualMu PRW config files.

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1167,6 +1167,17 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
 	prwConfigFiles.push_back( prwConfigFile );
     }
 
+  // Add actualMu config files
+  for(const auto& mcCampaign : mcCampaignList)
+    {
+      if( !m_prwActualMu2016File.empty() && mcCampaign == "mc16a" )
+	prwConfigFiles.push_back(m_prwActualMu2016File);
+      if( !m_prwActualMu2017File.empty() && (mcCampaign == "mc16c" || mcCampaign=="mc16d") )
+	prwConfigFiles.push_back(m_prwActualMu2017File);
+      if( !m_prwActualMu2018File.empty() && (mcCampaign == "mc16e" || mcCampaign=="mc16f") )
+	prwConfigFiles.push_back(m_prwActualMu2018File);
+    }
+
   // also need to handle lumicalc files: only use 2015+2016 with mc16a
   // and only use 2017 with mc16c
   // according to instructions on https://twiki.cern.ch/twiki/bin/view/AtlasProtected/ExtendedPileupReweighting#Tool_Properties

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -70,7 +70,7 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Apply GRL selection
     bool m_applyGRLCut = false;
     /// @brief Path to GRL XML file
-    std::string m_GRLxml = "xAODAnaHelpers/data15_13TeV.periodAllYear_HEAD_DQDefects-00-01-02_PHYS_StandardGRL_Atlas_Ready.xml";
+    std::string m_GRLxml = "";
     /// @brief Run numbers to skip in GRL
     std::string m_GRLExcludeList = "";
 
@@ -95,6 +95,12 @@ class BasicEventSelection : public xAH::Algorithm
     std::string m_PRWFileNames = "";
     /// @brief Automatically configure PRW using config files from SUSYTools instead of using m_PRWFileNames.
     bool m_autoconfigPRW = false;
+    /// @brief actualMu configuration file for the MC16a campaign (2015/2016). Added to the PRW tool when using PRW autoconfiguration.
+    std::string m_prwActualMu2016File = "";
+    /// @brief actualMu configuration file for the MC16d campaign (2017). Added to the PRW tool when using PRW autoconfiguration.
+    std::string m_prwActualMu2017File = "";
+    /// @brief actualMu configuration file for the MC16e campaign (2018). Added to the PRW tool when using PRW autoconfiguration.
+    std::string m_prwActualMu2018File = "";
     /**
       @rst
       mc16(acd) to bypass the automatic campaign determination from AMI, several campaigns can be separated by a comma. Only used


### PR DESCRIPTION
This PR adds `m_prwActualMu201XFile` options for all years. Then uses the determined `mcCampaign` value to add the right one. No default value is set, since it is GRL dependent. Also we don't set a default GRL*.

This should address #1284 .

* The default value was some old GRL for 2015. I'm also removing that in this PR, since it is outdated.

