### PR TITLE
Adding option to JetCalibrator to specify analysis-specific jet flavour composition files

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -297,6 +297,10 @@ EL::StatusCode JetCalibrator :: initialize ()
       ANA_MSG_WARNING("Overriding jet uncertainties calibration area to " << m_overrideUncertCalibArea);
       ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("CalibArea", m_overrideUncertCalibArea));
     }
+    if( !m_overrideAnalysisFile.empty() ) {
+      ANA_MSG_WARNING("Overriding jet uncertainties analysis file to " << m_overrideAnalysisFile);
+      ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("AnalysisFile", m_overrideAnalysisFile));
+    }
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JetUncertaintiesTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JetUncertaintiesTool_handle);

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -72,6 +72,8 @@ public:
   std::string m_overrideCalibArea = "";
   /// @brief Override uncertainties CalibArea tag (default recommended)
   std::string m_overrideUncertCalibArea = "";
+  /// @brief Set analysis-specific jet flavour composition file for JetUncertainties (default: unknown comp.)
+  std::string m_overrideAnalysisFile = "";
 
   /** @rst
     If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.


### PR DESCRIPTION
Adding an option to JetCalibrator which lets you specify an analysis-specific jet flavour composition for use with JetUncertainties. This basically amounts to setting the AnalysisFile option of JetUncertainties.

See the JES/JER recommendations for documentation of this functionality: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetUncertaintiesRel21Summer2018SmallR#Configuring_and_initializing_the

I've put an example file which gives a dijet flavour composition in the following location, in case people are interested in what these should look like:

/afs/cern.ch/user/m/mleblanc/afs/public/JetEtMiss/DijetFlavourComp_Run2.root

🍻 MLB