### PR TITLE
Store several l1 jet collections

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -614,59 +614,36 @@ void HelpTreeBase::ClearClusters(const std::string clusterName) {
  *
  ********************/
 
-void HelpTreeBase::AddL1Jets()
+void HelpTreeBase::AddL1Jets( const std::string jetName)
 {
 
-  if(m_debug) Info("AddL1Jets()", "Adding kinematics jet variables");
+  if(m_debug) Info("AddL1Jets()", "Adding %s L1 jets", jetName.c_str());
 
-  m_tree->Branch("nL1Jets",     &m_nL1Jet,"nL1Jets/I");
-  m_tree->Branch("L1Jet_et8x8", &m_l1Jet_et8x8);
-  m_tree->Branch("L1Jet_eta",   &m_l1Jet_eta);
-  m_tree->Branch("L1Jet_phi",   &m_l1Jet_phi);
+  m_l1Jets[jetName] = new xAH::L1JetContainer(jetName, m_units, m_isMC);
+  m_l1Jets[jetName]->m_debug = m_debug;
+
+  xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
+  thisL1Jet->setBranches(m_tree);
 
 }
 
-void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, bool sortL1Jets ) {
+void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string jetName, bool sortL1Jets ) {
 
-  this->ClearL1Jets();
+  this->ClearL1Jets(jetName);
 
-  if(!sortL1Jets) {
-    for( auto jet_itr : *jets ) {
-      m_l1Jet_et8x8.push_back ( jet_itr->et8x8() / m_units );
-      m_l1Jet_eta.push_back( jet_itr->eta() );
-      m_l1Jet_phi.push_back( jet_itr->phi() );
-      m_nL1Jet++;
-    }
-  }
+  xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
   
-  else {
-    std::vector< std::vector<float> > vec;
-    for( auto jet_itr : *jets ) {
-      std::vector<float> row;
-      row.clear();
-      row.push_back(jet_itr->et8x8());
-      row.push_back(jet_itr->eta());
-      row.push_back(jet_itr->phi());
-      vec.push_back(row);
-    }
-    
-    std::sort(vec.begin(), vec.end(), [&](const std::vector<float> a, const std::vector<float> b) { return a.at(0) < b.at(0);});
-    for (int i = int(vec.size())-1; i >= 0; i--) {
-      m_l1Jet_et8x8.push_back((vec.at(i)).at(0) / m_units);
-      m_l1Jet_eta.push_back((vec.at(i)).at(1));
-      m_l1Jet_phi.push_back((vec.at(i)).at(2));
-      m_nL1Jet++;
-    }
-    vec.clear();
-  }
+  thisL1Jet->FillL1Jets(jets,sortL1Jets);
+
 }
 
+void HelpTreeBase::ClearL1Jets(const std::string jetName) {
 
-void HelpTreeBase::ClearL1Jets() {
-  m_nL1Jet = 0;
-  m_l1Jet_et8x8.clear();
-  m_l1Jet_eta.clear();
-  m_l1Jet_phi.clear();
+  xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
+  std::cout << "Before thisL1Jet->clear()" << std::endl;
+  thisL1Jet->clear();
+  std::cout << "After thisL1Jet->clear()" << std::endl;
+
 }
 
 

--- a/Root/L1JetContainer.cxx
+++ b/Root/L1JetContainer.cxx
@@ -1,0 +1,79 @@
+#include "xAODAnaHelpers/L1JetContainer.h"
+#include <iostream>
+
+using namespace xAH;
+
+L1JetContainer::L1JetContainer(const std::string& name, float units, bool mc)
+  : ParticleContainer(name,"",units,mc)
+{
+  m_l1Jet_et8x8             =new std::vector<float>();
+  m_l1Jet_eta               =new std::vector<float>();
+  m_l1Jet_phi               =new std::vector<float>();
+}
+
+L1JetContainer::~L1JetContainer()
+{
+  if(m_debug) std::cout << " Deleting L1JetContainer "  << std::endl;
+  delete m_l1Jet_et8x8;
+  delete m_l1Jet_eta;
+  delete m_l1Jet_phi;
+}
+
+void L1JetContainer::setTree(TTree *tree)
+{
+  ParticleContainer::setTree(tree);
+  connectBranch<float>(tree,"et8x8",&m_l1Jet_et8x8);
+  connectBranch<float>(tree,"eta",  &m_l1Jet_eta);
+  connectBranch<float>(tree,"phi",  &m_l1Jet_phi);
+}
+
+void L1JetContainer::updateParticle(uint idx, Jet& jet)
+{
+  ParticleContainer::updateParticle(idx,jet);
+}
+
+void L1JetContainer::setBranches(TTree *tree)
+{
+  ParticleContainer::setBranches(tree);
+  setBranch<float>(tree,"et8x8",m_l1Jet_et8x8);
+  setBranch<float>(tree,"eta",  m_l1Jet_eta);
+  setBranch<float>(tree,"phi",  m_l1Jet_phi);
+  return;
+}
+
+void L1JetContainer::clear()
+{
+  ParticleContainer::clear();
+  m_l1Jet_et8x8->clear();
+  m_l1Jet_eta  ->clear();
+  m_l1Jet_phi  ->clear();
+  return;
+}
+
+void L1JetContainer::FillL1Jets( const xAOD::JetRoIContainer* jets, bool sort){
+  if(!sort) {
+    for( auto jet_itr : *jets ) {
+      m_l1Jet_et8x8->push_back ( jet_itr->et8x8() / m_units );
+      m_l1Jet_eta->push_back( jet_itr->eta() );
+      m_l1Jet_phi->push_back( jet_itr->phi() );
+    }
+  } else {
+    std::vector< std::vector<float> > vec;
+    for( auto jet_itr : *jets ) {
+      std::vector<float> row;
+      row.clear();
+      row.push_back(jet_itr->et8x8());
+      row.push_back(jet_itr->eta());
+      row.push_back(jet_itr->phi());
+      vec.push_back(row);
+    }
+    
+    std::sort(vec.begin(), vec.end(), [&](const std::vector<float> a, const std::vector<float> b) { return a.at(0) < b.at(0);});
+    for (int i = int(vec.size())-1; i >= 0; i--) {
+      m_l1Jet_et8x8->push_back((vec.at(i)).at(0) / m_units);
+      m_l1Jet_eta->push_back((vec.at(i)).at(1));
+      m_l1Jet_phi->push_back((vec.at(i)).at(2));
+    }
+    vec.clear();
+  }
+}

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -284,10 +284,8 @@ EL::StatusCode TreeAlgo :: execute ()
       }
     }
     if (!m_l1JetContainerName.empty() )         { helpTree->AddL1Jets();                                           }
-    // if (!m_trigJetContainerName.empty() )       { helpTree->AddJets(m_trigJetDetailStr, "trigJet");                }
     if (!m_trigJetContainerName.empty() )      {
       for(unsigned int ll=0; ll<m_trigJetContainers.size();++ll){
-        // helpTree->AddJets       (m_trigJetDetailStr, m_trigJetBranches.at(ll).c_str());
         if(m_trigJetDetails.size()==1) helpTree->AddJets       (m_trigJetDetailStr, m_trigJetBranches.at(ll).c_str());
 	else{ helpTree->AddJets       (m_trigJetDetails.at(ll), m_trigJetBranches.at(ll).c_str()); }
       }
@@ -298,11 +296,6 @@ EL::StatusCode TreeAlgo :: execute ()
       }
     }
     if ( !m_fatJetContainerName.empty() ) {
-      // std::string token;
-      // std::istringstream ss(m_fatJetContainerName);
-      // while ( std::getline(ss, token, ' ') ){
-        // helpTree->AddFatJets(m_fatJetDetailStr, token);
-      // }
       for(unsigned int ll=0; ll<m_fatJetContainers.size();++ll){
         if(m_fatJetDetails.size()==1) helpTree->AddFatJets       (m_fatJetDetailStr, m_fatJetBranches.at(ll).c_str());
 	else{ helpTree->AddFatJets       (m_fatJetDetails.at(ll), m_fatJetBranches.at(ll).c_str()); }

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -33,6 +33,7 @@
 #include "xAODAnaHelpers/EventInfo.h"
 #include "xAODAnaHelpers/MetContainer.h"
 #include "xAODAnaHelpers/JetContainer.h"
+#include "xAODAnaHelpers/L1JetContainer.h"
 #include "xAODAnaHelpers/ElectronContainer.h"
 #include "xAODAnaHelpers/PhotonContainer.h"
 #include "xAODAnaHelpers/ClusterContainer.h"
@@ -77,7 +78,7 @@ public:
   void AddPhotons     (const std::string detailStr = "", const std::string photonName = "ph");
   void AddClusters    (const std::string detailStr = "", const std::string clusterName = "cl");
   void AddJets        (const std::string detailStr = "", const std::string jetName = "jet");
-  void AddL1Jets      ();
+  void AddL1Jets      (const std::string jetName   = "");
   void AddTruthParts  (const std::string truthName,      const std::string detailStr = "");
   void AddTrackParts  (const std::string trackName,	 const std::string detailStr = "");
 
@@ -139,7 +140,7 @@ public:
 
   void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string jetName = "jet" );
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
-  void FillL1Jets( const xAOD::JetRoIContainer* jets, bool sortL1Jets = false );
+  void FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string jetName = "L1Jet", bool sortL1Jets = false );
 
   void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
@@ -175,7 +176,7 @@ public:
   void ClearPhotons     (const std::string photonName = "ph");
   void ClearClusters    (const std::string clusterName = "cl");
   void ClearJets        (const std::string jetName = "jet");
-  void ClearL1Jets      ();
+  void ClearL1Jets      (const std::string jetName = "L1Jet");
   void ClearTruth       (const std::string truthName);
   void ClearTracks	(const std::string trackName);
   void ClearFatJets     (const std::string fatjetName, const std::string suffix="");
@@ -349,10 +350,7 @@ protected:
   //
   // L1 Jets
   //
-  int m_nL1Jet;
-  std::vector<float> m_l1Jet_et8x8;
-  std::vector<float> m_l1Jet_eta;
-  std::vector<float> m_l1Jet_phi;
+  std::map<std::string, xAH::L1JetContainer*> m_l1Jets;
 
   //
   // Truth

--- a/xAODAnaHelpers/L1JetContainer.h
+++ b/xAODAnaHelpers/L1JetContainer.h
@@ -1,0 +1,41 @@
+#ifndef xAODAnaHelpers_L1JetContainer_H
+#define xAODAnaHelpers_L1JetContainer_H
+
+#include <TTree.h>
+#include <TLorentzVector.h>
+
+#include <vector>
+#include <string>
+
+#include <xAODAnaHelpers/HelperClasses.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+
+#include <xAODTrigger/JetRoIContainer.h>
+
+#include <xAODAnaHelpers/Jet.h>
+#include <xAODAnaHelpers/ParticleContainer.h>
+
+namespace xAH {
+
+    class L1JetContainer : public ParticleContainer<Jet,HelperClasses::JetInfoSwitch>
+    {
+    public:
+      L1JetContainer(const std::string& name = "L1Jet", float units = 1e3, bool mc = false);
+      virtual ~L1JetContainer();
+
+      virtual void setTree    (TTree *tree);
+      virtual void setBranches(TTree *tree);
+      virtual void clear();
+      virtual void FillL1Jets( const xAOD::JetRoIContainer* jets, bool sort);
+      virtual void updateParticle(uint idx, Jet& jet);
+
+    private:
+      // Vector branches
+      std::vector<float>* m_l1Jet_et8x8;
+      std::vector<float>* m_l1Jet_eta;
+      std::vector<float>* m_l1Jet_phi;
+    };
+
+}
+
+#endif // xAODAnaHelpers_L1JetContainer_H

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -56,6 +56,7 @@ public:
   std::string m_truthParticlesContainerName = "";
   std::string m_trackParticlesContainerName = "";
   std::string m_l1JetContainerName = "";
+  std::string m_l1JetBranchName    = "L1Jet";
   bool m_sortL1Jets = false;
   bool m_retrievePV = true;
 
@@ -80,11 +81,13 @@ protected:
   std::vector<std::string> m_truthJetContainers; //!
   std::vector<std::string> m_trigJetContainers; //!
   std::vector<std::string> m_fatJetContainers; //!
+  std::vector<std::string> m_l1JetContainers; //!
 
   std::vector<std::string> m_jetBranches; //!
   std::vector<std::string> m_truthJetBranches; //!
   std::vector<std::string> m_trigJetBranches; //!
   std::vector<std::string> m_fatJetBranches; //!
+  std::vector<std::string> m_l1JetBranches; //!
 
   std::vector<std::string> m_clusterDetails; //!
   std::vector<std::string> m_clusterContainers; //!


### PR DESCRIPTION
Similarly to reco/truth/HLT trigger jets, with these changes we could also save more than one L1 jet collection (for instance, Run 2 and Run 3 L1 jet collections).
Example of saving L1 jets with TreeAlgo:
c.algorithm("TreeAlgo",   {
  "m_name"                            : "outTree",
  "m_msgLevel"                      : "info",
  "m_l1JetContainerName"     : "LVL1JetRoIs jRoundJets",
  "m_l1JetBranchName"         : "Run2L1Jet Run3L1Jet",
  "m_sortL1Jets"                     : True,
} )