### PR TITLE
Simulation flavour from metadata

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1083,11 +1083,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
   ANA_CHECK( m_event->retrieve( eventInfo, "EventInfo" ) );
 
   // Determine simulation flavour
-  std::string SimulationFlavour;
-  if( isFastSim() )
-    SimulationFlavour = "AFII";
-  else
-    SimulationFlavour = "FS";
+  std::string SimulationFlavour = isFastSim() ? "AFII" : "FS";
 
   // Extract campaign automatically from Run Number
   std::string mcCampaignMD = "";

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -30,6 +30,7 @@
 #include "xAODCore/tools/IOStats.h"
 #include "xAODCore/tools/ReadStats.h"
 
+//TODO remove
 #include "xAODMetaData/FileMetaData.h"
 
 
@@ -1087,23 +1088,10 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
 
   // Determine simulation flavour
   std::string SimulationFlavour;
-  if( m_setAFII ){
-    SimulationFlavour="AFII";
-  }else if ( m_setFS ){
-    SimulationFlavour="FS";
-  }else{
-    const xAOD::FileMetaData* fmd = nullptr;
-    ANA_CHECK( wk()->xaodEvent()->retrieveMetaInput(fmd, "FileMetaData") );
-    fmd->value(xAOD::FileMetaData::simFlavour, SimulationFlavour);
-
-    if( SimulationFlavour == "AtlfastII" ){
-      SimulationFlavour="AFII";
-    }else{
-      SimulationFlavour="FS";
-    }
-  }
-  if(SimulationFlavour.empty())
-    SimulationFlavour="FS";
+  if( isFastSim() )
+    SimulationFlavour = "AFII";
+  else
+    SimulationFlavour = "FS";
 
   // Extract campaign automatically from Run Number
   std::string mcCampaignMD = "";

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1087,10 +1087,21 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
 
   // Determine simulation flavour
   std::string SimulationFlavour;
-  if( m_setAFII )
+  if( m_setAFII ){
     SimulationFlavour="AFII";
-  else
-    SimulationFlavour = wk()->metaData()->castString("SimulationFlavour");
+  }else if ( m_setFS ){
+    SimulationFlavour="FS";
+  }else{
+    const xAOD::FileMetaData* fmd = nullptr;
+    ANA_CHECK( wk()->xaodEvent()->retrieveMetaInput(fmd, "FileMetaData") );
+    fmd->value(xAOD::FileMetaData::simFlavour, SimulationFlavour);
+
+    if( SimulationFlavour == "AtlfastII" ){
+      SimulationFlavour="AFII";
+    }else{
+      SimulationFlavour="FS";
+    }
+  }
   if(SimulationFlavour.empty())
     SimulationFlavour="FS";
 

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -30,10 +30,6 @@
 #include "xAODCore/tools/IOStats.h"
 #include "xAODCore/tools/ReadStats.h"
 
-//TODO remove
-#include "xAODMetaData/FileMetaData.h"
-
-
 // this is needed to distribute the algorithm to the workers
 ClassImp(BasicEventSelection)
 

--- a/Root/ElectronCalibrator.cxx
+++ b/Root/ElectronCalibrator.cxx
@@ -140,28 +140,13 @@ EL::StatusCode ElectronCalibrator :: initialize ()
   m_EgammaCalibrationAndSmearingTool->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
   ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("ESModel", m_esModel));
   ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("decorrelationModel", m_decorrelationModel));
+
   //
   // For AFII samples
   //
-  if ( isMC() ) {
-
-    // Check simulation flavour for calibration config - cannot directly read metadata in xAOD otside of Athena!
-    //
-    // N.B.: With SampleHandler, you can define sample metadata in job steering macro!
-    //
-    //       They will be passed to the EL:;Worker automatically and can be retrieved anywhere in the EL::Algorithm
-    //       I reasonably suppose everyone will use SH...
-    //
-    //       IMPORTANT! the metadata name set in SH *must* be "AFII" (if not set, name will be *empty_string*)
-    //
-    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
-
-    if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ){
-
-      ANA_MSG_INFO( "Setting simulation flavour to AFII");
-      ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", 1));
-
-    }
+  if ( isFastSim() ){
+    ANA_MSG_INFO( "Setting simulation flavour to AFII");
+    ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", 1));
   }
   ANA_CHECK( m_EgammaCalibrationAndSmearingTool->initialize());
 

--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -117,15 +117,9 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   // *******************************************************
 
   int sim_flav(1); // default for FullSim
-  if ( isMC() ) {
-    const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
-    if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ) {
-      ANA_MSG_INFO( "Setting simulation flavour to AFII");
-      sim_flav = 3;
-    }
-    else if ( !m_setAFII && stringMeta.empty() ) {
-      ANA_MSG_WARNING( "No meta-data string found. Simulation flavour will be set to FullSim. Care if you are running on Fast-Sim MC.");
-    }
+  if ( isFastSim() ) {
+    ANA_MSG_INFO( "Setting simulation flavour to AFII");
+    sim_flav = 3;
   }
 
   // 1.

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -140,13 +140,9 @@ EL::StatusCode METConstructor :: initialize ()
     ANA_CHECK( m_metSignificance_handle.setProperty("SoftTermReso", m_significanceSoftTermReso) );
 
     // For AFII samples
-    if ( isMC() ) {
-      // Check simulation flavour for calibration config - cannot directly read metadata in xAOD otside of Athena!
-      const std::string stringMeta = wk()->metaData()->castString("SimulationFlavour");
-      if ( m_setAFII || ( !stringMeta.empty() && ( stringMeta.find("AFII") != std::string::npos ) ) ) {
-        ANA_MSG_INFO( "Setting simulation flavour to AFII");
-        ANA_CHECK( m_metSignificance_handle.setProperty("IsAFII", true));
-      }
+    if ( isFastSim() ){ 
+      ANA_MSG_INFO( "Setting simulation flavour to AFII");
+      ANA_CHECK( m_metSignificance_handle.setProperty("IsAFII", true));
     }
     ANA_CHECK( m_metSignificance_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_metSignificance_handle);

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -5,10 +5,12 @@
 #include "xAODRootAccess/Init.h"
 #include "xAODRootAccess/TEvent.h"
 #include "xAODRootAccess/TStore.h"
+#include "xAODMetaData/FileMetaData.h"
 
 // EL include(s):
 #include <EventLoop/StatusCode.h>
 #include <EventLoop/Algorithm.h>
+#include <EventLoop/Worker.h>
 
 #include <string>
 
@@ -24,6 +26,7 @@
 #include <AsgTools/MsgStream.h>
 #include <AsgTools/MsgStreamMacros.h>
 #include <AsgTools/MessageCheck.h>
+
 
 namespace xAH {
 
@@ -128,7 +131,7 @@ namespace xAH {
 
         /**
             @rst
-                This is an override at the algorithm level to force analyzing MC or not.
+                This stores the isMC decision, and can also be used to override at the algorithm level to force analyzing MC or not.
 
                 ===== ========================================================
                 Value Meaning
@@ -141,6 +144,31 @@ namespace xAH {
             @endrst
          */
         int m_isMC = -1;
+
+        /**
+            @rst
+                This stores the isFastSim decision, and can also be used to override at the algorithm level to force analyzing FastSim or not.
+
+                ===== ========================================================
+                Value Meaning
+                ===== ========================================================
+                -1    Default, use Metadata object to determine if FullSim or FastSim
+                0     Treat the input as FullSim
+                1     Treat the input as FastSim
+                ===== ========================================================
+
+            @endrst
+         */
+        int m_isFastSim = -1;
+
+        /** Flags to force a specific data-type, even if it disagrees with your input */
+        bool m_forceFastSim = false;
+        bool m_forceFullSim = false;
+        bool m_forceData    = false;
+
+        /** Backwards compatibility, same as m_forceFastSim */
+        bool m_setAFII = false;
+
 
       protected:
         /**
@@ -156,8 +184,6 @@ namespace xAH {
         /** The TStore object */
         xAOD::TStore* m_store = nullptr; //!
 
-        // will try to determine if data or if MC
-        // returns: 0=data, 1=mc
         /**
             @rst
                 Try to determine if we are running over data or MC. The :cpp:member:`xAH::Algorithm::m_isMC` can be used
@@ -175,6 +201,24 @@ namespace xAH {
             @endrst
          */
         bool isMC();
+        
+        /**
+            @rst
+                Try to determine if we are running over data or MC. The :cpp:member:`xAH::Algorithm::m_isFastSim` can be used
+		to fix the return value. Otherwise the metadata is queried.
+
+		An exception is thrown if the type cannot be determined.
+
+                ============ =======
+                Return Value Meaning
+                ============ =======
+                0            FullSim (or Data)
+                1            FastSim
+                ============ =======
+
+            @endrst
+         */
+        bool isFastSim();
 
         /**
             @rst

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -53,18 +53,10 @@ class BasicEventSelection : public xAH::Algorithm
     bool m_truthLevelOnly = false;
 
   /** @rst
-      If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.
-
-      With SampleHandler, one can define sample metadata in job steering macro. You can do this with relevant samples doing something like:
-
-      .. code-block:: c++
-
-      // access a single sample
-      Sample *sample = sh.get ("mc14_13TeV.blahblahblah");
-      sample->setMetaString("SimulationFlavour", "AFII");
-
+      SimulationFlavour will be determined from the sample MetaData, unless AFII or FS is explicitely requested with the following flags.
       @endrst */
     bool m_setAFII = false;
+    bool m_setFS = false;
 
   // GRL
     /// @brief Apply GRL selection

--- a/xAODAnaHelpers/ElectronCalibrator.h
+++ b/xAODAnaHelpers/ElectronCalibrator.h
@@ -70,9 +70,6 @@ public:
   std::string m_esModel = "";
   std::string m_decorrelationModel = "";
 
-  /** @brief Force AFII flag in calibration, in case metadata is broken */
-  bool m_setAFII = false;
-
   /** @brief Apply isolation correction, not needed by default */
   bool m_applyIsolationCorrection = false;
 

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -54,9 +54,6 @@ public:
   /// @brief Write systematics names to metadata
   bool m_writeSystToMetadata = false;
 
-  /** @brief Force AFII flag in calibration, in case metadata is broken */
-  bool m_setAFII = false;
-
   float m_systValPID = 0.0;
   float m_systValIso = 0.0;
   float m_systValReco = 0.0;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -78,19 +78,6 @@ public:
   /// @brief Set analysis-specific jet flavour composition file for JetUncertainties (default: unknown comp.)
   std::string m_overrideAnalysisFile = "";
 
-  /** @rst
-    If you do not want to use SampleHandler to mark samples as AFII, this flag can be used to force run the AFII configurations.
-
-    With SampleHandler, one can define sample metadata in job steering macro. You can do this with relevant samples doing something like:
-
-    .. code-block:: c++
-
-      // access a single sample
-      Sample *sample = sh.get ("mc14_13TeV.blahblahblah");
-      sample->setMetaString("SimulationFlavour", "AFII");
-
-  @endrst */
-  bool m_setAFII = false;
   /// @brief when running data "_Insitu" is appended to calibration sequence
   bool m_forceInsitu = false;
   /// @brief when running FullSim "_Smear" is appended to calibration sequence
@@ -140,8 +127,6 @@ private:
 
   int m_numEvent;         //!
   int m_numObject;        //!
-
-  bool m_isFullSim;       //!
 
   std::string m_calibConfig; //!
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -62,8 +62,6 @@ public:
   bool    m_addSoftClusterTerms = false;
 
   // MET significance
-  /// @brief Force AFII flag in calculation, in case metadata is broken
-  bool m_setAFII = false;
   /// @brief Enable MET significance calculation
   bool m_calculateSignificance = false;
   /// @brief Introduce "resolution" for jets with low JVT, if the analysis is sensitive to pileup jets

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -55,7 +55,7 @@ public:
   /// @brief this is the name of the vector of names of the systematically varied containers produced by THIS algo ( these will be the m_inputAlgoSystNames of the algo downstream
   std::string m_outputAlgoSystNames = "PhotonCalibrator_Syst";
 
-  bool        m_useAFII = false;
+  bool        m_useAFII = false; //For backwards compatibility
   float       m_systVal = 0.0;
   std::string m_systName = "";
 


### PR DESCRIPTION
Addresses #1389.  Properly gets FullSim vs FastSim information from MetaData unless otherwise specified.  isFastSim is a new function available to all algorithms, mirroring isMC.   Use m_forceData, m_forceFullSim, and m_forceFastSim flags to allow any algorithm to override the defaults & give xAH that flexibility we all love.  Includes backwards compatibility for older flags where needed.  Removes ability to force sample type using SampleHandler, but this should be unnecessary now that MetaData access properly works.