### PR TITLE
allow for configurable autoflush

### DIFF
--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -266,6 +266,7 @@ EL::StatusCode TreeAlgo :: execute ()
 
     // tell the tree to go into the file
     outTree->SetDirectory( treeFile->GetDirectory(m_name.c_str()) );
+    if(m_autoFlush != 0) outTree->SetAutoFlush(m_autoFlush);
     // choose if want to add tree to same directory as ouput histograms
     if ( m_outHistDir ) {
       if(m_trees.size() > 1) ANA_MSG_WARNING( "You're running systematics! You may find issues in writing all of the output TTrees to the output histogram file... Set `m_outHistDir = false` if you run into issues!");

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -71,6 +71,9 @@ public:
   /// @brief unit conversion from MeV, default is GeV
   float m_units = 1e3;
 
+  /// @brief Set to a large negative number, such as -1000000, to ensure that the tree flushes memory after a reasonable amount of time. Otherwise, jobs with a lot of systematics use too much memory.
+  int m_autoFlush = 0;
+
 protected:
   std::vector<std::string> m_jetDetails; //!
   std::vector<std::string> m_trigJetDetails; //!


### PR DESCRIPTION
Set the `m_autoFlush` of TreeAlgo to a non-zero number to enable autoflushing. This was inspired from #1198 and resolves #1170.