### PR TITLE
remove "unused variable 'cluster'" compiler warning

### DIFF
--- a/Root/ClusterContainer.cxx
+++ b/Root/ClusterContainer.cxx
@@ -50,6 +50,5 @@ void ClusterContainer::FillCluster( const xAOD::CaloCluster* cluster ){
 void ClusterContainer::FillCluster( const xAOD::IParticle* particle )
 {
   ParticleContainer::FillParticle(particle);
-  const xAOD::CaloCluster* cluster=dynamic_cast<const xAOD::CaloCluster*>(particle);
   return;
 }


### PR DESCRIPTION
This fixes issue #1409 by deleting the cast without effect that generated the compiler warning.