### PR TITLE
TrackSelector:  mcEvtWeight, harmonization, more options

### DIFF
--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -185,24 +185,18 @@ EL::StatusCode TrackSelector :: execute ()
 
   // MC event weight
   //
-  m_mcEvtWeight = 1.0;
-  static SG::AuxElement::Accessor< float > m_mcEvtWeightAcc("mcEventWeight");
-  if ( ! m_mcEvtWeightAcc.isAvailable( *eventInfo ) ) {
-    ANA_MSG_ERROR( "mcEventWeight is not available as decoration! Aborting" );
-    return EL::StatusCode::FAILURE;
-  }
-  m_mcEvtWeight = m_mcEvtWeightAcc( *eventInfo );
+  float mcEvtWeight = eventInfo->mcEventWeight();
 
   if(m_doTracksInJets){
     return executeTracksInJets();
   } else{
-    return executeTrackCollection();
+    return executeTrackCollection(mcEvtWeight);
   }
 
   return EL::StatusCode::SUCCESS;
 }
 
-EL::StatusCode TrackSelector :: executeTrackCollection ()
+EL::StatusCode TrackSelector :: executeTrackCollection (float mcEvtWeight)
 {
   m_numEvent++;
 
@@ -273,7 +267,7 @@ EL::StatusCode TrackSelector :: executeTrackCollection ()
   m_numEventPass++;
   if(m_useCutFlow) {
     m_cutflowHist ->Fill( m_cutflow_bin, 1 );
-    m_cutflowHistW->Fill( m_cutflow_bin, m_mcEvtWeight);
+    m_cutflowHistW->Fill( m_cutflow_bin, mcEvtWeight);
   }
 
   return EL::StatusCode::SUCCESS;

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -4,6 +4,7 @@
 #include "AthContainers/ConstDataVector.h"
 #include "xAODAnaHelpers/HelperFunctions.h"
 #include "xAODAnaHelpers/TrackSelector.h"
+#include "InDetTrackSelectionTool/InDetTrackSelectionTool.h"
 
 // ROOT include(s):
 #include "TFile.h"
@@ -22,8 +23,7 @@ ClassImp(TrackSelector)
 
 
 TrackSelector :: TrackSelector () :
-    Algorithm("TrackSelector"),
-    m_trkSelTool(nullptr)
+    Algorithm("TrackSelector")
 {
 }
 
@@ -134,41 +134,39 @@ EL::StatusCode TrackSelector :: initialize ()
   m_numObjectPass = 0;
 
   ANA_MSG_DEBUG( "Initializing InDetTrackSelectionTool..." );
-  m_trkSelTool = new InDet::InDetTrackSelectionTool( m_name );
+  if(m_pT_min                           != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minPt",                           m_pT_min));
+  if(m_p_min                            != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minP",                            m_p_min));
+  if(m_eta_max                          != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxAbsEta",                       m_eta_max));
+  if(m_d0_max                           != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxD0",                           m_d0_max));
+  if(m_sigmad0_max                      != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxSigmaD0",                      m_sigmad0_max));
+  if(m_d0oversigmad0_max                != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxD0overSigmaD0",                m_d0oversigmad0_max));
+  if(m_z0_max                           != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxZ0",                           m_z0_max));
+  if(m_z0sinT_max                       != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxZ0SinTheta",                   m_z0sinT_max));
+  if(m_sigmaz0_max                      != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxSigmaZ0",                      m_sigmaz0_max));
+  if(m_sigmaz0sintheta_max              != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxSigmaZ0SinTheta",              m_sigmaz0sintheta_max));
+  if(m_z0oversigmaz0_max                != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxZ0overSigmaZ0",                m_z0oversigmaz0_max));
+  if(m_z0sinthetaoversigmaz0sintheta_max!= 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxZ0SinThetaoverSigmaZ0SinTheta",m_z0sinthetaoversigmaz0sintheta_max));
+  if(m_nInnermostPixel_min              != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNInnermostLayerHits",          m_nInnermostPixel_min));
+  if(m_nNextToInnermostPixel_min        != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNNextToInnermostLayerHits",    m_nNextToInnermostPixel_min));
+  if(m_nBothInnermostLayersHits_min     != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNBothInnermostLayersHits",     m_nBothInnermostLayersHits_min));
+  if(m_nSi_min                          != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNSiHits",                      m_nSi_min));
+  if(m_nSiPhysical_min                  != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNSiHitsPhysical",              m_nSiPhysical_min));
+  if(m_nSiSharedHits_max                != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNSiSharedHits",                m_nSiSharedHits_max));
+  if(m_nSiHoles_max                     != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNSiHoles",                     m_nSiHoles_max));
+  if(m_nPixelHits_min                   != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNPixelHits",                   m_nPixelHits_min));
+  if(m_nPixelHitsPhysical_min           != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNPixelHitsPhysical",           m_nPixelHitsPhysical_min));
+  if(m_nPixelSharedHits_max             != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNPixelSharedHits",             m_nPixelSharedHits_max));
+  if(m_nPixHoles_max                    != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNPixelHoles",                  m_nPixHoles_max));
+  if(m_nSctHits_min                     != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNSctHits",                     m_nSctHits_min));
+  if(m_nSctHitsPhysical_min             != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minNSctHitsPhysical",             m_nSctHitsPhysical_min));
+  if(m_nSctSharedHits_max               != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNSctSharedHits",               m_nSctSharedHits_max));
+  if(m_nSctHoles_max                    != 2e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNSctHoles",                    m_nSctHoles_max));
+  if(m_nSiSharedModules_max             != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxNSiSharedModules",             m_nSiSharedModules_max));
+  if(m_chi2Prob_min                     != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("minProb",                         m_chi2Prob_min));
+  if(m_chi2NdofCut_max                  != 1e8)ANA_CHECK(m_trkSelTool_handle.setProperty("maxChiSqperNdf",                  m_chi2NdofCut_max));
+  if(m_cutLevelString                   != "" )ANA_CHECK(m_trkSelTool_handle.setProperty("CutLevel",                        m_cutLevelString));
 
-  if(m_pT_min                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minPt",                           m_pT_min));
-  if(m_p_min                            != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minP",                            m_p_min));
-  if(m_eta_max                          != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxAbsEta",                       m_eta_max));
-  if(m_d0_max                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxD0",                           m_d0_max));
-  if(m_sigmad0_max                      != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaD0",                      m_sigmad0_max));
-  if(m_d0oversigmad0_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxD0overSigmaD0",                m_d0oversigmad0_max));
-  if(m_z0_max                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0",                           m_z0_max));
-  if(m_z0sinT_max                       != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0SinTheta",                   m_z0sinT_max));
-  if(m_sigmaz0_max                      != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaZ0",                      m_sigmaz0_max));
-  if(m_sigmaz0sintheta_max              != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaZ0SinTheta",              m_sigmaz0sintheta_max));
-  if(m_z0oversigmaz0_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0overSigmaZ0",                m_z0oversigmaz0_max));
-  if(m_z0sinthetaoversigmaz0sintheta_max!= 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0SinThetaoverSigmaZ0SinTheta",m_z0sinthetaoversigmaz0sintheta_max));
-  if(m_nInnermostPixel_min              != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNInnermostLayerHits",          m_nInnermostPixel_min));
-  if(m_nNextToInnermostPixel_min        != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNNextToInnermostLayerHits",    m_nNextToInnermostPixel_min));
-  if(m_nBothInnermostLayersHits_min     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNBothInnermostLayersHits",     m_nBothInnermostLayersHits_min));
-  if(m_nSi_min                          != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSiHits",                      m_nSi_min));
-  if(m_nSiPhysical_min                  != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSiHitsPhysical",              m_nSiPhysical_min));
-  if(m_nSiSharedHits_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiSharedHits",                m_nSiSharedHits_max));
-  if(m_nSiHoles_max                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiHoles",                     m_nSiHoles_max));
-  if(m_nPixelHits_min                   != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNPixelHits",                   m_nPixelHits_min));
-  if(m_nPixelHitsPhysical_min           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNPixelHitsPhysical",           m_nPixelHitsPhysical_min));
-  if(m_nPixelSharedHits_max             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNPixelSharedHits",             m_nPixelSharedHits_max));
-  if(m_nPixHoles_max                    != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNPixelHoles",                  m_nPixHoles_max));
-  if(m_nSctHits_min                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSctHits",                     m_nSctHits_min));
-  if(m_nSctHitsPhysical_min             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSctHitsPhysical",             m_nSctHitsPhysical_min));
-  if(m_nSctSharedHits_max               != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSctSharedHits",               m_nSctSharedHits_max));
-  if(m_nSctHoles_max                    != 2e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSctHoles",                    m_nSctHoles_max));
-  if(m_nSiSharedModules_max             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiSharedModules",             m_nSiSharedModules_max));
-  if(m_chi2Prob_min                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minProb",                         m_chi2Prob_min));
-  if(m_chi2NdofCut_max                  != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxChiSqperNdf",                  m_chi2NdofCut_max));
-  if(m_cutLevelString                   != "" )ANA_CHECK(m_trkSelTool->setProperty("CutLevel",                        m_cutLevelString));
-
-  m_trkSelTool->initialize();
+  ANA_CHECK( m_trkSelTool_handle.retrieve() );
 
   ANA_MSG_DEBUG( "TrackSelector Interface succesfully initialized!" );
 
@@ -402,7 +400,7 @@ EL::StatusCode TrackSelector :: histFinalize ()
 int TrackSelector :: PassCuts( const xAOD::TrackParticle* trk, const xAOD::Vertex *pvx ) {
 
   // InDetTrackSelectionTool
-  if ( !m_trkSelTool->accept(*trk, pvx) ) { return 0; }
+  if ( !m_trkSelTool_handle->accept(*trk, pvx) ) { return 0; }
 
   // Cuts not available with the InDetTrackSelectionTool
   //

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -22,7 +22,8 @@ ClassImp(TrackSelector)
 
 
 TrackSelector :: TrackSelector () :
-    Algorithm("TrackSelector")
+    Algorithm("TrackSelector"),
+    m_trkSelTool(nullptr)
 {
 }
 
@@ -132,7 +133,44 @@ EL::StatusCode TrackSelector :: initialize ()
   m_numEventPass  = 0;
   m_numObjectPass = 0;
 
-  ANA_MSG_DEBUG("TrackSelector Interface succesfully initialized!" );
+  ANA_MSG_DEBUG( "Initializing InDetTrackSelectionTool..." );
+  m_trkSelTool = new InDet::InDetTrackSelectionTool( m_name );
+
+  if(m_pT_min                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minPt",                           m_pT_min));
+  if(m_p_min                            != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minP",                            m_p_min));
+  if(m_eta_max                          != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxAbsEta",                       m_eta_max));
+  if(m_d0_max                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxD0",                           m_d0_max));
+  if(m_sigmad0_max                      != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaD0",                      m_sigmad0_max));
+  if(m_d0oversigmad0_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxD0overSigmaD0",                m_d0oversigmad0_max));
+  if(m_z0_max                           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0",                           m_z0_max));
+  if(m_z0sinT_max                       != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0SinTheta",                   m_z0sinT_max));
+  if(m_sigmaz0_max                      != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaZ0",                      m_sigmaz0_max));
+  if(m_sigmaz0sintheta_max              != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxSigmaZ0SinTheta",              m_sigmaz0sintheta_max));
+  if(m_z0oversigmaz0_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0overSigmaZ0",                m_z0oversigmaz0_max));
+  if(m_z0sinthetaoversigmaz0sintheta_max!= 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxZ0SinThetaoverSigmaZ0SinTheta",m_z0sinthetaoversigmaz0sintheta_max));
+  if(m_nInnermostPixel_min              != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNInnermostLayerHits",          m_nInnermostPixel_min));
+  if(m_nNextToInnermostPixel_min        != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNNextToInnermostLayerHits",    m_nNextToInnermostPixel_min));
+  if(m_nBothInnermostLayersHits_min     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNBothInnermostLayersHits",     m_nBothInnermostLayersHits_min));
+  if(m_nSi_min                          != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSiHits",                      m_nSi_min));
+  if(m_nSiPhysical_min                  != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSiHitsPhysical",              m_nSiPhysical_min));
+  if(m_nSiSharedHits_max                != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiSharedHits",                m_nSiSharedHits_max));
+  if(m_nSiHoles_max                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiHoles",                     m_nSiHoles_max));
+  if(m_nPixelHits_min                   != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNPixelHits",                   m_nPixelHits_min));
+  if(m_nPixelHitsPhysical_min           != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNPixelHitsPhysical",           m_nPixelHitsPhysical_min));
+  if(m_nPixelSharedHits_max             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNPixelSharedHits",             m_nPixelSharedHits_max));
+  if(m_nPixHoles_max                    != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNPixelHoles",                  m_nPixHoles_max));
+  if(m_nSctHits_min                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSctHits",                     m_nSctHits_min));
+  if(m_nSctHitsPhysical_min             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minNSctHitsPhysical",             m_nSctHitsPhysical_min));
+  if(m_nSctSharedHits_max               != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSctSharedHits",               m_nSctSharedHits_max));
+  if(m_nSctHoles_max                    != 2e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSctHoles",                    m_nSctHoles_max));
+  if(m_nSiSharedModules_max             != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxNSiSharedModules",             m_nSiSharedModules_max));
+  if(m_chi2Prob_min                     != 1e8)ANA_CHECK(m_trkSelTool->setProperty("minProb",                         m_chi2Prob_min));
+  if(m_chi2NdofCut_max                  != 1e8)ANA_CHECK(m_trkSelTool->setProperty("maxChiSqperNdf",                  m_chi2NdofCut_max));
+  if(m_cutLevelString                   != "" )ANA_CHECK(m_trkSelTool->setProperty("CutLevel",                        m_cutLevelString));
+
+  m_trkSelTool->initialize();
+
+  ANA_MSG_DEBUG( "TrackSelector Interface succesfully initialized!" );
 
   return EL::StatusCode::SUCCESS;
 }
@@ -143,6 +181,19 @@ EL::StatusCode TrackSelector :: execute ()
 {
 
   ANA_MSG_DEBUG("Applying Track Selection... " << m_name);
+
+  const xAOD::EventInfo* eventInfo(nullptr);
+  ANA_CHECK( HelperFunctions::retrieve(eventInfo, m_eventInfoContainerName, m_event, m_store, msg()) );
+
+  // MC event weight
+  //
+  m_mcEvtWeight = 1.0;
+  static SG::AuxElement::Accessor< float > m_mcEvtWeightAcc("mcEventWeight");
+  if ( ! m_mcEvtWeightAcc.isAvailable( *eventInfo ) ) {
+    ANA_MSG_ERROR( "mcEventWeight is not available as decoration! Aborting" );
+    return EL::StatusCode::FAILURE;
+  }
+  m_mcEvtWeight = m_mcEvtWeightAcc( *eventInfo );
 
   if(m_doTracksInJets){
     return executeTracksInJets();
@@ -155,8 +206,6 @@ EL::StatusCode TrackSelector :: execute ()
 
 EL::StatusCode TrackSelector :: executeTrackCollection ()
 {
-  float mcEvtWeight(1); // FIXME - set to something from eventInfo
-
   m_numEvent++;
 
   // get the collection from TEvent or TStore
@@ -226,7 +275,7 @@ EL::StatusCode TrackSelector :: executeTrackCollection ()
   m_numEventPass++;
   if(m_useCutFlow) {
     m_cutflowHist ->Fill( m_cutflow_bin, 1 );
-    m_cutflowHistW->Fill( m_cutflow_bin, mcEvtWeight);
+    m_cutflowHistW->Fill( m_cutflow_bin, m_mcEvtWeight);
   }
 
   return EL::StatusCode::SUCCESS;
@@ -352,103 +401,64 @@ EL::StatusCode TrackSelector :: histFinalize ()
 
 int TrackSelector :: PassCuts( const xAOD::TrackParticle* trk, const xAOD::Vertex *pvx ) {
 
+  // InDetTrackSelectionTool
+  if ( !m_trkSelTool->accept(*trk, pvx) ) { return 0; }
 
-  // pT
+  // Cuts not available with the InDetTrackSelectionTool
+  //
+  // pT_max
+  //
   if( m_pT_max != 1e8 ) {
-    if( trk->pt() > m_pT_max ) { return 0; }
-  }
-  if( m_pT_min != 1e8 ) {
-    if( trk->pt() < m_pT_min ) { return 0; }
+    if ( trk->pt() > m_pT_max ) { return 0; }
   }
 
-  // eta
-  if( m_eta_max != 1e8 ) {
-    if( trk->eta() > m_eta_max ) { return 0; }
-  }
+  //
+  // eta 
+  //
   if( m_eta_min != 1e8 ) {
-    if( trk->eta() < m_eta_min ) { return 0; }
+    if( fabs(trk->eta()) < m_eta_min ) { return 0; }
+  }
+  if( m_etaSigned_max != 1e8 ) {
+    if( trk->eta() > m_etaSigned_max ) { return 0; }
+  }
+  if( m_etaSigned_min != 1e8 ) {
+    if( trk->eta() < m_etaSigned_min ) { return 0; }
   }
 
-  //
-  //  D0
-  //
-  if( m_d0_max != 1e8 ){
-    if( fabs(trk->d0()) > m_d0_max ) {return 0; }
-  }
 
-  //
-  //  Z0
-  //
-  float z0 = (trk->z0() + trk->vz() - HelperFunctions::getPrimaryVertexZ(pvx));
-  if( m_z0_max != 1e8 ){
-    if( fabs(z0) > m_z0_max ) {return 0; }
-  }
-
-  //
-  //  z0 sin(theta)
-  //
-  float sinT        = sin(trk->theta());
-  if( m_z0sinT_max != 1e8 ){
-    if( fabs(z0*sinT) > m_z0sinT_max ) {return 0; }
-  }
-
-  //
+ 
+  //  
   //  nBLayer
   //
   uint8_t nBL       = -1;
   if( m_nBL_min != 1e8 ){
-    if(!trk->summaryValue(nBL,       xAOD::numberOfBLayerHits))      ANA_MSG_ERROR( "BLayer hits not filled");
+    //  xAOD::numberOfBLayerHits is deprecated, keeping it for compatibility 
+    if(!trk->summaryValue(nBL, xAOD::numberOfBLayerHits)) ANA_MSG_ERROR( "BLayer hits not filled");
     if( nBL < m_nBL_min ) {return 0; }
   }
 
   //
-  //  nSi_min
-  //
-  uint8_t nSCT      = -1;
-  uint8_t nPix      = -1;
-  if( m_nSi_min != 1e8 ){
-    if(!trk->summaryValue(nPix,      xAOD::numberOfPixelHits))        ANA_MSG_ERROR( "Pix hits not filled");
-    if(!trk->summaryValue(nSCT,      xAOD::numberOfSCTHits))          ANA_MSG_ERROR( "SCT hits not filled");
-    if( (nSCT+nPix) < m_nSi_min ) {return 0;}
-  }
-
-  //
-  //  nPix Holes
-  //
-  uint8_t nPixHoles = -1;
-  if( m_nPixHoles_max != 1e8 ){
-    if(!trk->summaryValue(nPixHoles, xAOD::numberOfPixelHoles))       ANA_MSG_ERROR( "Pix holes not filled");
-    if( nPixHoles > m_nPixHoles_max ) {return 0;}
-  }
-
-  //
-  //  chi2
+  //  chi2Prob_max
   //
   float        chi2        = trk->chiSquared();
   float        ndof        = trk->numberDoF();
-  if( m_chi2NdofCut_max != 1e8){
-    float chi2NDoF     = (ndof > 0) ? chi2/ndof : -1;
-    if( chi2NDoF > m_chi2NdofCut_max ) {return 0;}
-  }
-
   if( m_chi2Prob_max != 1e8 ){
     float        chi2Prob    = TMath::Prob(chi2,ndof);
-    if( chi2Prob > m_chi2Prob_max) {return 0;}
+    if( chi2Prob > m_chi2Prob_max) { return 0; }
   }
-
 
   //
   //  Pass Keys
   //
   for(auto& passKey : m_passKeys){
-    if(!(trk->auxdata< char >(passKey) == '1')) { return 0;}
+    if(!(trk->auxdata< char >(passKey) == '1')) { return 0; }
   }
 
   //
   //  Fail Keys
   //
   for(auto& failKey : m_failKeys){
-    if(!(trk->auxdata< char >(failKey) == '0')) {return 0;}
+    if(!(trk->auxdata< char >(failKey) == '0')) { return 0; }
   }
 
 

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -4,12 +4,17 @@
 // ROOT include(s):
 #include "TH1D.h"
 
+// EDM include(s):
 #include "xAODTracking/VertexContainer.h"
 #include "xAODTracking/TrackParticleContainer.h"
-#include "InDetTrackSelectionTool/InDetTrackSelectionTool.h"
+
+// external tools include(s):
+#include "InDetTrackSelectionTool/IInDetTrackSelectionTool.h"
+#include "AsgTools/AnaToolHandle.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
+
 
 class TrackSelector : public xAH::Algorithm
 {
@@ -109,7 +114,7 @@ public:
   /// @brief require TMath::Prob(chi2,ndof) > chi2ProbMax
   float m_chi2Prob_min = 1e8;
   /// @brief require nIBL >= nBL_min (not recommended; for downward compatibility)
-  float m_nBL_min = 1e8;
+  int m_nBL_min = 1e8;
 
 
   std::string              m_passAuxDecorKeys = "";
@@ -125,7 +130,7 @@ private:
   std::vector<std::string> m_passKeys;
   std::vector<std::string> m_failKeys;
 
-  InDet::InDetTrackSelectionTool * m_trkSelTool;
+  asg::AnaToolHandle <InDet::IInDetTrackSelectionTool> m_trkSelTool_handle{"InDet::InDetTrackSelectionTool/TrackSelectionTool", this}; //!
 
   int m_numEvent;         //!
   int m_numObject;        //!

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -6,6 +6,7 @@
 
 #include "xAODTracking/VertexContainer.h"
 #include "xAODTracking/TrackParticleContainer.h"
+#include "InDetTrackSelectionTool/InDetTrackSelectionTool.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -35,30 +36,81 @@ public:
   int   m_pass_min = -1;
   /// @brief maximum number of objects passing cuts
   int   m_pass_max = -1;
+  /// @brief available: Loose LoosePrimary TightPrimary LooseMuon LooseElectron MinBias HILoose HITight 
+  std::string m_cutLevelString = "";
   /// @brief require pT < pt_max
   float m_pT_max = 1e8;
   /// @brief require pT > pt_max
   float m_pT_min = 1e8;
-  /// @brief require eta < eta_max
+  /// @brief require |p| > p_min
+  float m_p_min = 1e8;
+  /// @brief require |eta| < eta_max
   float m_eta_max = 1e8;
-  /// @brief require eta > eta_max
+  /// @brief require |eta| > eta_min
   float m_eta_min = 1e8;
+  /// @brief require eta > eta_min
+  float m_etaSigned_min = 1e8;
+  /// @brief require eta < eta_max
+  float m_etaSigned_max = 1e8;
   /// @brief require |d0| < d0_max
   float m_d0_max = 1e8;
   /// @brief require |z0| < z0_max
   float m_z0_max = 1e8;
-  /// @brief require |z0xsin(theat)| < z0sinT_max
+  /// @brief maximum error on d0 
+  float m_sigmad0_max = 1e8;
+  /// @brief maximum significance of |d0| 
+  float m_d0oversigmad0_max = 1e8;
+  /// @brief require |z0xsin(theta)| < z0sintheta_max
   float m_z0sinT_max = 1e8;
-  /// @brief require nBL > nBL_min
-  int   m_nBL_min = 1e8;
-  /// @brief require nSi > nSi_min
+  /// @brief maximum error on z0
+  float m_sigmaz0_max = 1e8;
+  /// @brief maximum error on z0*sin(theta)
+  float m_sigmaz0sintheta_max = 1e8;
+  /// @brief max |z0| significance
+  float m_z0oversigmaz0_max = 1e8;
+  /// @brief max |z0sin(theta)| significance
+  float m_z0sinthetaoversigmaz0sintheta_max=1e8;
+  /// @brief minimum pixel hits (counting dead sensors)
+  int   m_nPixelHits_min =1e8; 
+  /// @brief minimum pixel hits (no dead sensors)
+  int   m_nPixelHitsPhysical_min =1e8; 
+  /// @brief minimum SCT hits (counting dead sensors)
+  int   m_nSctHits_min =1e8; 
+  /// @brief minimum SCT hits (no dead sensors)
+  int   m_nSctHitsPhysical_min =1e8; 
+  /// @brief require nSi >= nSi_min (nSi = nPix + nSct)
   int   m_nSi_min = 1e8;
-  /// @brief require nPixHoles < nPixHoles_max
-  float m_nPixHoles_max = 1e8;
+  /// @brief require nSi >= nSi_min (nSi = nPix + nSct, no dead sensors)
+  int   m_nSiPhysical_min = 1e8;
+  /// @brief require nPixHoles <= nPixHoles_max
+  int   m_nPixHoles_max = 1e8;
+  /// @brief require nSCTHoles <= nSCTHoles_max
+  int   m_nSctHoles_max = 1e8;
+  /// @brief maximum silicon holes
+  int   m_nSiHoles_max =1e8; 
+  /// @brief minimum nIBL (if expected)
+  int   m_nInnermostPixel_min =1e8; 
+  /// @brief minimum nBL (if expected)
+  int   m_nNextToInnermostPixel_min =1e8; 
+  /// @brief minimum nIBL + nBL (if every hit that is not expected, we require one less)
+  int   m_nBothInnermostLayersHits_min =1e8; 
+  /// @brief maximum pixel hits shared with other tracks
+  int   m_nPixelSharedHits_max =1e8; 
+  /// @brief maximum SCT hits shared with other tracks
+  int   m_nSctSharedHits_max =1e8; 
+  /// @brief maximum silicon hits shared with other tracks
+  int   m_nSiSharedHits_max =1e8; 
+  /// @brief maximum (pixel + SCT/2) shared hits
+  int   m_nSiSharedModules_max =1e8; 
   /// @brief require chi2/ndof < chi2NdofCut_max
   float m_chi2NdofCut_max = 1e8;
   /// @brief require TMath::Prob(chi2,ndof) < chi2ProbMax
   float m_chi2Prob_max = 1e8;
+  /// @brief require TMath::Prob(chi2,ndof) > chi2ProbMax
+  float m_chi2Prob_min = 1e8;
+  /// @brief require nIBL >= nBL_min (not recommended; for downward compatibility)
+  float m_nBL_min = 1e8;
+
 
   std::string              m_passAuxDecorKeys = "";
   std::string              m_failAuxDecorKeys = "";
@@ -68,8 +120,12 @@ public:
 
 private:
 
+  float m_mcEvtWeight = 1.0;
+
   std::vector<std::string> m_passKeys;
   std::vector<std::string> m_failKeys;
+
+  InDet::InDetTrackSelectionTool * m_trkSelTool;
 
   int m_numEvent;         //!
   int m_numObject;        //!
@@ -85,9 +141,6 @@ private:
   // protected from being send from the submission node to the worker
   // node (done by the //!)
 public:
-  // Tree *myTree; //!
-  // TH1 *myHist; //!
-
 
 
   // this is a standard constructor

--- a/xAODAnaHelpers/TrackSelector.h
+++ b/xAODAnaHelpers/TrackSelector.h
@@ -125,8 +125,6 @@ public:
 
 private:
 
-  float m_mcEvtWeight = 1.0;
-
   std::vector<std::string> m_passKeys;
   std::vector<std::string> m_failKeys;
 
@@ -158,7 +156,7 @@ public:
   virtual EL::StatusCode changeInput (bool firstFile);
   virtual EL::StatusCode initialize ();
   virtual EL::StatusCode execute ();
-  EL::StatusCode executeTrackCollection ();
+  EL::StatusCode executeTrackCollection (float mcEvtWeight);
   EL::StatusCode executeTracksInJets ();
   virtual EL::StatusCode postExecute ();
   virtual EL::StatusCode finalize ();


### PR DESCRIPTION
- More options for the TrackSelector,
- Now uses InDetTrackSelectionTool. 
- Some option names are modified to harmonize with other selectors and with the official tool. To restore previous behavior:
    - m_eta_max -> m_etaSigned_max (m_eta_max is now the max absoiute value)
    - m_eta_min -> m_etaSigned_min (m_eta_min is now the min absoiute value)
    - m_nSi_min -> m_nSiPhysical_min (m_Si_min is now the number of Si hits counting dead sensors. This is the convention used in the official tool and what goes into the recommendations)
- nBL is kept for downward compatibility, but is not recommended since it uses the deprecated summary value xAOD::numberOfBLayerHits, which are actually the number of IBL hits. m_nInnermostPixel and m_nNextToInnermostPixel are provided.
- fix mcEvtWeight which was always 1.0 before

- [x] The tool seems to be setup correctly now. No more errors.