### PR TITLE
Add jet MC cleaning cut-point option

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -346,6 +346,15 @@ EL::StatusCode JetSelector :: initialize ()
     ANA_MSG_WARNING("***********************************************************");
   }
 
+  // Check MC cleaning option
+  if ( m_doMCCleaning && (m_mcCleaningCut < 1.0) ) {
+    ANA_MSG_WARNING("***********************************************************");
+    ANA_MSG_WARNING( "MC cleaning has been set :" );
+    ANA_MSG_WARNING( "\t reconstructed jet avg(pT1,pT2) > x*(truth jet pT1), x = " << m_mcCleaningCut );
+    ANA_MSG_WARNING( "As the specified cut < 1.0 is not the intended use of this procedure, will be reset to default = 1.4!" );
+    ANA_MSG_WARNING("***********************************************************");
+  }
+
   ANA_MSG_DEBUG( "JetSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -349,10 +349,11 @@ EL::StatusCode JetSelector :: initialize ()
   // Check MC cleaning option
   if ( m_doMCCleaning && (m_mcCleaningCut < 1.0) ) {
     ANA_MSG_WARNING("***********************************************************");
-    ANA_MSG_WARNING( "MC cleaning has been set :" );
+    ANA_MSG_WARNING( "(MC-only) pileup overlay event cleaning has been set :" );
     ANA_MSG_WARNING( "\t reconstructed jet avg(pT1,pT2) > x*(truth jet pT1), x = " << m_mcCleaningCut );
     ANA_MSG_WARNING( "As the specified cut < 1.0 is not the intended use of this procedure, will be reset to default = 1.4!" );
     ANA_MSG_WARNING("***********************************************************");
+    m_mcCleaningCut = 1.4;
   }
 
   ANA_MSG_DEBUG( "JetSelector Interface succesfully initialized!" );

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -445,7 +445,7 @@ EL::StatusCode JetSelector :: execute ()
     if ( isMC() && m_doMCCleaning && m_haveTruthJets ){
       float pTAvg = (inJets->size() > 0) ? inJets->at(0)->pt() : 0;
       if ( inJets->size() > 1 ) pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;
-      if( truthJets->size() == 0 || ( pTAvg / truthJets->at(0)->pt() ) > 1.4 ) {
+      if( truthJets->size() == 0 || ( pTAvg / truthJets->at(0)->pt() ) > m_mcCleaningCut ) {
         ANA_MSG_DEBUG("Failed MC cleaning, skipping event");
         wk()->skipEvent();
       }
@@ -471,7 +471,7 @@ EL::StatusCode JetSelector :: execute ()
       if ( isMC() && m_doMCCleaning && m_haveTruthJets && systName.empty() ){
         float pTAvg = (inJets->size() > 0) ? inJets->at(0)->pt() : 0;
         if ( inJets->size() > 1 ) pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;
-        if( truthJets->size() == 0 || ( pTAvg / truthJets->at(0)->pt() ) > 1.4 ) {
+        if( truthJets->size() == 0 || ( pTAvg / truthJets->at(0)->pt() ) > m_mcCleaningCut ) {
           passMCcleaning = false;
         }
       }

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -80,6 +80,7 @@ public:
   std::string m_jetScale4Selection = "Final";
   /// @brief (MC-only) Kill event if avg(pT[0],pT[1])>1.4*truth_pT[0]
   bool m_doMCCleaning = false;
+  float m_mcCleaningCut = 1.4;
   /// @brief minimum number of objects passing cuts
   int m_pass_min = -1;
   /// @brief maximum number of objects passing cuts

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -78,8 +78,9 @@ public:
   bool m_markCleanEvent = false;
   /** @brief Choose the scale at which the selection is performed (default "Final", i.e. default 4vector) */
   std::string m_jetScale4Selection = "Final";
-  /// @brief (MC-only) Kill event if avg(pT[0],pT[1])>1.4*truth_pT[0]
+  /// @brief (MC-only) Kill pileup overlay event if reconstructed jets avg(pT1,pT2) > 1.4*(truth jet pT1)
   bool m_doMCCleaning = false;
+  /// @brief Change the default 1.4 cut to x > 1.0
   float m_mcCleaningCut = 1.4;
   /// @brief minimum number of objects passing cuts
   int m_pass_min = -1;


### PR DESCRIPTION
I see that the standard procedure to apply an "cleaning" on multijet MC samples to remove pileup overlay, which requires that

leading dijet averge pT / leading truth jet pT < 1.4

Although this cut is loose enough to not be expected to bias any resolution effects, I think it would be helpful nonetheless to have the 1.4-cutoff point be a changeable default setting.