### PR TITLE
Histogram booking mods

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1007,8 +1007,10 @@ EL::StatusCode BasicEventSelection :: execute ()
 
     }
 
-    static SG::AuxElement::Decorator< float > weight_prescale("weight_prescale");
-    weight_prescale(*eventInfo) = triggerChainGroup->getPrescale();
+    if ( m_storePrescaleWeight ) {
+      static SG::AuxElement::Decorator< float > weight_prescale("weight_prescale");
+      weight_prescale(*eventInfo) = triggerChainGroup->getPrescale();
+    }
 
     if ( m_storePassL1 ) {
       static SG::AuxElement::Decorator< int > passL1("passL1");

--- a/Root/HistogramManager.cxx
+++ b/Root/HistogramManager.cxx
@@ -151,18 +151,16 @@ void HistogramManager::Sumw2(TH1* hist, bool flag /*=true*/) {
 void HistogramManager::record(TH1* hist) {
   m_allHists.push_back( hist );
 
-  // Check if the hash for this histName already exists, i.e., if we have a hash collision
+  // Check if this histName already exists
   std::string histName = hist->GetName();
-  const hash_t histHash = this->makeHash(histName);
-  HistMap_t::const_iterator it = m_histMap.find( histHash );
+  HistMap_t::const_iterator it = m_histMap.find( histName );
   if ( it != m_histMap.end() ) // It does exist!
     {
-      ANA_MSG_WARNING( "Detected a hash collision. The hash for the histogram with name=" << histName
-                       << " already exists and points to a histogram with name=" << it->second->GetName()
-                       << " - NOT entering into the hist map, but prepare for unexpected behaviour" );
+      ANA_MSG_WARNING( "The histogram with name=" << histName << " already exists! "
+                       << " NOT entering into the hist map, but prepare for unexpected behaviour" );
       return;
     }  
-  m_histMap.insert( m_histMap.end(), std::pair< const hash_t, TH1* >( histHash, hist ) );
+  m_histMap.insert( m_histMap.end(), std::pair< std::string, TH1* >( histName, hist ) );
 }
 
 void HistogramManager::record(EL::IWorker* wk) {
@@ -188,12 +186,9 @@ void HistogramManager::SetLabel(TH1* hist, std::string xlabel, std::string ylabe
   this->SetLabel(hist, xlabel, ylabel);
 }
 
-TH1* HistogramManager::findHist(std::string histName) {
-  // Build a 32 bit hash out of the name
-  const hash_t histHash = this->makeHash(histName);
-
+TH1* HistogramManager::findHist(const std::string& histName) {
   // See if this entry exists in the map
-  HistMap_t::const_iterator it = m_histMap.find( histHash );
+  HistMap_t::const_iterator it = m_histMap.find( histName );
   if ( it == m_histMap.end() ) {
     ANA_MSG_ERROR("Histogram name " << histName << " not found");
     return NULL;
@@ -203,13 +198,13 @@ TH1* HistogramManager::findHist(std::string histName) {
   }
 }
 
-void HistogramManager::fillHist(std::string histName, double value) {
+void HistogramManager::fillHist(const std::string& histName, double value) {
   TH1* histPointer(NULL);
   histPointer = this->findHist(histName);
   histPointer->Fill(value);
 }
 
-void HistogramManager::fillHist(std::string histName, double value, double weight) {
+void HistogramManager::fillHist(const std::string& histName, double value, double weight) {
   TH1* histPointer(NULL);
   histPointer = this->findHist(histName);
   histPointer->Fill(value, weight);

--- a/Root/HistogramManager.cxx
+++ b/Root/HistogramManager.cxx
@@ -150,6 +150,19 @@ void HistogramManager::Sumw2(TH1* hist, bool flag /*=true*/) {
 
 void HistogramManager::record(TH1* hist) {
   m_allHists.push_back( hist );
+
+  // Check if the hash for this histName already exists, i.e., if we have a hash collision
+  std::string histName = hist->GetName();
+  const hash_t histHash = this->makeHash(histName);
+  HistMap_t::const_iterator it = m_histMap.find( histHash );
+  if ( it != m_histMap.end() ) // It does exist!
+    {
+      ANA_MSG_WARNING( "Detected a hash collision. The hash for the histogram with name=" << histName
+                       << " already exists and points to a histogram with name=" << it->second->GetName()
+                       << " - NOT entering into the hist map, but prepare for unexpected behaviour" );
+      return;
+    }  
+  m_histMap.insert( m_histMap.end(), std::pair< const hash_t, TH1* >( histHash, hist ) );
 }
 
 void HistogramManager::record(EL::IWorker* wk) {
@@ -174,3 +187,32 @@ void HistogramManager::SetLabel(TH1* hist, std::string xlabel, std::string ylabe
   hist->GetZaxis()->SetTitle(zlabel.c_str());
   this->SetLabel(hist, xlabel, ylabel);
 }
+
+TH1* HistogramManager::findHist(std::string histName) {
+  // Build a 32 bit hash out of the name
+  const hash_t histHash = this->makeHash(histName);
+
+  // See if this entry exists in the map
+  HistMap_t::const_iterator it = m_histMap.find( histHash );
+  if ( it == m_histMap.end() ) {
+    ANA_MSG_ERROR("Histogram name " << histName << " not found");
+    return NULL;
+  }
+  else {
+    return it->second;
+  }
+}
+
+void HistogramManager::fillHist(std::string histName, double value) {
+  TH1* histPointer(NULL);
+  histPointer = this->findHist(histName);
+  histPointer->Fill(value);
+}
+
+void HistogramManager::fillHist(std::string histName, double value, double weight) {
+  TH1* histPointer(NULL);
+  histPointer = this->findHist(histName);
+  histPointer->Fill(value, weight);
+}
+
+

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -173,6 +173,9 @@ class BasicEventSelection : public xAH::Algorithm
     /// @brief Save master, L1, and HLT key
     bool m_storeTrigKeys = false;
 
+    /// @brief Save the trigger prescale weight
+    bool m_storePrescaleWeight = true;
+
   // Metadata
     /// @brief The name of the derivation (use this as an override)
     std::string m_derivationName = "";

--- a/xAODAnaHelpers/HistogramManager.h
+++ b/xAODAnaHelpers/HistogramManager.h
@@ -204,21 +204,9 @@ class HistogramManager {
     MsgStream& msg (int level) const;
 
     /**
-     * @brief typedef for the internal hash.
-    @rst
-      The following is mostly copied and modified from 
-      https://gitlab.cern.ch/atlas/athena/blob/master/Control/AthenaBaseComps/AthenaBaseComps/AthHistogramming.h 
-      and cxx. The idea is to create a map of histogram name hashes, and then search that map for 
-      entries allowing m_allHists to be accessed directly just by the histogram name, making for 
-      much easier histogram filling and hence declaration (no need for m_myHist32 = book(...)).
-    @endrst
-     */
-    typedef uint32_t hash_t;
-
-    /**
      * @brief Typedef for convenience
      */
-    typedef std::map< const hash_t, TH1* > HistMap_t;
+    typedef std::unordered_map< std::string, TH1* > HistMap_t;
 
     /**
      * @brief The map of histogram names to their pointers
@@ -226,18 +214,9 @@ class HistogramManager {
     HistMap_t m_histMap;
 
     /**
-     * @brief Create a 32-bit hash out of the histogram name
-     */
-    hash_t makeHash( const std::string& histName ) const
-    {
-      const uint64_t hash64 = std::hash<std::string>{}( histName );
-      return (hash_t)(hash64 & 0xFFFFFFFF);
-    }
-
-    /**
      * @brief Return the pointer to the histogram
      */
-    TH1* findHist(std::string histName);
+    TH1* findHist(const std::string& histName);
 
     /**
      * @brief Fill a histogram by name. Can be overloaded with weight.
@@ -245,11 +224,11 @@ class HistogramManager {
      * @param histName   The name of the histogram to be filled
      * @param value      The value to fill the histogram with
      */
-    void fillHist(std::string histName, double value);
+    void fillHist(const std::string& histName, double value);
     /**
      * @overload
      */
-    void fillHist(std::string histName, double value, double weight);
+    void fillHist(const std::string& histName, double value, double weight);
 
 
   private:

--- a/xAODAnaHelpers/HistogramManager.h
+++ b/xAODAnaHelpers/HistogramManager.h
@@ -203,6 +203,55 @@ class HistogramManager {
       */
     MsgStream& msg (int level) const;
 
+    /**
+     * @brief typedef for the internal hash.
+    @rst
+      The following is mostly copied and modified from 
+      https://gitlab.cern.ch/atlas/athena/blob/master/Control/AthenaBaseComps/AthenaBaseComps/AthHistogramming.h 
+      and cxx. The idea is to create a map of histogram name hashes, and then search that map for 
+      entries allowing m_allHists to be accessed directly just by the histogram name, making for 
+      much easier histogram filling and hence declaration (no need for m_myHist32 = book(...)).
+    @endrst
+     */
+    typedef uint32_t hash_t;
+
+    /**
+     * @brief Typedef for convenience
+     */
+    typedef std::map< const hash_t, TH1* > HistMap_t;
+
+    /**
+     * @brief The map of histogram names to their pointers
+     */
+    HistMap_t m_histMap;
+
+    /**
+     * @brief Create a 32-bit hash out of the histogram name
+     */
+    hash_t makeHash( const std::string& histName ) const
+    {
+      const uint64_t hash64 = std::hash<std::string>{}( histName );
+      return (hash_t)(hash64 & 0xFFFFFFFF);
+    }
+
+    /**
+     * @brief Return the pointer to the histogram
+     */
+    TH1* findHist(std::string histName);
+
+    /**
+     * @brief Fill a histogram by name. Can be overloaded with weight.
+     * 
+     * @param histName   The name of the histogram to be filled
+     * @param value      The value to fill the histogram with
+     */
+    void fillHist(std::string histName, double value);
+    /**
+     * @overload
+     */
+    void fillHist(std::string histName, double value, double weight);
+
+
   private:
     /**
      * @brief Turn on Sumw2 for the histogram
@@ -213,7 +262,7 @@ class HistogramManager {
     void Sumw2(TH1* hist, bool flag=true);
 
     /**
-     * @brief Push the new histogram to HistogramManager#m_allHists
+     * @brief Push the new histogram to HistogramManager#m_allHists and add its name to HistogramManager#m_histMap
      */
     void record(TH1* hist);
 
@@ -234,6 +283,7 @@ class HistogramManager {
      * @overload
      */
     void SetLabel(TH1* hist, std::string xlabel, std::string ylabel, std::string zlabel);
+
 
 };
 


### PR DESCRIPTION
This borrows some functionality from https://gitlab.cern.ch/atlas/athena/blob/master/Control/AthenaBaseComps/AthenaBaseComps/AthHistogramming.h and .cxx to make use of the existing m_allHists vector to avoid having to declare each histogram in the header file, simplifying development.

See examples of use in https://gitlab.cern.ch/atlas-phys-exotics-dijet-tla/TLAAlgosFullRun2/blob/master/Root/SelectAndHistogram.cxx. But a snippet would be:

.h:
```cpp
  HistogramManager* m_histManager = nullptr; //!
```

.cxx
```cpp
  // histInitialize()
  m_histManager = new HistogramManager(m_name, "");
  ANA_CHECK( m_histManager -> initialize() );
  m_histManager->book("myDir/h_jetPt", "", "jet pT [GeV]", 100, 0, 2000);
  m_histManager -> record( wk() );
  //
  // execute()
  m_histManager->fillHist("myDir/h_jetPt", jet->pt() * 0.001);
```

I'm not sure why commit 64cf7f4 has made it in here, it should already be in master, so perhaps I need to do a new rebase and cherry-pick just ffd5016, but I thought I'd create the pull request now so any discussion can start since this is a slightly bigger change than I normally make (albeit no existing workflows should be affected beyond some tiny extra overhead in record().