### PR TITLE
Use Python syntax for Booleans in example

### DIFF
--- a/docs/UsingUs.rst
+++ b/docs/UsingUs.rst
@@ -89,10 +89,10 @@ and I save this into ``xah_run_example.json``. If you want more variables in you
     from xAODAnaHelpers import Config
     c = Config()
 
-    c.setalg("BasicEventSelection", {"m_truthLevelOnly": false,
-                                     "m_applyGRLCut": true,
+    c.setalg("BasicEventSelection", {"m_truthLevelOnly": False,
+                                     "m_applyGRLCut": True,
                                      "m_GRLxml": "$ROOTCOREBIN/data/xAODAnaHelpers/data12_8TeV.periodAllYear_DetStatus-v61-pro14-02_DQDefects-00-01-00_PHYS_StandardGRL_All_Good.xml",
-                                     "m_doPUreweighting": false,
+                                     "m_doPUreweighting": False,
                                      "m_vertexContainerName": "PrimaryVertices",
                                      "m_PVNTrack": 2,
                                      "m_name": "myBaseEventSel"})


### PR DESCRIPTION
The current example will not run, as Python boolean values need to be capitalized (`True` and `False`), whereas in JSON they are lowercase.