### PR TITLE
add option to not store prescale weight

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1007,8 +1007,10 @@ EL::StatusCode BasicEventSelection :: execute ()
 
     }
 
-    static SG::AuxElement::Decorator< float > weight_prescale("weight_prescale");
-    weight_prescale(*eventInfo) = triggerChainGroup->getPrescale();
+    if ( m_storePrescaleWeight ) {
+      static SG::AuxElement::Decorator< float > weight_prescale("weight_prescale");
+      weight_prescale(*eventInfo) = triggerChainGroup->getPrescale();
+    }
 
     if ( m_storePassL1 ) {
       static SG::AuxElement::Decorator< int > passL1("passL1");

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -173,6 +173,9 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Save master, L1, and HLT key
     bool m_storeTrigKeys = false;
 
+    /// @brief Save the trigger prescale weight
+    bool m_storePrescaleWeight = true;
+
   // Metadata
     /// @brief The name of the derivation (use this as an override)
     std::string m_derivationName = "";


### PR DESCRIPTION
When running BasicEventSelection on a miniAOD, it complains of a locked store when any of the bools m_store* are True (they try to add or modify aux variables), and also if they are False when attempting to add the weight_prescale decorator to eventInfo. This PR adds a new m_storePrescaleWeight bool, default true so as to not change existing behaviour, so that BasicEventSelection can run on miniAODs.