### PR TITLE
Fix JVFcorr moment name and use JVT w/o truth jets

### DIFF
--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2638,7 +2638,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
           m_JVFPV->push_back( jvf( *jet )[pvLocation] );
         } else { m_JVFPV->push_back( -999 ); }
 
-        static SG::AuxElement::ConstAccessor< float > jvtJvfcorr ("JvtJvfcorr");
+        static SG::AuxElement::ConstAccessor< float > jvtJvfcorr ("JVFCorr");
         safeFill<float, float, xAOD::Jet>(jet, jvtJvfcorr, m_JvtJvfcorr, -999);
 
         static SG::AuxElement::ConstAccessor< float > jvtRpt ("JvtRpt");

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -690,7 +690,11 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   // Loop over selected jets and decorate with JVT efficiency SF
   // Do it only for MC
   //
-  if ( isMC() && m_doJVT && m_haveTruthJets ) {
+  if ( !m_haveTruthJets && m_getJVTSF) {
+    ANA_MSG_ERROR("Truth jets are needed to retrieve JVT SFs (set m_haveTruthJets to True to retrieve SFs OR set m_getJVTSF to False not to retrieve SFs");
+    return EL::StatusCode::FAILURE;
+  }
+  if ( isMC() && m_doJVT) {
 
     auto sysVariationNamesJVT = std::make_unique< std::vector< std::string > >();
 
@@ -752,7 +756,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               if ( syst_it.name().empty() ) {
                 passedJVT( *jet ) = 0; // mark as not passed
               }
-              if ( m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+              if ( m_getJVTSF && m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_ERROR( "Error in JVT Tool getInefficiencyScaleFactor");
                 return EL::StatusCode::FAILURE;
               }
@@ -760,7 +764,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               if ( syst_it.name().empty() ) {
                 passedJVT( *jet ) = 1;
               }
-              if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+              if ( m_getJVTSF && m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_ERROR( "Error in JVT Tool getEfficiencyScaleFactor");
                 return EL::StatusCode::FAILURE;
               }

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -135,6 +135,8 @@ public:
   bool m_jvtUsedBefore=false;
   /// @brief Does the input have truth jets? If not, cannot decorate with true hard scatter / pileup info
   bool m_haveTruthJets = true;
+  /// @brief Retrieve JVT SFs (true by default, when false: allows to get JVT decision w/o needing truth jets)
+  bool m_getJVTSF = true;
 
   /**
     @brief Minimum value of JVT for selecting jets.


### PR DESCRIPTION
News:
- Fix name of JVFcorr jet moment
- Allow to get JVT decision on samples w/o truth jets (by requesting no JVT SFs):
- - A new option (m_getJVTSF) was added. This is true by default which means JVT SFs will be retrieved. Truth jets are needed to retrieve JVT SFs. If one cares only about the JVT decision, not about SFs and truth jets are not in the input sample, one can set m_getJVTSF to false (jets will be decorated with JVT decision but not with SFs)