### PR TITLE
Truth-label jets at container level

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -449,17 +449,7 @@ EL::StatusCode JetCalibrator :: execute ()
         static SG::AuxElement::Decorator<char> accIsBjet("IsBjet"); // char due to limitations of ROOT I/O, still treat it as a bool
         accIsBjet(*jet_itr) = isBjet;
 
-      }
-
-      if(m_useLargeRTruthLabelingTool){
-        static SG::AuxElement::ConstAccessor<int> JetTruthLabel (m_truthLabelName);
-
-        // largeR jet truth labelling
-        if(m_JetTruthLabelingTool_handle.isInitialized() && !JetTruthLabel.isAvailable(*jet_itr)) {
-          m_JetTruthLabelingTool_handle->modifyJet(*jet_itr);
-        }
-      }
-    
+      } 
     }
 
     //
@@ -477,6 +467,11 @@ EL::StatusCode JetCalibrator :: execute ()
     }
 
   }//for jets
+
+  if(isMC() && m_useLargeRTruthLabelingTool && m_JetTruthLabelingTool_handle.isInitialized()){
+    // largeR jet truth labelling
+    m_JetTruthLabelingTool_handle->modify(*(calibJetsSC.first));
+  }
 
   // loop over available systematics - remember syst == "Nominal" --> baseline
   auto vecOutContainerNames = std::make_unique< std::vector< std::string > >();


### PR DESCRIPTION
Currently, jet truth labeling is done on a jet-by-jet basis (and based on a check for whether the label already exists for a given jet). This is a bit unsafe, as creating a decoration for one jet can implicitly initialize the decoration for other jets in the collection as well. I encountered this in a situation where the truth labeling tool wouldn't be run on subsequent jets because of this.

This PR moves the truth labeling to the container-level interface (i.e. labeling the whole container at once), which is safer and gives the intended behavior. This will also be the only interface in R22 (the jet-level function is only still there for backward compatibility).