### PR TITLE
add doIsolation to MuonSelector

### DIFF
--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -82,6 +82,8 @@ public:
   bool           m_removeEventBadMuon = true;
 
   // isolation
+  /** enable or disable isolation **/
+  bool           m_doIsolation = true;
   /** reject objects which do not pass this isolation cut - default = "" (no cut) */
   std::string    m_MinIsoWPCut = "";
   /** decorate objects with 'isIsolated_*' flag for each WP in this input list - default = all current ASG WPs */


### PR DESCRIPTION
Muon Isolation tool requires `ptvarcone30_TightTTVA_pt1000` which is only added in derivations and does not exist on AODs. Therefore a way to disable muon isolation tool is required.

[1] https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/IsolationSelectionTool