### PR TITLE
Activate AddTriggerUser() and FillTriggerUser() functionalities

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -192,7 +192,7 @@ void HelpTreeBase::AddTrigger( const std::string detailStr ) {
     m_tree->Branch("isPassBitsNames",      &m_isPassBitsNames     );
   }
 
-  //this->AddTriggerUser();
+  this->AddTriggerUser( detailStr );
 }
 
 // Fill the information in the trigger branches

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -275,7 +275,8 @@ void HelpTreeBase::FillTrigger( const xAOD::EventInfo* eventInfo ) {
     if( isPassBitsNames.isAvailable( *eventInfo ) ) { m_isPassBitsNames = isPassBitsNames( *eventInfo ); }
 
   }
-
+  
+  this->FillTriggerUser(eventInfo);
 }
 
 // Clear Trigger


### PR DESCRIPTION
I'd like to be able to save user-defined trigger information to my trees using the HelpTreeBase class. But the AddTriggerUser() function was commented out, while FillTriggerUser() was not being called. Shouldn't these two be available for use, in consistency with what is offered by others (Event,Jet,etc.)?