### PR TITLE
feat: Add ChargedFraction to jet cleaning variables

### DIFF
--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2355,9 +2355,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       static SG::AuxElement::ConstAccessor<int> LArBadHVNCell ("LArBadHVNCell");
       safeFill<int, int, xAOD::Jet>(jet, LArBadHVNCell, m_LArBadHVNCell, -999);
 
-      static SG::AuxElement::ConstAccessor<float> ChargedFraction ("ChargedFraction");
-      safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
-
       static SG::AuxElement::ConstAccessor<float> OotFracClus5 ("OotFracClusters5");
       safeFill<float, float, xAOD::Jet>(jet, OotFracClus5, m_OotFracClusters5, -999);
 
@@ -2658,6 +2655,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
 
     } // trackPV || JVT
 
+    // Can't use safeFill as ChargedFraction is not derivation level decoration
     if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
       if ( sumPt500.isAvailable( *jet ) ) {
         m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -1140,6 +1140,7 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
         jet.N90Constituents           =m_N90Constituents           ->at(idx);
         jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac        ->at(idx);
         jet.LArBadHVNCell             =m_LArBadHVNCell             ->at(idx);
+        jet.ChargeFrac                =m_ChargeFrac                ->at(idx);
         jet.OotFracClusters5          =m_OotFracClusters5          ->at(idx);
         jet.OotFracClusters10         =m_OotFracClusters10         ->at(idx);
         jet.LeadingClusterPt          =m_LeadingClusterPt          ->at(idx);

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2659,10 +2659,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
 
       static SG::AuxElement::ConstAccessor< float > ChargedFraction("ChargedFraction");
       static SG::AuxElement::Decorator< float > chargedFractionDecor("ChargedFraction");
-      if ( chargedFractionDecor.isAvailable( *jet ) ) {
-        safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
-      } else { // calculate and decorate
-
+      if ( !chargedFractionDecor.isAvailable( *jet ) ) {
+        // calculate and decorate
         if ( sumPt500.isAvailable( *jet ) ) {
           m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
         } else {
@@ -2670,6 +2668,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
         }
 
         chargedFractionDecor( *jet ) = m_ChargedFraction->back();
+      } else {
+        safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
       }
     } // clean
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2355,6 +2355,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       static SG::AuxElement::ConstAccessor<int> LArBadHVNCell ("LArBadHVNCell");
       safeFill<int, int, xAOD::Jet>(jet, LArBadHVNCell, m_LArBadHVNCell, -999);
 
+      static SG::AuxElement::ConstAccessor<float> ChargeFrac ("ChargeFrac");
+      safeFill<float, float, xAOD::Jet>(jet, ChargeFrac, m_ChargeFrac, -999);
+
       static SG::AuxElement::ConstAccessor<float> OotFracClus5 ("OotFracClusters5");
       safeFill<float, float, xAOD::Jet>(jet, OotFracClus5, m_OotFracClusters5, -999);
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -39,6 +39,7 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
       m_N90Constituents           =new std::vector<float>();
       m_LArBadHVEnergyFrac        =new std::vector<float>();
       m_LArBadHVNCell             =new std::vector<int>();
+      m_ChargeFrac                =new std::vector<float>();
       m_OotFracClusters5          =new std::vector<float>();
       m_OotFracClusters10         =new std::vector<float>();
       m_LeadingClusterPt          =new std::vector<float>();
@@ -466,6 +467,7 @@ JetContainer::~JetContainer()
       delete m_N90Constituents;
       delete m_LArBadHVEnergyFrac;
       delete m_LArBadHVNCell;
+      delete m_ChargeFrac;
       delete m_OotFracClusters5;
       delete m_OotFracClusters10;
       delete m_LeadingClusterPt;
@@ -883,6 +885,7 @@ void JetContainer::setTree(TTree *tree)
         connectBranch<float>(tree, "BchCorrCell",                &m_BchCorrCell);
         connectBranch<float>(tree, "N90Constituents",            &m_N90Constituents);
         connectBranch<float>(tree, "LArBadHVEnergyFrac",         &m_LArBadHVEnergyFrac);
+        connectBranch<float>(tree, "ChargeFrac",                 &m_ChargeFrac);
         connectBranch<float>(tree, "OotFracClusters5",           &m_OotFracClusters5);
         connectBranch<float>(tree, "OotFracClusters10",          &m_OotFracClusters10);
         connectBranch<float>(tree, "LeadingClusterPt",           &m_LeadingClusterPt);
@@ -1135,7 +1138,7 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
         jet.AverageLArQF              =m_AverageLArQF              ->at(idx);
         jet.BchCorrCell               =m_BchCorrCell               ->at(idx);
         jet.N90Constituents           =m_N90Constituents           ->at(idx);
-        jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac       ->at(idx);
+        jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac        ->at(idx);
         jet.LArBadHVNCell             =m_LArBadHVNCell             ->at(idx);
         jet.OotFracClusters5          =m_OotFracClusters5          ->at(idx);
         jet.OotFracClusters10         =m_OotFracClusters10         ->at(idx);
@@ -1491,6 +1494,7 @@ void JetContainer::setBranches(TTree *tree)
       setBranch<float>(tree,"N90Constituents",               m_N90Constituents           );
       setBranch<float>(tree,"LArBadHVEnergyFrac",            m_LArBadHVEnergyFrac   );
       setBranch<int>  (tree,"LArBadHVNCell",                 m_LArBadHVNCell  	  );
+      setBranch<float>(tree,"ChargeFrac",                    m_ChargeFrac);
       setBranch<float>(tree,"OotFracClusters5",              m_OotFracClusters5  	    );
       setBranch<float>(tree,"OotFracClusters10",             m_OotFracClusters10  	  );
       setBranch<float>(tree,"LeadingClusterPt",              m_LeadingClusterPt  	            );
@@ -1901,6 +1905,7 @@ void JetContainer::clear()
       m_N90Constituents           ->clear();
       m_LArBadHVEnergyFrac        ->clear();
       m_LArBadHVNCell             ->clear();
+      m_ChargeFrac                ->clear();
       m_OotFracClusters5          ->clear();
       m_OotFracClusters10         ->clear();
       m_LeadingClusterPt          ->clear();
@@ -2544,7 +2549,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     }
   }
 
-  if ( m_infoSwitch.m_trackAll || m_infoSwitch.m_trackPV || m_infoSwitch.m_jvt ) {
+  if ( m_infoSwitch.m_trackAll || m_infoSwitch.m_trackPV || m_infoSwitch.m_jvt || m_infoSwitch.m_clean ) {
 
     // several moments calculated from all verticies
     // one accessor for each and just use appropiately in the following
@@ -2648,6 +2653,12 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       //      } else { m_ghostTrackAssFrac->push_back( -999 ) ; }
 
     } // trackPV || JVT
+
+    if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
+      if ( sumPt500.isAvailable( *jet ) ) {
+        m_ChargeFrac->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
+      } else { m_ChargeFrac->push_back( -999 ); }
+    } // clean
 
   } // trackAll || trackPV || JVT
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2661,7 +2661,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       static SG::AuxElement::Decorator< float > chargedFractionDecor("ChargedFraction");
       if ( chargedFractionDecor.isAvailable( *jet ) ) {
         safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
-      } else { // calcualte and decorate
+      } else { // calculate and decorate
 
         if ( sumPt500.isAvailable( *jet ) ) {
           m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -39,7 +39,7 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
       m_N90Constituents           =new std::vector<float>();
       m_LArBadHVEnergyFrac        =new std::vector<float>();
       m_LArBadHVNCell             =new std::vector<int>();
-      m_ChargeFrac                =new std::vector<float>();
+      m_ChargedFraction           =new std::vector<float>();
       m_OotFracClusters5          =new std::vector<float>();
       m_OotFracClusters10         =new std::vector<float>();
       m_LeadingClusterPt          =new std::vector<float>();
@@ -467,7 +467,7 @@ JetContainer::~JetContainer()
       delete m_N90Constituents;
       delete m_LArBadHVEnergyFrac;
       delete m_LArBadHVNCell;
-      delete m_ChargeFrac;
+      delete m_ChargedFraction;
       delete m_OotFracClusters5;
       delete m_OotFracClusters10;
       delete m_LeadingClusterPt;
@@ -885,7 +885,7 @@ void JetContainer::setTree(TTree *tree)
         connectBranch<float>(tree, "BchCorrCell",                &m_BchCorrCell);
         connectBranch<float>(tree, "N90Constituents",            &m_N90Constituents);
         connectBranch<float>(tree, "LArBadHVEnergyFrac",         &m_LArBadHVEnergyFrac);
-        connectBranch<float>(tree, "ChargeFrac",                 &m_ChargeFrac);
+        connectBranch<float>(tree, "ChargedFraction",            &m_ChargedFraction);
         connectBranch<float>(tree, "OotFracClusters5",           &m_OotFracClusters5);
         connectBranch<float>(tree, "OotFracClusters10",          &m_OotFracClusters10);
         connectBranch<float>(tree, "LeadingClusterPt",           &m_LeadingClusterPt);
@@ -1140,7 +1140,7 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
         jet.N90Constituents           =m_N90Constituents           ->at(idx);
         jet.LArBadHVEFrac             =m_LArBadHVEnergyFrac        ->at(idx);
         jet.LArBadHVNCell             =m_LArBadHVNCell             ->at(idx);
-        jet.ChargeFrac                =m_ChargeFrac                ->at(idx);
+        jet.ChargedFraction           =m_ChargedFraction           ->at(idx);
         jet.OotFracClusters5          =m_OotFracClusters5          ->at(idx);
         jet.OotFracClusters10         =m_OotFracClusters10         ->at(idx);
         jet.LeadingClusterPt          =m_LeadingClusterPt          ->at(idx);
@@ -1495,7 +1495,7 @@ void JetContainer::setBranches(TTree *tree)
       setBranch<float>(tree,"N90Constituents",               m_N90Constituents           );
       setBranch<float>(tree,"LArBadHVEnergyFrac",            m_LArBadHVEnergyFrac   );
       setBranch<int>  (tree,"LArBadHVNCell",                 m_LArBadHVNCell  	  );
-      setBranch<float>(tree,"ChargeFrac",                    m_ChargeFrac);
+      setBranch<float>(tree,"ChargedFraction",               m_ChargedFraction);
       setBranch<float>(tree,"OotFracClusters5",              m_OotFracClusters5  	    );
       setBranch<float>(tree,"OotFracClusters10",             m_OotFracClusters10  	  );
       setBranch<float>(tree,"LeadingClusterPt",              m_LeadingClusterPt  	            );
@@ -1906,7 +1906,7 @@ void JetContainer::clear()
       m_N90Constituents           ->clear();
       m_LArBadHVEnergyFrac        ->clear();
       m_LArBadHVNCell             ->clear();
-      m_ChargeFrac                ->clear();
+      m_ChargedFraction           ->clear();
       m_OotFracClusters5          ->clear();
       m_OotFracClusters10         ->clear();
       m_LeadingClusterPt          ->clear();
@@ -2355,8 +2355,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       static SG::AuxElement::ConstAccessor<int> LArBadHVNCell ("LArBadHVNCell");
       safeFill<int, int, xAOD::Jet>(jet, LArBadHVNCell, m_LArBadHVNCell, -999);
 
-      static SG::AuxElement::ConstAccessor<float> ChargeFrac ("ChargeFrac");
-      safeFill<float, float, xAOD::Jet>(jet, ChargeFrac, m_ChargeFrac, -999);
+      static SG::AuxElement::ConstAccessor<float> ChargedFraction ("ChargedFraction");
+      safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
 
       static SG::AuxElement::ConstAccessor<float> OotFracClus5 ("OotFracClusters5");
       safeFill<float, float, xAOD::Jet>(jet, OotFracClus5, m_OotFracClusters5, -999);
@@ -2660,8 +2660,8 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
 
     if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
       if ( sumPt500.isAvailable( *jet ) ) {
-        m_ChargeFrac->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
-      } else { m_ChargeFrac->push_back( -999 ); }
+        m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
+      } else { m_ChargedFraction->push_back( -999 ); }
     } // clean
 
   } // trackAll || trackPV || JVT

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2655,12 +2655,21 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
 
     } // trackPV || JVT
 
-    // Can't use safeFill as ChargedFraction is not derivation level decoration
     if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
-      if ( sumPt500.isAvailable( *jet ) ) {
-        m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
-      } else {
-        m_ChargedFraction->push_back( -999. );
+
+      static SG::AuxElement::ConstAccessor< float > ChargedFraction("ChargedFraction");
+      static SG::AuxElement::Decorator< float > chargedFractionDecor("ChargedFraction");
+      if ( chargedFractionDecor.isAvailable( *jet ) ) {
+        safeFill<float, float, xAOD::Jet>(jet, ChargedFraction, m_ChargedFraction, -999);
+      } else { // calcualte and decorate
+
+        if ( sumPt500.isAvailable( *jet ) ) {
+          m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
+        } else {
+          m_ChargedFraction->push_back( -999. );
+        }
+
+        chargedFractionDecor( *jet ) = m_ChargedFraction->back();
       }
     } // clean
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2659,7 +2659,9 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
       if ( sumPt500.isAvailable( *jet ) ) {
         m_ChargedFraction->push_back( sumPt500( *jet )[pvLocation] / jet->pt() ); // units cancel out
-      } else { m_ChargedFraction->push_back( -999 ); }
+      } else {
+        m_ChargedFraction->push_back( -999. );
+      }
     } // clean
 
   } // trackAll || trackPV || JVT

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,7 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
-    m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Charge Fraction", 120, 0, 1);
+    m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Sum of charged tracks p_{T}/jet p_{T}", 120, 0, 1);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);
     //m_LeadingClusterPt           =book(m_name, "LeadingClusterPt",           m_titlePrefix+" jet Leading Cluster P_{T}" ,     120,   0, 1000);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,7 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
-    m_ChargeFrac  = book(m_name, "ChargeFrac",      m_titlePrefix+" Charge Fraction", 120, 0, 1);
+    m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Charge Fraction", 120, 0, 1);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);
     //m_LeadingClusterPt           =book(m_name, "LeadingClusterPt",           m_titlePrefix+" jet Leading Cluster P_{T}" ,     120,   0, 1000);
@@ -611,9 +611,9 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       m_N90Const ->  Fill( N90Const( *jet ), eventWeight );
     }
 
-    static SG::AuxElement::ConstAccessor<float> ChargeFrac ("ChargeFrac");
-    if( ChargeFrac.isAvailable( *jet ) ) {
-      m_ChargeFrac ->  Fill( ChargeFrac( *jet ), eventWeight );
+    static SG::AuxElement::ConstAccessor<float> ChargedFraction ("ChargedFraction");
+    if( ChargedFraction.isAvailable( *jet ) ) {
+      m_ChargedFraction ->  Fill( ChargedFraction( *jet ), eventWeight );
     }
 
 
@@ -1675,7 +1675,7 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       //m_LArQmean                  ->Fill(jet->AverageLArQF/65535        ,eventWeight);
       //m_LArBadHVEFrac             ->Fill(jet->LArBadHVEFrac             ,eventWeight);
       //m_LArBadHVNCell             ->Fill(jet->LArBadHVNCell             ,eventWeight);
-      m_ChargeFrac                ->Fill(jet->ChargeFrac                ,eventWeight);
+      m_ChargedFraction           ->Fill(jet->ChargedFraction           ,eventWeight);
       //m_OotFracClusters5          ->Fill(jet->OotFracClusters5          ,eventWeight);
       //m_OotFracClusters10         ->Fill(jet->OotFracClusters10         ,eventWeight);
       //m_LeadingClusterPt          ->Fill(jet->LeadingClusterPt          ,eventWeight);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,7 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
-    m_ChargeFrac                 =book(m_name, "ChargeFrac",                 m_titlePrefix+" jet Charge Fraction",            120,   0,    1);
+    m_ChargeFrac  = book(m_name, "ChargeFrac",      m_titlePrefix+" Charge Fraction", 120, 0, 1);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);
     //m_LeadingClusterPt           =book(m_name, "LeadingClusterPt",           m_titlePrefix+" jet Leading Cluster P_{T}" ,     120,   0, 1000);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,7 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
-    m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Sum of charged tracks p_{T}/jet p_{T}", 120, 0, 1);
+    m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Sum of charged tracks p_{T}/jet p_{T}", 120, 0, 2);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);
     //m_LeadingClusterPt           =book(m_name, "LeadingClusterPt",           m_titlePrefix+" jet Leading Cluster P_{T}" ,     120,   0, 1000);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,6 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
+    // Range is [0, 2] instead of [0, 1] to include tail of events that spill over 1
     m_ChargedFraction = book(m_name, "ChargedFraction", m_titlePrefix+" Sum of charged tracks p_{T}/jet p_{T}", 120, 0, 2);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -39,6 +39,7 @@ StatusCode JetHists::initialize() {
 
     //m_LArBadHVEFrac              =book(m_name, "LArBadHVEFrac",              m_titlePrefix+" jet LAr Bad HV Energy Fraction", 120,   0,    1);
     //m_LArBadHVNCell              =book(m_name, "LArBadHVNCell",              m_titlePrefix+" jet LAr Bad HV N_{cells}",       120,  -0.5,499.5);
+    m_ChargeFrac                 =book(m_name, "ChargeFrac",                 m_titlePrefix+" jet Charge Fraction",            120,   0,    1);
     //m_OotFracClusters5           =book(m_name, "OotFracClusters5",           m_titlePrefix+" jet OotFracClusters5" ,          120,   0,    1);
     //m_OotFracClusters10          =book(m_name, "OotFracClusters10",          m_titlePrefix+" jet OotFracClusters10" ,         120,   0,    1);
     //m_LeadingClusterPt           =book(m_name, "LeadingClusterPt",           m_titlePrefix+" jet Leading Cluster P_{T}" ,     120,   0, 1000);
@@ -608,6 +609,11 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
     static SG::AuxElement::ConstAccessor<float> N90Const ("N90Constituents");
     if( N90Const.isAvailable( *jet ) ) {
       m_N90Const ->  Fill( N90Const( *jet ), eventWeight );
+    }
+
+    static SG::AuxElement::ConstAccessor<float> ChargeFrac ("ChargeFrac");
+    if( ChargeFrac.isAvailable( *jet ) ) {
+      m_ChargeFrac ->  Fill( ChargeFrac( *jet ), eventWeight );
     }
 
 
@@ -1669,6 +1675,7 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
       //m_LArQmean                  ->Fill(jet->AverageLArQF/65535        ,eventWeight);
       //m_LArBadHVEFrac             ->Fill(jet->LArBadHVEFrac             ,eventWeight);
       //m_LArBadHVNCell             ->Fill(jet->LArBadHVNCell             ,eventWeight);
+      m_ChargeFrac                ->Fill(jet->ChargeFrac                ,eventWeight);
       //m_OotFracClusters5          ->Fill(jet->OotFracClusters5          ,eventWeight);
       //m_OotFracClusters10         ->Fill(jet->OotFracClusters10         ,eventWeight);
       //m_LeadingClusterPt          ->Fill(jet->LeadingClusterPt          ,eventWeight);

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -36,6 +36,7 @@ namespace xAH {
       float N90Constituents;
       float LArBadHVEFrac;
       int   LArBadHVNCell;
+      float ChargeFrac;
       float OotFracClusters5;
       float OotFracClusters10;
       float LeadingClusterPt;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -36,7 +36,7 @@ namespace xAH {
       float N90Constituents;
       float LArBadHVEFrac;
       int   LArBadHVNCell;
-      float ChargeFrac;
+      float ChargedFraction;
       float OotFracClusters5;
       float OotFracClusters10;
       float LeadingClusterPt;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -62,6 +62,7 @@ namespace xAH {
       std::vector<float> *m_N90Constituents;
       std::vector<float> *m_LArBadHVEnergyFrac;
       std::vector<int>   *m_LArBadHVNCell;
+      std::vector<float> *m_ChargeFrac;
       std::vector<float> *m_OotFracClusters5;
       std::vector<float> *m_OotFracClusters10;
       std::vector<float> *m_LeadingClusterPt;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -62,7 +62,7 @@ namespace xAH {
       std::vector<float> *m_N90Constituents;
       std::vector<float> *m_LArBadHVEnergyFrac;
       std::vector<int>   *m_LArBadHVNCell;
-      std::vector<float> *m_ChargeFrac;
+      std::vector<float> *m_ChargedFraction;
       std::vector<float> *m_OotFracClusters5;
       std::vector<float> *m_OotFracClusters10;
       std::vector<float> *m_LeadingClusterPt;

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -53,6 +53,7 @@ class JetHists : public IParticleHists
     //TH1F* m_LArQmean;
     //TH1F* m_LArBadHVEFrac;
     //TH1F* m_LArBadHVNCell;
+    TH1F* m_ChargeFrac;             //!
     //TH1F* m_OotFracClusters5;
     //TH1F* m_OotFracClusters10;
     //TH1F* m_LeadingClusterPt;

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -53,7 +53,7 @@ class JetHists : public IParticleHists
     //TH1F* m_LArQmean;
     //TH1F* m_LArBadHVEFrac;
     //TH1F* m_LArBadHVNCell;
-    TH1F* m_ChargeFrac;             //!
+    TH1F* m_ChargedFraction;        //!
     //TH1F* m_OotFracClusters5;
     //TH1F* m_OotFracClusters10;
     //TH1F* m_LeadingClusterPt;


### PR DESCRIPTION
Resolves #1445 

For jet cleaning studies, add the charge fraction (the scalar sum of the pT of tracks from the primary vertex associated with a jet divided by the jet pT) to the variables that are associated with the `clean` detail string. Given reasons brought up by @mattleblanc in discussion of Issue #1445 RE: the tracks of interest, `m_ChargedFraction` is calculated in a similar manner to how `m_SumPtTrkPt500PV` is instead of using the derivation dependent `DFCommonJets_TrackSumPt` decoration.

## Suggested squash and merge commit log

```
* Add ChargedFraction to the jet cleaning variables
   - Scalar sum of the pT of tracks from the primary vertex associated with a jet divided by the jet pT
* Add ChargedFraction to jet cleaning variables set of jet histograms
```