### PR TITLE
MuonInFatJetCorrector: Add support for different jet calibrations

### DIFF
--- a/Root/MuonInFatJetCorrector.cxx
+++ b/Root/MuonInFatJetCorrector.cxx
@@ -65,8 +65,7 @@ EL::StatusCode MuonInFatJetCorrector :: initialize()
 
   //
   // Automatically determine calibrated mass decorators, if asked
-  if(m_calibratedMassDecorator.empty())
-      m_calibratedMassDecorator=(isMC())?"JetJMSScaleMomentum":"JetInsituScaleMomentum";
+  m_calibratedMassDecorator=(isMC())?m_calibratedMassDecoratorFullSim:m_calibratedMassDecoratorData;
 
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/MuonInFatJetCorrector.cxx
+++ b/Root/MuonInFatJetCorrector.cxx
@@ -63,6 +63,11 @@ EL::StatusCode MuonInFatJetCorrector :: initialize()
   m_event = wk()->xaodEvent();
   m_store = wk()->xaodStore();
 
+  //
+  // Automatically determine calibrated mass decorators, if asked
+  if(m_calibratedMassDecorator.empty())
+      m_calibratedMassDecorator=(isMC())?"JetJMSScaleMomentum":"JetInsituScaleMomentum";
+
   return EL::StatusCode::SUCCESS;
 }
 
@@ -282,7 +287,7 @@ const xAOD::JetFourMom_t MuonInFatJetCorrector::getMuonCorrectedJetFourMom(const
       {
 	// muon-in-jet correction for jets calibrated using calorimeter mass
 	xAOD::JetFourMom_t CaloJet_tlv = jet.jetP4();
-	if (useJMSScale) CaloJet_tlv = jet.jetP4("JetJMSScaleMomentumCalo");
+	if (useJMSScale) CaloJet_tlv = jet.jetP4(m_calibratedMassDecorator+"Calo");
 	for(const xAOD::Muon* muon : muons)
 	  {
 	    // get energy loss of muon in the calorimeter
@@ -306,8 +311,8 @@ const xAOD::JetFourMom_t MuonInFatJetCorrector::getMuonCorrectedJetFourMom(const
       {
 	// muon-in-jet correction for jets calibrated using track-assisted mass
 	xAOD::JetFourMom_t TAJet_tlv = jet.jetP4();
-	if (useJMSScale) TAJet_tlv = jet.jetP4("JetJMSScaleMomentumTA");
-	xAOD::JetFourMom_t CaloJet_tlv = jet.jetP4("JetJMSScaleMomentumCalo");
+	if (useJMSScale) TAJet_tlv = jet.jetP4(m_calibratedMassDecorator+"TA");
+	xAOD::JetFourMom_t CaloJet_tlv = jet.jetP4(m_calibratedMassDecorator+"Calo");
 	xAOD::JetFourMom_t CaloJetCorr_tlv =  getMuonCorrectedJetFourMom(jet, muons, Scheme::Calorimeter, true);
 	float TAJetCorr_m = TAJet_tlv.M() / CaloJet_tlv.Pt() * CaloJetCorr_tlv.Pt() ;
 	float TAJetCorr_pt = sqrt((CaloJetCorr_tlv.E() * CaloJetCorr_tlv.E()) - (TAJetCorr_m * TAJetCorr_m)) / cosh(CaloJetCorr_tlv.Eta());
@@ -318,9 +323,9 @@ const xAOD::JetFourMom_t MuonInFatJetCorrector::getMuonCorrectedJetFourMom(const
     case Scheme::Combined:
       {
 	// muon-in-jet correction for jets calibrated using combined mass
-	xAOD::JetFourMom_t TAJet_tlv       = jet.jetP4("JetJMSScaleMomentumTA");
+	xAOD::JetFourMom_t TAJet_tlv       = jet.jetP4(m_calibratedMassDecorator+"TA");
 	xAOD::JetFourMom_t TAJetCorr_tlv   = getMuonCorrectedJetFourMom(jet, muons, Scheme::TrackAssisted, true);
-	xAOD::JetFourMom_t CaloJet_tlv     = jet.jetP4("JetJMSScaleMomentumCalo");
+	xAOD::JetFourMom_t CaloJet_tlv     = jet.jetP4(m_calibratedMassDecorator+"Calo");
 	xAOD::JetFourMom_t CaloJetCorr_tlv = getMuonCorrectedJetFourMom(jet, muons, Scheme::Calorimeter  , true);
 	xAOD::JetFourMom_t CombJet_tlv = jet.jetP4();
 	float CaloWeight = (CombJet_tlv.M() -   TAJet_tlv.M()) / (CaloJet_tlv.M() - TAJet_tlv.M());

--- a/xAODAnaHelpers/MuonInFatJetCorrector.h
+++ b/xAODAnaHelpers/MuonInFatJetCorrector.h
@@ -29,6 +29,8 @@ public:
   std::string m_muonContainerName = "";
   /// @brief The name of the link to matched track jets
   std::string m_trackJetLinkName = "GhostVR30Rmax4Rmin02TrackJet";
+  /// @brief Name of calibrated jet mass decorator, without the TA/Calo prefix (empty means determine automatically)
+  std::string m_calibratedMassDecorator;
   /// @brief Algortihm systematics loop
   std::string m_inputAlgo;
 

--- a/xAODAnaHelpers/MuonInFatJetCorrector.h
+++ b/xAODAnaHelpers/MuonInFatJetCorrector.h
@@ -29,8 +29,10 @@ public:
   std::string m_muonContainerName = "";
   /// @brief The name of the link to matched track jets
   std::string m_trackJetLinkName = "GhostVR30Rmax4Rmin02TrackJet";
-  /// @brief Name of calibrated jet mass decorator, without the TA/Calo prefix (empty means determine automatically)
-  std::string m_calibratedMassDecorator;
+  /// @brief Name of calibrated jet mass decorator, without the TA/Calo suffix, for data
+  std::string m_calibratedMassDecoratorData = "JetInsituScaleMomentum";
+  /// @brief Name of calibrated jet mass decorator, without the TA/Calo suffix, for full sim
+  std::string m_calibratedMassDecoratorFullSim = "JetJMSScaleMomentum";
   /// @brief Algortihm systematics loop
   std::string m_inputAlgo;
 
@@ -64,7 +66,10 @@ public:
   const xAOD::JetFourMom_t getMuonCorrectedJetFourMom(const xAOD::Jet &jet, std::vector<const xAOD::Muon*> muons,
 						      Scheme scheme, bool useJMSScale = false) const;
 
-
+private:
+   /// @brief Name of calibrated jet mass decorator, without the TA/Calo suffix, for the given sample type
+  std::string m_calibratedMassDecorator;
+ 
   ClassDef(MuonInFatJetCorrector, 1);
 };
 


### PR DESCRIPTION
Make the calibration used to obtain the calibrated calorimeter and track assisted masses configurable. Different values might be needed depending on the latest available calibrations.

The default is now `JetInsituScaleMomentum` for data and `JetJMSScaleMomentum` for MC.