### PR TITLE
Set jet uncertainties path

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -298,6 +298,10 @@ EL::StatusCode JetCalibrator :: initialize ()
       ANA_MSG_WARNING("Overriding jet uncertainties analysis file to " << m_overrideAnalysisFile);
       ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("AnalysisFile", m_overrideAnalysisFile));
     }
+    if( !m_overrideUncertPath.empty() ){
+      ANA_MSG_WARNING("Overriding jet uncertainties path to " << m_overrideUncertPath);
+      ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("Path", m_overrideUncertPath));
+    }
     ANA_CHECK( m_JetUncertaintiesTool_handle.setProperty("OutputLevel", msg().level()));
     ANA_CHECK( m_JetUncertaintiesTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_JetUncertaintiesTool_handle);

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -77,6 +77,8 @@ public:
   std::string m_overrideUncertCalibArea = "";
   /// @brief Set analysis-specific jet flavour composition file for JetUncertainties (default: unknown comp.)
   std::string m_overrideAnalysisFile = "";
+  /// @brief Override uncertainties path (not recommended)
+  std::string m_overrideUncertPath = "";
 
   /// @brief when running data "_Insitu" is appended to calibration sequence
   bool m_forceInsitu = false;


### PR DESCRIPTION
Fabrizio asked in the xAH mailing list to be able to set the "Path" property of JetUncertaintiesTool in JetCalibrator. This is now possible but the default remains the same.