### PR TITLE
MC Cleaning in JetSelector

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -442,7 +442,7 @@ EL::StatusCode JetSelector :: execute ()
     }
 
     // Check against pile-up only jets:
-    if( isMC() && m_doMCCleaning && m_haveTruthJets ){
+    if( isMC() && m_doMCCleaning && m_haveTruthJets && inJets->size()>1 ){
     	
         float pTAvg = 0.;
     	pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -441,14 +441,13 @@ EL::StatusCode JetSelector :: execute ()
       }
     }
 
-    // Check against pile-up only jets: if fails in nominal, it should always fail..//
+    // Check against pile-up only jets:
     if( isMC() && m_doMCCleaning && m_haveTruthJets ){
     	
-        ANA_MSG_DEBUG("Mariana debug: doing pileup requirement!");
         float pTAvg = 0.;
     	pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;
         if(  ( pTAvg / truthJets->at(0)->pt() ) > 1.4 ) {
-	  ANA_MSG_DEBUG("Failed truth pileup requirement, skipping event");
+	  ANA_MSG_DEBUG("Failed MC cleaning, skipping event");
 	  wk()->skipEvent();
 	}
     }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -416,7 +416,7 @@ EL::StatusCode JetSelector :: execute ()
   const xAOD::JetContainer* inJets(nullptr);
 
   const xAOD::JetContainer *truthJets = nullptr;
-  if ( isMC() && m_doJVT && m_haveTruthJets) ANA_CHECK( HelperFunctions::retrieve(truthJets, m_truthJetContainer, m_event, m_store, msg()) );
+  if ( isMC() && (m_doJVT || m_doMCCleaning ) && m_haveTruthJets) ANA_CHECK( HelperFunctions::retrieve(truthJets, m_truthJetContainer, m_event, m_store, msg()) );
 
   // if input comes from xAOD, or just running one collection,
   // then get the one collection and be done with it
@@ -439,6 +439,18 @@ EL::StatusCode JetSelector :: execute ()
         isHS(*jet)=ishs;
         isPU(*jet)=ispu;
       }
+    }
+
+    // Check against pile-up only jets: if fails in nominal, it should always fail..//
+    if( isMC() && m_doMCCleaning && m_haveTruthJets ){
+    	
+        ANA_MSG_DEBUG("Mariana debug: doing pileup requirement!");
+        float pTAvg = 0.;
+    	pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;
+        if(  ( pTAvg / truthJets->at(0)->pt() ) > 1.4 ) {
+	  ANA_MSG_DEBUG("Failed truth pileup requirement, skipping event");
+	  wk()->skipEvent();
+	}
     }
 
     pass = executeSelection( inJets, mcEvtWeight, count, m_outContainerName, true );

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -73,13 +73,13 @@ public:
       @endrst
 
    */
-
-  /** @brief Choose the scale at which the selection is performed (default "Final", i.e. default 4vector) */
-  std::string m_jetScale4Selection = "Final";
-
   bool m_cleanEvent = false;
   /** @brief Mark event with decorator if any passing jets are not clean */
   bool m_markCleanEvent = false;
+  /** @brief Choose the scale at which the selection is performed (default "Final", i.e. default 4vector) */
+  std::string m_jetScale4Selection = "Final";
+  /// @brief (MC-only) Kill event if avg(pT[0],pT[1])>1.4*truth_pT[0]
+  bool m_doMCCleaning = false;
   /// @brief minimum number of objects passing cuts
   int m_pass_min = -1;
   /// @brief maximum number of objects passing cuts


### PR DESCRIPTION
Implementing MC Cleaning criteria wrt jets in JetSelector.
Comparing the average pT of leading and subleading jet with leading truth jet pT to remove events in which the leading truth jet has low pT but the leading reco one has high pT due to pile up overlay.
