### PR TITLE
Fix TrackContainer type mismatch

### DIFF
--- a/Root/TrackContainer.cxx
+++ b/Root/TrackContainer.cxx
@@ -309,12 +309,12 @@ void TrackContainer::FillTrack( const xAOD::IParticle* particle ){
     m_numberDoF->push_back( track->numberDoF() );
     //m_definingParametersCovMatrix ->push_back(track->definingParametersCovMatrix() ); // fix this too
 
-    static SG::AuxElement::ConstAccessor<char> expectInnermostPixelLayerHit("expectInnermostPixelLayerHit");
+    static SG::AuxElement::ConstAccessor<unsigned char> expectInnermostPixelLayerHit("expectInnermostPixelLayerHit");
     //safeFill<char, int, xAOD::TrackParticle>(track, expectInnermostPixelLayerHit, m_expectInnermostPixelLayerHit, -999);
     m_expectInnermostPixelLayerHit->push_back(expectInnermostPixelLayerHit(*track));
 
     //m_expectNextToInnermostPixelLayerHit->push_back(track->expectNextToInnermostPixelLayerHit() );
-    static SG::AuxElement::ConstAccessor<char> expectNextToInnermostPixelLayerHit("expectNextToInnermostPixelLayerHit");
+    static SG::AuxElement::ConstAccessor<unsigned char> expectNextToInnermostPixelLayerHit("expectNextToInnermostPixelLayerHit");
     m_expectNextToInnermostPixelLayerHit->push_back(expectNextToInnermostPixelLayerHit(*track));
   }
 


### PR DESCRIPTION
There seams to be a type mismatch between the `ConstAccessor`s of `expectInnermostPixelLayerHit` and `expectNextToInnermostPixelLayerHit`, and their vectors. This PR solves this.

The problem came to my attention when I use the TrackContainer with the `m_infoSwitch.m_fitpars` flag, resulting in the following error:
```
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/MessageCheck.cxx:35 (void EL::Detail::report_exception()): caught exception: SG::ExcAuxTypeMismatch: Type mismatch for aux variable `::expectInnermostPixelLayerHit' (664); old type is unsigned char new type is char
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:654 (StatusCode EL::Worker::algsExecute()): while calling execute() on algorithm DHNLNtup
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:517 (StatusCode EL::Worker::processEvents(EL::EventRange&)): processing event 0 on file DAOD_RPVLL.15524896._000032.pool.root.1
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:763 (StatusCode EL::Worker::directExecute(const SH::SamplePtr&, const EL::Job&, const string&, const SH::MetaObject&)): Failed to call "processEvents (eventRange)"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/DirectDriver.cxx:81 (virtual StatusCode EL::DirectDriver::doManagerStep(EL::Detail::ManagerData&) const): Failed to call "worker.directExecute (*sample, *data.job, data.submitDir, data.options)"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/ManagerData.cxx:67 (StatusCode EL::Detail::ManagerData::run()): while performing manager step 14
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/21.2/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/ManagerData.cxx:68 (StatusCode EL::Detail::ManagerData::run()): on submission directory /afs/cern.ch/work/s/sgalantz/DHNLAlgorithm/run/BE_data_3_first
```