### PR TITLE
Choose the scale at which the selection is performed

### DIFF
--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -74,6 +74,9 @@ public:
 
    */
 
+  /** @brief Choose the scale at which the selection is performed (default "Final", i.e. default 4vector) */
+  std::string m_jetScale4Selection = "Final";
+
   bool m_cleanEvent = false;
   /** @brief Mark event with decorator if any passing jets are not clean */
   bool m_markCleanEvent = false;


### PR DESCRIPTION
These changes allow choosing the scale at which the selection is performed in JetSelector. The default still remains to be the final (default) jet momentum scale.

This functionality allows, for instance, to derive and apply a calibration to the same set of jets.

This doesn't change the scale at which the jets are saved in the output container.