### PR TITLE
Multiple origin conditions in TruthSelector

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -463,6 +463,7 @@ namespace HelperClasses{
     m_parents       = has_exact("parents");
     m_children      = has_exact("children");
     m_dressed       = has_exact("dressed");
+    m_origin        = has_exact("origin");
   }
 
   void TrackInfoSwitch::initialize(){

--- a/Root/TruthContainer.cxx
+++ b/Root/TruthContainer.cxx
@@ -47,6 +47,10 @@ TruthContainer::TruthContainer(const std::string& name, const std::string& detai
     m_e_dressed   = new std::vector<float>();
   }
 
+  if(m_infoSwitch.m_origin){
+    m_origin = new std::vector<unsigned int>();
+  }
+
 }
 
 TruthContainer::~TruthContainer()
@@ -90,6 +94,10 @@ TruthContainer::~TruthContainer()
     delete m_e_dressed;
   }
 
+  if(m_infoSwitch.m_origin){
+    delete m_origin;
+  }
+
 }
 
 void TruthContainer::setTree(TTree *tree)
@@ -128,10 +136,14 @@ void TruthContainer::setTree(TTree *tree)
   }
 
   if(m_infoSwitch.m_dressed){
-    connectBranch<float> (tree,"pt_dressd",  &m_pt_dressed);
-    connectBranch<float> (tree,"eta_dressd", &m_eta_dressed);
-    connectBranch<float> (tree,"phi_dressd", &m_phi_dressed);
-    connectBranch<float> (tree,"e_dressd",   &m_e_dressed);
+    connectBranch<float> (tree,"pt_dressed",  &m_pt_dressed);
+    connectBranch<float> (tree,"eta_dressed", &m_eta_dressed);
+    connectBranch<float> (tree,"phi_dressed", &m_phi_dressed);
+    connectBranch<float> (tree,"e_dressed",   &m_e_dressed);
+  }
+
+  if(m_infoSwitch.m_origin){
+    connectBranch<unsigned int> (tree,"origin",  &m_origin);
   }
 
 }
@@ -177,6 +189,10 @@ void TruthContainer::updateParticle(uint idx, TruthPart& truth)
     truth.eta_dressed = m_eta_dressed->at(idx);
     truth.phi_dressed = m_phi_dressed->at(idx);
     truth.e_dressed   = m_e_dressed->at(idx);
+  }
+
+  if(m_infoSwitch.m_origin){
+    truth.origin = m_origin->at(idx);
   }
 
   if(m_debug) std::cout << "leave TruthContainer::updateParticle " << std::endl;
@@ -226,6 +242,10 @@ void TruthContainer::setBranches(TTree *tree)
     setBranch<float> (tree,"e_dressed", m_e_dressed );
   }
 
+  if(m_infoSwitch.m_origin){
+    setBranch<unsigned int> (tree,"origin",m_origin);
+  }
+
   return;
 }
 
@@ -269,6 +289,10 @@ void TruthContainer::clear()
     m_eta_dressed->clear();
     m_phi_dressed->clear();
     m_e_dressed->clear();
+  }
+
+  if(m_infoSwitch.m_origin){
+    m_origin->clear();
   }
 
   return;
@@ -380,6 +404,15 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
       m_e_dressed->push_back(e_dressed / m_units);
     } else {
       m_e_dressed->push_back(-999);
+    }
+  }
+
+  if(m_infoSwitch.m_origin){
+    if( truth->isAvailable<unsigned int>("classifierParticleOrigin") ){
+      unsigned int origin = truth->auxdata<unsigned int>("classifierParticleOrigin");
+      m_origin->push_back(origin);
+    } else {
+      m_origin->push_back(0); // Non-defined
     }
   }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -339,26 +339,29 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
   }
 
   // origin
+  if ( !m_originOptions.empty() ) { // check w.r.t. multiple possible origin values
+    if ( m_origin != 1000 ) { ANA_MSG_WARNING( "single and multiple origin conditions were selected, only the former will be used" );
+    } else {
+      std::string token;
+      std::vector<int> originVec;
+      std::istringstream ss(m_originOptions);
+      while ( std::getline(ss, token, '|') ) originVec.push_back(std::stoi(token));
+      bool found = false;
+      if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
+        unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
+        for (unsigned int i=0;i<originVec.size();++i){
+          if (origin == originVec.at(i)) found = true;
+        }
+        if (!found) { return 0; }
+      } else {
+        ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
+      }
+    }
+  }
   if ( m_origin != 1000 ) { // single origin value
     if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
       unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
       if ( origin != m_origin ) { return 0; }
-    } else {
-      ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
-    }
-  }
-  if ( !m_originOptions.empty() ) { // check w.r.t. multiple possible origin values
-    std::string token;
-    std::vector<int> originVec;
-    std::istringstream ss(m_originOptions);
-    while ( std::getline(ss, token, '|') ) originVec.push_back(std::stoi(token));
-    bool found = false;
-    if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
-      unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
-      for (unsigned int i=0;i<originVec.size();++i){
-        if (origin == originVec.at(i)) found = true;
-      }
-      if (!found) { return 0; }
     } else {
       ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
     }

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -339,10 +339,26 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
   }
 
   // origin
-  if ( m_origin != 1000 ) {
+  if ( m_origin != 1000 ) { // single origin value
     if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
       unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
       if ( origin != m_origin ) { return 0; }
+    } else {
+      ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
+    }
+  }
+  if ( !m_originOptions.empty() ) { // check w.r.t. multiple possible origin values
+    std::string token;
+    std::vector<int> originVec;
+    std::istringstream ss(m_originOptions);
+    while ( std::getline(ss, token, '|') ) originVec.push_back(std::stoi(token));
+    bool found = false;
+    if( truthPart->isAvailable<unsigned int>("classifierParticleOrigin") ){
+      unsigned int origin = truthPart->auxdata<unsigned int>("classifierParticleOrigin");
+      for (unsigned int i=0;i<originVec.size();++i){
+        if (origin == originVec.at(i)) found = true;
+      }
+      if (!found) { return 0; }
     } else {
       ANA_MSG_WARNING( "classifierParticleOrigin is not available" );
     }

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -554,6 +554,7 @@ namespace HelperClasses {
         m_parents        parents        exact
         m_children       children       exact
         m_dressed        dressed        exact
+        m_origin         origin         exact
         ================ ============== =======
 
 
@@ -566,6 +567,7 @@ namespace HelperClasses {
     bool m_parents;
     bool m_children;
     bool m_dressed;
+    bool m_origin;
     TruthInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();

--- a/xAODAnaHelpers/TruthContainer.h
+++ b/xAODAnaHelpers/TruthContainer.h
@@ -73,6 +73,9 @@ namespace xAH {
       std::vector<float>* m_phi_dressed;
       std::vector<float>* m_e_dressed;
 
+      // origin
+      std::vector<unsigned int>* m_origin;
+
     };
 }
 

--- a/xAODAnaHelpers/TruthPart.h
+++ b/xAODAnaHelpers/TruthPart.h
@@ -42,6 +42,9 @@ namespace xAH {
       float phi_dressed;
       float e_dressed;
 
+      // Origin
+      unsigned int origin;
+
     };
 
 }//xAH

--- a/xAODAnaHelpers/TruthSelector.h
+++ b/xAODAnaHelpers/TruthSelector.h
@@ -58,6 +58,8 @@ public:
   unsigned int m_type = 1000; // this will apply no selection
   /// @brief require classifierParticleOrigin == origin (defined by TruthClassifier: https://gitlab.cern.ch/atlas/athena/blob/21.2/PhysicsAnalysis/MCTruthClassifier/MCTruthClassifier/MCTruthClassifierDefs.h)
   unsigned int m_origin = 1000; // this will apply no selection
+  /// @brief require classifierParticleOrigin to match any of the "|" separated origin values (e.g. "10|12|13")
+  std::string m_originOptions; // this will apply no selection
   /// @brief require pt_dressed > pt_dressed_min
   float m_pT_dressed_min = 1e8;
   /// @brief require eta_dressed > eta_dressed_min


### PR DESCRIPTION
New option in TruthSelector: m_originOptions to be able to select truth particles from different origins.
Usage: "|" separated origin values. Example: "10|12|13". If m_origin and m_originOptions are both used, a warning is thrown and only m_origin is used. This is useful for instance for diboson (WZ) samples.

This MR also adds the possibility to save origin ("classifierParticleOrigin") to the TTree using "origin". 

This also fixes a typo: dressd -> dressed