### PR TITLE
WIP: Update electron isolation working point list from IsolationSelectionTool TWiki

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -209,7 +209,7 @@ EL::StatusCode ElectronSelector :: initialize ()
   // Make sure it's not empty!
   //
   if ( m_IsoWPList.empty() ) {
-    m_IsoWPList = "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
+      ANA_MSG_ERROR("Empty isolation WP list");
   }
   std::string token;
   std::istringstream ss(m_IsoWPList);

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -156,7 +156,7 @@ public:
   /** @brief reject objects which do not pass this isolation cut - default = "" (no cut) */
   std::string    m_MinIsoWPCut = "";
   /** @brief decorate objects with ``isIsolated_*`` flag for each WP in this input list - default = all current ASG WPs */
-  std::string    m_IsoWPList = "LooseTrackOnly,Loose,Tight,Gradient,GradientLoose";
+  std::string    m_IsoWPList = "FCLoose,FCTight,Gradient,FCHighPtCaloOnly";
   /** @rst
      to define a custom WP - make sure ``"UserDefined"`` is added in :cpp:member:`~ElectronSelector::m_IsoWPList`
   @endrst */


### PR DESCRIPTION
Resolves #1340

Following the effort of PR #1325 electron isolation working point list to match the [nominal working point names in the IsolationSelectionTool TWiki](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/IsolationSelectionTool?rev=94#Leptons).