### PR TITLE
Allow not to use large-R truth labellling tool

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -260,7 +260,7 @@ EL::StatusCode JetCalibrator :: initialize ()
   }// if m_doCleaning
 
   // initialize largeR jet truth labelling tool
-  if(isMC() && m_inContainerName.find("AntiKt10") != std::string::npos){
+  if(isMC() && m_useLargeRTruthLabelingTool && m_inContainerName.find("AntiKt10") != std::string::npos){
     // Truth labelling is required for systematics on largeR jets.
     // TruthLabelName typically should not be changed until new recommendations are available
     // The other properties have default values but need to be configured by the user
@@ -446,11 +446,13 @@ EL::StatusCode JetCalibrator :: execute ()
 
       }
 
-      static SG::AuxElement::ConstAccessor<int> JetTruthLabel (m_truthLabelName);
-      
-      // largeR jet truth labelling
-      if(m_JetTruthLabelingTool_handle.isInitialized() && !JetTruthLabel.isAvailable(*jet_itr)) {
-        m_JetTruthLabelingTool_handle->modifyJet(*jet_itr);
+      if(m_useLargeRTruthLabelingTool){
+        static SG::AuxElement::ConstAccessor<int> JetTruthLabel (m_truthLabelName);
+
+        // largeR jet truth labelling
+        if(m_JetTruthLabelingTool_handle.isInitialized() && !JetTruthLabel.isAvailable(*jet_itr)) {
+          m_JetTruthLabelingTool_handle->modifyJet(*jet_itr);
+        }
       }
     
     }

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -117,6 +117,8 @@ public:
   bool    m_cleanParent = false;
   bool    m_applyFatJetPreSel = false;
 
+  /// @brief Use large-R jet truth labeling tool (needed for systematics)
+  bool m_useLargeRTruthLabelingTool = true;
   /// @brief Name of the large-R jet truth labeling definition
   std::string m_truthLabelName = "R10TruthLabel_R21Consolidated";
   /// @brief Flag to indicate if using a truth jet collection


### PR DESCRIPTION
This allows not to use the large-R truth labelling tool for cases where there is missing information in derivations and systematic uncertainties are not needed. This is needed for the TLA analysis. Default behaviour is not changed.

@marianatoscani 