### PR TITLE
fix HighPt and LowPt parsing for MuQuality

### DIFF
--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -183,7 +183,8 @@ EL::StatusCode MuonSelector :: initialize ()
 
   HelperClasses::EnumParser<xAOD::Muon::Quality> muQualityParser;
   m_muonQuality             = static_cast<int>( muQualityParser.parseEnum(m_muonQualityStr) );
-
+  if (m_muonQualityStr=="HighPt") m_muonQuality=4;
+  else if (m_muonQualityStr=="LowPt") m_muonQuality=5;
 
   m_outAuxContainerName     = m_outContainerName + "Aux."; // the period is very important!
 

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -126,6 +126,8 @@ public:
   float m_pt_max_JVT = 60e3;
   /// @brief detector eta cut
   float m_eta_max_JVT = 2.4;
+  /// @brief was JVT already run in an earlier instance of JetSelector?
+  bool m_jvtUsedBefore=false;
   /// @brief Does the input have truth jets? If not, cannot decorate with true hard scatter / pileup info
   bool m_haveTruthJets = true;
 
@@ -203,6 +205,8 @@ public:
 
   float         m_systValfJVT = 0.0;
   std::string   m_systNamefJVT = "";
+  /// @brief was fJVT already run in an earlier instance of JetSelector?
+  bool m_fjvtUsedBefore=false;
 
   /// @brief Flag to apply btagging cut, if false just decorate decisions
   bool  m_doBTagCut = false;


### PR DESCRIPTION
This PR fixes the attempt to add HighPt and LowPt WP functionality to the MuonSelector in PR #1308, which was buggy and was assigning Loose rather than HighPt or LowPt.

Because the HighPt and LowPt WPs are not in xAOD::Muon::Quality, they cannot be added to the HelperClasses muon quality parser, so we have to check by hand.

The second commit updates the way the JVT SF vectors are filled. Currently if the JVT needs to be done twice (i.e. once in baseline jet selection, so the JVT decision is available for MET, and once in signal jet selection, to do the JVT veto), these vectors are filled each time --> twice for every signal jet, so there is a misalignment between this and other jet vectors. This commit checks if the vector was already filled for this jet, and if so, skips the SF calculation/ vector filling.