### PR TITLE
HelpTreeBase: Allow non-default object names for user-defined branches

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -413,6 +413,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -413,7 +413,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -325,7 +325,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
   SG::AuxElement::Decorator< char > dec_isBTag( m_decor );
   SG::AuxElement::Decorator< std::vector<float> > dec_sfBTag( m_decorSF );
-  SG::AuxElement::Decorator< char > dec_isBTagOR( m_decor+"OR" );
 
   SG::AuxElement::Decorator< char > dec_isBTagOR( m_decor+"OR" );
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,6 +1,7 @@
 
 
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -414,6 +414,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -417,7 +417,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -414,7 +414,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -417,6 +417,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -414,6 +414,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,4 +1,3 @@
-
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.
@@ -54,6 +53,7 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
   return EL::StatusCode::SUCCESS;
 }
+
 
 
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,7 +1,3 @@
-
-
-
-
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -413,7 +413,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -389,7 +389,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
     ANA_MSG_DEBUG( "Jet is out of validity range");
   }
-
 	// Add it to vector
 	sfVec.push_back(SF);
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -56,8 +56,6 @@ EL::StatusCode BJetEfficiencyCorrector :: setupJob (EL::Job& job)
 
 
 
-
-
 EL::StatusCode BJetEfficiencyCorrector :: histInitialize ()
 {
   ANA_CHECK( xAH::Algorithm::algInitialize());
@@ -391,6 +389,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
     ANA_MSG_DEBUG( "Jet is out of validity range");
   }
+
 	// Add it to vector
 	sfVec.push_back(SF);
 

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -415,6 +415,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -418,6 +418,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -417,7 +417,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -416,7 +416,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -414,7 +414,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -418,7 +418,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,3 +1,4 @@
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,4 +1,5 @@
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -417,6 +417,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -326,8 +326,8 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
   SG::AuxElement::Decorator< char > dec_isBTag( m_decor );
   SG::AuxElement::Decorator< std::vector<float> > dec_sfBTag( m_decorSF );
-
   SG::AuxElement::Decorator< char > dec_isBTagOR( m_decor+"OR" );
+
   //
   // run the btagging decision and get scale factors
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -415,7 +415,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     dec_sfBTag( *jet_itr ) = sfVec;
   }
 
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -416,7 +416,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
-
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -413,6 +413,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -416,6 +416,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
     idx++;
     dec_sfBTag( *jet_itr ) = sfVec;
   }
+
   //
   // Store list of available systematics
   //

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -1,5 +1,6 @@
 
 
+
 /**************************************************
  *
  * Interface to CP BJet Efficiency Correction Tool.

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -360,7 +360,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
   }
 
   thisMuon->setBranches(m_tree);
-  this->AddMuonsUser();
+  this->AddMuonsUser(detailStr, muonName);
 }
 
 void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string muonName ) {
@@ -478,7 +478,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr, const std::string e
   xAH::ElectronContainer* thisElec = m_elecs[elecName];
 
   thisElec->setBranches(m_tree);
-  this->AddElectronsUser(elecName);
+  this->AddElectronsUser(detailStr, elecName);
 }
 
 
@@ -526,7 +526,7 @@ void HelpTreeBase::AddPhotons(const std::string detailStr, const std::string pho
   xAH::PhotonContainer* thisPhoton = m_photons[photonName];
 
   thisPhoton->setBranches(m_tree);
-  this->AddPhotonsUser(photonName);
+  this->AddPhotonsUser(detailStr, photonName);
 }
 
 
@@ -574,7 +574,7 @@ void HelpTreeBase::AddClusters(const std::string detailStr, const std::string cl
   xAH::ClusterContainer* thisCluster = m_clusters[clusterName];
 
   thisCluster->setBranches(m_tree);
-  this->AddClustersUser(clusterName);
+  this->AddClustersUser(detailStr, clusterName);
 }
 
 
@@ -747,7 +747,7 @@ void HelpTreeBase::AddTruthParts(const std::string truthName, const std::string 
 
   xAH::TruthContainer* thisTruth = m_truth[truthName];
   thisTruth->setBranches(m_tree);
-  this->AddTruthUser(truthName);
+  this->AddTruthUser(truthName, detailStr);
 }
 
 void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truthParts ) {
@@ -802,7 +802,7 @@ void HelpTreeBase::AddTrackParts(const std::string trackName, const std::string 
 
   xAH::TrackContainer* thisTrack = m_tracks[trackName];
   thisTrack->setBranches(m_tree);
-  this->AddTracksUser(trackName);
+  this->AddTracksUser(trackName, detailStr);
 }
 
 void HelpTreeBase::FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* trackParts ) {
@@ -971,7 +971,7 @@ void HelpTreeBase::AddTaus(const std::string detailStr, const std::string tauNam
   xAH::TauContainer* thisTau = m_taus[tauName];
 
   thisTau->setBranches(m_tree);
-  this->AddTausUser();
+  this->AddTausUser(detailStr, tauName);
 }
 
 void HelpTreeBase::FillTaus( const xAOD::TauJetContainer* taus, const std::string tauName ) {
@@ -1018,7 +1018,7 @@ void HelpTreeBase::AddMET( const std::string detailStr, const std::string metNam
   xAH::MetContainer* thisMet = m_met[metName];
 
   thisMet->setBranches(m_tree);
-  this->AddMETUser(metName);
+  this->AddMETUser(detailStr, metName);
 }
 
 void HelpTreeBase::FillMET( const xAOD::MissingETContainer* met, const std::string metName ) {

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -200,23 +200,23 @@ public:
     return;
   };
 
-  virtual void AddMuonsUser(const std::string detailStr = "")      {
-    if(m_debug) Info("AddMuonsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+  virtual void AddMuonsUser(const std::string detailStr = "", const std::string muonName="muon"){
+    if(m_debug) Info("AddMuonsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),muonName.c_str());
+    return;
+    };
+
+  virtual void AddElectronsUser(const std::string detailStr = "", const std::string elecName="el"){
+    if(m_debug) Info("AddElectronsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),elecName.c_str());
     return;
   };
 
-  virtual void AddElectronsUser(const std::string detailStr = "")  {
-    if(m_debug) Info("AddElectronsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+  virtual void AddPhotonsUser(const std::string detailStr = "", const std::string photonName="ph"){
+    if(m_debug) Info("AddPhotonsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),photonName.c_str());
     return;
   };
 
-  virtual void AddPhotonsUser(const std::string detailStr = "")  {
-    if(m_debug) Info("AddPhotonsUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
-    return;
-  };
-
-  virtual void AddClustersUser(const std::string detailStr = "")  {
-    if(m_debug) Info("AddClustersUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+  virtual void AddClustersUser(const std::string detailStr = "", const std::string clusterName="cl"){
+    if(m_debug) Info("AddClustersUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),clusterName.c_str());
     return;
   };
 
@@ -252,8 +252,8 @@ public:
     return;
   };
 
-  virtual void AddTausUser(const std::string detailStr = "")       {
-    if(m_debug) Info("AddTausUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
+  virtual void AddTausUser(const std::string detailStr = "", const std::string tauName="tau")   {
+    if(m_debug) Info("AddTausUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),tauName.c_str());
     return;
   };
 


### PR DESCRIPTION
This commit adds functionality to allow for a non-default name for object containers, like those that can already be set with the Add\[Objects\](...) functions. 

So for example if the user wanted two separate muon containers, they could create them by calling AddMuons(m_muDetailStr, "MuonContainer1") and AddMuons(m_muDetailStr, "MuonContainer2"). The standard branches (those filled by HelpTreeBase) would have names corresponding to each container. But the user-added branches would still be restricted to the standard "muon_" branch name. This commit corrects that, so now AddMuonsUser can also pass the object name.

Additionally, I noticed that AddTruthParts and AddTrackParts (and the corresponding User functions) are inconsistent with the rest of the Add(User) functions in the ordering of the "name" and "detailStr" arguments, but I didn't change this to avoid incompatibilities. But it could certainly lead to confusion on the user's side.