### PR TITLE
Allow custom fJVT decoration in METConstructor

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -116,7 +116,7 @@ EL::StatusCode METConstructor :: initialize ()
 
   //////////// IMETMaker ////////////////
   if ( m_dofJVTCut ) {
-    ANA_CHECK(m_metmaker_handle.setProperty("JetRejectionDec", "passFJVT"));
+    ANA_CHECK(m_metmaker_handle.setProperty("JetRejectionDec", m_fJVTdecorName));
   }
   if ( m_doPFlow ) {
     ANA_CHECK(m_metmaker_handle.setProperty("DoPFlow", true));

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -48,6 +48,9 @@ public:
   bool    m_doJVTCut = false;
   bool    m_dofJVTCut = false;
 
+  /// @brief Name of fJVT decoration
+  std::string m_fJVTdecorName = "passFJVT";
+
   /// @brief To turn on p-flow MET calculation set m_doPFlow to true
   bool    m_doPFlow = false;
 


### PR DESCRIPTION
This allows using the decoration added by JetSelector which is not the hard-coded string used now in METConstructor