### PR TITLE
Update for egamma bug ATLSUSYSW-445

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -966,15 +966,29 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
     if ( m_readIDFlagsFromDerivation ) {
 
+      const static SG::AuxElement::ConstAccessor<char> acc_EG_Loose("DFCommonElectronsLHLoose");
+      const static SG::AuxElement::ConstAccessor<char> acc_EG_Medium("DFCommonElectronsLHMedium");
+      const static SG::AuxElement::ConstAccessor<char> acc_EG_Tight("DFCommonElectronsLHTight");
+
       if ( m_doLHPIDcut ) {
 
         bool passSelID(false);
         static SG::AuxElement::ConstAccessor< char > LHDecision( "DFCommonElectronsLH" + m_LHOperatingPoint );
-        if( LHDecision.isAvailable( *electron ) )
+        if( LHDecision.isAvailable( *electron ) ){
+	  if (m_doModifiedEleId){
+	    if(m_LHOperatingPoint == "Tight"){
+	      passSelID = acc_EG_Medium( *electron ) && acc_EG_Tight( *electron );
+	    } else if(m_LHOperatingPoint == "Medium"){
+	      passSelID = ( acc_EG_Loose( *electron ) && acc_EG_Medium( *electron ) ) || acc_EG_Tight( *electron );
+	    } else if (m_LHOperatingPoint == "Loose") {
+	      passSelID = acc_EG_Medium( *electron ) || acc_EG_Loose( *electron );
+	    } else { passSelID = LHDecision( *electron ); }
+	  }
+	  else
             passSelID = LHDecision( *electron );
-
-        if ( !passSelID ) {
-          ANA_MSG_DEBUG( "Electron failed likelihood PID cut w/ operating point " << m_LHOperatingPoint );
+	}
+	if ( !passSelID ) {
+	  ANA_MSG_DEBUG( "Electron failed likelihood PID cut w/ operating point " << m_LHOperatingPoint );
           return 0;
         }
       }
@@ -986,8 +1000,19 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
         bool passThisID(false);
         SG::AuxElement::ConstAccessor< char > LHDecisionAll( "DFCommonElectrons" + decorWP );
-        if( LHDecisionAll.isAvailable( *electron ) )
+        if( LHDecisionAll.isAvailable( *electron ) ){
+	  if (m_doModifiedEleId){
+	    if(decorWP == "LHTight"){
+	      passThisID = acc_EG_Medium( *electron ) && acc_EG_Tight( *electron );
+	    } else if(decorWP == "LHMedium"){
+	      passThisID = ( acc_EG_Loose( *electron ) && acc_EG_Medium( *electron ) ) || acc_EG_Tight( *electron );
+	    } else if (decorWP == "LHLoose") {
+	      passThisID = acc_EG_Medium( *electron ) || acc_EG_Loose( *electron );
+	    } else { passThisID = LHDecisionAll( *electron ); }
+	  }
+	  else
             passThisID = LHDecisionAll( *electron );
+	}
 
         ANA_MSG_DEBUG( "Decorating electron with decision for LH WP : " << decorWP );
         ANA_MSG_DEBUG( "\t does electron pass " << decorWP << "? " << passThisID );
@@ -1017,7 +1042,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       }
 
     }
-  }// if m_doLHPID
+    }// if m_doLHPID
 
   //
   // cut-based PID

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -133,6 +133,9 @@ public:
   /** @brief To read electron PID decision from DAOD, rather than recalculate with tool */
   bool           m_readIDFlagsFromDerivation = false;
 
+  /** @brief To correct egamma bug, see ATLSUSYSW-445 */
+  bool          m_doModifiedEleId = false;
+
 //// likelihood-based  ////
   /** @brief Instantiate and perform the electron Likelihood PID */
   bool           m_doLHPID = true;


### PR DESCRIPTION
Copied from the corresponding SusyTools commit (https://gitlab.cern.ch/atlas/athena/merge_requests/20690): 
Due to an issue with some Egamma working points in certain pt/eta bins a workaround is needed in order to guarantee loose looser than medium, and medium looser than tight.  This is applied only for the default case where the input being run over has the needed DFCommon variables in the DAOD. SFs are not changed.

The logic of the changes is identical to the ST commit linked above. To pick up this change, the user should set `m_doModifiedEleId=True` in their config.