### PR TITLE
Harmonize TreeAlgo Add & Fill methods argument ordering

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -124,7 +124,7 @@ void HelpTreeBase::Fill() {
  *
  ********************/
 
-void HelpTreeBase::AddEvent( const std::string detailStr ) {
+void HelpTreeBase::AddEvent( const std::string& detailStr ) {
 
   if(m_debug)  Info("AddEvent()", "Adding event variables: %s", detailStr.c_str());
 
@@ -152,7 +152,7 @@ void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*
  *   TRIGGER
  *
  ********************/
-void HelpTreeBase::AddTrigger( const std::string detailStr ) {
+void HelpTreeBase::AddTrigger( const std::string& detailStr ) {
 
   if(m_debug) Info("AddTrigger()", "Adding trigger variables: %s", detailStr.c_str());
 
@@ -306,7 +306,7 @@ void HelpTreeBase::ClearTrigger() {
 
 /* TODO: jet trigger */
 //CD: is this useful at all?
-void HelpTreeBase::AddJetTrigger( const std::string detailStr )
+void HelpTreeBase::AddJetTrigger( const std::string& detailStr )
 {
   if ( m_debug )  Info("AddJetTrigger()", "Adding jet trigger variables: %s", detailStr.c_str());
 }
@@ -320,7 +320,7 @@ void HelpTreeBase::ClearJetTrigger(  ) { }
  *
  ********************/
 
-void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonName) {
+void HelpTreeBase::AddMuons(const std::string& detailStr, const std::string& muonName) {
 
   if ( m_debug )  Info("AddMuons()", "Adding muon variables: %s", detailStr.c_str());
 
@@ -364,7 +364,7 @@ void HelpTreeBase::AddMuons(const std::string detailStr, const std::string muonN
   this->AddMuonsUser(detailStr, muonName);
 }
 
-void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string muonName ) {
+void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string& muonName ) {
 
   this->ClearMuons(muonName);
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = m_muons[muonName]->m_infoSwitch;
@@ -415,7 +415,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
 }
 
-void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primaryVertex, const std::string muonName ) {
+void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primaryVertex, const std::string& muonName ) {
 
   xAH::MuonContainer* thisMuon = m_muons[muonName];
 
@@ -426,7 +426,7 @@ void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primary
   return;
 }
 
-void HelpTreeBase::ClearMuons(const std::string muonName) {
+void HelpTreeBase::ClearMuons(const std::string& muonName) {
 
   std::string tname = m_tree->GetName();
   xAH::MuonContainer* thisMuon = m_muons[muonName];
@@ -470,7 +470,7 @@ void HelpTreeBase::ClearMuons(const std::string muonName) {
  *
  ********************/
 
-void HelpTreeBase::AddElectrons(const std::string detailStr, const std::string elecName) {
+void HelpTreeBase::AddElectrons(const std::string& detailStr, const std::string& elecName) {
 
   if(m_debug)  Info("AddElectrons()", "Adding electron variables: %s", detailStr.c_str());
 
@@ -483,7 +483,7 @@ void HelpTreeBase::AddElectrons(const std::string detailStr, const std::string e
 }
 
 
-void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, const xAOD::Vertex* primaryVertex, const std::string elecName ) {
+void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, const xAOD::Vertex* primaryVertex, const std::string& elecName ) {
 
   this->ClearElectrons(elecName);
 
@@ -492,7 +492,7 @@ void HelpTreeBase::FillElectrons( const xAOD::ElectronContainer* electrons, cons
   }
 }
 
-void HelpTreeBase::FillElectron ( const xAOD::Electron* elec, const xAOD::Vertex* primaryVertex, const std::string elecName ) {
+void HelpTreeBase::FillElectron ( const xAOD::Electron* elec, const xAOD::Vertex* primaryVertex, const std::string& elecName ) {
 
   xAH::ElectronContainer* thisElec = m_elecs[elecName];
 
@@ -504,7 +504,7 @@ void HelpTreeBase::FillElectron ( const xAOD::Electron* elec, const xAOD::Vertex
 }
 
 
-void HelpTreeBase::ClearElectrons(const std::string elecName) {
+void HelpTreeBase::ClearElectrons(const std::string& elecName) {
 
   xAH::ElectronContainer* thisElec = m_elecs[elecName];
   thisElec->clear();
@@ -518,7 +518,7 @@ void HelpTreeBase::ClearElectrons(const std::string elecName) {
  *
  ********************/
 
-void HelpTreeBase::AddPhotons(const std::string detailStr, const std::string photonName) {
+void HelpTreeBase::AddPhotons(const std::string& detailStr, const std::string& photonName) {
 
   if(m_debug)  Info("AddPhotons()", "Adding photon variables: %s", detailStr.c_str());
 
@@ -531,7 +531,7 @@ void HelpTreeBase::AddPhotons(const std::string detailStr, const std::string pho
 }
 
 
-void HelpTreeBase::FillPhotons( const xAOD::PhotonContainer* photons, const std::string photonName ) {
+void HelpTreeBase::FillPhotons( const xAOD::PhotonContainer* photons, const std::string& photonName ) {
 
   this->ClearPhotons(photonName);
 
@@ -540,7 +540,7 @@ void HelpTreeBase::FillPhotons( const xAOD::PhotonContainer* photons, const std:
   }
 }
 
-void HelpTreeBase::FillPhoton( const xAOD::Photon* photon, const std::string photonName ) {
+void HelpTreeBase::FillPhoton( const xAOD::Photon* photon, const std::string& photonName ) {
 
   xAH::PhotonContainer* thisPhoton = m_photons[photonName];
 
@@ -552,7 +552,7 @@ void HelpTreeBase::FillPhoton( const xAOD::Photon* photon, const std::string pho
 }
 
 
-void HelpTreeBase::ClearPhotons(const std::string photonName) {
+void HelpTreeBase::ClearPhotons(const std::string& photonName) {
 
   xAH::PhotonContainer* thisPhoton = m_photons[photonName];
   thisPhoton->clear();
@@ -566,7 +566,7 @@ void HelpTreeBase::ClearPhotons(const std::string photonName) {
  *
  *********************/
 
-void HelpTreeBase::AddClusters(const std::string detailStr, const std::string clusterName) {
+void HelpTreeBase::AddClusters(const std::string& detailStr, const std::string& clusterName) {
 
   if(m_debug)  Info("AddClusters()", "Adding cluster variables: %s", detailStr.c_str());
 
@@ -579,7 +579,7 @@ void HelpTreeBase::AddClusters(const std::string detailStr, const std::string cl
 }
 
 
-void HelpTreeBase::FillClusters( const xAOD::CaloClusterContainer* clusters, const std::string clusterName ) {
+void HelpTreeBase::FillClusters( const xAOD::CaloClusterContainer* clusters, const std::string& clusterName ) {
 
   this->ClearClusters(clusterName);
 
@@ -588,7 +588,7 @@ void HelpTreeBase::FillClusters( const xAOD::CaloClusterContainer* clusters, con
   }
 }
 
-void HelpTreeBase::FillCluster( const xAOD::CaloCluster* cluster, const std::string clusterName ) {
+void HelpTreeBase::FillCluster( const xAOD::CaloCluster* cluster, const std::string& clusterName ) {
 
   xAH::ClusterContainer* thisCluster = m_clusters[clusterName];
 
@@ -600,7 +600,7 @@ void HelpTreeBase::FillCluster( const xAOD::CaloCluster* cluster, const std::str
 }
 
 
-void HelpTreeBase::ClearClusters(const std::string clusterName) {
+void HelpTreeBase::ClearClusters(const std::string& clusterName) {
 
   xAH::ClusterContainer* thisCluster = m_clusters[clusterName];
   thisCluster->clear();
@@ -614,7 +614,7 @@ void HelpTreeBase::ClearClusters(const std::string clusterName) {
  *
  ********************/
 
-void HelpTreeBase::AddL1Jets( const std::string jetName)
+void HelpTreeBase::AddL1Jets( const std::string& jetName)
 {
 
   if(m_debug) Info("AddL1Jets()", "Adding %s L1 jets", jetName.c_str());
@@ -627,7 +627,7 @@ void HelpTreeBase::AddL1Jets( const std::string jetName)
 
 }
 
-void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string jetName, bool sortL1Jets ) {
+void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName, bool sortL1Jets ) {
 
   this->ClearL1Jets(jetName);
 
@@ -637,7 +637,7 @@ void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::str
 
 }
 
-void HelpTreeBase::ClearL1Jets(const std::string jetName) {
+void HelpTreeBase::ClearL1Jets(const std::string& jetName) {
 
   xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
   thisL1Jet->clear();
@@ -651,7 +651,7 @@ void HelpTreeBase::ClearL1Jets(const std::string jetName) {
  *
  ********************/
 
-void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetName)
+void HelpTreeBase::AddJets(const std::string& detailStr, const std::string& jetName)
 {
 
   if(m_debug) Info("AddJets()", "Adding jet %s with variables: %s", jetName.c_str(), detailStr.c_str());
@@ -666,7 +666,7 @@ void HelpTreeBase::AddJets(const std::string detailStr, const std::string jetNam
 }
 
 
-void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, const std::string jetName ) {
+void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, const std::string& jetName ) {
 
   this->ClearJets(jetName);
 
@@ -689,7 +689,7 @@ void HelpTreeBase::FillJets( const xAOD::JetContainer* jets, int pvLocation, con
 
 
 
-void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName ) {
+void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string& jetName ) {
 
   xAH::JetContainer* thisJet = m_jets[jetName];
 
@@ -700,7 +700,7 @@ void HelpTreeBase::FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, in
   return;
 }
 
-void HelpTreeBase::ClearJets(const std::string jetName) {
+void HelpTreeBase::ClearJets(const std::string& jetName) {
 
   xAH::JetContainer* thisJet = m_jets[jetName];
   thisJet->clear();
@@ -715,7 +715,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
  *
  ********************/
 
-void HelpTreeBase::AddTruthParts(const std::string detailStr, const std::string truthName)
+void HelpTreeBase::AddTruthParts(const std::string& detailStr, const std::string& truthName)
 {
 
   if(m_debug) Info("AddTruthParts()", "Adding truth particle %s with variables: %s", truthName.c_str(), detailStr.c_str());
@@ -726,7 +726,7 @@ void HelpTreeBase::AddTruthParts(const std::string detailStr, const std::string 
   this->AddTruthUser(truthName, detailStr);
 }
 
-void HelpTreeBase::FillTruth( const xAOD::TruthParticleContainer* truthParts, const std::string truthName  ) {
+void HelpTreeBase::FillTruth( const xAOD::TruthParticleContainer* truthParts, const std::string& truthName  ) {
 
   this->ClearTruth(truthName);
 
@@ -745,7 +745,7 @@ void HelpTreeBase::FillTruth( const xAOD::TruthParticleContainer* truthParts, co
 
 }
 
-void HelpTreeBase::FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName )
+void HelpTreeBase::FillTruth( const xAOD::TruthParticle* truthPart, const std::string& truthName )
 {
   xAH::TruthContainer* thisTruth = m_truth[truthName];
 
@@ -756,7 +756,7 @@ void HelpTreeBase::FillTruth( const xAOD::TruthParticle* truthPart, const std::s
   return;
 }
 
-void HelpTreeBase::ClearTruth(const std::string truthName) {
+void HelpTreeBase::ClearTruth(const std::string& truthName) {
 
   xAH::TruthContainer* thisTruth = m_truth[truthName];
   thisTruth->clear();
@@ -771,7 +771,7 @@ void HelpTreeBase::ClearTruth(const std::string truthName) {
  *
  ********************/
 
-void HelpTreeBase::AddTrackParts(const std::string detailStr, const std::string trackName)
+void HelpTreeBase::AddTrackParts(const std::string& detailStr, const std::string& trackName)
 {
   if(m_debug) Info("AddTrackParts()", "Adding track particle %s with variables: %s", trackName.c_str(), detailStr.c_str());
   m_tracks[trackName] = new xAH::TrackContainer(trackName, detailStr, m_units);
@@ -781,7 +781,7 @@ void HelpTreeBase::AddTrackParts(const std::string detailStr, const std::string 
   this->AddTracksUser(trackName, detailStr);
 }
 
-void HelpTreeBase::FillTracks( const xAOD::TrackParticleContainer* trackParts, const std::string trackName  ) {
+void HelpTreeBase::FillTracks( const xAOD::TrackParticleContainer* trackParts, const std::string& trackName  ) {
 
   this->ClearTracks(trackName);
 
@@ -800,7 +800,7 @@ void HelpTreeBase::FillTracks( const xAOD::TrackParticleContainer* trackParts, c
 
 }
 
-void HelpTreeBase::FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName )
+void HelpTreeBase::FillTrack( const xAOD::TrackParticle* trackPart, const std::string& trackName )
 {
   xAH::TrackContainer* thisTrack = m_tracks[trackName];
 
@@ -811,7 +811,7 @@ void HelpTreeBase::FillTrack( const xAOD::TrackParticle* trackPart, const std::s
   return;
 }
 
-void HelpTreeBase::ClearTracks(const std::string trackName) {
+void HelpTreeBase::ClearTracks(const std::string& trackName) {
 
   xAH::TrackContainer* thisTrack = m_tracks[trackName];
   thisTrack->clear();
@@ -827,18 +827,18 @@ void HelpTreeBase::ClearTracks(const std::string trackName) {
  ********************/
 
 // make a unique container:suffix key to lookup the branches in the maps
-std::string HelpTreeBase::FatJetCollectionName(const std::string fatjetName,
-					       const std::string suffix) {
+std::string HelpTreeBase::FatJetCollectionName(const std::string& fatjetName,
+					       const std::string& suffix) {
   return suffix.empty() ? fatjetName : (fatjetName + ":" + suffix);
 }
 
-void HelpTreeBase::AddFatJets(const std::string detailStr, const std::string fatjetName,
-			      const std::string subjetDetailStr,
-			      const std::string suffix) {
+void HelpTreeBase::AddFatJets(const std::string& detailStr, const std::string& fatjetName,
+			      const std::string& subjetDetailStr,
+			      const std::string& suffix) {
 
   if(m_debug) Info("AddFatJets()", "Adding fat jet variables: %s", detailStr.c_str());
 
-  const std::string collectionName = FatJetCollectionName(fatjetName, suffix);
+  const std::string& collectionName = FatJetCollectionName(fatjetName, suffix);
   m_fatjets[collectionName] = new xAH::FatJetContainer(fatjetName, detailStr, subjetDetailStr, suffix, m_units, m_isMC);
 
   xAH::FatJetContainer* thisFatJet = m_fatjets[collectionName];
@@ -847,7 +847,7 @@ void HelpTreeBase::AddFatJets(const std::string detailStr, const std::string fat
   this->AddFatJetsUser(detailStr, fatjetName, suffix);
 }
 
-void HelpTreeBase::AddTruthFatJets(const std::string detailStr, const std::string truthFatJetName) {
+void HelpTreeBase::AddTruthFatJets(const std::string& detailStr, const std::string& truthFatJetName) {
 
   if(m_debug) Info("AddTruthFatJets()", "Adding fat jet variables: %s", detailStr.c_str());
 
@@ -860,7 +860,7 @@ void HelpTreeBase::AddTruthFatJets(const std::string detailStr, const std::strin
 }
 
 
-void HelpTreeBase::FillFatJets( const xAOD::JetContainer* fatJets , const std::string fatjetName, const std::string suffix) {
+void HelpTreeBase::FillFatJets( const xAOD::JetContainer* fatJets , const std::string& fatjetName, const std::string& suffix) {
 
   this->ClearFatJets(fatjetName, suffix);
 
@@ -872,9 +872,9 @@ void HelpTreeBase::FillFatJets( const xAOD::JetContainer* fatJets , const std::s
 
 }
 
-void HelpTreeBase::FillFatJet( const xAOD::Jet* fatjet_itr, const std::string fatjetName, const std::string suffix ) {
+void HelpTreeBase::FillFatJet( const xAOD::Jet* fatjet_itr, const std::string& fatjetName, const std::string& suffix ) {
 
-  const std::string collectionName = FatJetCollectionName(fatjetName, suffix);
+  const std::string& collectionName = FatJetCollectionName(fatjetName, suffix);
   xAH::FatJetContainer* thisFatJet = m_fatjets[collectionName];
 
   thisFatJet->FillFatJet(fatjet_itr);
@@ -886,7 +886,7 @@ void HelpTreeBase::FillFatJet( const xAOD::Jet* fatjet_itr, const std::string fa
 
 
 
-void HelpTreeBase::FillTruthFatJets( const xAOD::JetContainer* truthTruthFatJets, const std::string truthFatJetName ) {
+void HelpTreeBase::FillTruthFatJets( const xAOD::JetContainer* truthTruthFatJets, const std::string& truthFatJetName ) {
   this->ClearTruthFatJets(truthFatJetName);
 
   for( auto truth_fatjet_itr : *truthTruthFatJets ) {
@@ -897,7 +897,7 @@ void HelpTreeBase::FillTruthFatJets( const xAOD::JetContainer* truthTruthFatJets
 
 }
 
-void HelpTreeBase::FillTruthFatJet( const xAOD::Jet* truth_fatjet_itr, const std::string truthFatJetName ) {
+void HelpTreeBase::FillTruthFatJet( const xAOD::Jet* truth_fatjet_itr, const std::string& truthFatJetName ) {
 
   xAH::FatJetContainer* thisTruthFatJet = m_truth_fatjets[truthFatJetName];
 
@@ -909,8 +909,8 @@ void HelpTreeBase::FillTruthFatJet( const xAOD::Jet* truth_fatjet_itr, const std
 }
 
 
-void HelpTreeBase::ClearFatJets(const std::string fatjetName, const std::string suffix) {
-  const std::string collectionName = FatJetCollectionName(fatjetName, suffix);
+void HelpTreeBase::ClearFatJets(const std::string& fatjetName, const std::string& suffix) {
+  const std::string& collectionName = FatJetCollectionName(fatjetName, suffix);
 
   xAH::FatJetContainer* thisFatJet = m_fatjets[collectionName];
   thisFatJet->clear();
@@ -918,7 +918,7 @@ void HelpTreeBase::ClearFatJets(const std::string fatjetName, const std::string 
   this->ClearFatJetsUser(fatjetName, suffix);
 }
 
-void HelpTreeBase::ClearTruthFatJets(const std::string truthFatJetName) {
+void HelpTreeBase::ClearTruthFatJets(const std::string& truthFatJetName) {
 
   xAH::FatJetContainer* thisTruthFatJet = m_truth_fatjets[truthFatJetName];
   thisTruthFatJet->clear();
@@ -938,7 +938,7 @@ void HelpTreeBase::ClearEvent() {
  *
  ********************/
 
-void HelpTreeBase::AddTaus(const std::string detailStr, const std::string tauName) {
+void HelpTreeBase::AddTaus(const std::string& detailStr, const std::string& tauName) {
 
   if ( m_debug )  Info("AddTaus()", "Adding tau variables: %s", detailStr.c_str());
 
@@ -950,7 +950,7 @@ void HelpTreeBase::AddTaus(const std::string detailStr, const std::string tauNam
   this->AddTausUser(detailStr, tauName);
 }
 
-void HelpTreeBase::FillTaus( const xAOD::TauJetContainer* taus, const std::string tauName ) {
+void HelpTreeBase::FillTaus( const xAOD::TauJetContainer* taus, const std::string& tauName ) {
 
   this->ClearTaus();
 
@@ -959,7 +959,7 @@ void HelpTreeBase::FillTaus( const xAOD::TauJetContainer* taus, const std::strin
   }
 }
 
-void HelpTreeBase::FillTau( const xAOD::TauJet* tau, const std::string tauName ) {
+void HelpTreeBase::FillTau( const xAOD::TauJet* tau, const std::string& tauName ) {
 
   xAH::TauContainer* thisTau = m_taus[tauName];
 
@@ -968,7 +968,7 @@ void HelpTreeBase::FillTau( const xAOD::TauJet* tau, const std::string tauName )
   this->FillTausUser(tau, tauName);
 }
 
-void HelpTreeBase::ClearTaus(const std::string tauName) {
+void HelpTreeBase::ClearTaus(const std::string& tauName) {
 
   xAH::TauContainer* thisTau = m_taus[tauName];
 
@@ -985,7 +985,7 @@ void HelpTreeBase::ClearTaus(const std::string tauName) {
  *     MET
  *
  ********************/
-void HelpTreeBase::AddMET( const std::string detailStr, const std::string metName ) {
+void HelpTreeBase::AddMET( const std::string& detailStr, const std::string& metName ) {
 
   if(m_debug) Info("AddMET()", "Adding MET variables: %s", detailStr.c_str());
 
@@ -997,7 +997,7 @@ void HelpTreeBase::AddMET( const std::string detailStr, const std::string metNam
   this->AddMETUser(detailStr, metName);
 }
 
-void HelpTreeBase::FillMET( const xAOD::MissingETContainer* met, const std::string metName ) {
+void HelpTreeBase::FillMET( const xAOD::MissingETContainer* met, const std::string& metName ) {
 
   // Clear previous events
   this->ClearMET(metName);
@@ -1009,7 +1009,7 @@ void HelpTreeBase::FillMET( const xAOD::MissingETContainer* met, const std::stri
   this->FillMETUser(met, metName);
 }
 
-void HelpTreeBase::ClearMET( const std::string metName ) {
+void HelpTreeBase::ClearMET( const std::string& metName ) {
   xAH::MetContainer* thisMet = m_met[metName];
 
   thisMet->clear();
@@ -1031,7 +1031,7 @@ bool HelpTreeBase::writeTo( TFile* file ) {
  *
  ********************/
 
-void HelpTreeBase::AddVertices( const std::string detailStr, const std::string vertexName )
+void HelpTreeBase::AddVertices( const std::string& detailStr, const std::string& vertexName )
 {
 
   if(m_debug) Info("AddVertices()", "Adding %s vertices", vertexName.c_str());
@@ -1042,7 +1042,7 @@ void HelpTreeBase::AddVertices( const std::string detailStr, const std::string v
 
 }
 
-void HelpTreeBase::FillVertices( const xAOD::VertexContainer* vertices, const std::string vertexName ) {
+void HelpTreeBase::FillVertices( const xAOD::VertexContainer* vertices, const std::string& vertexName ) {
 
   this->ClearVertices(vertexName);
 
@@ -1052,7 +1052,7 @@ void HelpTreeBase::FillVertices( const xAOD::VertexContainer* vertices, const st
 
 }
 
-void HelpTreeBase::ClearVertices( const std::string vertexName )
+void HelpTreeBase::ClearVertices( const std::string& vertexName )
 {
 
   xAH::VertexContainer* thisVertex = m_vertices[vertexName];
@@ -1060,7 +1060,7 @@ void HelpTreeBase::ClearVertices( const std::string vertexName )
 
 }
 
-void HelpTreeBase::AddTruthVertices( const std::string detailStr, const std::string truthVertexName )
+void HelpTreeBase::AddTruthVertices( const std::string& detailStr, const std::string& truthVertexName )
 {
 
   if(m_debug) Info("AddTruthVertices()", "Adding %s vertices", truthVertexName.c_str());
@@ -1071,7 +1071,7 @@ void HelpTreeBase::AddTruthVertices( const std::string detailStr, const std::str
 
 }
 
-void HelpTreeBase::FillTruthVertices( const xAOD::TruthVertexContainer* truthVertices, const std::string truthVertexName ) {
+void HelpTreeBase::FillTruthVertices( const xAOD::TruthVertexContainer* truthVertices, const std::string& truthVertexName ) {
 
   this->ClearTruthVertices(truthVertexName);
 
@@ -1081,7 +1081,7 @@ void HelpTreeBase::FillTruthVertices( const xAOD::TruthVertexContainer* truthVer
 
 }
 
-void HelpTreeBase::ClearTruthVertices( const std::string truthVertexName )
+void HelpTreeBase::ClearTruthVertices( const std::string& truthVertexName )
 {
 
   xAH::VertexContainer* thisTruthVertex = m_truth_vertices[truthVertexName];

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -715,7 +715,7 @@ void HelpTreeBase::ClearJets(const std::string jetName) {
  *
  ********************/
 
-void HelpTreeBase::AddTruthParts(const std::string truthName, const std::string detailStr)
+void HelpTreeBase::AddTruthParts(const std::string detailStr, const std::string truthName)
 {
 
   if(m_debug) Info("AddTruthParts()", "Adding truth particle %s with variables: %s", truthName.c_str(), detailStr.c_str());
@@ -726,7 +726,7 @@ void HelpTreeBase::AddTruthParts(const std::string truthName, const std::string 
   this->AddTruthUser(truthName, detailStr);
 }
 
-void HelpTreeBase::FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truthParts ) {
+void HelpTreeBase::FillTruth( const xAOD::TruthParticleContainer* truthParts, const std::string truthName  ) {
 
   this->ClearTruth(truthName);
 
@@ -751,7 +751,7 @@ void HelpTreeBase::FillTruth( const xAOD::TruthParticle* truthPart, const std::s
 
   thisTruth->FillTruth(truthPart);
 
-  this->FillTruthUser(truthName, truthPart);
+  this->FillTruthUser(truthPart, truthName);
 
   return;
 }
@@ -771,7 +771,7 @@ void HelpTreeBase::ClearTruth(const std::string truthName) {
  *
  ********************/
 
-void HelpTreeBase::AddTrackParts(const std::string trackName, const std::string detailStr)
+void HelpTreeBase::AddTrackParts(const std::string detailStr, const std::string trackName)
 {
   if(m_debug) Info("AddTrackParts()", "Adding track particle %s with variables: %s", trackName.c_str(), detailStr.c_str());
   m_tracks[trackName] = new xAH::TrackContainer(trackName, detailStr, m_units);
@@ -781,7 +781,7 @@ void HelpTreeBase::AddTrackParts(const std::string trackName, const std::string 
   this->AddTracksUser(trackName, detailStr);
 }
 
-void HelpTreeBase::FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* trackParts ) {
+void HelpTreeBase::FillTracks( const xAOD::TrackParticleContainer* trackParts, const std::string trackName  ) {
 
   this->ClearTracks(trackName);
 
@@ -806,7 +806,7 @@ void HelpTreeBase::FillTrack( const xAOD::TrackParticle* trackPart, const std::s
 
   thisTrack->FillTrack(trackPart);
 
-  this->FillTracksUser(trackName, trackPart);
+  this->FillTracksUser(trackPart, trackName);
 
   return;
 }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -353,8 +353,8 @@ EL::StatusCode TreeAlgo :: execute ()
     if (!m_METContainerName.empty() )           { helpTree->AddMET(m_METDetailStr);                                }
     if (!m_METReferenceContainerName.empty() )  { helpTree->AddMET(m_METReferenceDetailStr, "referenceMet");       }
     if (!m_photonContainerName.empty() )        { helpTree->AddPhotons(m_photonDetailStr);                         }
-    if (!m_truthParticlesContainerName.empty()) { helpTree->AddTruthParts("xAH_truth", m_truthParticlesDetailStr); }
-    if (!m_trackParticlesContainerName.empty()) { helpTree->AddTrackParts(m_trackParticlesContainerName, m_trackParticlesDetailStr); }
+    if (!m_truthParticlesContainerName.empty()) { helpTree->AddTruthParts(m_truthParticlesDetailStr, "xAH_truth"); }
+    if (!m_trackParticlesContainerName.empty()) { helpTree->AddTrackParts(m_trackParticlesDetailStr, m_trackParticlesContainerName); }
     if (!m_clusterContainerName.empty() )      {
       for(unsigned int ll=0; ll<m_clusterContainers.size();++ll){
         if(m_clusterDetails.size()==1)
@@ -592,7 +592,7 @@ EL::StatusCode TreeAlgo :: execute ()
 
       const xAOD::TruthParticleContainer* inTruthParticles(nullptr);
       ANA_CHECK( HelperFunctions::retrieve(inTruthParticles, m_truthParticlesContainerName, m_event, m_store, msg()));
-      helpTree->FillTruth("xAH_truth", inTruthParticles);
+      helpTree->FillTruth(inTruthParticles,"xAH_truth");
     }
 
     if ( !m_trackParticlesContainerName.empty() ) {
@@ -600,7 +600,7 @@ EL::StatusCode TreeAlgo :: execute ()
 
       const xAOD::TrackParticleContainer* inTrackParticles(nullptr);
       ANA_CHECK( HelperFunctions::retrieve(inTrackParticles, m_trackParticlesContainerName, m_event, m_store, msg()));
-      helpTree->FillTracks(m_trackParticlesContainerName, inTrackParticles);
+      helpTree->FillTracks(inTrackParticles,m_trackParticlesContainerName);
     }
 
     if ( !m_vertexContainerName.empty() && !m_vertexDetailStr.empty() ){

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -71,19 +71,19 @@ public:
   HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false );
   virtual ~HelpTreeBase();
 
-  void AddEvent         (const std::string detailStr = "");
-  void AddTrigger       (const std::string detailStr = "");
-  void AddJetTrigger    (const std::string detailStr = "");
-  void AddMuons         (const std::string detailStr = "", const std::string muonName = "muon");
-  void AddElectrons     (const std::string detailStr = "", const std::string elecName = "el");
-  void AddPhotons       (const std::string detailStr = "", const std::string photonName = "ph");
-  void AddClusters      (const std::string detailStr = "", const std::string clusterName = "cl");
-  void AddJets          (const std::string detailStr = "", const std::string jetName = "jet");
-  void AddL1Jets        (const std::string jetName   = "");
-  void AddTruthParts    (const std::string detailStr = "", const std::string truthName = "xAH_truth");
-  void AddTrackParts    (const std::string detailStr = "", const std::string trackName = "trk");
-  void AddVertices      (const std::string detailStr = "", const std::string vertexName = "vertex"); // options for detailStr: "all" or "primary"
-  void AddTruthVertices (const std::string detailStr = "", const std::string vertexName = "truth_vertex"); // options for detailStr: "all" or "primary"
+  void AddEvent         (const std::string& detailStr = "");
+  void AddTrigger       (const std::string& detailStr = "");
+  void AddJetTrigger    (const std::string& detailStr = "");
+  void AddMuons         (const std::string& detailStr = "", const std::string& muonName = "muon");
+  void AddElectrons     (const std::string& detailStr = "", const std::string& elecName = "el");
+  void AddPhotons       (const std::string& detailStr = "", const std::string& photonName = "ph");
+  void AddClusters      (const std::string& detailStr = "", const std::string& clusterName = "cl");
+  void AddJets          (const std::string& detailStr = "", const std::string& jetName = "jet");
+  void AddL1Jets        (const std::string& jetName   = "");
+  void AddTruthParts    (const std::string& detailStr = "", const std::string& truthName = "xAH_truth");
+  void AddTrackParts    (const std::string& detailStr = "", const std::string& trackName = "trk");
+  void AddVertices      (const std::string& detailStr = "", const std::string& vertexName = "vertex"); // options for detailStr: "all" or "primary"
+  void AddTruthVertices (const std::string& detailStr = "", const std::string& vertexName = "truth_vertex"); // options for detailStr: "all" or "primary"
 
   /**
    *  @brief  Declare a new collection of fatjets to be written to the output tree.
@@ -94,11 +94,11 @@ public:
    *  @param  fatjetName  The (prefix) name of the container. Default: `fatjet`.
    *  @param  subjetDetailStr List of detail options to pass to the subjet container. See :cpp:member:`HelpTreeBase::AddJets` for list of supported values.
    **/
-  void AddFatJets     (const std::string detailStr = "", const std::string fatjetName = "fatjet", const std::string subjetDetailStr="", const std::string suffix="");
-  void AddTruthFatJets(const std::string detailStr = "", const std::string truthFatJetName = "truth_fatjet");
+  void AddFatJets     (const std::string& detailStr = "", const std::string& fatjetName = "fatjet", const std::string& subjetDetailStr="", const std::string& suffix="");
+  void AddTruthFatJets(const std::string& detailStr = "", const std::string& truthFatJetName = "truth_fatjet");
 
-  void AddTaus        (const std::string detailStr = "", const std::string tauName = "tau");
-  void AddMET         (const std::string detailStr = "", const std::string metName = "met");
+  void AddTaus        (const std::string& detailStr = "", const std::string& tauName = "tau");
+  void AddMET         (const std::string& detailStr = "", const std::string& metName = "met");
 
   /**
    *  @brief  Helper function to lookup each fatjet container name/suffix combo in the internal map
@@ -106,10 +106,9 @@ public:
    *          implementing `[Add/Fill/Clear]FatJetsUser()`.
    *  @param  fatjetName  The (prefix) name of the container.
    *  @param  suffix      The container branch suffix.
-   *
    *  @return a string that uniquely identifies the collection name/suffix in the lookup map.
    **/
-  static std::string FatJetCollectionName(const std::string fatjetName = "fatjet", const std::string suffix = "");
+  static std::string FatJetCollectionName(const std::string& fatjetName = "fatjet", const std::string& suffix = "");
 
   xAOD::TEvent* m_event;
   xAOD::TStore* m_store;
@@ -130,30 +129,30 @@ public:
   void FillTrigger( const xAOD::EventInfo* eventInfo );
   void FillJetTrigger();
 
-  void FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string muonName = "muon" );
-  void FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primaryVertex, const std::string muonName = "muon" );
+  void FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vertex* primaryVertex, const std::string& muonName = "muon" );
+  void FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primaryVertex, const std::string& muonName = "muon" );
 
-  void FillElectrons( const xAOD::ElectronContainer* electrons, const xAOD::Vertex* primaryVertex, const std::string elecName = "el" );
-  void FillElectron ( const xAOD::Electron* elec, const xAOD::Vertex* primaryVertex, const std::string elecName = "el" );
+  void FillElectrons( const xAOD::ElectronContainer* electrons, const xAOD::Vertex* primaryVertex, const std::string& elecName = "el" );
+  void FillElectron ( const xAOD::Electron* elec, const xAOD::Vertex* primaryVertex, const std::string& elecName = "el" );
 
-  void FillPhotons( const xAOD::PhotonContainer* photons, const std::string photonName = "ph" );
-  void FillPhoton ( const xAOD::Photon*          photon,  const std::string photonName = "ph" );
+  void FillPhotons( const xAOD::PhotonContainer* photons, const std::string& photonName = "ph" );
+  void FillPhoton ( const xAOD::Photon*          photon,  const std::string& photonName = "ph" );
 
-  void FillClusters( const xAOD::CaloClusterContainer* clusters, const std::string clusterName = "cl" );
-  void FillCluster ( const xAOD::CaloCluster*          cluster,  const std::string clusterName = "cl" );
+  void FillClusters( const xAOD::CaloClusterContainer* clusters, const std::string& clusterName = "cl" );
+  void FillCluster ( const xAOD::CaloCluster*          cluster,  const std::string& clusterName = "cl" );
 
-  void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string jetName = "jet" );
-  void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
-  void FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string jetName = "L1Jet", bool sortL1Jets = false );
+  void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string& jetName = "jet" );
+  void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string& jetName = "jet" );
+  void FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName = "L1Jet", bool sortL1Jets = false );
 
-  void FillTruth( const xAOD::TruthParticleContainer* truth, const std::string truthName = "truth_particle" );
-  void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
+  void FillTruth( const xAOD::TruthParticleContainer* truth, const std::string& truthName = "truth_particle" );
+  void FillTruth( const xAOD::TruthParticle* truthPart, const std::string& truthName );
 
-  void FillTracks( const xAOD::TrackParticleContainer* tracks, const std::string trackName = "trk" );
-  void FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName );
+  void FillTracks( const xAOD::TrackParticleContainer* tracks, const std::string& trackName = "trk" );
+  void FillTrack( const xAOD::TrackParticle* trackPart, const std::string& trackName );
 
-  void FillVertices( const xAOD::VertexContainer* vertices, const std::string vertexName = "vertex" );
-  void FillTruthVertices( const xAOD::TruthVertexContainer* truthVertices, const std::string truthVertexName = "truth_vertex" );
+  void FillVertices( const xAOD::VertexContainer* vertices, const std::string& vertexName = "vertex" );
+  void FillTruthVertices( const xAOD::TruthVertexContainer* truthVertices, const std::string& truthVertexName = "truth_vertex" );
 
   /**
    *  @brief  Write a container of jets to the specified container name (and optionally suffix). The
@@ -164,83 +163,83 @@ public:
    *  @param  fatjetName  The name of the output collection to write to.
    *  @param  suffix      The suffix of the output collection to write to.
    */
-  void FillFatJets( const xAOD::JetContainer* fatJets , const std::string fatjetName = "fatjet", const std::string suffix = "");
-  void FillFatJet ( const xAOD::Jet* fatjet_itr,        const std::string fatjetName = "fatjet", const std::string suffix = "");
+  void FillFatJets( const xAOD::JetContainer* fatJets , const std::string& fatjetName = "fatjet", const std::string& suffix = "");
+  void FillFatJet ( const xAOD::Jet* fatjet_itr,        const std::string& fatjetName = "fatjet", const std::string& suffix = "");
 
-  void FillTruthFatJets( const xAOD::JetContainer* truthFatJets,     const std::string truthFatJetName="truth_fatjet" );
-  void FillTruthFatJet ( const xAOD::Jet*          truth_fatjet_itr, const std::string truthFatJetName="truth_fatjet" );
+  void FillTruthFatJets( const xAOD::JetContainer* truthFatJets,     const std::string& truthFatJetName="truth_fatjet" );
+  void FillTruthFatJet ( const xAOD::Jet*          truth_fatjet_itr, const std::string& truthFatJetName="truth_fatjet" );
 
-  void FillTaus( const xAOD::TauJetContainer* taus, const std::string tauName = "tau" );
-  void FillTau ( const xAOD::TauJet* tau,           const std::string tauName = "tau" );
-  void FillMET( const xAOD::MissingETContainer* met, const std::string metName = "met" );
+  void FillTaus( const xAOD::TauJetContainer* taus, const std::string& tauName = "tau" );
+  void FillTau ( const xAOD::TauJet* tau,           const std::string& tauName = "tau" );
+  void FillMET( const xAOD::MissingETContainer* met, const std::string& metName = "met" );
 
   void Fill();
   void ClearEvent();
   void ClearTrigger();
   void ClearJetTrigger();
-  void ClearMuons         (const std::string jetName = "muon");
-  void ClearElectrons     (const std::string elecName = "el");
-  void ClearPhotons       (const std::string photonName = "ph");
-  void ClearClusters      (const std::string clusterName = "cl");
-  void ClearJets          (const std::string jetName = "jet");
-  void ClearL1Jets        (const std::string jetName = "L1Jet");
-  void ClearTruth         (const std::string truthName);
-  void ClearTracks	      (const std::string trackName);
-  void ClearFatJets       (const std::string fatjetName, const std::string suffix="");
-  void ClearTruthFatJets  (const std::string truthFatJetName = "truth_fatjet");
-  void ClearTaus          (const std::string tauName = "tau" );
-  void ClearMET           (const std::string metName = "met");
-  void ClearVertices      (const std::string vertexName = "vertex");
-  void ClearTruthVertices (const std::string vertexName = "truth_vertex");
+  void ClearMuons         (const std::string& jetName = "muon");
+  void ClearElectrons     (const std::string& elecName = "el");
+  void ClearPhotons       (const std::string& photonName = "ph");
+  void ClearClusters      (const std::string& clusterName = "cl");
+  void ClearJets          (const std::string& jetName = "jet");
+  void ClearL1Jets        (const std::string& jetName = "L1Jet");
+  void ClearTruth         (const std::string& truthName);
+  void ClearTracks	      (const std::string& trackName);
+  void ClearFatJets       (const std::string& fatjetName, const std::string& suffix="");
+  void ClearTruthFatJets  (const std::string& truthFatJetName = "truth_fatjet");
+  void ClearTaus          (const std::string& tauName = "tau" );
+  void ClearMET           (const std::string& metName = "met");
+  void ClearVertices      (const std::string& vertexName = "vertex");
+  void ClearTruthVertices (const std::string& vertexName = "truth_vertex");
 
   bool writeTo( TFile *file );
 
-  virtual void AddEventUser(const std::string detailStr = "")      {
+  virtual void AddEventUser(const std::string& detailStr = "")      {
     if(m_debug) Info("AddEventUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
     return;
   };
 
-  virtual void AddTriggerUser(const std::string detailStr = "")      {
+  virtual void AddTriggerUser(const std::string& detailStr = "")      {
     if(m_debug) Info("AddTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
     return;
   };
 
-  virtual void AddJetTriggerUser(const std::string detailStr = "")      {
+  virtual void AddJetTriggerUser(const std::string& detailStr = "")      {
     if(m_debug) Info("AddJetTriggerUser","Empty function called from HelpTreeBase %s",detailStr.c_str());
     return;
   };
 
-  virtual void AddMuonsUser(const std::string detailStr = "", const std::string muonName="muon"){
+  virtual void AddMuonsUser(const std::string& detailStr = "", const std::string& muonName="muon"){
     if(m_debug) Info("AddMuonsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),muonName.c_str());
     return;
     };
 
-  virtual void AddElectronsUser(const std::string detailStr = "", const std::string elecName="el"){
+  virtual void AddElectronsUser(const std::string& detailStr = "", const std::string& elecName="el"){
     if(m_debug) Info("AddElectronsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),elecName.c_str());
     return;
   };
 
-  virtual void AddPhotonsUser(const std::string detailStr = "", const std::string photonName="ph"){
+  virtual void AddPhotonsUser(const std::string& detailStr = "", const std::string& photonName="ph"){
     if(m_debug) Info("AddPhotonsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),photonName.c_str());
     return;
   };
 
-  virtual void AddClustersUser(const std::string detailStr = "", const std::string clusterName="cl"){
+  virtual void AddClustersUser(const std::string& detailStr = "", const std::string& clusterName="cl"){
     if(m_debug) Info("AddClustersUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),clusterName.c_str());
     return;
   };
 
-  virtual void AddJetsUser(const std::string detailStr = "", const std::string jetName = "jet")       {
+  virtual void AddJetsUser(const std::string& detailStr = "", const std::string& jetName = "jet")       {
     if(m_debug) Info("AddJetsUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(), jetName.c_str());
     return;
   };
 
-  virtual void AddTruthUser(const std::string truthName = "", const std::string detailStr = "xAH_truth")       {
+  virtual void AddTruthUser(const std::string& truthName = "", const std::string& detailStr = "xAH_truth")       {
     if(m_debug) Info("AddTruthUser","Empty function called from HelpTreeBase %s %s",truthName.c_str(), detailStr.c_str());
     return;
   };
 
-  virtual void AddTracksUser(const std::string trackName = "", const std::string detailStr = "trk")       {
+  virtual void AddTracksUser(const std::string& trackName = "", const std::string& detailStr = "trk")       {
     if(m_debug) Info("AddTracksUser","Empty function called from HelpTreeBase %s %s",trackName.c_str(), detailStr.c_str());
     return;
   };
@@ -252,48 +251,48 @@ public:
    *  @param  fatjetName  The (prefix) name of the output collection.
    *  @param  suffix      A suffix to be appeneded to the end of the output branch name(s).
    */
-  virtual void AddFatJetsUser(const std::string detailStr = "", const std::string fatjetName = "", const std::string suffix = "")       {
+  virtual void AddFatJetsUser(const std::string& detailStr = "", const std::string& fatjetName = "", const std::string& suffix = "")       {
     if(m_debug) Info("AddFatJetsUser","Empty function called from HelpTreeBase %s for %s with suffix %s", detailStr.c_str(), fatjetName.c_str(), suffix.c_str());
     return;
   };
 
-  virtual void AddTruthFatJetsUser(const std::string detailStr = "", const std::string truthFatJetName = "truth_fatjet")       {
+  virtual void AddTruthFatJetsUser(const std::string& detailStr = "", const std::string& truthFatJetName = "truth_fatjet")       {
     if(m_debug) Info("AddTruthFatJetsUser","Empty function called from HelpTreeBase %s for %s", detailStr.c_str(), truthFatJetName.c_str());
     return;
   };
 
-  virtual void AddTausUser(const std::string detailStr = "", const std::string tauName="tau")   {
+  virtual void AddTausUser(const std::string& detailStr = "", const std::string& tauName="tau")   {
     if(m_debug) Info("AddTausUser","Empty function called from HelpTreeBase %s %s",detailStr.c_str(),tauName.c_str());
     return;
   };
 
-  virtual void AddMETUser(const std::string detailStr = "", const std::string metName = "met")       {
+  virtual void AddMETUser(const std::string& detailStr = "", const std::string& metName = "met")       {
     if(m_debug) Info("AddMETUser","Empty function called from HelpTreeBase %s for %s",detailStr.c_str(), metName.c_str());
     return;
   };
 
   virtual void ClearEventUser       ()     { return; };
   virtual void ClearTriggerUser     ()   { return; };
-  virtual void ClearMuonsUser       (const std::string /*muonName = muon"*/)     { return; };
-  virtual void ClearElectronsUser   (const std::string /*elecName = "el"*/) { return; };
-  virtual void ClearPhotonsUser     (const std::string /*photonName = "ph"*/) { return; };
-  virtual void ClearClustersUser    (const std::string /*clusterName = "cl"*/) { return; };
-  virtual void ClearTruthUser       (const std::string /*truthName*/) 	    { return; };
-  virtual void ClearTracksUser      (const std::string /*trackName*/)       { return; };
-  virtual void ClearJetsUser        (const std::string /*jetName = "jet"*/ ) 	    { return; };
-  virtual void ClearFatJetsUser     (const std::string /*fatjetName = "fatjet"*/, const std::string /*suffix = ""*/)   { return; };
-  virtual void ClearTruthFatJetsUser(const std::string /*truthFatJetName = "truth_fatjet"*/)   { return; };
-  virtual void ClearTausUser        (const std::string /*tauName = "tau"*/) 	    { return; };
-  virtual void ClearMETUser         (const std::string /*metName = "met"*/)       { return; };
+  virtual void ClearMuonsUser       (const std::string& /*muonName = muon"*/)     { return; };
+  virtual void ClearElectronsUser   (const std::string& /*elecName = "el"*/) { return; };
+  virtual void ClearPhotonsUser     (const std::string& /*photonName = "ph"*/) { return; };
+  virtual void ClearClustersUser    (const std::string& /*clusterName = "cl"*/) { return; };
+  virtual void ClearTruthUser       (const std::string& /*truthName*/) 	    { return; };
+  virtual void ClearTracksUser      (const std::string& /*trackName*/)       { return; };
+  virtual void ClearJetsUser        (const std::string& /*jetName = "jet"*/ ) 	    { return; };
+  virtual void ClearFatJetsUser     (const std::string& /*fatjetName = "fatjet"*/, const std::string& /*suffix = ""*/)   { return; };
+  virtual void ClearTruthFatJetsUser(const std::string& /*truthFatJetName = "truth_fatjet"*/)   { return; };
+  virtual void ClearTausUser        (const std::string& /*tauName = "tau"*/) 	    { return; };
+  virtual void ClearMETUser         (const std::string& /*metName = "met"*/)       { return; };
 
   virtual void FillEventUser    ( const xAOD::EventInfo*  )        { return; };
-  virtual void FillMuonsUser    ( const xAOD::Muon*,        const std::string /*muonName = "muon"*/  )             { return; };
-  virtual void FillElectronsUser( const xAOD::Electron*,    const std::string /*elecName = "el"*/ )     { return; };
-  virtual void FillPhotonsUser  ( const xAOD::Photon*,      const std::string /*photonName = "ph"*/ )     { return; };
-  virtual void FillClustersUser ( const xAOD::CaloCluster*, const std::string /*clusterName = "cl"*/ )     { return; };
-  virtual void FillJetsUser     ( const xAOD::Jet*,         const std::string /*jetName = "jet"*/  )               { return; };
-  virtual void FillTruthUser    ( const xAOD::TruthParticle*, const std::string /*truthName*/ )               { return; };
-  virtual void FillTracksUser   ( const xAOD::TrackParticle*, const std::string /*trackName*/ )               { return; };
+  virtual void FillMuonsUser    ( const xAOD::Muon*,        const std::string& /*muonName = "muon"*/  )             { return; };
+  virtual void FillElectronsUser( const xAOD::Electron*,    const std::string& /*elecName = "el"*/ )     { return; };
+  virtual void FillPhotonsUser  ( const xAOD::Photon*,      const std::string& /*photonName = "ph"*/ )     { return; };
+  virtual void FillClustersUser ( const xAOD::CaloCluster*, const std::string& /*clusterName = "cl"*/ )     { return; };
+  virtual void FillJetsUser     ( const xAOD::Jet*,         const std::string& /*jetName = "jet"*/  )               { return; };
+  virtual void FillTruthUser    ( const xAOD::TruthParticle*, const std::string& /*truthName*/ )               { return; };
+  virtual void FillTracksUser   ( const xAOD::TrackParticle*, const std::string& /*trackName*/ )               { return; };
   /**
    *  @brief  Called once per call to `FillFatJets()`.Ooverride this if you want to any additional
    *          information to your jet collection.
@@ -302,10 +301,10 @@ public:
    *  @param  fatjetName  the (prefix) name of the output collection
    *  @param  suffix      the suffix to append to output branches.
    */
-  virtual void FillFatJetsUser( const xAOD::Jet* /*jet*/, const std::string /*fatjetName = "fatjet"*/, const std::string /*suffix = ""*/) { return; };
-  virtual void FillTruthFatJetsUser( const xAOD::Jet* /*jet*/, const std::string /*fatjetName = "truth_fatjet"*/   )            { return; };
-  virtual void FillTausUser( const xAOD::TauJet*,           const std::string /*tauName = "tau"*/  )            { return; };
-  virtual void FillMETUser( const xAOD::MissingETContainer*, const std::string /*metName = "met"*/ ) { return; };
+  virtual void FillFatJetsUser( const xAOD::Jet* /*jet*/, const std::string& /*fatjetName = "fatjet"*/, const std::string& /*suffix = ""*/) { return; };
+  virtual void FillTruthFatJetsUser( const xAOD::Jet* /*jet*/, const std::string& /*fatjetName = "truth_fatjet"*/   )            { return; };
+  virtual void FillTausUser( const xAOD::TauJet*,           const std::string& /*tauName = "tau"*/  )            { return; };
+  virtual void FillMETUser( const xAOD::MissingETContainer*, const std::string& /*metName = "met"*/ ) { return; };
   virtual void FillTriggerUser( const xAOD::EventInfo*  )      { return; };
   virtual void FillJetTriggerUser()                            { return; };
 

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -80,8 +80,8 @@ public:
   void AddClusters      (const std::string detailStr = "", const std::string clusterName = "cl");
   void AddJets          (const std::string detailStr = "", const std::string jetName = "jet");
   void AddL1Jets        (const std::string jetName   = "");
-  void AddTruthParts    (const std::string truthName,      const std::string detailStr = "");
-  void AddTrackParts    (const std::string trackName,	 const std::string detailStr = "");
+  void AddTruthParts    (const std::string detailStr = "", const std::string truthName = "xAH_truth");
+  void AddTrackParts    (const std::string detailStr = "", const std::string trackName = "trk");
   void AddVertices      (const std::string detailStr = "", const std::string vertexName = "vertex"); // options for detailStr: "all" or "primary"
   void AddTruthVertices (const std::string detailStr = "", const std::string vertexName = "truth_vertex"); // options for detailStr: "all" or "primary"
 
@@ -146,10 +146,10 @@ public:
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string jetName = "jet" );
   void FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string jetName = "L1Jet", bool sortL1Jets = false );
 
-  void FillTruth( const std::string truthName, const xAOD::TruthParticleContainer* truth);
+  void FillTruth( const xAOD::TruthParticleContainer* truth, const std::string truthName = "truth_particle" );
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string truthName );
 
-  void FillTracks( const std::string trackName, const xAOD::TrackParticleContainer* tracks);
+  void FillTracks( const xAOD::TrackParticleContainer* tracks, const std::string trackName = "trk" );
   void FillTrack( const xAOD::TrackParticle* trackPart, const std::string trackName );
 
   void FillVertices( const xAOD::VertexContainer* vertices, const std::string vertexName = "vertex" );
@@ -235,12 +235,12 @@ public:
     return;
   };
 
-  virtual void AddTruthUser(const std::string truthName, const std::string detailStr = "")       {
+  virtual void AddTruthUser(const std::string truthName = "", const std::string detailStr = "xAH_truth")       {
     if(m_debug) Info("AddTruthUser","Empty function called from HelpTreeBase %s %s",truthName.c_str(), detailStr.c_str());
     return;
   };
 
-  virtual void AddTracksUser(const std::string trackName, const std::string detailStr = "")       {
+  virtual void AddTracksUser(const std::string trackName = "", const std::string detailStr = "trk")       {
     if(m_debug) Info("AddTracksUser","Empty function called from HelpTreeBase %s %s",trackName.c_str(), detailStr.c_str());
     return;
   };
@@ -292,8 +292,8 @@ public:
   virtual void FillPhotonsUser  ( const xAOD::Photon*,      const std::string /*photonName = "ph"*/ )     { return; };
   virtual void FillClustersUser ( const xAOD::CaloCluster*, const std::string /*clusterName = "cl"*/ )     { return; };
   virtual void FillJetsUser     ( const xAOD::Jet*,         const std::string /*jetName = "jet"*/  )               { return; };
-  virtual void FillTruthUser    ( const std::string /*truthName*/, const xAOD::TruthParticle*  )               { return; };
-  virtual void FillTracksUser   ( const std::string /*trackName*/, const xAOD::TrackParticle*  )               { return; };
+  virtual void FillTruthUser    ( const xAOD::TruthParticle*, const std::string /*truthName*/ )               { return; };
+  virtual void FillTracksUser   ( const xAOD::TrackParticle*, const std::string /*trackName*/ )               { return; };
   /**
    *  @brief  Called once per call to `FillFatJets()`.Ooverride this if you want to any additional
    *          information to your jet collection.


### PR DESCRIPTION
This is a follow-up on #1371.

I've changed the ordering of the Track/TruthPart methods in HelpTreeBase & TreeAlgo to be:

Add*(detailStr,objectName)
Fill*(objectContainer,objectName)

As in accordance with the other container methods. I've tested that this does not change results for the track information in my personal TreeAlgo config. If this is merged into the master, there would have to be an announcement to analyzers with custom HelpTreeBase-based algorithms that the API has been changed.

Please let me know how this looks!