### PR TITLE
Adding jet PFO information to tree

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -271,6 +271,7 @@ namespace HelperClasses{
     m_layer         = has_exact("layer");
     m_trackPV       = has_exact("trackPV");
     m_trackAll      = has_exact("trackAll");
+    m_chargedPFOPV  = has_exact("chargedPFOPV");
     m_jvt           = has_exact("JVT");
     m_allTrack      = has_exact("allTrack");
     m_allTrackPVSel = has_exact("allTrackPVSel");

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -435,6 +435,7 @@ namespace HelperClasses {
         m_layer          layer          exact
         m_trackPV        trackPV        exact
         m_trackAll       trackAll       exact
+        m_chargedPFOPV   chargedPFOPV   exact 
         m_jvt            JVT            exact
         m_sfJVTName      sfJVT          partial
         m_sffJVTName     sffJVT         partial
@@ -504,6 +505,7 @@ namespace HelperClasses {
     bool m_layer;
     bool m_trackPV;
     bool m_trackAll;
+    bool m_chargedPFOPV; 
     bool m_jvt;
     bool m_allTrack;
     bool m_allTrackDetail;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -73,6 +73,10 @@ namespace xAH {
       float Jvt;
       float JvtJvfcorr;
       float JvtRpt;
+
+      // chargedPFOPV 
+      float SumPtChargedPFOPt500PV;
+      float fCharged;
     
       //JVC
       float JVC;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -148,6 +148,10 @@ namespace xAH {
       std::vector<int> *m_fJvtPass_Tight;
       std::vector< std::vector<float> > *m_fJvtEff_SF_Tight;
 
+      // chargedPFOPV 
+      std::vector<float> *m_SumPtChargedPFOPt500PV;
+      std::vector<float> *m_fCharged;
+
       // allTrack
       std::vector<int>                  *m_GhostTrackCount;
       std::vector<float>                *m_GhostTrackPt;


### PR DESCRIPTION
Adding PFO-related information for PFlow jets - SumPtChargedPFOPt500PV and fCharged, as well as adding the necessary configuration string in TreeAlgo ("chargedPFOPV").

Tagging @jbossios.