### PR TITLE
Updates to FatJetContainer

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -458,7 +458,7 @@ void FatJetContainer::setBranches(TTree *tree)
     setBranch<float> (tree, "muonCorrected_m"  , m_muonCorrected_m  );
   }
 
-  for(const std::pair< std::string, std::vector<std::vector<unsigned int>>* >& kv : m_trkJetsIdx)
+  for(const auto& kv : m_trkJets)
     {
       kv.second->setBranches(tree);
       setBranch< std::vector<unsigned int> >(tree, "trkJetsIdx_"+kv.first, m_trkJetsIdx[kv.first]);

--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -66,11 +66,11 @@ FatJetContainer::FatJetContainer(const std::string& name, const std::string& det
 
   
   if ( m_infoSwitch.m_truth && m_mc ) {
-      m_truth_m  =new std::vector<float>;
-      m_truth_pt =new std::vector<float>;
-      m_truth_phi=new std::vector<float>;
-      m_truth_eta=new std::vector<float>;
-    }
+    m_truth_m  =new std::vector<float>;
+    m_truth_pt =new std::vector<float>;
+    m_truth_phi=new std::vector<float>;
+    m_truth_eta=new std::vector<float>;
+  }
 
   if ( m_infoSwitch.m_bosonCount && m_mc) {
     m_nTQuarks  = new std::vector< int > ();
@@ -95,9 +95,6 @@ FatJetContainer::FatJetContainer(const std::string& name, const std::string& det
 
       m_trkJetsIdx[trackJetName] = new std::vector<std::vector<unsigned int> > ();
     }
-
-  m_trackJetPtCut  = m_infoSwitch.m_trackJetPtCut *1e3;
-  m_trackJetEtaCut = m_infoSwitch.m_trackJetEtaCut*1e3;
 
 }
 
@@ -275,7 +272,7 @@ void FatJetContainer::setTree(TTree *tree)
 	
   } 
 
-  for(const auto& kv : m_trkJets)
+  for(const std::pair< std::string, std::vector<std::vector<unsigned int>>* >& kv : m_trkJetsIdx)
     {
       m_trkJets[kv.first]->JetContainer::setTree(tree);
       if(tree->GetBranch(branchName("trkJetsIdx").c_str()))
@@ -441,18 +438,11 @@ void FatJetContainer::setBranches(TTree *tree)
     setBranch< std::vector<float> >(tree, "constituent_e",       m_constituent_e);
   }
 
-    if ( m_infoSwitch.m_truth && m_mc ) {
-    m_truth_m  =new std::vector<float>;
-    m_truth_pt =new std::vector<float>;
-    m_truth_phi=new std::vector<float>;
-    m_truth_eta=new std::vector<float>;
-  }
-
   if ( m_infoSwitch.m_truth && m_mc ) {
-    setBranch<float>(tree,"truth_m",   m_truth_m);
-    setBranch<float>(tree,"truth_pt",  m_truth_pt);
-    setBranch<float>(tree,"truth_phi", m_truth_phi);
-    setBranch<float>(tree,"truth_eta", m_truth_eta);
+    setBranch<float>(tree, "truth_m"  , m_truth_m  );
+    setBranch<float>(tree, "truth_pt" , m_truth_pt );
+    setBranch<float>(tree, "truth_phi", m_truth_phi);
+    setBranch<float>(tree, "truth_eta", m_truth_eta);
   }
     
   if ( m_infoSwitch.m_bosonCount && m_mc ) {
@@ -468,7 +458,7 @@ void FatJetContainer::setBranches(TTree *tree)
     setBranch<float> (tree, "muonCorrected_m"  , m_muonCorrected_m  );
   }
 
-  for(const auto& kv : m_trkJets)
+  for(const std::pair< std::string, std::vector<std::vector<unsigned int>>* >& kv : m_trkJetsIdx)
     {
       kv.second->setBranches(tree);
       setBranch< std::vector<unsigned int> >(tree, "trkJetsIdx_"+kv.first, m_trkJetsIdx[kv.first]);
@@ -799,7 +789,7 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle ){
 	  std::sort( assotrkjets.begin(), assotrkjets.end(), HelperFunctions::sort_pt );
 	}
 	catch (...){
-	  //Warning("execute()", "Unable to fetch \"%s\" link from leading calo-jet", trackJetName.data());
+	  Warning("execute()", "Unable to fetch \"%s\" link from leading calo-jet", trackJetName.data());
 	}
 
 	std::vector<unsigned int> trkJetsIdx;

--- a/xAODAnaHelpers/FatJet.h
+++ b/xAODAnaHelpers/FatJet.h
@@ -58,6 +58,9 @@ namespace xAH {
       std::vector<float>  constituent_phi;
       std::vector<float>  constituent_e;
 
+      // truth
+      TLorentzVector truth_p4;
+      
       // bosons 
       int nTQuarks;
       int nHBosons;

--- a/xAODAnaHelpers/FatJetContainer.h
+++ b/xAODAnaHelpers/FatJetContainer.h
@@ -30,8 +30,8 @@ namespace xAH {
       virtual void FillFatJet( const xAOD::IParticle* particle );
       using ParticleContainer::setTree; // make other overloaded version of execute() to show up in subclass
 
-      float       m_trackJetPtCut  =10e3;
-      float       m_trackJetEtaCut =2.5;
+      float       m_trackJetPtCut  =10e3; // slimming pT cut on associated track jets
+      float       m_trackJetEtaCut =2.5;  // slimmint eta cut on associated track jets
 
     protected:
 

--- a/xAODAnaHelpers/FatJetContainer.h
+++ b/xAODAnaHelpers/FatJetContainer.h
@@ -7,11 +7,14 @@
 #include <vector>
 #include <string>
 
+#include <xAODJet/JetContainer.h>
+
 #include <xAODAnaHelpers/HelperClasses.h>
 #include <xAODAnaHelpers/HelperFunctions.h>
 
 #include <xAODAnaHelpers/FatJet.h>
 #include <xAODAnaHelpers/ParticleContainer.h>
+#include <xAODAnaHelpers/JetContainer.h>
 
 
 namespace xAH {

--- a/xAODAnaHelpers/FatJetContainer.h
+++ b/xAODAnaHelpers/FatJetContainer.h
@@ -7,16 +7,11 @@
 #include <vector>
 #include <string>
 
-#include "xAODJet/JetContainer.h"
-
 #include <xAODAnaHelpers/HelperClasses.h>
 #include <xAODAnaHelpers/HelperFunctions.h>
 
 #include <xAODAnaHelpers/FatJet.h>
 #include <xAODAnaHelpers/ParticleContainer.h>
-#include <xAODAnaHelpers/JetContainer.h>
-
-#include "InDetTrackSelectionTool/InDetTrackSelectionTool.h"
 
 
 namespace xAH {
@@ -35,8 +30,8 @@ namespace xAH {
       virtual void FillFatJet( const xAOD::IParticle* particle );
       using ParticleContainer::setTree; // make other overloaded version of execute() to show up in subclass
 
-      float       m_trackJetPtCut;
-      float       m_trackJetEtaCut;
+      float       m_trackJetPtCut  =10e3;
+      float       m_trackJetEtaCut =2.5;
 
     protected:
 
@@ -101,6 +96,12 @@ namespace xAH {
       std::vector< std::vector<float> >  *m_constituent_phi;
       std::vector< std::vector<float> >  *m_constituent_e;
 
+      // truth
+      std::vector<float> *m_truth_m;
+      std::vector<float> *m_truth_pt;
+      std::vector<float> *m_truth_phi;
+      std::vector<float> *m_truth_eta;
+      
       // bosonCount
       std::vector< int > *m_nTQuarks;
       std::vector< int > *m_nHBosons;


### PR DESCRIPTION
A few updates to the `FatJetContainer` class responsible for ntupling fat jets.

* Move default values of track jet kinematic cuts into header for better visilibily.
* Save mass instead of energy for the fat jet four-vector. This is the more useful variable.
* Add matched truth jet kinematics. 
* Synchronize fat jet parent finding code between boson truth tagging and VR jet association.