### PR TITLE
Make tau selection decoration configurable

### DIFF
--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -456,7 +456,7 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
 {
 
   int nPass(0); int nObj(0);
-  static SG::AuxElement::Decorator< char > passSelDecor( "passSel" );
+  static SG::AuxElement::Decorator< char > passSelDecor( m_decorationName.c_str() );
 
   ANA_MSG_DEBUG( "Initial Taus: " << static_cast<uint32_t>(inTaus->size()) );
 

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -44,6 +44,8 @@ public:
   bool       	 m_decorateWithTracks = false;
   /* decorate selected objects - default "passSel" */
   bool       	 m_decorateSelectedObjects = true;
+  /* Name for selected object decoration*/
+  std::string  m_decorationName = "passSel";
   /* fill using SG::VIEW_ELEMENTS to be light weight */
   bool       	 m_createSelectedContainer = false;
   /* look at n objects */


### PR DESCRIPTION
The `TauSelectionTool` decorates taus with the selection decision; the decoration is hard-coded to be called `"passSel"`. It would be useful to be able to configure this, for instance if I want to run multiple copies of this tool on the same taus with different selection definitions.

This simply makes that decoration name configurable, the default is `"passSel"` so the behavior remains unchanged if the user doesn't specifically configure this,