### PR TITLE
docs: Mention list of input paths is newline separated

### DIFF
--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -73,7 +73,7 @@ standard = {
     "inputList": {
         "dest": "use_inputFileList",
         "action": "store_true",
-        "help": "If enabled, will read in a text file containing a list of paths/filenames.",
+        "help": "If enabled, will read in a text file containing a list of newline separated paths/filenames.",
     },
     "inputTag": {
         "dest": "inputTag",

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -107,7 +107,7 @@ parser._positionals.title = "required"
 parser._optionals.title = "optional"
 
 # positional argument, require the first argument to be the input filename
-parser_requiredNamed.add_argument('--files', dest='input_filename', metavar='file', type=str, nargs='+', required=True, help='input file(s) to read. This gives all the input files for the script to use. Depending on the other options specified, these could be rucio sample names, local paths, or text files containing a list of newline separated filenames/paths.')
+parser_requiredNamed.add_argument('--files', dest='input_filename', metavar='file', type=str, nargs='+', required=True, help='input file(s) to read. This gives all the input files for the script to use. Depending on the other options specified, these could be rucio sample names, local paths, or text files containing a list of newline separated paths/filenames.')
 parser_requiredNamed.add_argument('--config', metavar='', type=str, required=True, help='configuration for the algorithms. This tells the script which algorithms to load, configure, run, and in which order. Without it, it becomes a headless chicken.')
 
 parser.add_argument('--version', action='version', version='xAH_run.py {version}'.format(version=__version__), help='{version}'.format(version=__version__))

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -107,7 +107,7 @@ parser._positionals.title = "required"
 parser._optionals.title = "optional"
 
 # positional argument, require the first argument to be the input filename
-parser_requiredNamed.add_argument('--files', dest='input_filename', metavar='file', type=str, nargs='+', required=True, help='input file(s) to read. This gives all the input files for the script to use. Depending on the other options specified, these could be rucio sample names, local paths, or text files containing a list of filenames/paths.')
+parser_requiredNamed.add_argument('--files', dest='input_filename', metavar='file', type=str, nargs='+', required=True, help='input file(s) to read. This gives all the input files for the script to use. Depending on the other options specified, these could be rucio sample names, local paths, or text files containing a list of newline separated filenames/paths.')
 parser_requiredNamed.add_argument('--config', metavar='', type=str, required=True, help='configuration for the algorithms. This tells the script which algorithms to load, configure, run, and in which order. Without it, it becomes a headless chicken.')
 
 parser.add_argument('--version', action='version', version='xAH_run.py {version}'.format(version=__version__), help='{version}'.format(version=__version__))


### PR DESCRIPTION
Add to the docs that when using the `--files` `xAH_run.py` option with `--inputList` that the input file must be newline separated.