### PR TITLE
Update minimum release to 21.2.61 and switch EL::Worker -> EL::IWorker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.51
-    - RELEASE=AnalysisTop,21.2.51
-    - RELEASE=AnalysisBase,21.2.56
-    - RELEASE=AnalysisTop,21.2.56
+    - RELEASE=AnalysisBase,21.2.61
+    - RELEASE=AnalysisTop,21.2.61
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/Root/HistogramManager.cxx
+++ b/Root/HistogramManager.cxx
@@ -152,7 +152,7 @@ void HistogramManager::record(TH1* hist) {
   m_allHists.push_back( hist );
 }
 
-void HistogramManager::record(EL::Worker* wk) {
+void HistogramManager::record(EL::IWorker* wk) {
   for( auto hist : m_allHists ){
     wk->addOutput(hist);
   }

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -544,7 +544,7 @@ StatusCode JetHists::initialize() {
   return StatusCode::SUCCESS;
 }
 
-void JetHists::record(EL::Worker* wk) {
+void JetHists::record(EL::IWorker* wk) {
   HistogramManager::record(wk);
 
   if(m_infoSwitch->m_tracksInJet){

--- a/Root/TracksInJetHists.cxx
+++ b/Root/TracksInJetHists.cxx
@@ -53,7 +53,7 @@ StatusCode TracksInJetHists::initialize() {
 }
 
 
-void TracksInJetHists::record(EL::Worker* wk) {
+void TracksInJetHists::record(EL::IWorker* wk) {
   HistogramManager::record(wk);
   m_trkPlots -> record( wk );
 }

--- a/xAODAnaHelpers/HistogramManager.h
+++ b/xAODAnaHelpers/HistogramManager.h
@@ -13,7 +13,7 @@
 #include <TH2F.h>
 #include <TH3F.h>
 #include <TProfile.h>
-#include <EventLoop/Worker.h>
+#include <EventLoop/IWorker.h>
 #include <xAODRootAccess/TEvent.h>
 
 // for StatusCode::isSuccess
@@ -192,7 +192,7 @@ class HistogramManager {
     /**
      * @brief record all histograms from HistogramManager#m_allHists to the worker
      */
-    void record(EL::Worker* wk);
+    void record(EL::IWorker* wk);
 
     /**
       * @brief the standard message stream for this algorithm

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -27,7 +27,7 @@ class JetHists : public IParticleHists
 
     using HistogramManager::book; // make other overloaded version of book() to show up in subclass
     using IParticleHists::execute; // overload
-    virtual void record(EL::Worker* wk);
+    virtual void record(EL::IWorker* wk);
 
   protected:
 

--- a/xAODAnaHelpers/TracksInJetHists.h
+++ b/xAODAnaHelpers/TracksInJetHists.h
@@ -20,7 +20,7 @@ class TracksInJetHists : public HistogramManager
     StatusCode execute( const xAOD::TrackParticle* trk, const xAOD::Jet* jet,  const xAOD::Vertex *pvx, float eventWeight, const xAOD::EventInfo* eventInfo );
     using HistogramManager::book; // make other overloaded versions of book() to show up in subclass
     using HistogramManager::execute; // overload
-    virtual void record(EL::Worker* wk);
+    virtual void record(EL::IWorker* wk);
 
   protected:
 


### PR DESCRIPTION
The change of `EL::Worker` to `EL::IWorker` that came with [release 21.2.61](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/AnalysisBaseReleaseNotes21_2#21_2_61_built_on_2019_01_31) messes up the xAH histogram recording functions.

This PR renames all usages of `EL::Worker`. Also since I believe this is not backwards compatible with older releases, I updated the minimum required to 21.2.61.