### PR TITLE
Utility additions for b-tagging

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -167,6 +167,10 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     ANA_MSG_WARNING( "Attempting to run BTagging Jet Scale Factors on data.  Turning off scale factors." );
     m_getScaleFactors = false;
   }
+  if ( m_tagDecisionOnly && m_getScaleFactors ) {
+    ANA_MSG_WARNING( "BTagging scale factors have been manually disabled. This is not recommended!" );
+    m_getScaleFactors = false;
+  }
 
   // initialize the BJetSelectionTool
   // A few which are not configurable as of yet....

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -403,44 +403,43 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   //
   // run the btagging decision or get weight and quantile if running continuous
   //
-  for( const xAOD::Jet* jet_itr : *(inJets))
-    {
+  for( const xAOD::Jet* jet_itr : *(inJets)){
 
-      if(!m_useContinuous)
-	{ // get tagging decision
-	  ANA_MSG_DEBUG(" Getting tagging decision ");
+    if(!m_useContinuous){
+      // get tagging decision
+      ANA_MSG_DEBUG(" Getting tagging decision ");
 
-	  // Add decorator for decision
-	  if( m_BJetSelectTool_handle->accept( *jet_itr ) )
-	    dec_isBTag( *jet_itr ) = 1;
-	  else
-	    dec_isBTag( *jet_itr ) = 0;
-
-	  // Add pT-dependent b-tag decision decorator (intended for use in OR)
-	  if ((m_orBJetPtUpperThres < 0 || m_orBJetPtUpperThres > (*jet_itr).pt()/1000.) // passes pT criteria
-	      && m_BJetSelectTool_handle->accept( *jet_itr ) )
-	    dec_isBTagOR( *jet_itr ) = 1;
-	  else
-	    dec_isBTagOR( *jet_itr ) = 0;
-	}
+      // Add decorator for decision
+      if( m_BJetSelectTool_handle->accept( *jet_itr ) )
+        dec_isBTag( *jet_itr ) = 1;
       else
-	{ // continuous b-tagging
+        dec_isBTag( *jet_itr ) = 0;
 
-	  ANA_MSG_DEBUG(" Getting TaggerWeight and Quantile");
-
-	  double tagWeight;
-	  if( m_BJetSelectTool_handle->getTaggerWeight( *jet_itr, tagWeight)!=CP::CorrectionCode::Ok )
-	    {
-	      ANA_MSG_ERROR(" Error retrieving b-tagger weight ");
-	      return EL::StatusCode::FAILURE;
-	    }
-	  int quantile = m_BJetSelectTool_handle->getQuantile(*jet_itr);
-	  ANA_MSG_DEBUG( "tagWeight: " << tagWeight );
-	  ANA_MSG_DEBUG( "quantile: " << quantile );
-	  dec_Weight( *jet_itr)    = tagWeight;
-	  dec_Quantile( *jet_itr ) = quantile;
-	}
+      // Add pT-dependent b-tag decision decorator (intended for use in OR)
+      if ((m_orBJetPtUpperThres < 0 || m_orBJetPtUpperThres > (*jet_itr).pt()/1000.) // passes pT criteria
+          && m_BJetSelectTool_handle->accept( *jet_itr ) )
+        dec_isBTagOR( *jet_itr ) = 1;
+      else
+        dec_isBTagOR( *jet_itr ) = 0;
     }
+    else{
+      ANA_MSG_DEBUG(" Getting Quantile");
+      int quantile = m_BJetSelectTool_handle->getQuantile(*jet_itr);
+      ANA_MSG_DEBUG( "quantile: " << quantile );
+      dec_Quantile( *jet_itr ) = quantile;
+    }
+    if(m_useContinuous || m_alwaysGetTagWeight){
+      ANA_MSG_DEBUG(" Getting TaggerWeight");
+      
+      double tagWeight;
+      if( m_BJetSelectTool_handle->getTaggerWeight( *jet_itr, tagWeight)!=CP::CorrectionCode::Ok ){
+        ANA_MSG_ERROR(" Error retrieving b-tagger weight ");
+        return EL::StatusCode::FAILURE;
+      }
+      ANA_MSG_DEBUG( "tagWeight: " << tagWeight );
+	    dec_Weight( *jet_itr)    = tagWeight;
+    }
+  }
 
   //
   // get the scale factors for all jets

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -548,6 +548,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   TString tmp_name(sample_name);
   tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
   tmp_name.ReplaceAll("Py8","Pythia8");
+  tmp_name.ReplaceAll("H7","HERWIG");
   if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
   //capitalize the entire sample name

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -547,6 +547,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   //pre-process sample name
   TString tmp_name(sample_name);
   tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
+  tmp_name.ReplaceAll("Py8EvtGen","PYTHIA8EVTGEN");
   tmp_name.ReplaceAll("Py8","Pythia8");
   tmp_name.ReplaceAll("H7","HERWIG");
   if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -62,6 +62,8 @@ public:
   bool m_useContinuous = false;
   /// @brief The decoration key written to passing objects
   std::string m_decor = "BTag";
+  /// @brief Only apply b-tag decision decoration; don't retrieve scale factors (Not recommended. For expert use.)
+  bool m_tagDecisionOnly = false;
 
   /// @brief Select an efficiency map for use in MC/MC and inefficiency scale factors, based on user specified selection of efficiency maps
   bool m_setMapIndex = false;

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -47,6 +47,8 @@ public:
   std::string m_systematicsStrategy = "SFEigen";
   /// @brief BTaggingSelectionTool throws an error on missing tagging weights. If false, a warning is given instead
   bool        m_errorOnTagWeightFailure = true;
+  /// @brief Decorate tag weights even if we're not doing pseudocontinuous b-tagging
+  bool        m_alwaysGetTagWeight = false;
 
   // allowed operating points:
   // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#xAOD_interface


### PR DESCRIPTION
This adds a few options for b-tagging which we found useful in the HH->4b analysis and figured we should share centrally:

- Add an option to `BJetEfficiencyCorrector` to decorate the b-tag weights even when not using pseudocontinuous b-tagging (useful for using truth-weighting methods)
- Add an option to `BJetEfficiencyCorrector` to ignore scale factors (setting them to 1) and only apply the b-tag decision decoration. This will produce a warning since it's really only for expert use (SFs should always be applied unless there's a very specific reason, but we've encountered such a reason as part of some R&D studies).
- Also adds a few string patterns to the set of recognized sample names for determining shower types.