### PR TITLE
Convert lists, tuples of numbers to C++ vectors

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -10,5 +10,7 @@ try:
 except:
     xAH_logging.logger.warning("xAH::Config could not be imported.")
 
+from .utils import vector
+
 __version__ = "1.0.0"
 __all__ = ["utils", "config"]

--- a/python/config.py
+++ b/python/config.py
@@ -12,7 +12,7 @@ ROOT.gROOT.SetBatch(True)
 import inspect
 from AnaAlgorithm.AnaAlgorithmConfig import AnaAlgorithmConfig
 
-from .utils import NameGenerator
+from .utils import NameGenerator, vector
 
 class Config(object):
   def __init__(self):
@@ -100,7 +100,11 @@ class Config(object):
 
   def _set_algo_attribute(self, alg_obj, name, value, className, algName):
     #handle unicode from json
-    if isinstance(value, unicode): value = value.encode('utf-8')
+    if isinstance(value, unicode):
+      value = value.encode('utf-8')
+    elif isinstance(value, (list, tuple)):
+      # manually call vector in user code when this fails on an empty list/tuple
+      value = vector(value) 
     self._log.append((algName, name, value))
     try:
       setattr(alg_obj, name, value)

--- a/python/config.py
+++ b/python/config.py
@@ -82,14 +82,7 @@ class Config(object):
         if not hasattr(alg_obj, k) and k not in ['m_msgLevel', 'm_name']:
           raise AttributeError(k)
         elif hasattr(alg_obj, k):
-          #handle unicode from json
-          if isinstance(v, unicode): v = v.encode('utf-8')
-          self._log.append((algName, k, v))
-          try:
-            setattr(alg_obj, k, v)
-          except:
-            logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
-            raise
+          self._set_algo_attribute(alg_obj, k, v, className, algName)
     elif ROOT.EL.AnaAlgorithm in parents:
       alg_obj = AnaAlgorithmConfig(className)
       alg_obj.setName(algName)
@@ -98,18 +91,23 @@ class Config(object):
       #setattr(alg_obj, "OutputLevel", msgLevel)
       for k,v in options.items():
         if k in ['m_msgLevel', 'm_name']: continue
-        if isinstance(v, unicode): v = v.encode('utf-8')
-        self._log.append((algName, k, v))
-        try:
-          setattr(alg_obj, k, v)
-        except:
-          logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
-          raise
+        self._set_algo_attribute(alg_obj, k, v, className, algName)
     else:
       raise TypeError("Algorithm {0:s} is not an EL::Algorithm or EL::AnaAlgorithm. I do not know how to configure it. {1}".format(className, parents))
 
     # Add the constructed algo to the list of algorithms to run
     self._algorithms.append(alg_obj)
+
+  def _set_algo_attribute(self, alg_obj, name, value, className, algName):
+    #handle unicode from json
+    if isinstance(value, unicode): value = value.encode('utf-8')
+    self._log.append((algName, name, value))
+    try:
+      setattr(alg_obj, name, value)
+    except:
+      logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(name, value, className, algName))
+      raise
+    
 
   # set based on patterns
   def sample(self, pattern, **kwargs):

--- a/python/utils.py
+++ b/python/utils.py
@@ -9,6 +9,7 @@ import json
 import os
 import random
 import re
+import ROOT
 
 class NameGenerator(object):
   adjectives = None
@@ -122,3 +123,50 @@ def update_clioption_defaults(argdict, newvalues):
 
   for key,value in newvalues.items():
     if key in argdict: argdict[key]['default']=value
+
+def _find_element_type(iterable, element_type):
+  supported = (int, float)
+
+  if element_type is None:
+    try:
+      element_type = type(iterable[0])
+    except IndexError: 
+      # for empty iterables, c++ still needs a type, 
+      raise ValueError(
+          '`vector` cannot determine the element type of an empty input iterable.'
+          ' Please specify the expected type using the element_type argument.')
+    
+    if element_type not in supported:
+      raise NotImplementedError(
+          '`vector` recieved iterable with elements of '
+          + 'unsupported type "{}". '.format(element_type.__name__)
+          + 'The following types are supported: "'
+          + '", "'.join([s.__name__ for s in supported])
+          + '"')
+  else:
+    if element_type not in supported:
+      raise NotImplementedError(
+        'The specified element_type ("{}")'.format(element_type.__name__)
+        + ' is not supported. The following types are supported: "'
+        + '", "'.join([s.__name__ for s in supported])
+        + '"')
+    
+    if iterable and not isinstance(iterable[0], element_type):
+      raise ValueError(
+          'The specified element_type ("{}") '.format(element_type.__name__)
+          + 'does not match the types of the iterable elements.')
+
+
+  if not all(isinstance(e, element_type) for e in iterable):
+    raise TypeError(
+        '`vector` needs a single element type, '
+        'iterable {} has more than one type of element'.format(iterable))
+
+  return element_type
+
+def to_vector(iterable, element_type = None):
+  element_type = _find_element_type(iterable, element_type)
+  vector = ROOT.std.vector(element_type.__name__)()
+  for element in iterable:
+    vector.push_back(element)
+  return vector

--- a/python/utils.py
+++ b/python/utils.py
@@ -124,6 +124,7 @@ def update_clioption_defaults(argdict, newvalues):
   for key,value in newvalues.items():
     if key in argdict: argdict[key]['default']=value
 
+# helper function to deal with type madness in vector(...)
 def _find_element_type(iterable, element_type):
   supported = (int, float)
 
@@ -164,7 +165,29 @@ def _find_element_type(iterable, element_type):
 
   return element_type
 
-def to_vector(iterable, element_type = None):
+def vector(iterable, element_type = None):
+  """
+  Convert a list or tuple of ints or floats into a c++ std::vector.
+
+
+  Input elements need to have a single shared type.
+  >>> my_vector = vector([0.8, 2.3, -0.7]) # a vector of floats
+
+  Inputs may be empty (specify element_type to avoid type mismatches).
+  >>> my_vector = vector([], element_type = float) # an empty vector of floats
+  
+  Arguments:
+     - iterable : a list or tuple of numbers, to be converted into a vector
+     - element_type : type of the vector elements. With non-empty
+                      iterables, the element type is deduced, so 
+                      this argument is optional. On empty iterables,
+                      you need to specify it.
+  Returns:
+    A new vector containing the elements of the input iterable.
+  
+  Raises an exception if the element types are not matching, or not supported.
+  """
+  
   element_type = _find_element_type(iterable, element_type)
   vector = ROOT.std.vector(element_type.__name__)()
   for element in iterable:


### PR DESCRIPTION
Adds support for lists of numbers as python/JSON-configurable attributes, 
by implementing #578 in `config.Config.algorithm`. 

The element type of the new vector is deduced from the list elements. 
To explicitly specify empty vectors of the correct type, 
users can now do `from xAODAnaHelpers import vector` in the python config, 
and  then set the attribute to `vector([], element_type = float)`. 
This implementation only supports lists or tuples of int or float, anything else raises an exception.