### PR TITLE
Random updates

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -118,15 +118,15 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if (m_operatingPt == "HybBEff_85")  { opOK = true; m_getScaleFactors =  true; }
 
   // Only DL1 and MV2c10 are calibrated
-  if (m_taggerName == "MV2c10")    { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "MV2c10rnn") { taggerOK = true; m_getScaleFactors =  false; }
-  if (m_taggerName == "MV2c10mu")  { taggerOK = true; m_getScaleFactors =  false; }
-  if (m_taggerName == "DL1")       { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "DL1rnn")    { taggerOK = true; m_getScaleFactors =  false; }
-  if (m_taggerName == "DL1mu")     { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "MV2c10") { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "MV2r")   { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "MV2rmu") { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "DL1")    { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "DL1r")   { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "DL1rmu") { taggerOK = true; m_getScaleFactors =  false; }
 
   if( !opOK || !taggerOK ) {
-    ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_operatingPt);
+    ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);
     return EL::StatusCode::FAILURE;
   }
 
@@ -273,7 +273,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 
 EL::StatusCode BJetEfficiencyCorrector :: execute ()
 {
-  ANA_MSG_DEBUG( "Applying BJet Efficency Corrector... ");
+  ANA_MSG_DEBUG( "Applying BJetEfficiencyCorrector for " << m_taggerName << " tagger... ");
 
   //
   // retrieve event
@@ -303,7 +303,7 @@ EL::StatusCode BJetEfficiencyCorrector :: execute ()
       // Check the existence of the container
       ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName+systName, m_event, m_store, msg()) );
 
-      executeEfficiencyCorrection( inJets, eventInfo, doNominal );
+      ANA_CHECK( executeEfficiencyCorrection( inJets, eventInfo, doNominal ) );
     }
 
   }
@@ -375,20 +375,20 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
 	// get the scale factor
 	float SF(-1.0);
-  CP::CorrectionCode BJetEffCode;
-  // if passes cut take the efficiency scale factor
-  // if failed cut take the inefficiency scale factor
-  if( tagged ) {
-    BJetEffCode = m_BJetEffSFTool_handle->getScaleFactor( *jet_itr, SF );
-  } else {
-    BJetEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, SF );
-  }
-  if (BJetEffCode == CP::CorrectionCode::Error) {
-    ANA_MSG_ERROR( "Error in getEfficiencyScaleFactor");
-    return EL::StatusCode::FAILURE;
-  } else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
-    ANA_MSG_DEBUG( "Jet is out of validity range");
-  }
+	CP::CorrectionCode BJetEffCode;
+	// if passes cut take the efficiency scale factor
+	// if failed cut take the inefficiency scale factor
+	if( tagged ) {
+	  BJetEffCode = m_BJetEffSFTool_handle->getScaleFactor( *jet_itr, SF );
+	} else {
+	  BJetEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, SF );
+	}
+	if (BJetEffCode == CP::CorrectionCode::Error) {
+	  ANA_MSG_ERROR( "Error in getEfficiencyScaleFactor");
+	  return EL::StatusCode::FAILURE;
+	} else if (BJetEffCode == CP::CorrectionCode::OutOfValidityRange) {
+	  ANA_MSG_DEBUG( "Jet is out of validity range");
+	}
 
 	// Add it to vector
 	sfVec.push_back(SF);

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1155,7 +1155,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
   std::vector<std::string> prwConfigFiles;
   for(const auto& mcCampaign : mcCampaignList)
     {
-      std::string prwConfigFile = PathResolverFindCalibFile("/dev/SUSYTools/PRW_AUTOCONFIG_SIM/files/pileup_" + mcCampaign + "_dsid" + std::to_string(DSID_INT) + "_" + SimulationFlavour + ".root");
+      std::string prwConfigFile = PathResolverFindCalibFile("/dev/PileupReweighting/share/DSID" + std::to_string(DSID_INT/1000) +"xxx/pileup_" + mcCampaign + "_dsid" + std::to_string(DSID_INT) + "_" + SimulationFlavour + ".root");
       TFile testF(prwConfigFile.data(),"read");
       if(testF.IsZombie())
 	{

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -19,8 +19,6 @@
 #include "AsgTools/AnaToolHandle.h"
 #include "JetCalibTools/IJetCalibrationTool.h"
 #include "JetCPInterfaces/ICPJetUncertaintiesTool.h"
-#include "JetResolution/IJERTool.h"
-#include "JetResolution/IJERSmearingTool.h"
 #include "JetInterface/IJetSelector.h"
 #include "JetInterface/IJetUpdateJvt.h"
 #include "JetCPInterfaces/IJetTileCorrectionTool.h"

--- a/xAODAnaHelpers/ParticleContainer.h
+++ b/xAODAnaHelpers/ParticleContainer.h
@@ -13,25 +13,26 @@
 #include <xAODAnaHelpers/Particle.h>
 #include <xAODBase/IParticle.h>
 
-namespace xAH {
+namespace xAH
+{
 
-    template <class T_PARTICLE, class T_INFOSWITCH>
-    class ParticleContainer
-    {
-    public:
+  template <class T_PARTICLE, class T_INFOSWITCH>
+  class ParticleContainer
+  {
+  public:
     ParticleContainer(const std::string& name,
 		      const std::string& detailStr="",
 		      float units = 1e3,
 		      bool mc = false,
 		      bool useMass=false,
-          bool storeSystSFs = true,
+		      bool storeSystSFs = true,
 		      const std::string& suffix="")
       : m_name(name),
 	m_infoSwitch(detailStr),
 	m_mc(mc),
 	m_debug(false),
 	m_units(units),
-  m_storeSystSFs(storeSystSFs),
+	m_storeSystSFs(storeSystSFs),
 	m_useMass(useMass),
 	m_suffix(suffix)
       {
@@ -118,7 +119,7 @@ namespace xAH {
 	m_n++;
 
 	if( m_infoSwitch.m_kinematic ){
-	  m_pt  -> push_back ( particle->pt() / m_units );
+	  m_pt  -> push_back( particle->pt() / m_units );
 	  m_eta -> push_back( particle->eta() );
 	  m_phi -> push_back( particle->phi() );
 	  if(m_useMass) m_M->push_back  ( particle->m() / m_units );
@@ -128,18 +129,17 @@ namespace xAH {
 
       void updateEntry()
       {
-        m_particles.clear();
+        m_particles.resize(m_n);
 
         for(int i=0;i<m_n;i++)
-          {
-	    T_PARTICLE particle;
-	    updateParticle(i,particle);
-	    m_particles.push_back(particle);
-          }
+	  updateParticle(i,m_particles[i]);
       }
+      
+      std::vector<T_PARTICLE>& particles()
+      { return m_particles; }
 
       T_PARTICLE& at_nonConst(uint idx)
-	{ return m_particles[idx]; }
+      { return m_particles[idx]; }
 
       const T_PARTICLE& at(uint idx) const
       { return m_particles[idx]; }


### PR DESCRIPTION
Random updates I had laying around. Mostly updating code to latest recommendations.

* Remove JER smearing tool inclues from JetCalibrator since they are no longer used.
* Change autoPRW location to the new common PileupReweighting one.
* Update list of supported taggers in BJetEfficiencyCorrector and improve error output.
* Speed up particle loading in `ParticleContainer` by reusing particle objects in memory.
 * Add `ParticleContainer::particles()` for direct access to the particles list.

All should be backward compatible. The removed btaggers will fail in the btagging tool anways. Maybe we should remove this check inside xAH anyway, since it is also done in `BTaggingSelectionTool`?
