### PR TITLE
Add information about SLC6 vs CC7 for grid subm.

### DIFF
--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -84,3 +84,13 @@ How do I...
    6. The tool associated to the handle will be automatically destroyed when appropriate. Hence, no need to call ``delete`` anywhere.
 
    If the same tool (identified by its name) needs to be used in another xAH algorithm downstream, just declare a tool handle member with the same ``IMyToolType``, call its constructor in the initialisation list and (if needed) change its tool name with ``make()``. Then in ``EL::initialize()`` simply call ``m_mytool_handle.initialize()``, without setting any property. It will automagically get the pointer to the correct tool from a registry, and all the tool properties will be preserved from the previous initialisation.
+
+SLC6 vs CC7
+-----------
+
+If you're running into issues with grid submission because of checks for SLC6-compatible machines in `xAH_run.py` preventing you from doing so, then you can either:
+
+- ssh into lxplus SLC6 (`lxplus6.cern.ch`)
+- run in a containerized SLC6 environment (`setupATLAS -c slc6`)
+
+

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -90,7 +90,10 @@ SLC6 vs CC7
 
 If you're running into issues with grid submission because of checks for SLC6-compatible machines in `xAH_run.py` preventing you from doing so, then you can either:
 
-- ssh into lxplus SLC6 (`lxplus6.cern.ch`)
-- run in a containerized SLC6 environment (`setupATLAS -c slc6`)
+- ssh into lxplus SLC6 (``lxplus6.cern.ch``)
+- run in a containerized SLC6 environment (``setupATLAS -c slc6``)
 
+If you think this message is happening in error, `file an issue <https://github.com/UCATLAS/xAODAnaHelpers/issues/new>`_ giving us the output from the following commands:
 
+- ``lsb_release -d``
+- ``printenv | grep _PLATFORM``

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
           isSLC6 = False
 
       if not isSLC6:
-        raise EnvironmentError('We think you\'re not running on SLC6. Grid jobs cannot be submitted from this machine.')
+        raise EnvironmentError('We think you\'re not running on SLC6. Grid jobs cannot be submitted from this machine. See https://xaodanahelpers.readthedocs.io/en/master/FAQs.html#slc6-vs-cc7 for more information.')
 
     # check submission directory
     if args.force_overwrite:


### PR DESCRIPTION
This adds a link to the error message when xAH_run.py determines that you're not running on an SLC6-compatible machine.