### PR TITLE
Allow multiple TauSelectionTools

### DIFF
--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -456,7 +456,7 @@ bool TauSelector :: executeSelection ( const xAOD::TauJetContainer* inTaus, floa
 {
 
   int nPass(0); int nObj(0);
-  static SG::AuxElement::Decorator< char > passSelDecor( m_decorationName.c_str() );
+  const SG::AuxElement::Decorator< char > passSelDecor( m_decorationName.c_str() );
 
   ANA_MSG_DEBUG( "Initial Taus: " << static_cast<uint32_t>(inTaus->size()) );
 


### PR DESCRIPTION
In #1479 the decorator for the selection decision from `TauSelectionTool` was made configurable such that the user could specify a name for the decoration. However, the decorator was still `static`, which prevented configuring multiple instances of `TauSelectionTool` with different decoration names. This removes that `static` specifier to allow this to be different across instances (and makes it `const` just as a matter of style).