### PR TITLE
Grabbing TEvent and TStore in BES::initialize()

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -346,6 +346,11 @@ EL::StatusCode BasicEventSelection :: initialize ()
     m_doPUreweightingSys = false;
   }
 
+  // get TEvent and TStore
+  //
+  m_event = wk()->xaodEvent();
+  m_store = wk()->xaodStore();
+
   const xAOD::EventInfo* eventInfo(nullptr);
   ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
 


### PR DESCRIPTION
Because of what looks like a change in execution order in 21.2.61, the TEvent and TStore being grabbed in the `fileExecute()` doesn't make it available for the `initialize()`. So proposing that these are also grabbed in the `initialize()` to protect against this. Maybe a bit redundant, but would make this less sensitive to function call order. Can we do something like this?

Without this, the current HEAD gives us the error:

```
Both TEvent and TStore objects are null. Cannot retrieve anything.
```

Thanks!

-L