### PR TITLE
Allow HighPt and LowPt muon WPs

### DIFF
--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -192,6 +192,8 @@ EL::StatusCode MuonSelector :: initialize ()
   muonQualitySet.insert(1);
   muonQualitySet.insert(2);
   muonQualitySet.insert(3);
+  muonQualitySet.insert(4);
+  muonQualitySet.insert(5);
   if ( muonQualitySet.find(m_muonQuality) == muonQualitySet.end() ) {
     ANA_MSG_ERROR( "Unknown muon quality requested: " << m_muonQuality);
     return EL::StatusCode::FAILURE;


### PR DESCRIPTION
This commit adds the integers corresponding to HighPt and LowPtEfficiency muon WPs. If using HighPt or LowPtEfficiency, the user will get a std::cerr printed: "Could not find input string in enum!" from https://github.com/UCATLAS/xAODAnaHelpers/blob/master/xAODAnaHelpers/HelperClasses.h#L52 but the jobs run successfully anyway. The error is printed only because these WPs have not yet been added to Muon::Quality.