### PR TITLE
Per-user defaults for xAH_run (aka a dotfile)

### DIFF
--- a/docs/UsingUs.rst
+++ b/docs/UsingUs.rst
@@ -171,6 +171,8 @@ API Reference
 
     eval "$(register-python-argcomplete xAH_run.py)"
 
+.. note:: All of the following properties can be set in a user-specific dotfile located at ``${HOME}/.xah``. It is a simple ``key=value`` per-line format, where the `key` is the argument being set without the preceeding dashes. There is no separation of the arguments to the different drivers.
+
 
 .. argparse::
    :ref: xAH_run.parser

--- a/docs/UsingUs.rst
+++ b/docs/UsingUs.rst
@@ -171,8 +171,20 @@ API Reference
 
     eval "$(register-python-argcomplete xAH_run.py)"
 
-.. note:: All of the following properties can be set in a user-specific dotfile located at ``${HOME}/.xah``. It is a simple ``key=value`` per-line format, where the `key` is the argument being set without the preceeding dashes. There is no separation of the arguments to the different drivers. All lines starting with # are ignored.
+All of the following properties can be set in a user-specific dotfile located at ``${HOME}/.xah``. It is an `INI file <https://en.wikipedia.org/wiki/INI_file>`_, with the `general` section used for the generic options and other sections named after sub-commands. The keys in each section are the options without the preceeding dashes.
 
+The following example configures the Slurm driver for NERCS' Cori and records usage statistics:
+::
+   
+   [general]
+   stats=1
+
+   [slurm]
+   optBatchSharedFileSystem=1
+   optBatchWait=1
+   optSlurmRunTime=5:00:00
+   optSlurmExtraConfigLines=#SBATCH --qos=shared --tasks-per-node=1 --constraint=haswell --image=centos:centos7 --export=NONE
+   optSlurmWrapperExec=export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/global/project/projectdirs/atlas/scripts/extra_libs_180822; hostname; shifter --module=cvmfs /bin/
 
 .. argparse::
    :ref: xAH_run.parser

--- a/docs/UsingUs.rst
+++ b/docs/UsingUs.rst
@@ -171,7 +171,7 @@ API Reference
 
     eval "$(register-python-argcomplete xAH_run.py)"
 
-.. note:: All of the following properties can be set in a user-specific dotfile located at ``${HOME}/.xah``. It is a simple ``key=value`` per-line format, where the `key` is the argument being set without the preceeding dashes. There is no separation of the arguments to the different drivers.
+.. note:: All of the following properties can be set in a user-specific dotfile located at ``${HOME}/.xah``. It is a simple ``key=value`` per-line format, where the `key` is the argument being set without the preceeding dashes. There is no separation of the arguments to the different drivers. All lines starting with # are ignored.
 
 
 .. argparse::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ try:
     travis_env.sort(key=lambda s: map(int, s['RELEASE'].split(',')[1].split('.')), reverse=True)
     latest_release = travis_env[0].get('RELEASE', 'unknown')
 except:
+    travis_env = []
     latest_release = 'unknown'
 
 def release_to_color(release):

--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -4,6 +4,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 import logging
 
+#
+# Update the default fields of an argument definition dictionary
+#
+# argdict: reference to the argument definitions
+# newvalues: dictionary with the argument name as key and new default value as value
+def update_defaults(argdict, newvalues):
+    for option,optdata in argdict.iteritems():
+        if option in newvalues: optdata['default']=newvalues[option]
+
+
 logger = logging.getLogger("xAH.cli_options")
 
 
@@ -327,7 +337,7 @@ drivers_slurm = {
         "metavar": "",
         "type": str,
         "required": False,
-        "default": "shared-chos",
+        "default": "",
         "help": "the name of the partition to use",
     },
     "optSlurmRunTime": {
@@ -341,7 +351,7 @@ drivers_slurm = {
         "metavar": "",
         "type": str,
         "required": False,
-        "default": "1800",
+        "default": "",
         "help": "the maximum memory usage of the job (MB)",
     },
     "optSlurmConstrain": {

--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -193,6 +193,10 @@ drivers_common = {
     },
 }
 
+# define arguments for direct driver
+drivers_direct = {}
+drivers_direct.update(copy.deepcopy(drivers_common))
+
 # define arguments for prooflite driver
 drivers_prooflite = {}
 drivers_prooflite.update(copy.deepcopy(drivers_common))

--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -4,16 +4,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 import logging
 
-#
-# Update the default fields of an argument definition dictionary
-#
-# argdict: reference to the argument definitions
-# newvalues: dictionary with the argument name as key and new default value as value
-def update_defaults(argdict, newvalues):
-    for option,optdata in argdict.iteritems():
-        if option in newvalues: optdata['default']=newvalues[option]
-
-
 logger = logging.getLogger("xAH.cli_options")
 
 

--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import logging
+import copy
 
 logger = logging.getLogger("xAH.cli_options")
 
@@ -193,7 +194,9 @@ drivers_common = {
 }
 
 # define arguments for prooflite driver
-drivers_prooflite = {
+drivers_prooflite = {}
+drivers_prooflite.update(copy.deepcopy(drivers_common))
+drivers_prooflite.update({
     "optPerfTree": {
         "metavar": "",
         "type": int,
@@ -208,10 +211,12 @@ drivers_prooflite = {
         "default": None,
         "help": "the option to do processing in a background process in PROOF",
     },
-}
+})
 
 # define arguments for prun driver
-drivers_prun = {
+drivers_prun = {}
+drivers_prun.update(copy.deepcopy(drivers_common))
+drivers_prun.update({
     "optGridDestSE": {"metavar": "", "type": str, "required": False, "default": None},
     "optGridSite": {"metavar": "", "type": str, "required": False, "default": None},
     "optGridCloud": {"metavar": "", "type": str, "required": False, "default": None},
@@ -293,9 +298,11 @@ drivers_prun = {
         "default": False,
         "help": "Submit all input datasets under a single task.",
     },
-}
+})
 
-drivers_condor = {
+drivers_condor = {}
+drivers_condor.update(copy.deepcopy(drivers_common))
+drivers_condor.update({
     "optCondorConf": {
         "metavar": "",
         "type": str,
@@ -303,9 +310,11 @@ drivers_condor = {
         "default": "stream_output = true",
         "help": "the name of the option for supplying extra parameters for condor systems",
     }
-}
+})
 
-drivers_lsf = {
+drivers_lsf = {}
+drivers_lsf.update(copy.deepcopy(drivers_common))
+drivers_lsf.update({
     "optResetShell": {
         "metavar": "",
         "type": bool,
@@ -313,9 +322,11 @@ drivers_lsf = {
         "default": False,
         "help": "the option to reset the shell on the worker nodes",
     }
-}
+})
 
-drivers_slurm = {
+drivers_slurm = {}
+drivers_slurm.update(copy.deepcopy(drivers_common))
+drivers_slurm.update({
     "optSlurmAccount": {
         "metavar": "",
         "type": str,
@@ -365,4 +376,4 @@ drivers_slurm = {
         "default": "",
         "help": "the wrapper around the run script",
     },
-}
+})

--- a/python/utils.py
+++ b/python/utils.py
@@ -131,11 +131,8 @@ def read_dotfile(dotpath):
     with open(dotpath) as fh :
       for line in fh:
         line=line.strip()
-        if line=='': continue
-        if line[0]=='#': continue
-        parts=line.split('=')
-        key=parts[0].strip()
-        value='='.join(parts[1:]).strip()
+        if line=='' or line[0]=='#': continue
+        key,value=line.split('=',1)
         dotconfig[key]=value
 
     return dotconfig

--- a/python/utils.py
+++ b/python/utils.py
@@ -120,5 +120,5 @@ def update_clioption_defaults(argdict, newvalues):
   newvalues -- dictionary with the argument name as key and new default value as value
   """
 
-  for key,value in newvalues.iteritems():
+  for key,value in newvalues.items():
     if key in argdict: argdict[key]['default']=value

--- a/python/utils.py
+++ b/python/utils.py
@@ -120,20 +120,5 @@ def update_clioption_defaults(argdict, newvalues):
   newvalues -- dictionary with the argument name as key and new default value as value
   """
 
-  for option,optdata in argdict.iteritems():
-    if option in newvalues: optdata['default']=newvalues[option]
-
-def read_dotfile(dotpath):
-  """Return the contents of dotpath configuration file as a dictionary."""
-
-  dotconfig={}
-  if os.path.exists(dotpath):
-    with open(dotpath) as fh :
-      for line in fh:
-        line=line.strip()
-        if line=='' or line[0]=='#': continue
-        key,value=line.split('=',1)
-        dotconfig[key]=value
-
-  return dotconfig
-
+  for key,value in newvalues.iteritems():
+    if key in argdict: argdict[key]['default']=value

--- a/python/utils.py
+++ b/python/utils.py
@@ -135,5 +135,5 @@ def read_dotfile(dotpath):
         key,value=line.split('=',1)
         dotconfig[key]=value
 
-    return dotconfig
+  return dotconfig
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -112,11 +112,31 @@ def register_on_parser(cli_options, parser):
         flags = optConfig.pop("flags", ["--{0:s}".format(optName)])
         parser.add_argument(*flags, **optConfig)
 
-#
-# Update the default fields of an argument definition dictionary from cli-options
-#
-# argdict: reference to the argument definitions
-# newvalues: dictionary with the argument name as key and new default value as value
 def update_clioption_defaults(argdict, newvalues):
-    for option,optdata in argdict.iteritems():
-        if option in newvalues: optdata['default']=newvalues[option]
+  """Update the default fields of an argument definition dictionary from cli-options.
+
+  Keyword arguments:
+  argdict -- reference to the argument definitions
+  newvalues -- dictionary with the argument name as key and new default value as value
+  """
+
+  for option,optdata in argdict.iteritems():
+    if option in newvalues: optdata['default']=newvalues[option]
+
+def read_dotfile(dotpath):
+  """Return the contents of dotpath configuration file as a dictionary."""
+
+  dotconfig={}
+  if os.path.exists(dotpath):
+    with open(dotpath) as fh :
+      for line in fh:
+        line=line.strip()
+        if line=='': continue
+        if line[0]=='#': continue
+        parts=line.split('=')
+        key=parts[0].strip()
+        value='='.join(parts[1:]).strip()
+        dotconfig[key]=value
+
+    return dotconfig
+

--- a/python/utils.py
+++ b/python/utils.py
@@ -111,3 +111,12 @@ def register_on_parser(cli_options, parser):
         # no flags specified? that's fine, use '--{optName}' as default
         flags = optConfig.pop("flags", ["--{0:s}".format(optName)])
         parser.add_argument(*flags, **optConfig)
+
+#
+# Update the default fields of an argument definition dictionary from cli-options
+#
+# argdict: reference to the argument definitions
+# newvalues: dictionary with the argument name as key and new default value as value
+def update_clioption_defaults(argdict, newvalues):
+    for option,optdata in argdict.iteritems():
+        if option in newvalues: optdata['default']=newvalues[option]

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -39,30 +39,25 @@ except ImportError:
 #
 # Load default options configuration
 userconfigpath = os.path.expanduser("~/.xAH")
-config = ConfigParser.ConfigParser()
-config.read(userconfigpath)
+dotconfig={}
+with open(userconfigpath) as fh :
+    for line in fh:
+        line=line.strip()
+        if line=='': continue
+        if line[0]=='#': continue
+        parts=line.split('=')
+        key=parts[0].strip()
+        value='='.join(parts[1:]).strip()
+        dotconfig[key]=value
 
-# 
-for option,optdata in xAH_cli_options.standard.iteritems():
-    if config.has_option('standard',option): optdata['default']=config.get('standard', option)
-
-for option,optdata in xAH_cli_options.drivers_common.iteritems():
-    if config.has_option('drivers',option): optdata['default']=config.get('drivers', option)
-
-for option,optdata in xAH_cli_options.drivers_prooflite.iteritems():
-    if config.has_option('prooflite',option): optdata['default']=config.get('prooflite', option)
-
-for option,optdata in xAH_cli_options.drivers_prun.iteritems():
-    if config.has_option('prun',option): optdata['default']=config.get('prun', option)
-
-for option,optdata in xAH_cli_options.drivers_condor.iteritems():
-    if config.has_option('condor',option): optdata['default']=config.get('condor', option)
-
-for option,optdata in xAH_cli_options.drivers_lsf.iteritems():
-    if config.has_option('lsf',option): optdata['default']=config.get('lsf', option)
-
-for option,optdata in xAH_cli_options.drivers_slurm.iteritems():
-    if config.has_option('slurm',option): optdata['default']=config.get('slurm', option)
+# Apply the configuration defaults
+xAH_cli_options.update_defaults(xAH_cli_options.standard         , dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_common   , dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_prooflite, dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_prun     , dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_condor   , dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_lsf      , dotconfig)
+xAH_cli_options.update_defaults(xAH_cli_options.drivers_slurm    , dotconfig)
 
 #
 # if we want multiple custom formatters, use inheriting

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -37,18 +37,8 @@ except ImportError:
 
 #
 # Load default options configuration
-userconfigpath = os.path.expanduser("~/.xah")
 dotconfig={}
-if os.path.exists(userconfigpath):
-    with open(userconfigpath) as fh :
-        for line in fh:
-            line=line.strip()
-            if line=='': continue
-            if line[0]=='#': continue
-            parts=line.split('=')
-            key=parts[0].strip()
-            value='='.join(parts[1:]).strip()
-            dotconfig[key]=value
+dotconfig.update(xAH_utils.read_dotfile(os.path.expanduser("~/.xah")))
 
 # Apply the configuration defaults
 xAH_utils.update_clioption_defaults(xAH_cli_options.standard         , dotconfig)

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -22,7 +22,11 @@ import subprocess
 import sys
 import datetime
 import time
-import ConfigParser
+
+try:
+    import configparser
+except ImportError: # Python 2.x fallback
+    import ConfigParser as configparser
 
 try:
     import xAODAnaHelpers
@@ -38,7 +42,7 @@ except ImportError:
 
 #
 # Load default options configuration
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.optionxform = str
 config.read(os.path.expanduser("~/.xah"))
 

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -17,11 +17,12 @@ from __future__ import print_function
 import argparse
 try: import argcomplete
 except: pass
-import os
+import os, os.path
 import subprocess
 import sys
 import datetime
 import time
+import ConfigParser
 
 try:
     import xAODAnaHelpers
@@ -35,6 +36,35 @@ except ImportError:
     import python.cli_options as xAH_cli_options
     import python.utils as xAH_utils
 
+#
+# Load default options configuration
+userconfigpath = os.path.expanduser("~/.xAH")
+config = ConfigParser.ConfigParser()
+config.read(userconfigpath)
+
+# 
+for option,optdata in xAH_cli_options.standard.iteritems():
+    if config.has_option('standard',option): optdata['default']=config.get('standard', option)
+
+for option,optdata in xAH_cli_options.drivers_common.iteritems():
+    if config.has_option('drivers',option): optdata['default']=config.get('drivers', option)
+
+for option,optdata in xAH_cli_options.drivers_prooflite.iteritems():
+    if config.has_option('prooflite',option): optdata['default']=config.get('prooflite', option)
+
+for option,optdata in xAH_cli_options.drivers_prun.iteritems():
+    if config.has_option('prun',option): optdata['default']=config.get('prun', option)
+
+for option,optdata in xAH_cli_options.drivers_condor.iteritems():
+    if config.has_option('condor',option): optdata['default']=config.get('condor', option)
+
+for option,optdata in xAH_cli_options.drivers_lsf.iteritems():
+    if config.has_option('lsf',option): optdata['default']=config.get('lsf', option)
+
+for option,optdata in xAH_cli_options.drivers_slurm.iteritems():
+    if config.has_option('slurm',option): optdata['default']=config.get('slurm', option)
+
+#
 # if we want multiple custom formatters, use inheriting
 class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter):
   pass
@@ -579,8 +609,8 @@ if __name__ == "__main__":
       driver.SetAccount         (args.optSlurmAccount             )
       driver.SetPartition       (args.optSlurmPartition           )
       driver.SetRunTime         (args.optSlurmRunTime             )
-      driver.SetMemory          (args.optSlurmMemory              )
-      driver.SetConstrain       (args.optSlurmConstrain           )
+      if args.optSlurmMemory:    driver.SetMemory          (args.optSlurmMemory              )
+      if args.optSlurmConstrain: driver.SetConstrain       (args.optSlurmConstrain           )
       for opt, t in map(lambda x: (x.dest, x.type), slurm._actions):
         if getattr(args, opt) is None: continue  # skip if not set
         if opt in ['help', 'optBatchWait', 'optBatchShellInit', 'optSlurmAccount', 'optSlurmPartition', 'optSlurmRunTime', 'optSlurmMemory', 'optSlurmConstrain']: continue  # skip some options

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -39,24 +39,25 @@ except ImportError:
 # Load default options configuration
 userconfigpath = os.path.expanduser("~/.xah")
 dotconfig={}
-with open(userconfigpath) as fh :
-    for line in fh:
-        line=line.strip()
-        if line=='': continue
-        if line[0]=='#': continue
-        parts=line.split('=')
-        key=parts[0].strip()
-        value='='.join(parts[1:]).strip()
-        dotconfig[key]=value
+if os.path.exists(userconfigpath):
+    with open(userconfigpath) as fh :
+        for line in fh:
+            line=line.strip()
+            if line=='': continue
+            if line[0]=='#': continue
+            parts=line.split('=')
+            key=parts[0].strip()
+            value='='.join(parts[1:]).strip()
+            dotconfig[key]=value
 
 # Apply the configuration defaults
-xAH_cli_options.update_defaults(xAH_cli_options.standard         , dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_common   , dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_prooflite, dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_prun     , dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_condor   , dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_lsf      , dotconfig)
-xAH_cli_options.update_defaults(xAH_cli_options.drivers_slurm    , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.standard         , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_common   , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prooflite, dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prun     , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_condor   , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_lsf      , dotconfig)
+xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_slurm    , dotconfig)
 
 #
 # if we want multiple custom formatters, use inheriting

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import datetime
 import time
+import ConfigParser
 
 try:
     import xAODAnaHelpers
@@ -37,17 +38,17 @@ except ImportError:
 
 #
 # Load default options configuration
-dotconfig={}
-dotconfig.update(xAH_utils.read_dotfile(os.path.expanduser("~/.xah")))
+config = ConfigParser.ConfigParser()
+config.optionxform = str
+config.read(os.path.expanduser("~/.xah"))
 
 # Apply the configuration defaults
-xAH_utils.update_clioption_defaults(xAH_cli_options.standard         , dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_common   , dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prooflite, dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prun     , dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_condor   , dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_lsf      , dotconfig)
-xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_slurm    , dotconfig)
+if config.has_section('general'  ): xAH_utils.update_clioption_defaults(xAH_cli_options.standard         , dict(config.items('general'  )))
+if config.has_section('prooflite'): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prooflite, dict(config.items('prooflite')))
+if config.has_section('prun'     ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prun     , dict(config.items('prun'     )))
+if config.has_section('condor'   ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_condor   , dict(config.items('condor'   )))
+if config.has_section('lsf'      ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_lsf      , dict(config.items('lsf'      )))
+if config.has_section('slurm'    ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_slurm    , dict(config.items('slurm'    )))
 
 #
 # if we want multiple custom formatters, use inheriting
@@ -107,58 +108,48 @@ parser_requiredNamed.add_argument('--config', metavar='', type=str, required=Tru
 parser.add_argument('--version', action='version', version='xAH_run.py {version}'.format(version=__version__), help='{version}'.format(version=__version__))
 xAH_utils.register_on_parser(xAH_cli_options.standard, parser)
 
-# first is the driver common arguments
-drivers_common = argparse.ArgumentParser(add_help=False, description='Common Driver Arguments')
-xAH_utils.register_on_parser(xAH_cli_options.drivers_common, drivers_common)
-
-# then the drivers we provide support for
+# drivers we provide support for
 drivers_parser = parser.add_subparsers(prog='xAH_run.py', title='drivers', dest='driver', description='specify where to run jobs')
 direct = drivers_parser.add_parser('direct',
                                    help='Run your jobs locally.',
                                    usage=baseUsageStr.format('direct'),
-                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                   parents=[drivers_common])
+                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
 
 prooflite = drivers_parser.add_parser('prooflite',
                                       help='Run your jobs using ProofLite',
                                       usage=baseUsageStr.format('prooflite'),
-                                      formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                      parents=[drivers_common])
+                                      formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
 xAH_utils.register_on_parser(xAH_cli_options.drivers_prooflite, prooflite)
 
 prun = drivers_parser.add_parser('prun',
                                  help='Run your jobs on the grid using prun. Use prun --help for descriptions of the options.',
                                  usage=baseUsageStr.format('prun'),
-                                 formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                 parents=[drivers_common])
+                                 formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
 xAH_utils.register_on_parser(xAH_cli_options.drivers_prun, prun)
 
 condor = drivers_parser.add_parser('condor',
                                    help='Flock your jobs to condor',
                                    usage=baseUsageStr.format('condor'),
-                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                   parents=[drivers_common])
+                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
 xAH_utils.register_on_parser(xAH_cli_options.drivers_condor, condor)
 
 lsf = drivers_parser.add_parser('lsf',
                                 help='Flock your jobs to lsf',
                                 usage=baseUsageStr.format('lsf'),
-                                formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                parents=[drivers_common])
+                                formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
 xAH_utils.register_on_parser(xAH_cli_options.drivers_lsf, lsf)
 
 slurm = drivers_parser.add_parser('slurm',
                                    help='Flock your jobs to SLURM',
                                    usage=baseUsageStr.format('slurm'),
-                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                   parents=[drivers_common])
-xAH_utils.register_on_parser(xAH_cli_options.drivers_slurm, slurm)
+                                   formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
+xAH_utils.register_on_parser(xAH_cli_options.drivers_slurm , slurm)
 
 local = drivers_parser.add_parser('local',
                                   help='Run using the LocalDriver',
                                   usage=baseUsageStr.format('local'),
-                                  formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30),
-                                  parents=[drivers_common])
+                                  formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
+
 
 # start the script
 if __name__ == "__main__":

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -22,7 +22,6 @@ import subprocess
 import sys
 import datetime
 import time
-import ConfigParser
 
 try:
     import xAODAnaHelpers

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import argparse
 try: import argcomplete
 except: pass
-import os, os.path
+import os
 import subprocess
 import sys
 import datetime
@@ -37,7 +37,7 @@ except ImportError:
 
 #
 # Load default options configuration
-userconfigpath = os.path.expanduser("~/.xAH")
+userconfigpath = os.path.expanduser("~/.xah")
 dotconfig={}
 with open(userconfigpath) as fh :
     for line in fh:

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -48,6 +48,7 @@ config.read(os.path.expanduser("~/.xah"))
 
 # Apply the configuration defaults
 if config.has_section('general'  ): xAH_utils.update_clioption_defaults(xAH_cli_options.standard         , dict(config.items('general'  )))
+if config.has_section('direct'   ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_direct   , dict(config.items('direct'   )))
 if config.has_section('prooflite'): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prooflite, dict(config.items('prooflite')))
 if config.has_section('prun'     ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_prun     , dict(config.items('prun'     )))
 if config.has_section('condor'   ): xAH_utils.update_clioption_defaults(xAH_cli_options.drivers_condor   , dict(config.items('condor'   )))
@@ -118,6 +119,7 @@ direct = drivers_parser.add_parser('direct',
                                    help='Run your jobs locally.',
                                    usage=baseUsageStr.format('direct'),
                                    formatter_class=lambda prog: CustomFormatter(prog, max_help_position=30))
+xAH_utils.register_on_parser(xAH_cli_options.drivers_direct, direct)
 
 prooflite = drivers_parser.add_parser('prooflite',
                                       help='Run your jobs using ProofLite',


### PR DESCRIPTION
To run on my institution's cluster, I need to specify a lot of options (ie: queue, setup commands...) to xAH_run.py. This is not very practical if I want to run one-off tests.

This PR solves this by adding a dotfile (`~/.xah`) that is read by `xAH_run.py` at start and overrides any defaults passed to the argument parser. It is an INI file with a section per sub-command and a `general` section for the general options. The keys are the options being set.

As an example, my .xah looks as follows:
```
[slurm]
optBatchSharedFileSystem=1
optBatchWait=1
optSlurmRunTime=5:00:00
optSlurmExtraConfigLines=#SBATCH --qos=shared --tasks-per-node=1 --constraint=haswell --image=centos:centos7 --export=NONE
optSlurmWrapperExec=export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/global/project/projectdirs/atlas/scripts/extra_libs_180822; hostname; shifter --module=cvmfs /bin/bash \
```