### PR TITLE
Fix listTrigChains lepton branch and allow to turn ON ApplyRelPt in OveralRemover

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -18,7 +18,7 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   if ( m_infoSwitch.m_trigger ){
     m_isTrigMatched               = new std::vector<int>               ();
     m_isTrigMatchedToChain        = new std::vector<std::vector<int> > ();
-    m_listTrigChains              = new std::vector<std::string>       ();
+    m_listTrigChains              = new std::vector<std::vector<std::string> > ();
   }
 
   if ( m_infoSwitch.m_isolation ) {
@@ -243,7 +243,7 @@ void ElectronContainer::setTree(TTree *tree)
   if ( m_infoSwitch.m_trigger ){
     connectBranch<int>         (tree,"isTrigMatched",        &m_isTrigMatched);
     connectBranch<vector<int> >(tree,"isTrigMatchedToChain", &m_isTrigMatchedToChain);
-    connectBranch<std::string> (tree,"listTrigChains",       &m_listTrigChains);
+    connectBranch<vector<std::string> > (tree,"listTrigChains",       &m_listTrigChains);
   }
 
   if ( m_infoSwitch.m_isolation ) {
@@ -476,7 +476,7 @@ void ElectronContainer::setBranches(TTree *tree)
   if ( m_infoSwitch.m_trigger ){
     setBranch<int>         (tree,"isTrigMatched",        m_isTrigMatched);
     setBranch<vector<int> >(tree,"isTrigMatchedToChain", m_isTrigMatchedToChain);
-    setBranch<std::string> (tree,"listTrigChains",       m_listTrigChains);
+    setBranch<vector<std::string> > (tree,"listTrigChains",       m_listTrigChains);
   }
 
   if ( m_infoSwitch.m_isolation ) {
@@ -706,20 +706,22 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
     static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapElAcc("isTrigMatchedMapEl");
 
     std::vector<int> matches;
+    std::vector<string> trigChains;
 
     if ( isTrigMatchedMapElAcc.isAvailable( *elec ) ) {
       // loop over map and fill branches
       //
       for ( auto const &it : (isTrigMatchedMapElAcc( *elec )) ) {
         matches.push_back( static_cast<int>(it.second) );
-        m_listTrigChains->push_back( it.first );
+        trigChains.push_back( static_cast<string>(it.first) );
       }
     } else {
       matches.push_back( -1 );
-      m_listTrigChains->push_back("NONE");
+      trigChains.push_back("NONE");
     }
 
     m_isTrigMatchedToChain->push_back(matches);
+    m_listTrigChains->push_back(trigChains);
 
     // if at least one match among the chains is found, say this electron is trigger matched
     if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_isTrigMatched->push_back(1); }

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -18,7 +18,7 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
   if ( m_infoSwitch.m_trigger ) {
     m_isTrigMatched          = new     vector<int>               ();
     m_isTrigMatchedToChain   = new     vector<vector<int> >      ();
-    m_listTrigChains         = new     vector<std::string>       ();
+    m_listTrigChains         = new     vector<vector<std::string> >();
   }
     
   // isolation
@@ -269,7 +269,7 @@ void MuonContainer::setTree(TTree *tree)
   if ( m_infoSwitch.m_trigger ){
     connectBranch<int>         (tree, "isTrigMatched",        &m_isTrigMatched);
     connectBranch<vector<int> >(tree, "isTrigMatchedToChain", &m_isTrigMatchedToChain );
-    connectBranch<string>      (tree, "listTrigChains",       &m_listTrigChains );
+    connectBranch<vector<string> >(tree, "listTrigChains",    &m_listTrigChains );
   }
 
   if ( m_infoSwitch.m_isolation ) {
@@ -513,7 +513,7 @@ void MuonContainer::setBranches(TTree *tree)
     // a vector of trigger match decision for each muon trigger chain
     setBranch<vector<int> >(tree,"isTrigMatchedToChain", m_isTrigMatchedToChain );
     // a vector of strings for each muon trigger chain - 1:1 correspondence w/ vector above
-    setBranch<string>(tree, "listTrigChains", m_listTrigChains );
+    setBranch<vector<string> >(tree, "listTrigChains", m_listTrigChains );
   }
 
   if ( m_infoSwitch.m_isolation ) {
@@ -751,20 +751,22 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     static SG::AuxElement::Accessor< std::map<std::string,char> > isTrigMatchedMapMuAcc("isTrigMatchedMapMu");
 
     std::vector<int> matches;
+    std::vector<string> trigChains;
 
     if ( isTrigMatchedMapMuAcc.isAvailable( *muon ) ) {
       // loop over map and fill branches
       //
       for ( auto const &it : (isTrigMatchedMapMuAcc( *muon )) ) {
 	matches.push_back( static_cast<int>(it.second) );
-	m_listTrigChains->push_back( it.first );
+	trigChains.push_back( static_cast<string>(it.first) );
       }
     } else {
       matches.push_back( -1 );
-      m_listTrigChains->push_back("NONE");
+      trigChains.push_back("NONE");
     }
 
     m_isTrigMatchedToChain->push_back(matches);
+    m_listTrigChains->push_back(trigChains);
     
     // if at least one match among the chains is found, say this muon is trigger matched
     if ( std::find(matches.begin(), matches.end(), 1) != matches.end() ) { m_isTrigMatched->push_back(1); }

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -165,9 +165,10 @@ EL::StatusCode OverlapRemover :: initialize ()
   orFlags.doMuPFJetOR = m_doMuPFJetOR;
 
   ANA_CHECK( ORUtils::recommendedTools(orFlags, m_ORToolbox));
+  if(m_applyRelPt) ANA_CHECK( m_ORToolbox.muJetORT.setProperty("ApplyRelPt", true) );
   ANA_CHECK( m_ORToolbox.initialize());
   ANA_MSG_INFO( "OverlapRemover Interface succesfully initialized!" );
-  
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -17,7 +17,7 @@ namespace xAH {
     // trigger
     int               isTrigMatched;
     std::vector<int>  isTrigMatchedToChain;
-    std::string       listTrigChains;
+    std::vector<std::string> listTrigChains;
 
     // isolation
     std::map< std::string, int > isIsolated;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -41,7 +41,7 @@ namespace xAH {
       // trigger
       std::vector<int>*  m_isTrigMatched;
       std::vector<std::vector<int> >* m_isTrigMatchedToChain;
-      std::vector<std::string>*       m_listTrigChains;
+      std::vector<std::vector<std::string> >* m_listTrigChains;
 
       // isolation
       std::map< std::string, std::vector< int >* >* m_isIsolated;

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -19,7 +19,7 @@ namespace xAH {
     // trigger
     int               isTrigMatched;
     std::vector<int>  isTrigMatchedToChain;
-    std::string       listTrigChains;
+    std::vector<std::string> listTrigChains;
     
       // isolation
     std::map< std::string, int > isIsolated;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -40,7 +40,7 @@ namespace xAH {
       // trigger
       std::vector<int>               *m_isTrigMatched;
       std::vector<std::vector<int> > *m_isTrigMatchedToChain;
-      std::vector<std::string>       *m_listTrigChains;
+      std::vector<std::vector<std::string> > *m_listTrigChains;
     
       // isolation
       std::map< std::string, std::vector< int >* >* m_isIsolated;

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -110,6 +110,8 @@ class OverlapRemover : public xAH::Algorithm
   bool m_useBoostedLeptons = false;
   /** @brief Do overlap removal between electrons (HSG2 prescription) */
   bool m_doEleEleOR = false;
+  /** @brief Turn ON ApplyRelPt in MuJetOverlapTool (default is false) */
+  bool m_applyRelPt = false;
 
   /** @brief Output systematics list container name */
   std::string  m_outputAlgoSystNames = "ORAlgo_Syst";


### PR DESCRIPTION
The fix on listTrigChains lepton branch allows to use it to know which chains are matched to the offline leptons.