### PR TITLE
Fix large-R truth labeling for modern derivations

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -549,6 +549,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
+  if(tmp_name.Contains("H7")) tmp_name.ReplaceAll("H7","HERWIG");
   //capitalize the entire sample name
   tmp_name.ToUpper();
 

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -549,6 +549,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
+  if(tmp_name.Contains("Py8EvtGen")) tmp_name.ReplaceAll("Py8EvtGen","PYTHIA8EVTGEN");
   if(tmp_name.Contains("H7")) tmp_name.ReplaceAll("H7","HERWIG");
   //capitalize the entire sample name
   tmp_name.ToUpper();

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -266,6 +266,10 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("CalibArea" , "SmoothedWZTaggers/Rel21"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("ConfigFile", "SmoothedContainedWTagger_AntiKt10LCTopoTrimmed_FixedSignalEfficiency50_MC16d_20190410.dat"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("DSID", ei->mcChannelNumber()));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthWBosonContainerName", "TruthBoson"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthZBosonContainerName", "TruthBoson"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthHBosonContainerName", "TruthBoson"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthTopQuarkContainerName", "TruthTop"));
     ANA_CHECK(m_SmoothedWZTagger_handle.retrieve());
   }// if MC && largeR
 
@@ -451,6 +455,9 @@ EL::StatusCode JetCalibrator :: execute ()
       if (this_TruthLabel == 5) isBjet = true;
       static SG::AuxElement::Decorator<char> accIsBjet("IsBjet"); // char due to limitations of ROOT I/O, still treat it as a bool
       accIsBjet(*jet_itr) = isBjet;
+      
+      SG::AuxElement::Accessor< int > accTruth("FatJetTruthLabel");
+
 
       // largeR jet truth labelling
       if(m_SmoothedWZTagger_handle.isInitialized()) {
@@ -481,7 +488,6 @@ EL::StatusCode JetCalibrator :: execute ()
   for ( const auto& syst_it : m_systList ) {
 
     bool nominal = syst_it.name().empty();
-
     // always append the name of the variation, including nominal which is an empty string
     outSCContainerName   =m_outContainerName+syst_it.name()+"ShallowCopy";
     outSCAuxContainerName=m_outContainerName+syst_it.name()+"ShallowCopyAux.";
@@ -504,6 +510,7 @@ EL::StatusCode JetCalibrator :: execute ()
       }
 
       for ( auto jet_itr : *(uncertCalibJetsSC.first) ) {
+
         if (m_applyFatJetPreSel) {
           bool validForJES = (jet_itr->pt() >= 150e3 && jet_itr->pt() < 3000e3);
           validForJES &= (jet_itr->m()/jet_itr->pt() >= 0 && jet_itr->m()/jet_itr->pt() < 1);

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -266,6 +266,18 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("CalibArea" , "SmoothedWZTaggers/Rel21"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("ConfigFile", "SmoothedContainedWTagger_AntiKt10LCTopoTrimmed_FixedSignalEfficiency50_MC16d_20190410.dat"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty("DSID", ei->mcChannelNumber()));
+    std::string truthBosonContainer = "TruthParticles";
+    if(evtStore()->contains<xAOD::TruthParticleContainer>( "TruthBoson" )){
+      truthBosonContainer = "TruthBoson";
+    } else if(evtStore()->contains<xAOD::TruthParticleContainer>( "TruthBosonsWithDecayParticles" )){
+      truthBosonContainer = "TruthBosonsWithDecayParticles";
+    }
+    std::string truthTopContainer = "TruthParticles";
+    if(evtStore()->contains<xAOD::TruthParticleContainer>( "TruthTop" )){
+      truthTopContainer = "TruthTop";
+    } else if(evtStore()->contains<xAOD::TruthParticleContainer>( "TruthTopQuarkWithDecayParticles" )){
+      truthTopContainer = "TruthTopQuarkWithDecayParticles";
+    }
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthWBosonContainerName", "TruthBoson"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthZBosonContainerName", "TruthBoson"));
     ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthHBosonContainerName", "TruthBoson"));

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -278,10 +278,10 @@ EL::StatusCode JetCalibrator :: initialize ()
     } else if(evtStore()->contains<xAOD::TruthParticleContainer>( "TruthTopQuarkWithDecayParticles" )){
       truthTopContainer = "TruthTopQuarkWithDecayParticles";
     }
-    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthWBosonContainerName", "TruthBoson"));
-    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthZBosonContainerName", "TruthBoson"));
-    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthHBosonContainerName", "TruthBoson"));
-    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthTopQuarkContainerName", "TruthTop"));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthWBosonContainerName", truthBosonContainer));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthZBosonContainerName", truthBosonContainer));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthHBosonContainerName", truthBosonContainer));
+    ANA_CHECK(m_SmoothedWZTagger_handle.setProperty( "TruthTopQuarkContainerName", truthTopContainer));
     ANA_CHECK(m_SmoothedWZTagger_handle.retrieve());
   }// if MC && largeR
 


### PR DESCRIPTION
I'm not sure this is the right way to handle this.

But the truth decoration for large-R jets, in DAOD formats that have Truth3 type containers, requires a few more configurations than before, as described here: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JetUncertaintiesRel21Summer2019LargeR#Truth_labelling_via_BoostedJetTa

Probably this should be configurable, but I'm opening the MR with my current fix so we can discuss how to proceed