### PR TITLE
Remove muons reconstructed as PF jets in OR

### DIFF
--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -162,6 +162,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   orFlags.doTaus      = m_useTaus;
   orFlags.doPhotons   = m_usePhotons;
   orFlags.doFatJets   = false;
+  if( m_doMuPFJetOR ) orFlags.doMuPFJetOR = true;
 
   ANA_CHECK( ORUtils::recommendedTools(orFlags, m_ORToolbox));
   ANA_CHECK( m_ORToolbox.initialize());

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -142,6 +142,10 @@ class OverlapRemover : public xAH::Algorithm
   std::string  m_outContainerName_Taus = "";
   std::string  m_inputAlgoTaus = "";
 
+  /** @brief To remove muons reconstructed as p-flow jets
+  https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJetsR21#Muons_Reconstructed_as_Jets_in_P */
+  bool m_doMuPFJetOR = false;
+
  protected:
 
   /** @brief A counter for the number of processed events */


### PR DESCRIPTION
Following JetEtmiss recs:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJetsR21#Muons_Reconstructed_as_Jets_in_P