### PR TITLE
Updating fJVT+JVT default settings

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -237,6 +237,7 @@ EL::StatusCode JetSelector :: initialize ()
     ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("UseMuSFFormat",       m_UseMuSFFormatfJVT ));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("ScaleFactorDecorationName", "fJVTSF"));
     ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("OutputLevel",  msg().level()));
     ANA_CHECK( m_fJVT_eff_tool_handle.retrieve());

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -161,7 +161,7 @@ public:
 
     @endrst
   */
-  std::string m_WorkingPointJVT = "Medium";
+  std::string m_WorkingPointJVT = "Tight";
 
   /**
      @brief Configuration containting JVT scale factors.
@@ -172,7 +172,7 @@ public:
      See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration for latest recommendation.
      @endrst
   */
-  std::string m_SFFileJVT = "JetJvtEfficiency/Moriond2017/JvtSFFile_EM.root";
+  std::string m_SFFileJVT = "JetJvtEfficiency/Moriond2018/JvtSFFile_EMPFlow.root";
   std::string m_outputSystNamesJVT = "JetJvtEfficiency_JVTSyst";
 
   float         m_systValJVT = 0.0;
@@ -194,7 +194,7 @@ public:
         See :https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/FJVTCalibration for more information.
     @endrst
   */
-  std::string m_WorkingPointfJVT = "Medium";
+  std::string m_WorkingPointfJVT = "Loose";
 
   /**
      @brief Configuration containting fJVT scale factors.
@@ -205,7 +205,11 @@ public:
         See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/FJVTCalibration for latest recommendation.
      @endrst
   */
-  std::string m_SFFilefJVT = "JetJvtEfficiency/Moriond2016_v2/fJvtSFFile.root";
+
+  // Set the correct SF file and format
+  std::string m_SFFilefJVT = "JetJvtEfficiency/May2020/fJvtSFFile.EMPFlow.root";
+  bool m_UseMuSFFormatfJVT = true; // To account for new SF binning
+
   std::string m_outputSystNamesfJVT = "JetJvtEfficiency_fJVTSyst";
 
   float         m_systValfJVT = 0.0;


### PR DESCRIPTION
Updating JVT default settings (which were pretty out-of-date), requires `AnalysisBase,21.2.123+` for PFlow fJVT SFs. Added an option which is used with the new fJVT configs (`UseMuSFFormat`).

Info from the usual place:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/PileupJetRecommendations

Pinging @mswiatlo as the resident MET/JVT expert.

🍻 MLB