### PR TITLE
Muon container primary vertex check

### DIFF
--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -780,8 +780,11 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
       float d0_significance =  ( d0SigAcc.isAvailable( *muon ) ) ? d0SigAcc( *muon ) : -1.0;
       m_trkd0sig->push_back( d0_significance );
 
-      m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
-
+      if (primaryVertex)
+        m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
+      else
+        m_trkz0->push_back( -999.0 );
+	    
       static SG::AuxElement::Accessor<float> z0sinthetaAcc("z0sintheta");
       float z0sintheta =  ( z0sinthetaAcc.isAvailable( *muon ) ) ? z0sinthetaAcc( *muon ) : -999.0;
       m_trkz0sintheta->push_back( z0sintheta );

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -185,7 +185,9 @@ EL::StatusCode TrackSelector :: execute ()
 
   // MC event weight
   //
-  float mcEvtWeight = eventInfo->mcEventWeight();
+  float mcEvtWeight(1);
+  if ( eventInfo->eventType(xAOD::EventInfo::IS_SIMULATION) )
+	mcEvtWeight = eventInfo->mcEventWeight();
 
   if(m_doTracksInJets){
     return executeTracksInJets();


### PR DESCRIPTION
In MuonContainer.cxx, the primary vertex is accessed without checking if it is a null pointer. This caused infrequent but fatal failures when filling muon trackparams. A simple check is added so if the primary vertex is null, m_trkz0 is filled with -999.
