### PR TITLE
Prevent crashes when unable to find a primary vertex

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -749,7 +749,8 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       static SG::AuxElement::Accessor<float> d0SigAcc ("d0sig");
       float d0_significance =  ( d0SigAcc.isAvailable( *elec ) ) ? d0SigAcc( *elec ) : -1.0;
       m_trkd0sig->push_back( d0_significance );
-      m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
+      if (primaryVertex)
+        m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
 
       static SG::AuxElement::Accessor<float> z0sinthetaAcc("z0sintheta");
       float z0sintheta =  ( z0sinthetaAcc.isAvailable( *elec ) ) ? z0sinthetaAcc( *elec ) : -999.0;

--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -751,6 +751,9 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       m_trkd0sig->push_back( d0_significance );
       if (primaryVertex)
         m_trkz0->push_back( trk->z0()  - ( primaryVertex->z() - trk->vz() ) );
+      else
+        m_trkz0->push_back( -999.0 );
+
 
       static SG::AuxElement::Accessor<float> z0sinthetaAcc("z0sintheta");
       float z0sintheta =  ( z0sinthetaAcc.isAvailable( *elec ) ) ? z0sinthetaAcc( *elec ) : -999.0;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -1200,6 +1200,8 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
     if ( jetPt < m_pt_max_JVF ) {
       xAOD::JetFourMom_t jetScaleP4 = jet->getAttribute< xAOD::JetFourMom_t >( m_jetScaleType.c_str() );
       if ( fabs(jetScaleP4.eta()) < m_eta_max_JVF ){
+        if ( m_pvLocation < 0 )
+          return 0;
         if ( jet->getAttribute< std::vector<float> >( "JVF" ).at( m_pvLocation ) < m_JVFCut ) {
           return 0;
         }

--- a/Root/VertexContainer.cxx
+++ b/Root/VertexContainer.cxx
@@ -59,6 +59,10 @@ void VertexContainer::FillVertices( const xAOD::VertexContainer* vertices){
       m_vertex_x->push_back(vertices->at(pvLocation)->x());
       m_vertex_y->push_back(vertices->at(pvLocation)->y());
       m_vertex_z->push_back(vertices->at(pvLocation)->z());
+    } else {
+      m_vertex_x->push_back( -999.0 );
+      m_vertex_y->push_back( -999.0 );
+      m_vertex_z->push_back( -999.0 );
     }
   } else if (m_detailStr == "all"){
     for( auto vertex : *vertices) {

--- a/Root/VertexContainer.cxx
+++ b/Root/VertexContainer.cxx
@@ -55,9 +55,11 @@ void VertexContainer::clear()
 void VertexContainer::FillVertices( const xAOD::VertexContainer* vertices){
   if(m_detailStr == "primary"){ // hard-scatter vertex only
     int pvLocation = HelperFunctions::getPrimaryVertexLocation( vertices );
-    m_vertex_x->push_back( vertices->at(pvLocation)->x() );
-    m_vertex_y->push_back( vertices->at(pvLocation)->y() );
-    m_vertex_z->push_back( vertices->at(pvLocation)->z() );
+    if (pvLocation >= 0) {
+      m_vertex_x->push_back(vertices->at(pvLocation)->x());
+      m_vertex_y->push_back(vertices->at(pvLocation)->y());
+      m_vertex_z->push_back(vertices->at(pvLocation)->z());
+    }
   } else if (m_detailStr == "all"){
     for( auto vertex : *vertices) {
       m_vertex_x->push_back( vertex->x() );


### PR DESCRIPTION
Addresses #1431

These changes keep the ntuple filler from crashing in the event that a primary vertex cannot be found.
This pull request only affects `VertexContainer.cxx` and `ElectronContainer.cxx` though there may be other sources of crashes that I have not yet tested.