### PR TITLE
Extend TruthSelector and TruthContainer

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -459,6 +459,7 @@ namespace HelperClasses{
     m_bVtx          = has_exact("bVtx");
     m_parents       = has_exact("parents");
     m_children      = has_exact("children");
+    m_dressed       = has_exact("dressed");
   }
 
   void TrackInfoSwitch::initialize(){

--- a/Root/TruthContainer.cxx
+++ b/Root/TruthContainer.cxx
@@ -21,6 +21,11 @@ TruthContainer::TruthContainer(const std::string& name, const std::string& detai
     m_is_bhad   = new std::vector<int>();
   }
 
+  if(m_infoSwitch.m_type){
+    m_is_higgs  = new std::vector<int>();
+    m_is_bhad   = new std::vector<int>();
+  }
+
   if(m_infoSwitch.m_bVtx){
     m_Bdecay_x  = new std::vector<float>();
     m_Bdecay_y  = new std::vector<float>();
@@ -41,6 +46,12 @@ TruthContainer::TruthContainer(const std::string& name, const std::string& detai
     m_child_status   = new std::vector< std::vector<int> >();
   }
 
+  if(m_infoSwitch.m_dressed){
+    m_pt_dressed  = new std::vector<float>();
+    m_eta_dressed = new std::vector<float>();
+    m_phi_dressed = new std::vector<float>();
+    m_e_dressed   = new std::vector<float>();
+  }
 
 }
 
@@ -78,6 +89,13 @@ TruthContainer::~TruthContainer()
     delete m_child_status;
   }
 
+  if(m_infoSwitch.m_dressed){
+    delete m_pt_dressed;
+    delete m_eta_dressed;
+    delete m_phi_dressed;
+    delete m_e_dressed;
+  }
+
 }
 
 void TruthContainer::setTree(TTree *tree)
@@ -113,6 +131,13 @@ void TruthContainer::setTree(TTree *tree)
     connectBranch<std::vector<int> >(tree,"child_pdgId",   &m_child_pdgId);
     connectBranch<std::vector<int> >(tree,"child_barcode", &m_child_barcode);
     connectBranch<std::vector<int> >(tree,"child_status",  &m_child_status);
+  }
+
+  if(m_infoSwitch.m_dressed){
+    connectBranch<float> (tree,"pt_dressd",  &m_pt_dressed);
+    connectBranch<float> (tree,"eta_dressd", &m_eta_dressed);
+    connectBranch<float> (tree,"phi_dressd", &m_phi_dressed);
+    connectBranch<float> (tree,"e_dressd",   &m_e_dressed);
   }
 
 }
@@ -153,6 +178,12 @@ void TruthContainer::updateParticle(uint idx, TruthPart& truth)
     truth.child_status  = m_child_status ->at(idx);
   }
 
+  if(m_infoSwitch.m_dressed){
+    truth.pt_dressed  = m_pt_dressed->at(idx);
+    truth.eta_dressed = m_eta_dressed->at(idx);
+    truth.phi_dressed = m_phi_dressed->at(idx);
+    truth.e_dressed   = m_e_dressed->at(idx);
+  }
 
   if(m_debug) std::cout << "leave TruthContainer::updateParticle " << std::endl;
   return;
@@ -194,6 +225,12 @@ void TruthContainer::setBranches(TTree *tree)
     setBranch<std::vector<int> >(tree,"child_status",                 m_child_status         );
   }
 
+  if(m_infoSwitch.m_dressed){
+    setBranch<float> (tree,"pt_dressed", m_pt_dressed );
+    setBranch<float> (tree,"eta_dressed", m_eta_dressed );
+    setBranch<float> (tree,"phi_dressed", m_phi_dressed );
+    setBranch<float> (tree,"e_dressed", m_e_dressed );
+  }
 
   return;
 }
@@ -231,6 +268,13 @@ void TruthContainer::clear()
     m_child_pdgId->clear();
     m_child_barcode->clear();
     m_child_status->clear();
+  }
+
+  if(m_infoSwitch.m_dressed){
+    m_pt_dressed->clear();
+    m_eta_dressed->clear();
+    m_phi_dressed->clear();
+    m_e_dressed->clear();
   }
 
   return;
@@ -318,6 +362,32 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
     }
   }
 
+  if(m_infoSwitch.m_dressed){
+    if( truth->isAvailable<float>("pt_dressed") ){
+      float pt_dressed = truth->auxdata<float>("pt_dressed");
+      m_pt_dressed->push_back(pt_dressed / m_units);
+    } else {
+      m_pt_dressed->push_back(-999);
+    }
+    if( truth->isAvailable<float>("eta_dressed") ){
+      float eta_dressed = truth->auxdata<float>("eta_dressed");
+      m_eta_dressed->push_back(eta_dressed);
+    } else {
+      m_eta_dressed->push_back(-999);
+    }
+    if( truth->isAvailable<float>("phi_dressed") ){
+      float phi_dressed = truth->auxdata<float>("phi_dressed");
+      m_phi_dressed->push_back(phi_dressed);
+    } else {
+      m_phi_dressed->push_back(-999);
+    }
+    if( truth->isAvailable<float>("e_dressed") ){
+      float e_dressed = truth->auxdata<float>("e_dressed");
+      m_e_dressed->push_back(e_dressed / m_units);
+    } else {
+      m_e_dressed->push_back(-999);
+    }
+  }
 
   if(m_debug) std::cout << "Leave Fill Truth " << std::endl;
   return;

--- a/Root/TruthContainer.cxx
+++ b/Root/TruthContainer.cxx
@@ -15,12 +15,6 @@ TruthContainer::TruthContainer(const std::string& name, const std::string& detai
   m_status  = new std::vector<int>();
   m_barcode = new std::vector<int>();
 
-
-  if(m_infoSwitch.m_type){
-    m_is_higgs  = new std::vector<int>();
-    m_is_bhad   = new std::vector<int>();
-  }
-
   if(m_infoSwitch.m_type){
     m_is_higgs  = new std::vector<int>();
     m_is_bhad   = new std::vector<int>();

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -326,6 +326,56 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
     if ( truthPart->rapidity() < m_rapidity_min ) { return 0; }
   }
 
+  // selections for partiles from TruthClassifier
+
+  // type
+  if ( m_type != 1000 ) {
+    if( truthPart->isAvailable<unsigned int>("classifierParticleType") ){
+      unsigned int type = truthPart->auxdata<unsigned int>("classifierParticleType");
+      if ( type != m_type ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "classifierParticleType is not available" );
+    }
+  }
+
+  // origin
+  if ( m_origin != 1000 ) {
+    if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
+      unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
+      if ( origin != m_origin ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
+    }
+  }
+
+  // pt_dressed
+  if ( m_pT_dressed_min != 1e8 ) {
+    if( truthPart->isAvailable<float>("pt_dressed") ){
+      float pT_dressed = truthPart->auxdata<float>("pt_dressed");
+      if ( pT_dressed < m_pT_dressed_min ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "pt_dressed is not available" );
+    }
+  }
+
+  // eta_dressed
+  if ( m_eta_dressed_min != 1e8 ) {
+    if( truthPart->isAvailable<float>("eta_dressed") ){
+      float eta_dressed = truthPart->auxdata<float>("eta_dressed");
+      if ( eta_dressed < m_eta_dressed_min ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "eta_dressed is not available" );
+    }
+  }
+  if ( m_eta_dressed_max != 1e8 ) {
+    if( truthPart->isAvailable<float>("eta_dressed") ){
+      float eta_dressed = truthPart->auxdata<float>("eta_dressed");
+      if ( eta_dressed > m_eta_dressed_max ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "eta_dressed is not available" );
+    }
+  }
+
   return 1;
 }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -326,7 +326,7 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
     if ( truthPart->rapidity() < m_rapidity_min ) { return 0; }
   }
 
-  // selections for partiles from TruthClassifier
+  // selections for particles from MCTruthClassifier
 
   // type
   if ( m_type != 1000 ) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -549,6 +549,7 @@ namespace HelperClasses {
         m_bVtx           bVtx           exact
         m_parents        parents        exact
         m_children       children       exact
+        m_dressed        dressed        exact
         ================ ============== =======
 
 
@@ -560,6 +561,7 @@ namespace HelperClasses {
     bool m_bVtx;
     bool m_parents;
     bool m_children;
+    bool m_dressed;
     TruthInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();

--- a/xAODAnaHelpers/TruthContainer.h
+++ b/xAODAnaHelpers/TruthContainer.h
@@ -67,6 +67,12 @@ namespace xAH {
       std::vector< std::vector<int> >* m_child_barcode;
       std::vector< std::vector<int> >* m_child_status;
 
+      // dressed
+      std::vector<float>* m_pt_dressed;
+      std::vector<float>* m_eta_dressed;
+      std::vector<float>* m_phi_dressed;
+      std::vector<float>* m_e_dressed;
+
     };
 }
 

--- a/xAODAnaHelpers/TruthPart.h
+++ b/xAODAnaHelpers/TruthPart.h
@@ -36,6 +36,12 @@ namespace xAH {
       std::vector<int> child_barcode;
       std::vector<int> child_status;
 
+      // Dressed
+      float pt_dressed;
+      float eta_dressed;
+      float phi_dressed;
+      float e_dressed;
+
     };
 
 }//xAH

--- a/xAODAnaHelpers/TruthSelector.h
+++ b/xAODAnaHelpers/TruthSelector.h
@@ -40,7 +40,7 @@ public:
   int m_pass_max = -1;
   /// @brief require pT < pt_max
   float m_pT_max = 1e8;
-  /// @brief require pT > pt_max
+  /// @brief require pT > pt_min
   float m_pT_min = 1e8;
   /// @brief require eta < eta_max
   float m_eta_max = 1e8;
@@ -54,6 +54,16 @@ public:
   float m_rapidity_max = 1e8;
   /// @brief require rapidity > rapidity_min
   float m_rapidity_min = 1e8;
+  /// @brief require classifierParticleType == type (defined by TruthClassifier: https://gitlab.cern.ch/atlas/athena/blob/21.2/PhysicsAnalysis/MCTruthClassifier/MCTruthClassifier/MCTruthClassifierDefs.h)
+  unsigned int m_type = 1000; // this will apply no selection
+  /// @brief require classifierParticleOrigin == origin (defined by TruthClassifier: https://gitlab.cern.ch/atlas/athena/blob/21.2/PhysicsAnalysis/MCTruthClassifier/MCTruthClassifier/MCTruthClassifierDefs.h)
+  unsigned int m_origin = 1000; // this will apply no selection
+  /// @brief require pt_dressed > pt_dressed_min
+  float m_pT_dressed_min = 1e8;
+  /// @brief require eta_dressed > eta_dressed_min
+  float m_eta_dressed_min = 1e8;
+  /// @brief require eta_dressed > eta_dressed_max
+  float m_eta_dressed_max = 1e8;
 
 private:
   int m_numEvent;         //!


### PR DESCRIPTION
These changes allow to select truth muons/electrons from
STDMTruthMuons/Electrons and do not change the previous behaviour.

We can now select on *_dressed, classifierParticleType and classifierParticleOrigin in TruthSelector (these quantities are calculated with MCTruthClassifier).

We can now store pT_dressed, eta_dressed, phi_dressed and e_dressed into
the TTrees.

This will be used in the SM Z+HF analysis.