### PR TITLE
Deprecate SLC6 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ env:
     - secure: "NKEq9tEPPQhcEJWgy06LaTRjVObqb57GMllFrWa8zQ7/a6kVr4l0VMSqREeDeLrwIXo3RK3nG01sBFavy1Ge4RqUhPjbSBln/xXSEZiMSA1PI97FX3L+emOum4knVIudR1V3WXwRCxK138Fpwudbf0Hi/zLNh/stmApCStWBHmyCrxbfmnI3n+cTKC6RvINY6DJi9QbagCaZCfmLYGSqiNzoQbMEm5T5EkB8xdPFwSoGD7KTBwpcjkqhpS+lGoxcxdXimyEN5lmoR9+EIw6ZUZJzeaANHui6H2keBDe4tJaDeAqZeWkpfw8ixvJO/2OTtPEU5y4DcPzVW3x0GO4B/97oCLZI9PrYDiEq9inBL3xmUmeqXcBV8PLnUVzbosvd0W1kSWiw9Cude223of5VNpiXP7keCNbsklIwWfMNnlDNOKlrI0k+J5dvdf3gH3E+166FykA78/PNgiBCTiZRACuCY00170LLPnXCHFvDvZcUsDhGx8XbxQGEyPfjKyq5Fgythexg03PGW0LjxYR275RLGxa5o4fd/AoZiLQY+NVs1TZeexMIvgjHk03FpHKbCxSzRalCVeibZymc7pnH3huWMuOfPM2It5cd2MlH3iR/M9wln+RNkU+VUsu205PdUbnXYc3YFCy30vUdvb3B2CQntwfiU1sH23ZB9uVR6rE="
     - DOCKER_ORG=ucatlas
   matrix:
-    - RELEASE=AnalysisBase,21.2.84
-    - RELEASE=AnalysisTop,21.2.84
-    - RELEASE=AnalysisBase,21.2.85
-    - RELEASE=AnalysisTop,21.2.85
+    - RELEASE=AnalysisBase,21.2.90
+    - RELEASE=AnalysisTop,21.2.90
 
 script:
   - export RELEASE_TYPE=${RELEASE%%,*}

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -85,13 +85,13 @@ How do I...
 
    If the same tool (identified by its name) needs to be used in another xAH algorithm downstream, just declare a tool handle member with the same ``IMyToolType``, call its constructor in the initialisation list and (if needed) change its tool name with ``make()``. Then in ``EL::initialize()`` simply call ``m_mytool_handle.initialize()``, without setting any property. It will automagically get the pointer to the correct tool from a registry, and all the tool properties will be preserved from the previous initialisation.
 
-SLC6 vs CC7
+SLC6 vs SLC7
 -----------
 
-If you're running into issues with grid submission because of checks for SLC6-compatible machines in `xAH_run.py` preventing you from doing so, then you can either:
+If you're running into issues with grid submission because of checks for SLC7-compatible machines in `xAH_run.py` preventing you from doing so, then you can either:
 
-- ssh into lxplus SLC6 (``lxplus6.cern.ch``)
-- run in a containerized SLC6 environment (``setupATLAS -c slc6``)
+- ssh into lxplus SLC7 (``lxplus.cern.ch``)
+- run in a containerized SLC7 environment (``setupATLAS -c slc6``)
 
 If you think this message is happening in error, `file an issue <https://github.com/UCATLAS/xAODAnaHelpers/issues/new>`_ giving us the output from the following commands:
 

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -185,18 +185,18 @@ if __name__ == "__main__":
         if os.getenv(env_var) is None:
           raise EnvironmentError('Panda client is not setup. Run localSetupPandaClient.')
 
-      isSLC6 = True
+      isSLC7 = True
       # check that we're not submitting to grid from CC7 machines
       try:
         xAH_logger.debug('Running lsb_release -d.')
         lsb_release = subprocess.check_output(["lsb_release", "-d"], cwd=os.path.dirname(os.path.realpath(__file__)), stderr=subprocess.STDOUT).strip()
         xAH_logger.debug('  - command output: {}'.format(lsb_release))
-        slc6_release_names = ['Scientific Linux release 6', 'Scientific Linux CERN SLC release 6', 'Red Hat Enterprise Linux Server release 6' ,'CentOS release 6']
-        if not any(name in lsb_release for name in slc6_release_names):
-          xAH_logger.debug('  - did not find SLC6 in output.')
-          isSLC6 = False
+        slc7_release_names = ['CentOS Linux release 7', 'Scientific Linux release 7']
+        if not any(name in lsb_release for name in slc7_release_names):
+          xAH_logger.debug('  - did not find SLC7 in output.')
+          isSLC7 = False
         else:
-          xAH_logger.debug('  - found SLC6 in output.')
+          xAH_logger.debug('  - found SLC7 in output.')
 
       except:
         xAH_logger.debug('Previous command could not run correctly. Searching through env. variables.')
@@ -205,12 +205,12 @@ if __name__ == "__main__":
         env_vars = [(k,v) for k,v in os.environ.iteritems() if k.endswith('_PLATFORM') and k != 'Analysis'+ASG_framework_type+'_PLATFORM']
         xAH_logger.debug('Relevant environment variables found:')
         for (k,v) in env_vars: xAH_logger.debug('  - {0} = {1}'.format(k, v))
-        if any(['centos7' in v for (k,v) in env_vars]):
-          xAH_logger.debug('Found CC7 in environment variable, cannot submit from this machine.')
-          isSLC6 = False
+        if any(['slc6' in v for (k,v) in env_vars]):
+          xAH_logger.debug('Found SLC6 in environment variable, cannot submit from this machine.')
+          isSLC7 = False
 
-      if not isSLC6:
-        raise EnvironmentError('We think you\'re not running on SLC6. Grid jobs cannot be submitted from this machine. See https://xaodanahelpers.readthedocs.io/en/master/FAQs.html#slc6-vs-cc7 for more information.')
+      if not isSLC7:
+        raise EnvironmentError('We think you\'re not running on SLC7. Grid jobs cannot be submitted from this machine. See https://xaodanahelpers.readthedocs.io/en/master/FAQs.html#slc6-vs-slc7 for more information.')
 
     # check submission directory
     if args.force_overwrite:


### PR DESCRIPTION
This resolves #1357. SLC6 is now not the supported environment for grid submission.