### PR TITLE
Crack-Electron topocluster association bugfix

### DIFF
--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -188,6 +188,9 @@ public:
   /// Recommended threshold for egamma triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.07;
 
+  /// @brief Apply fix to EGamma Crack-Electron topocluster association bug for MET (PFlow) / false by default
+  bool m_applyCrackVetoCleaning = false;
+
 private:
 
   /**


### PR DESCRIPTION
This adds the posibility to apply the second solution to the EGamma Crack-Electron topocluster association bug for MET (when using PFlow jets):

https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJetsR21#EGamma_Crack_Electron_topocluste

Note: I added it only for electrons, would have to be added to photons if someone needs it...