### PR TITLE
Add ungrtrk500 of subjets to RC large-R jets

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -699,7 +699,15 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle, int pvLocatio
         if ( acc_NumTrkPt500.isAvailable( *fatjetParent ) ) {
           m_ungrtrk500->push_back( acc_NumTrkPt500( *fatjetParent )[pvLocation] );
         } else { 
-          m_ungrtrk500->push_back( -999 );
+	  //Perhaps the case if we are dealing with reclustered jets
+	  const xAOD::Jet* subjet(nullptr);
+	  for(auto constit: fatjet->getConstituents()){
+            subjet = static_cast<const xAOD::Jet*>(constit->rawConstituent());
+            if (subjet->type() != xAOD::Type::Jet) continue;
+	    if ( acc_NumTrkPt500.isAvailable( *subjet ) ) {
+              m_ungrtrk500->push_back( acc_NumTrkPt500( *subjet )[pvLocation] );
+            } else { m_ungrtrk500->push_back( -999 ); }
+	  }
         }
       } else {
         m_ungrtrk500->push_back(-999);

--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -700,14 +700,14 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle, int pvLocatio
           m_ungrtrk500->push_back( acc_NumTrkPt500( *fatjetParent )[pvLocation] );
         } else { 
 	  //Perhaps the case if we are dealing with reclustered jets
+	  int sumUngrtrk500 = 0;
 	  const xAOD::Jet* subjet(nullptr);
 	  for(auto constit: fatjet->getConstituents()){
             subjet = static_cast<const xAOD::Jet*>(constit->rawConstituent());
             if (subjet->type() != xAOD::Type::Jet) continue;
-	    if ( acc_NumTrkPt500.isAvailable( *subjet ) ) {
-              m_ungrtrk500->push_back( acc_NumTrkPt500( *subjet )[pvLocation] );
-            } else { m_ungrtrk500->push_back( -999 ); }
+	    if ( acc_NumTrkPt500.isAvailable( *subjet ) ) sumUngrtrk500+=acc_NumTrkPt500( *subjet )[pvLocation];
 	  }
+          m_ungrtrk500->push_back( sumUngrtrk500 );
         }
       } else {
         m_ungrtrk500->push_back(-999);


### PR DESCRIPTION
This feature allows to access & store the number of tracks for reclustered large-R jets via a loop over its subjets.
Default large-R jets can simply access the parent-jet to access this information, but this fails for reclustered jets. Thus, the else {} block should only be entered if RC jets are processed.