### PR TITLE
Official and Voms are set as strings, not ints

### DIFF
--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -292,8 +292,8 @@ drivers_prun.update({
         "required": False,
         "default": None,
     },
-    "optOfficial": {"metavar": "", "type": int, "required": False, "default": None},
-    "optVoms": {"metavar": "", "type": int, "required": False, "default": None},
+    "optOfficial": {"metavar": "", "type": str, "required": False, "default": None},      
+    "optVoms": {"metavar": "", "type": str, "required": False, "default": None},
     # the following is not technically supported by Job.h but it is a valid option for prun, emailed pathelp about it
     "optGridOutputSampleName": {
         "metavar": "",


### PR DESCRIPTION
Just tweaking some options used when running group production.

I have successfully launched jobs just now using this change, by running with

```
    cmd = xAH_str
    cmd += " prun "
    cmd += " --optOfficial=\"true\" --optVoms=\"atlas:/atlas/phys-sm/Role=production\" "
    cmd += " --optGridOutputSampleName=\"group.phys-sm.%in:name[2]%.%in:name[3]%."+tag+s[0]+"\" "
```

:beers: MLB