### PR TITLE
added 'ANN_score' variable to the FatJet class

### DIFF
--- a/xAODAnaHelpers/FatJet.h
+++ b/xAODAnaHelpers/FatJet.h
@@ -47,6 +47,7 @@ namespace xAH {
       float  NTrimSubjets;
       int    NClusters;
       int    nTracks;
+      float ANN_score;
 
       // constituent
       int    numConstituents;


### PR DESCRIPTION
The score of the adversarial NN used in ATL-PHYS-PUB-2018-014.
It was implemented recently in the BoostedJetTaggers package.