### PR TITLE
add protection to MuonEfficiencyCorrector for when running over MC16a

### DIFF
--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -695,7 +695,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
       auto trig_it = trig.second;
       if (trig.first.find("2015")!=std::string::npos && run>284484) continue;
-      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos) && run<=284484) continue;
+      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos || trig.first.find("2018")!=std::string::npos) && run<=284484) continue;
 
       std::unique_ptr< std::vector< std::string > > sysVariationNamesTrig = nullptr;
       if ( writeSystNames ) sysVariationNamesTrig = std::make_unique< std::vector< std::string > >();


### PR DESCRIPTION
This PR fixes an issue when running the MuonEfficiencyCorrector over MC16a and providing trigger legs for 2018 as described in #1461. A missing protection resulted in a crash which is now resolved. 

Resolves #1460