### PR TITLE
Save vertex information

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -640,9 +640,7 @@ void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::str
 void HelpTreeBase::ClearL1Jets(const std::string jetName) {
 
   xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
-  std::cout << "Before thisL1Jet->clear()" << std::endl;
   thisL1Jet->clear();
-  std::cout << "After thisL1Jet->clear()" << std::endl;
 
 }
 
@@ -1025,4 +1023,39 @@ bool HelpTreeBase::writeTo( TFile* file ) {
   int status( m_tree->Write() );
   if ( status == 0 ) { return false; }
   return true;
+}
+
+/*********************
+ *
+ *   VERTICES
+ *
+ ********************/
+
+void HelpTreeBase::AddVertices( const std::string detailStr, const std::string vertexName )
+{
+
+  if(m_debug) Info("AddVertices()", "Adding %s vertices", vertexName.c_str());
+
+  m_vertices[vertexName] = new xAH::VertexContainer(detailStr, vertexName);
+  xAH::VertexContainer* thisVertex = m_vertices[vertexName];
+  thisVertex->setBranches(m_tree);
+
+}
+
+void HelpTreeBase::FillVertices( const xAOD::VertexContainer* vertices, const std::string vertexName ) {
+
+  this->ClearVertices(vertexName);
+
+  xAH::VertexContainer* thisVertex = m_vertices[vertexName];
+
+  thisVertex->FillVertices(vertices);
+
+}
+
+void HelpTreeBase::ClearVertices( const std::string vertexName )
+{
+
+  xAH::VertexContainer* thisVertex = m_vertices[vertexName];
+  thisVertex->clear();
+
 }

--- a/Root/VertexContainer.cxx
+++ b/Root/VertexContainer.cxx
@@ -53,10 +53,11 @@ void VertexContainer::clear()
 }
 
 void VertexContainer::FillVertices( const xAOD::VertexContainer* vertices){
-  if(m_detailStr == "primary"){
-    m_vertex_x->push_back( vertices->at(0)->x() );
-    m_vertex_y->push_back( vertices->at(0)->y() );
-    m_vertex_z->push_back( vertices->at(0)->z() );
+  if(m_detailStr == "primary"){ // hard-scatter vertex only
+    int pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
+    m_vertex_x->push_back( vertices->at(pvLocation)->x() );
+    m_vertex_y->push_back( vertices->at(pvLocation)->y() );
+    m_vertex_z->push_back( vertices->at(pvLocation)->z() );
   } else if (m_detailStr == "all"){
     for( auto vertex : *vertices) {
       m_vertex_x->push_back( vertex->x() );

--- a/Root/VertexContainer.cxx
+++ b/Root/VertexContainer.cxx
@@ -1,0 +1,67 @@
+#include "xAODAnaHelpers/VertexContainer.h"
+#include <iostream>
+
+using namespace xAH;
+
+VertexContainer::VertexContainer(const std::string& detailStr, const std::string& name)
+{
+  m_name      = name;
+  m_detailStr = detailStr;
+  if(m_detailStr!=""){
+    m_vertex_x  = new std::vector<float>();
+    m_vertex_y  = new std::vector<float>();
+    m_vertex_z  = new std::vector<float>();
+  }
+}
+
+VertexContainer::~VertexContainer()
+{
+  if(m_detailStr!=""){
+    delete m_vertex_x;
+    delete m_vertex_y;
+    delete m_vertex_z;
+  }
+}
+
+void VertexContainer::setTree(TTree *tree)
+{
+  if(m_detailStr!=""){
+    connectBranch<float>(tree,"x",&m_vertex_x);
+    connectBranch<float>(tree,"y",&m_vertex_y);
+    connectBranch<float>(tree,"z",&m_vertex_z);
+  }
+}
+
+void VertexContainer::setBranches(TTree *tree)
+{
+  if(m_detailStr!=""){
+    setBranch<float>(tree,"x",m_vertex_x);
+    setBranch<float>(tree,"y",m_vertex_y);
+    setBranch<float>(tree,"z",m_vertex_z);
+  }
+  return;
+}
+
+void VertexContainer::clear()
+{
+  if(m_detailStr!=""){
+    m_vertex_x->clear();
+    m_vertex_y->clear();
+    m_vertex_z->clear();
+  }
+  return;
+}
+
+void VertexContainer::FillVertices( const xAOD::VertexContainer* vertices){
+  if(m_detailStr == "primary"){
+    m_vertex_x->push_back( vertices->at(0)->x() );
+    m_vertex_y->push_back( vertices->at(0)->y() );
+    m_vertex_z->push_back( vertices->at(0)->z() );
+  } else if (m_detailStr == "all"){
+    for( auto vertex : *vertices) {
+      m_vertex_x->push_back( vertex->x() );
+      m_vertex_y->push_back( vertex->y() );
+      m_vertex_z->push_back( vertex->z() );
+    }
+  }
+}

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -34,6 +34,7 @@
 #include "xAODAnaHelpers/MetContainer.h"
 #include "xAODAnaHelpers/JetContainer.h"
 #include "xAODAnaHelpers/L1JetContainer.h"
+#include "xAODAnaHelpers/VertexContainer.h"
 #include "xAODAnaHelpers/ElectronContainer.h"
 #include "xAODAnaHelpers/PhotonContainer.h"
 #include "xAODAnaHelpers/ClusterContainer.h"
@@ -81,6 +82,7 @@ public:
   void AddL1Jets      (const std::string jetName   = "");
   void AddTruthParts  (const std::string truthName,      const std::string detailStr = "");
   void AddTrackParts  (const std::string trackName,	 const std::string detailStr = "");
+  void AddVertices    (const std::string detailStr = "", const std::string vertexName = "vertex"); // options for detailStr: "all" or "primary"
 
   /**
    *  @brief  Declare a new collection of fatjets to be written to the output tree.
@@ -148,6 +150,8 @@ public:
   void FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* tracks);
   void FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName );
 
+  void FillVertices( const xAOD::VertexContainer* vertices, const std::string vertexName = "vertex");
+
   /**
    *  @brief  Write a container of jets to the specified container name (and optionally suffix). The
    *          container name and suffix should be declared beforehand using `AddFatJets()`.
@@ -183,6 +187,7 @@ public:
   void ClearTruthFatJets(const std::string truthFatJetName = "truth_fatjet");
   void ClearTaus        (const std::string tauName = "tau" );
   void ClearMET         (const std::string metName = "met");
+  void ClearVertices    (const std::string vertexName = "vertex");
 
   bool writeTo( TFile *file );
 
@@ -406,6 +411,11 @@ protected:
   // met
   //
   std::map<std::string, xAH::MetContainer* > m_met;
+
+  //
+  // vertices
+  //
+  std::map<std::string, xAH::VertexContainer*> m_vertices;
 
 };
 

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -33,6 +33,7 @@ public:
   std::string m_clusterDetailStr = "";
   std::string m_truthParticlesDetailStr = "";
   std::string m_trackParticlesDetailStr = "";
+  std::string m_vertexDetailStr = "";
 
   std::string m_evtContainerName = "";
   std::string m_muContainerName = "";
@@ -57,6 +58,7 @@ public:
   std::string m_trackParticlesContainerName = "";
   std::string m_l1JetContainerName = "";
   std::string m_l1JetBranchName    = "L1Jet";
+  std::string m_vertexBranchName   = "vertex";
   bool m_sortL1Jets = false;
   bool m_retrievePV = true;
 
@@ -82,16 +84,20 @@ protected:
   std::vector<std::string> m_trigJetContainers; //!
   std::vector<std::string> m_fatJetContainers; //!
   std::vector<std::string> m_l1JetContainers; //!
+  std::vector<std::string> m_vertexContainers; //!
 
   std::vector<std::string> m_jetBranches; //!
   std::vector<std::string> m_truthJetBranches; //!
   std::vector<std::string> m_trigJetBranches; //!
   std::vector<std::string> m_fatJetBranches; //!
   std::vector<std::string> m_l1JetBranches; //!
+  std::vector<std::string> m_vertexBranches; //!
 
   std::vector<std::string> m_clusterDetails; //!
   std::vector<std::string> m_clusterContainers; //!
   std::vector<std::string> m_clusterBranches; //!
+
+  std::vector<std::string> m_vertexDetails; //!
 
   std::map<std::string, HelpTreeBase*> m_trees;            //!
 

--- a/xAODAnaHelpers/VertexContainer.h
+++ b/xAODAnaHelpers/VertexContainer.h
@@ -1,0 +1,63 @@
+#ifndef xAODAnaHelpers_VertexContainer_H
+#define xAODAnaHelpers_VertexContainer_H
+
+#include <TTree.h>
+#include <TLorentzVector.h>
+
+#include <vector>
+#include <string>
+
+#include <xAODAnaHelpers/HelperClasses.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+
+#include "xAODTracking/VertexContainer.h"
+
+namespace xAH {
+
+    class VertexContainer
+    {
+    public:
+      VertexContainer(const std::string& detailStr, const std::string& name = "vertex");
+      virtual ~VertexContainer();
+
+      virtual void setTree    (TTree *tree);
+      virtual void setBranches(TTree *tree);
+      virtual void clear();
+      virtual void FillVertices( const xAOD::VertexContainer* vertices);
+
+      std::string m_name;
+
+      std::string branchName(const std::string& varName)
+      {
+        std::string name = m_name + "_" + varName;
+        return name;
+      }
+
+      template <typename T_BR> void connectBranch(TTree *tree, const std::string& branch, std::vector<T_BR> **variable)
+      {
+        std::string name = branchName(branch);
+        if(*variable) { delete (*variable); (*variable)=0; }
+        if(tree->GetBranch(name.c_str()))
+          {
+            (*variable)=new std::vector<T_BR>();
+            tree->SetBranchStatus  (name.c_str()  , 1);
+            tree->SetBranchAddress (name.c_str()  , variable);
+          }
+      }
+
+      template<typename T> void setBranch(TTree* tree, std::string varName, std::vector<T>* localVectorPtr){
+        std::string name = branchName(varName);
+        tree->Branch(name.c_str(),        localVectorPtr);
+      }
+
+    private:
+      // Vector branches
+      std::vector<float>* m_vertex_x;
+      std::vector<float>* m_vertex_y;
+      std::vector<float>* m_vertex_z;
+      std::string         m_detailStr;
+    };
+
+}
+
+#endif // xAODAnaHelpers_VertexContainer_H


### PR DESCRIPTION
When "m_vertexDetails" from TreeAlgo is "primary" or "all", vertex information (x, y and z) for, respectively, primary/hard-scatter vertex or all vertices is saved.
Similarly to other objects, it is possible to save more than one vertex container by listing them in "m_vertexContainerName" (space separated). It is also possible to choose the branch name(s) with "m_vertexBranchName".

When saving more than one vertex collection, the first vertex collection in "m_vertexContainerName" is the one used elsewhere, for instance for track-based jet moments.
