### PR TITLE
Fix selection based on DFCommonCrackVetoCleaning

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -579,11 +579,6 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
       continue;
     }
 
-    // check DFCommonCrackVetoCleaning flag for topocluster association bugfix
-    if (m_applyCrackVetoCleaning){
-      if ( !acc_CrackVetoCleaning( *el_itr ) ) passCrackVetoCleaning = false;
-    }
-
     nObj++;
     bool passSel = this->passCuts( el_itr, pvx );
     if ( m_decorateSelectedObjects ) {

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -579,11 +579,6 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
       continue;
     }
 
-    // check DFCommonCrackVetoCleaning flag for topocluster association bugfix
-    if (m_applyCrackVetoCleaning){
-      if ( !acc_CrackVetoCleaning( *el_itr ) ) passCrackVetoCleaning = false;
-    }
-
     nObj++;
     bool passSel = this->passCuts( el_itr, pvx );
     if ( m_decorateSelectedObjects ) {
@@ -591,6 +586,12 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
     }
 
     if ( passSel ) {
+
+      // check DFCommonCrackVetoCleaning flag for topocluster association bugfix
+      if (m_applyCrackVetoCleaning){
+        if ( !acc_CrackVetoCleaning( *el_itr ) ) passCrackVetoCleaning = false;
+      }
+
       nPass++;
       if ( m_createSelectedContainer ) {
         selectedElectrons->push_back( el_itr );

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -188,6 +188,9 @@ public:
   /// Recommended threshold for egamma triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.07;
 
+  /// @brief Apply fix to EGamma Crack-Electron topocluster association bug for MET (PFlow) / false by default
+  bool m_applyCrackVetoCleaning = false;
+
 private:
 
   /**


### PR DESCRIPTION
The selection should be applied to selected leptons and not all electrons. Electrons not passing the rest of the selections are not going to be given as inputs to MET reconstruction, so we don't care if any of those do not pass that flag since those buggy electrons will not be used, so no need to discard the event.