### PR TITLE
Add configuration parameter for BTagSelectionTool

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -180,6 +180,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("TaggerName",          m_taggerName));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("OperatingPoint",      m_operatingPt));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("JetAuthor",           m_jetAuthor));
+  ANA_CHECK( m_BJetSelectTool_handle.setProperty("ErrorOnTagWeightFailure", m_errorOnTagWeightFailure));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("OutputLevel", msg().level() ));
   ANA_CHECK( m_BJetSelectTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_BJetSelectTool_handle);
@@ -371,6 +372,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   //
   for( const xAOD::Jet* jet_itr : *(inJets))
     {
+
       if(!m_useContinuous)
 	{ // get tagging decision
 	  ANA_MSG_DEBUG(" Getting tagging decision ");
@@ -468,7 +470,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 	      if(m_useContinuous && !dec_ineffsfBTag.isAvailable( *jet_itr ))
 		dec_ineffsfBTag( *jet_itr ) = std::vector<float>();
 
-	      
+
 	      dec_sfBTag( *jet_itr ).push_back(SF);
 	      if(m_useContinuous) dec_ineffsfBTag( *jet_itr ).push_back(inefficiencySF);
       }

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -43,6 +43,7 @@ public:
   bool        m_useDevelopmentFile = true;
   bool        m_coneFlavourLabel = true;
   std::string m_systematicsStrategy = "SFEigen";
+  bool        m_errorOnTagWeightFailure = true;
 
   // allowed operating points:
   // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#xAOD_interface

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -43,6 +43,7 @@ public:
   bool        m_useDevelopmentFile = true;
   bool        m_coneFlavourLabel = true;
   std::string m_systematicsStrategy = "SFEigen";
+  /// @brief BTaggingSelectionTool throws an error on missing tagging weights. If false, a warning is given instead
   bool        m_errorOnTagWeightFailure = true;
 
   // allowed operating points:


### PR DESCRIPTION
Makes the ErrorOnTagWeightFailure option of the BTaggingSelectionTool configurable in the BJetEfficiencyCorrector. The option defaults to true and the tool throws errors when attempting to tag jets without DL1 pu/pc/pb scores. Setting it to false makes the tool give a warning instead.
Needed for hh->4b analysis to be able to store low pt track jets (for VR overlap removal) which are occasionally missing DL1 scores.