### PR TITLE
Implement largeR truth-labelling in JetCalibrator for systematics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,16 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.65
-    - RELEASE=AnalysisTop,21.2.65
-    - RELEASE=AnalysisBase,21.2.64
-    - RELEASE=AnalysisTop,21.2.64
-    - RELEASE=AnalysisBase,21.2.62
-    - RELEASE=AnalysisTop,21.2.62
-    - RELEASE=AnalysisBase,21.2.61
-    - RELEASE=AnalysisTop,21.2.61
+    - RELEASE=AnalysisBase,21.2.81
+    - RELEASE=AnalysisTop,21.2.81
+    - RELEASE=AnalysisBase,21.2.80
+    - RELEASE=AnalysisTop,21.2.80
+    - RELEASE=AnalysisBase,21.2.79
+    - RELEASE=AnalysisTop,21.2.79
+    - RELEASE=AnalysisBase,21.2.78
+    - RELEASE=AnalysisTop,21.2.78
+    - RELEASE=AnalysisBase,21.2.77
+    - RELEASE=AnalysisTop,21.2.77
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,10 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.81
-    - RELEASE=AnalysisTop,21.2.81
-    - RELEASE=AnalysisBase,21.2.80
-    - RELEASE=AnalysisTop,21.2.80
-    - RELEASE=AnalysisBase,21.2.79
-    - RELEASE=AnalysisTop,21.2.79
-    - RELEASE=AnalysisBase,21.2.78
-    - RELEASE=AnalysisTop,21.2.78
-    - RELEASE=AnalysisBase,21.2.77
-    - RELEASE=AnalysisTop,21.2.77
+    - RELEASE=AnalysisBase,21.2.84
+    - RELEASE=AnalysisTop,21.2.84
+    - RELEASE=AnalysisBase,21.2.85
+    - RELEASE=AnalysisTop,21.2.85
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    JetCPInterfaces xAODBTaggingEfficiencyLib TrigConfxAODLib
                    TrigDecisionToolLib xAODCutFlow JetMomentToolsLib
                    TriggerMatchingToolLib xAODMetaDataCnv xAODMetaData
-                   JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils JetTileCorrectionLib
+                   JetJvtEfficiencyLib PMGToolsLib JetSubStructureUtils JetTileCorrectionLib BoostedJetTaggersLib
                    ${release_libs}
 )
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -469,7 +469,7 @@ EL::StatusCode JetCalibrator :: execute ()
 
       // largeR jet truth labelling
       if(m_SmoothedWZTagger_handle.isInitialized()) {
-	m_SmoothedWZTagger_handle->decorateTruthLabel(*jet_itr, "FatjetTruthLabel");
+	m_SmoothedWZTagger_handle->decorateTruthLabel(*jet_itr);
       }
     }
 

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -215,6 +215,10 @@ EL::StatusCode JetCalibrator :: initialize ()
       ANA_MSG_WARNING("Calibrating AntiKt4EM jets in fullsim without the smearing step. This is not recommended, make sure it's really what you want!");
   }
 
+  // retrieve EventInfo to get sample information
+  const xAOD::EventInfo* ei(nullptr);
+  ANA_CHECK(HelperFunctions::retrieve(ei, m_eventInfoContainerName, m_event, m_store, msg()));
+
   // initialize jet calibration tool
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JetCalibrationTool_handle, JetCalibrationTool));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("JetCollection",m_jetAlgo));
@@ -274,6 +278,16 @@ EL::StatusCode JetCalibrator :: initialize ()
       }// For each cleaning decision
     }//If save all cleaning decisions
   }// if m_doCleaning
+
+  // initialize largeR jet truth labelling tool
+  if(isMC() && m_inContainerName.find("AntiKt10") != std::string::npos){
+    // Truth labelling is required for systematics on largeR jets and is provided by the WZ tagger tool.
+    // Since only the truth-labelling functionality is used, the tagger config is hard-coded as it does not matter.
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("CalibArea" , "SmoothedWZTaggers/Rel21"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("ConfigFile", "SmoothedContainedWTagger_AntiKt10LCTopoTrimmed_FixedSignalEfficiency50_MC16d_20190410.dat"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("DSID", ei->mcChannelNumber()));
+    ANA_CHECK(m_SmoothedWZTagger_handle.retrieve());
+  }// if MC && largeR
 
   // Generate nominal systematic
   const CP::SystematicSet recSyst = CP::SystematicSet();;
@@ -430,30 +444,37 @@ EL::StatusCode JetCalibrator :: execute ()
   for ( auto jet_itr : *(calibJetsSC.first) ) {
     m_numObject++;
 
-    //Set isBjet for Jet Systematics
+    //
+    // truth labelling for systematics
     if(isMC() && m_runSysts){
 
+      // b-jet truth labelling
       int this_TruthLabel = 0;
 
       static SG::AuxElement::ConstAccessor<int> TruthLabelID ("TruthLabelID");
       static SG::AuxElement::ConstAccessor<int> PartonTruthLabelID ("PartonTruthLabelID");
 
       if ( TruthLabelID.isAvailable( *jet_itr) ) {
-  this_TruthLabel = TruthLabelID( *jet_itr );
-  if (this_TruthLabel == 21 || this_TruthLabel<4) this_TruthLabel = 0;
+	this_TruthLabel = TruthLabelID( *jet_itr );
+	if (this_TruthLabel == 21 || this_TruthLabel<4) this_TruthLabel = 0;
       } else if(PartonTruthLabelID.isAvailable( *jet_itr) ) {
-  this_TruthLabel = PartonTruthLabelID( *jet_itr );
-  if (this_TruthLabel == 21 || this_TruthLabel<4) this_TruthLabel = 0;
+	this_TruthLabel = PartonTruthLabelID( *jet_itr );
+	if (this_TruthLabel == 21 || this_TruthLabel<4) this_TruthLabel = 0;
       }
 
       bool isBjet = false; // decide whether or not the jet is a b-jet (truth-labelling + kinematic selections)
       if (this_TruthLabel == 5) isBjet = true;
       static SG::AuxElement::Decorator<char> accIsBjet("IsBjet"); // char due to limitations of ROOT I/O, still treat it as a bool
       accIsBjet(*jet_itr) = isBjet;
+
+      // largeR jet truth labelling
+      if(m_SmoothedWZTagger_handle.isInitialized()) {
+	m_SmoothedWZTagger_handle->decorateTruthLabel(*jet_itr, "FatjetTruthLabel");
+      }
     }
 
-
-
+    //
+    // the calibration
     if ( m_JetCalibrationTool_handle->applyCorrection( *jet_itr ) == CP::CorrectionCode::Error ) {
       ANA_MSG_ERROR( "JetCalibration tool reported a CP::CorrectionCode::Error");
       ANA_MSG_ERROR( m_name );

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -22,6 +22,7 @@
 #include "JetInterface/IJetSelector.h"
 #include "JetInterface/IJetUpdateJvt.h"
 #include "JetCPInterfaces/IJetTileCorrectionTool.h"
+#include "BoostedJetTaggers/SmoothedWZTagger.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -153,6 +154,7 @@ private:
   asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , this}; //!
   asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , this}; //!
   asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", this}; //!
+  asg::AnaToolHandle<SmoothedWZTagger>           m_SmoothedWZTagger_handle     {"SmoothedWZTagger"     , this}; //!
 
   std::vector<asg::AnaToolHandle<IJetSelector>>  m_AllJetCleaningTool_handles; //!
   std::vector<std::string>  m_decisionNames;    //!


### PR DESCRIPTION
The latest JetUncertainties tool requires the largeR jets to be truth-labelled. This PR adds the functionality using the SmoothedWZTaggers tool ([following the recommendation](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetUncertaintiesRel21Summer2019LargeR#Truth_labelling_via_BoostedJetTa)).

Tagging the resisdent largeR jet expert for cross-check. @mattleblanc 

Marking as WIP until my grid run with this finishes.