### PR TITLE
Remove MsgStream name growth

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -59,7 +59,6 @@ int HelperFunctions::countPrimaryVertices(const xAOD::VertexContainer* vertexCon
 
 int HelperFunctions::getPrimaryVertexLocation(const xAOD::VertexContainer* vertexContainer, MsgStream& msg)
 {
-  msg.setName(msg.name()+".getPrimaryVertexLocation");
   int location(0);
 
   if(vertexContainer == nullptr) {
@@ -340,7 +339,6 @@ TLorentzVector HelperFunctions::jetTrimming(
 
 const xAOD::Vertex* HelperFunctions::getPrimaryVertex(const xAOD::VertexContainer* vertexContainer, MsgStream& msg)
 {
-  msg.setName(msg.name()+".getPrimaryVertex");
 
   // vertex types are listed on L328 of
   // https://svnweb.cern.ch/trac/atlasoff/browser/Event/xAOD/xAODTracking/trunk/xAODTracking/TrackingPrimitives.h
@@ -373,7 +371,6 @@ bool HelperFunctions::sort_pt(const xAOD::IParticle* partA, const xAOD::IParticl
 // prune down to 1 systematic if only request that one.  It does however include the
 // nominal case as a null SystematicSet
 std::vector< CP::SystematicSet > HelperFunctions::getListofSystematics(const CP::SystematicSet inSysts, std::string systNames, float systVal, MsgStream& msg ) {
-  msg.setName(msg.name()+".getListofSystematics");
 
   std::vector< CP::SystematicSet > outSystList;
 


### PR DESCRIPTION
Alex Melzer found this but can't get a GitHub setup, so I'm making the PR for him.

msg() returns a static MsgStream object for messaging. This means that every time getPrimaryVertex( ... msg() ) was being called, ".getPrimaryVertex" was being appended to the static object's name. When running over enough events (easy to happen when you run with systematics), there would be a huge amount of memory and time spent around managing this single gigantic string. This PR fixes the three instances of this stream name change in HelperFunctions.

We found that without this, time to finish an algorithm was exponentially dependent on the number of events. After the fix, we see a linear dependence, as expected.

There are probably alternate fixes for this (changing how msg() works?) but I think this is the simplest and cleanest solution.