### PR TITLE
Allow to save ntrimsubjets and timing alone

### DIFF
--- a/Root/FatJetContainer.cxx
+++ b/Root/FatJetContainer.cxx
@@ -52,7 +52,10 @@ FatJetContainer::FatJetContainer(const std::string& name, const std::string& det
     m_ungrtrk500	= new std::vector<int>  ();
     m_EMFrac		= new std::vector<float>();
     m_nChargedParticles = new std::vector<int>();
+  }
 
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ) {
+    m_NTrimSubjets = new std::vector<float>();
   }
 
   if ( m_infoSwitch.m_constituent) {
@@ -148,6 +151,10 @@ FatJetContainer::~FatJetContainer()
     delete m_ungrtrk500		;
     delete m_EMFrac		;
     delete m_nChargedParticles	;
+  }
+
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ){
+    delete m_NTrimSubjets;
   }
 
   if ( m_infoSwitch.m_constituent) {
@@ -246,6 +253,10 @@ void FatJetContainer::setTree(TTree *tree)
     connectBranch<int>  (tree, "nChargedParticles",	&m_nChargedParticles);
   }
 
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ){
+    connectBranch<float>(tree, "NTrimSubjets", &m_NTrimSubjets);
+  }
+
   if ( m_infoSwitch.m_constituent) {
     connectBranch<int>  (tree, "numConstituents",    &m_numConstituents);
   }
@@ -338,6 +349,10 @@ void FatJetContainer::updateParticle(uint idx, FatJet& fatjet)
     fatjet.ungrtrk500		= m_ungrtrk500  	->at(idx);
     fatjet.EMFrac		= m_EMFrac		->at(idx);
     fatjet.nChargedParticles	= m_nChargedParticles	->at(idx);
+  }
+
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ){
+    fatjet.NTrimSubjets = m_NTrimSubjets->at(idx);
   }
 
   if ( m_infoSwitch.m_constituent) {
@@ -441,6 +456,10 @@ void FatJetContainer::setBranches(TTree *tree)
     setBranch<int>  (tree, "nChargedParticles",	m_nChargedParticles);
   }
 
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure){
+    setBranch<float>(tree, "NTrimSubjets", m_NTrimSubjets);
+  }
+
   if ( m_infoSwitch.m_constituent) {
     setBranch<int>  (tree, "numConstituents",    m_numConstituents);
   }
@@ -530,6 +549,10 @@ void FatJetContainer::clear()
     m_ungrtrk500  	->clear();
     m_EMFrac	  	->clear();
     m_nChargedParticles	->clear();
+  }
+
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ){
+    m_NTrimSubjets->clear();
   }
 
   if ( m_infoSwitch.m_constituent) {
@@ -723,6 +746,11 @@ void FatJetContainer::FillFatJet( const xAOD::IParticle* particle, int pvLocatio
       m_nChargedParticles->push_back( acc_nChargedParticles( *fatjet ));
     } else { m_nChargedParticles->push_back(-999); }
 
+  }
+
+  if ( m_infoSwitch.m_ntrimsubjets && !m_infoSwitch.m_substructure ){
+    static SG::AuxElement::ConstAccessor<int> NTrimSubjets("NTrimSubjets");
+    safeFill<int, float, xAOD::Jet>(fatjet, NTrimSubjets, m_NTrimSubjets, -999);
   }
 
   if( m_infoSwitch.m_constituent ){

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -254,12 +254,14 @@ namespace HelperClasses{
 
     m_trigger       = has_exact("trigger");
     m_substructure  = has_exact("substructure");
+    m_ntrimsubjets  = has_exact("ntrimsubjets");
     m_bosonCount    = has_exact("bosonCount");
     m_VTags         = has_exact("VTags");
     m_rapidity      = has_exact("rapidity");
     m_clean         = has_exact("clean");
     m_cleanLight    = has_exact("cleanLight");
     m_cleanTrig     = has_exact("cleanTrig");
+    m_timing        = has_exact("timing");
     m_energy        = has_exact("energy");
     m_energyLight   = has_exact("energyLight");
     m_scales        = has_exact("scales");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -62,6 +62,9 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
       m_clean_passTightBad        =new std::vector<int>();
     }
   }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    m_Timing = new std::vector<float>();
+  }
 
   // energy
   if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
@@ -490,6 +493,9 @@ JetContainer::~JetContainer()
       delete m_clean_passTightBad;
     }
   }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    delete m_Timing;
+  }
 
   // energy
   if ( m_infoSwitch.m_energy || m_infoSwitch.m_energyLight ) {
@@ -908,6 +914,9 @@ void JetContainer::setTree(TTree *tree)
         connectBranch<int>  (tree, "clean_passTightBad",         &m_clean_passTightBad);
       }
     }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    connectBranch<float>(tree, "Timing", &m_Timing);
+  }
 
   if(m_infoSwitch.m_energy || m_infoSwitch.m_energyLight )
     {
@@ -1162,6 +1171,9 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
         jet.clean_passLooseBad        =m_clean_passLooseBad        ->at(idx);
         jet.clean_passTightBad        =m_clean_passTightBad        ->at(idx);
       }
+    }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    jet.Timing = m_Timing->at(idx);
     }
 
   if(m_infoSwitch.m_energy || m_infoSwitch.m_energyLight)
@@ -1517,6 +1529,9 @@ void JetContainer::setBranches(TTree *tree)
       setBranch<int>  (tree,"clean_passLooseBad",            m_clean_passLooseBad             );
       setBranch<int>  (tree,"clean_passTightBad",            m_clean_passTightBad             );
     }
+  }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    setBranch<float>(tree,"Timing",m_Timing);
   }
 
 
@@ -1928,6 +1943,9 @@ void JetContainer::clear()
       m_clean_passLooseBad        ->clear();
       m_clean_passTightBad        ->clear();
     }
+  }
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    m_Timing->clear();
   }
 
 
@@ -2400,6 +2418,10 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     }
 
   } // clean
+  if(m_infoSwitch.m_timing && !m_infoSwitch.m_clean){
+    static SG::AuxElement::ConstAccessor<float> jetTime ("Timing");
+    safeFill<float, float, xAOD::Jet>(jet, jetTime, m_Timing, -999);
+  }
 
 
   if ( m_infoSwitch.m_energy | m_infoSwitch.m_energyLight ) {

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -418,6 +418,7 @@ namespace HelperClasses {
         m_kinematic      kinematic      exact
         m_trigger        trigger        exact
         m_substructure   substructure   exact
+        m_ntrimsubjets   ntrimsubjets   exact
         m_bosonCount     bosonCount     exact
         m_VTags          VTags          exact
         m_rapidity       rapidity       exact
@@ -487,6 +488,7 @@ namespace HelperClasses {
   public:
     bool m_trigger;
     bool m_substructure;
+    bool m_ntrimsubjets;
     bool m_bosonCount;
     bool m_VTags;
     bool m_rapidity;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -425,6 +425,7 @@ namespace HelperClasses {
         m_clean          clean          exact
         m_cleanLight     cleanLight     exact
         m_cleanTrig      cleanTrig      exact
+        m_timing         timing         exact
         m_energy         energy         exact
         m_energyLight    energyLight    exact
         m_scales         scales         exact
@@ -495,6 +496,7 @@ namespace HelperClasses {
     bool m_clean;
     bool m_cleanLight;
     bool m_cleanTrig;
+    bool m_timing;
     bool m_energy;
     bool m_energyLight;
     bool m_scales;


### PR DESCRIPTION
As the title says, new options (timing and ntrimsubjets) are added in order to only save timing and NTrimSubJets (instead of saving a bunch of other things when asking respectively for substructure and clean).