### PR TITLE
Adding jet cleaning and isBadBatman cleaning to BES

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -412,6 +412,10 @@ EL::StatusCode BasicEventSelection :: initialize ()
       m_cutflow_grl  = m_cutflowHist->GetXaxis()->FindBin("GRL");
       m_cutflowHistW->GetXaxis()->FindBin("GRL");
     }
+    if ( m_applyIsBadBatmanFlag ) {
+      m_cutflow_isbadbatman =  m_cutflowHist->GetXaxis()->FindBin("IsBadBatman");
+      m_cutflowHistW->GetXaxis()->FindBin("IsBadBatman");
+    }
     m_cutflow_lar  = m_cutflowHist->GetXaxis()->FindBin("LAr");
     m_cutflowHistW->GetXaxis()->FindBin("LAr");
     m_cutflow_tile = m_cutflowHist->GetXaxis()->FindBin("tile");
@@ -427,7 +431,10 @@ EL::StatusCode BasicEventSelection :: initialize ()
     m_cutflow_trigger  = m_cutflowHist->GetXaxis()->FindBin("Trigger");
     m_cutflowHistW->GetXaxis()->FindBin("Trigger");
   }
-
+  if ( m_applyJetCleaningEventFlag ) {
+    m_cutflow_jetcleaning = m_cutflowHist->GetXaxis()->FindBin("JetCleaning");
+    m_cutflowHistW->GetXaxis()->FindBin("JetCleaning");
+  }
 
   ANA_MSG_INFO( "Histograms set up!");
 
@@ -857,6 +864,27 @@ EL::StatusCode BasicEventSelection :: execute ()
     m_cutflowHistW->Fill( m_cutflow_core, mcEvtWeight);
 
   }
+
+  // more info: https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/HowToCleanJets2017
+  if ( m_applyJetCleaningEventFlag && eventInfo->isAvailable<Char_t>("DFCommonJets_eventClean_LooseBad") ) {
+    if(eventInfo->auxdataConst<Char_t>("DFCommonJets_eventClean_LooseBad")<1) {
+	wk()->skipEvent();
+	return EL::StatusCode::SUCCESS;
+      }
+  }
+  m_cutflowHist ->Fill( m_cutflow_jetcleaning, 1 );
+  m_cutflowHistW->Fill( m_cutflow_jetcleaning, mcEvtWeight);
+
+  // n.b. this cut should only be applied in 2015+16 data, and not to MC!
+  // details here: https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/HowToCleanJets2017#IsBadBatMan_Event_Flag_and_EMEC
+  if ( m_applyIsBadBatmanFlag && eventInfo->isAvailable<Char_t>("DFCommonJets_isBadBatman") &&  !isMC() ) {
+    if(eventInfo->auxdataConst<Char_t>("DFCommonJets_isBadBatman")>0) {
+      wk()->skipEvent();
+      return EL::StatusCode::SUCCESS;
+    }
+  }
+  m_cutflowHist ->Fill( m_cutflow_isbadbatman, 1 );
+  m_cutflowHistW->Fill( m_cutflow_isbadbatman, mcEvtWeight);
 
   //-----------------------------
   // Primary Vertex 'quality' cut

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -129,6 +129,10 @@ class BasicEventSelection : public xAH::Algorithm
     bool m_applyEventCleaningCut = false;
     bool m_applyCoreFlagsCut = false;
 
+    // Jet Cleaning
+    bool m_applyJetCleaningEventFlag = false;
+    bool m_applyIsBadBatmanFlag = false;
+
     // Print Branch List
     bool m_printBranchList = false;
 
@@ -228,6 +232,8 @@ class BasicEventSelection : public xAH::Algorithm
     int m_cutflow_tile;       //!
     int m_cutflow_SCT;        //!
     int m_cutflow_core;       //!
+    int m_cutflow_jetcleaning; //!
+    int m_cutflow_isbadbatman; //!
     int m_cutflow_npv;        //!
     int m_cutflow_trigger;    //!
 


### PR DESCRIPTION
I finally got around to it! This seems to be working, as the flags removes a small handful of events in my local tests. A reminder of the recommendations --

* The event-level jet cleaning flag is the recommended way to clean *all* jets, but especially collections other than EMTopo.

* The isBadBatman cleaning is an optional flag which should only ever be used in 2015 and 2016 data, for analyses which may be of interest for analyses where fake MET can be an issue. It will remove 1.66% of the 2016 data and a small amount from 2015.

See also https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/HowToCleanJets2017

I'm not actually sure how to get things into the cutflow histograms properly, @kratsg feel free to change or tell me what to do if you want that done differently.

This closes #1283, and I would say also closes #449 and #412  ... but I would maybe confirm with the original people who opened those issues first.

🍻 MLB