### PR TITLE
Default `btagOpPoint::m_op` to None

### DIFF
--- a/Root/ClusterContainer.cxx
+++ b/Root/ClusterContainer.cxx
@@ -50,6 +50,5 @@ void ClusterContainer::FillCluster( const xAOD::CaloCluster* cluster ){
 void ClusterContainer::FillCluster( const xAOD::IParticle* particle )
 {
   ParticleContainer::FillParticle(particle);
-  const xAOD::CaloCluster* cluster=dynamic_cast<const xAOD::CaloCluster*>(particle);
   return;
 }

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -1,6 +1,7 @@
 #include "xAODAnaHelpers/JetContainer.h"
 #include <xAODAnaHelpers/HelperFunctions.h>
 #include <iostream>
+#include <exception> // std::domain_error
 #include "xAODTruth/TruthEventContainer.h"
 
 using namespace xAH;
@@ -1748,7 +1749,9 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
       jet.SF_DL1rmu_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
       break;
 	default:
-	  break;
+    throw std::domain_error(
+        __FILE__ + std::string(", in ") + __func__ + ": "
+        + "unexpected value of btag->m_op (of type xAH::Jet::BTaggerOP)");
 	}
     }
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -1373,6 +1373,8 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
     {
       switch(btag->m_op)
 	{
+  case Jet::BTaggerOP::None: // has a point, see: https://github.com/UCATLAS/xAODAnaHelpers/issues/1420 
+    break; 
 	case Jet::BTaggerOP::DL1rnn_FixedCutBEff_60:
 	  jet.is_DL1rnn_FixedCutBEff_60=       btag->m_isTag->at(idx);
 	  jet.SF_DL1rnn_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -323,7 +323,7 @@ namespace xAH {
         std::vector< std::vector<float> >* m_ineffSf; // for continuous
 
         btagOpPoint(bool mc, const std::string& accessorName)
-	  : m_mc(mc), m_accessorName(accessorName),m_old(true) {
+	  : m_mc(mc), m_accessorName(accessorName),m_op(Jet::BTaggerOP::None),m_old(true) {
           m_isTag = new std::vector<int>();
           m_sf    = new std::vector< std::vector<float> >();
 
@@ -364,7 +364,7 @@ namespace xAH {
         }
 
         btagOpPoint(bool mc, const std::string& tagger, const std::string& wp)
-	  : m_mc(mc), m_accessorName(tagger+"_"+wp),m_old(false) {
+	  : m_mc(mc), m_accessorName(tagger+"_"+wp),m_op(Jet::BTaggerOP::None),m_old(false) {
           m_isTag     = new std::vector<int>();
           m_sf        = new std::vector< std::vector<float> >();
 


### PR DESCRIPTION
This fixes the crashes in issue #1420 by giving the undefined `m_op` field in `xAH::JetContainer::btagOpPoint` the default value `xAH::Jet::BTaggerOP::None`.
It's difficult to test against this kind of thing, so I also added an exception being thrown 
if an unanticipated value is encountered in this field. 
Hopefully that will draw peoples attention if e.g. `btagOpPoint` gains a third c'tor  that forgets to set this default again. 

Finally, sorry for the indentation, but those files are a wild and inconsistent mix of tabs and spaces, so I just went with what my editor suggested. 