### PR TITLE
BasicEventSelection::finalize(): Remove TDT from ToolStore

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1269,7 +1269,12 @@ EL::StatusCode BasicEventSelection :: finalize ()
 
   m_RunNr_VS_EvtNr.clear();
 
-  if ( m_trigDecTool_handle.isInitialized() )  m_trigDecTool_handle->finalize();
+  if ( m_trigDecTool_handle.isInitialized() ){
+    if (asg::ToolStore::contains<Trig::TrigDecisionTool>("ToolSvc.TrigDecisionTool") ){
+      m_trigDecTool_handle->finalize();
+      asg::ToolStore::remove("ToolSvc.TrigDecisionTool").ignore();
+    }
+  }
 
   //after execution loop
   if(m_printBranchList){


### PR DESCRIPTION
Simply calling finalize of the TDT does some nasty things under the hood in the TDT itself. So say if you have two algs (say, `xAH` and `SUSYTools` -- don't hate. Let's be friends.) grabbing the TDT from the tool store, if they both try to finalize, it barfs a bit.

```
ToolSvc.TrigDecisionTool ERROR   /build2/atnight/localbuilds/nightlies/21.2/AnalysisBase/athena/Trigger/TrigAnalysis/TrigDecisionTool/Root/TrigDecisionTool.cxx:246 (virtual StatusCode Trig::TrigDecisionTool::finalize()): could not find instance name in instance list, but must have been added in ::initialize(). Name: ToolSvc.TrigDecisionTool
```

The proposed change from Hass ensures that after calling `finalize()` on the TDT, it's removed from the `ToolStore` so that nobody else can try to call `finalize()` again.

Just tested on my side and we no longer see this error with this change! Yay.

-L