### PR TITLE
Save passOR/Sel, remove dataInfo/nObjects when requested and allow to choose OR decor

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -118,6 +118,14 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
     m_PromptLeptonVeto                  = new std::vector<float> ();
   }
 
+
+  if ( m_infoSwitch.m_passSel ) {
+    m_passSel = new std::vector<char>();
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    m_passOR = new std::vector<char>();
+  }
+
 }
 
 ElectronContainer::~ElectronContainer()
@@ -225,6 +233,13 @@ ElectronContainer::~ElectronContainer()
     delete m_PromptLeptonInput_sv1_jf_ntrkv    ;
     delete m_PromptLeptonIso                   ;
     delete m_PromptLeptonVeto                  ;
+  }
+
+  if ( m_infoSwitch.m_passSel ) {
+    delete m_passSel;
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    delete m_passOR;
   }
 
 }
@@ -344,6 +359,9 @@ void ElectronContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "PromptLeptonVeto",                 &m_PromptLeptonVeto);
   }
 
+  if(m_infoSwitch.m_passSel) connectBranch<char>(tree,"passSel",&m_passSel);
+  if(m_infoSwitch.m_passOR) connectBranch<char>(tree,"passOR",&m_passOR);
+
 }
 
 void ElectronContainer::updateParticle(uint idx, Electron& elec)
@@ -461,6 +479,9 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
     elec.PromptLeptonVeto                  = m_PromptLeptonVeto                  ->at(idx);
   }
 
+  if ( m_infoSwitch.m_passSel ) elec.passSel = m_passSel->at(idx);
+  if ( m_infoSwitch.m_passOR ) elec.passOR = m_passOR->at(idx);
+
 }
 
 
@@ -566,6 +587,13 @@ void ElectronContainer::setBranches(TTree *tree)
     setBranch<int>  (tree, "PromptLeptonInput_sv1_jf_ntrkv",    m_PromptLeptonInput_sv1_jf_ntrkv);
     setBranch<float>(tree, "PromptLeptonIso",                   m_PromptLeptonIso);
     setBranch<float>(tree, "PromptLeptonVeto",                  m_PromptLeptonVeto);
+  }
+
+  if ( m_infoSwitch.m_passSel ) {
+    setBranch<char>(tree,"passSel",m_passSel);
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    setBranch<char>(tree,"passOR",m_passOR);
   }
 
   return;
@@ -674,6 +702,13 @@ void ElectronContainer::clear()
     m_PromptLeptonInput_sv1_jf_ntrkv     -> clear();
     m_PromptLeptonIso                    -> clear();
     m_PromptLeptonVeto                   -> clear();
+  }
+
+  if ( m_infoSwitch.m_passSel ){
+    m_passSel->clear();
+  }
+  if ( m_infoSwitch.m_passOR ){
+    m_passOR->clear();
   }
 
 }
@@ -915,9 +950,18 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
       }
     }
 
-   static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElRecoEff_SF_syst_Reconstruction");
-   safeSFVecFill<float, xAOD::Electron>( elec, accRecoSF, m_RecoEff_SF, junkSF );
- }
+    static SG::AuxElement::Accessor< std::vector< float > > accRecoSF("ElRecoEff_SF_syst_Reconstruction");
+    safeSFVecFill<float, xAOD::Electron>( elec, accRecoSF, m_RecoEff_SF, junkSF );
+  }
+
+  if ( m_infoSwitch.m_passSel ) {
+    static SG::AuxElement::Accessor<char> accElectron_passSel( "passSel" );
+    safeFill<char, char, xAOD::Electron>(elec, accElectron_passSel, m_passSel, -99);
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    static SG::AuxElement::Accessor<char> accElectron_passOR( "passOR" );
+    safeFill<char, char, xAOD::Electron>(elec, accElectron_passOR, m_passOR, -99);
+  }
 
   return;
 }

--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -21,11 +21,13 @@ EventInfo::~EventInfo()
 void EventInfo::setTree(TTree *tree)
 {
 
-  connectBranch<int>     (tree, "runNumber",   &m_runNumber);
-  connectBranch<Long64_t>(tree, "eventNumber", &m_eventNumber);
-  connectBranch<int>     (tree, "lumiBlock",   &m_lumiBlock);
-  connectBranch<uint32_t>(tree, "coreFlags",   &m_coreFlags);
-  connectBranch<int     >(tree, "bcid",                       &m_bcid);
+  if (!m_infoSwitch.m_noDataInfo){ // saved always (unless specifically requiring not to)
+    connectBranch<int>     (tree, "runNumber",   &m_runNumber);
+    connectBranch<Long64_t>(tree, "eventNumber", &m_eventNumber);
+    connectBranch<int>     (tree, "lumiBlock",   &m_lumiBlock);
+    connectBranch<uint32_t>(tree, "coreFlags",   &m_coreFlags);
+    connectBranch<int     >(tree, "bcid",                       &m_bcid);
+  }
 
   if(m_mc){
     connectBranch<int     >(tree, "mcEventNumber",              &m_mcEventNumber);
@@ -121,12 +123,13 @@ void EventInfo::setTree(TTree *tree)
 void EventInfo::setBranches(TTree *tree)
 {
 
-  // always
-  tree->Branch("runNumber",          &m_runNumber,      "runNumber/I");
-  tree->Branch("eventNumber",        &m_eventNumber,    "eventNumber/L");
-  tree->Branch("lumiBlock",          &m_lumiBlock,      "lumiBlock/I");
-  tree->Branch("coreFlags",          &m_coreFlags,      "coreFlags/i");
-  tree->Branch("bcid",               &m_bcid,           "bcid/I");
+  if (!m_infoSwitch.m_noDataInfo){ // saved always (unless specifically requiring not to)
+    tree->Branch("runNumber",          &m_runNumber,      "runNumber/I");
+    tree->Branch("eventNumber",        &m_eventNumber,    "eventNumber/L");
+    tree->Branch("lumiBlock",          &m_lumiBlock,      "lumiBlock/I");
+    tree->Branch("coreFlags",          &m_coreFlags,      "coreFlags/i");
+    tree->Branch("bcid",               &m_bcid,           "bcid/I");
+  }
 
   if( m_mc ) {
     tree->Branch("mcEventNumber",      &m_mcEventNumber,  "mcEventNumber/I");
@@ -267,11 +270,13 @@ void EventInfo::clear()
 
 void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event, const xAOD::VertexContainer* vertices) {
 
-  m_runNumber             = eventInfo->runNumber();
-  m_eventNumber           = eventInfo->eventNumber();
-  m_lumiBlock             = eventInfo->lumiBlock();
-  m_coreFlags             = eventInfo->eventFlags(xAOD::EventInfo::Core);
-  m_bcid                  = eventInfo->bcid();
+  if (!m_infoSwitch.m_noDataInfo){ // saved always (unless specifically requiring not to)
+    m_runNumber             = eventInfo->runNumber();
+    m_eventNumber           = eventInfo->eventNumber();
+    m_lumiBlock             = eventInfo->lumiBlock();
+    m_coreFlags             = eventInfo->eventFlags(xAOD::EventInfo::Core);
+    m_bcid                  = eventInfo->bcid();
+  }
 
   if ( m_mc ) {
     m_mcEventNumber         = eventInfo->mcEventNumber();

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -119,6 +119,7 @@ namespace HelperClasses{
   */
 
   void EventInfoSwitch::initialize(){
+    m_noDataInfo    = has_exact("noDataInfo");
     m_pileup        = has_exact("pileup");
     m_pileupsys     = has_exact("pileupsys");
     m_eventCleaning = has_exact("eventCleaning");
@@ -141,6 +142,7 @@ namespace HelperClasses{
   }
 
   void IParticleInfoSwitch::initialize(){
+    m_noMultiplicity= has_exact("noMultiplicity");
     m_kinematic     = has_exact("kinematic");
 
     m_numLeading    = 0;
@@ -187,6 +189,11 @@ namespace HelperClasses{
         m_trigWPs.push_back(token.substr(5));
       }
     }
+
+    // passSel
+    m_passSel = has_exact("passSel");
+    // passOR
+    m_passOR = has_exact("passOR");
 
     m_recoEff_sysNames = has_exact("recoEff_sysNames");
     m_isoEff_sysNames  = has_exact("isoEff_sysNames");
@@ -235,6 +242,11 @@ namespace HelperClasses{
         m_trigWPs.push_back(token.substr(5));
       }
     }
+
+    // passSel
+    m_passSel = has_exact("passSel");
+    // passOR
+    m_passOR = has_exact("passOR");
   }
 
   void PhotonInfoSwitch::initialize(){
@@ -331,6 +343,7 @@ namespace HelperClasses{
     m_onlineBSTool        = has_exact("onlineBSTool");
 
     m_passSel             = has_exact("passSel");
+    m_passOR              = has_exact("passOR");
 
     m_charge              = has_exact("charge");
     m_etaPhiMap           = has_exact("etaPhiMap");
@@ -406,6 +419,7 @@ namespace HelperClasses{
   }
 
   void TrackInfoSwitch::initialize(){
+    m_noMultiplicity= has_exact("noMultiplicity");
     m_kinematic     = has_exact("kinematic");
     m_fitpars	    = has_exact("fitpars");
     m_numbers	    = has_exact("numbers");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -442,6 +442,16 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_passSel  =new std::vector<char>();
   }
 
+  // passOR
+  if ( m_infoSwitch.m_passOR ) {
+    m_passOR  =new std::vector<char>();
+  }
+
+  // custom chat decorations
+  if ( !m_infoSwitch.m_jetBTagCts.empty() ){ // Temporary
+    // Think what to do since technically I would like a separated branch for each of the requested decorations...
+  }
+
 }
 
 JetContainer::~JetContainer()
@@ -859,6 +869,11 @@ JetContainer::~JetContainer()
     delete m_passSel;
   }
 
+  // passOR
+  if ( m_infoSwitch.m_passOR ) {
+    delete m_passOR;
+  }
+
 }
 
 void JetContainer::setTree(TTree *tree)
@@ -1116,6 +1131,9 @@ void JetContainer::setTree(TTree *tree)
 
   // passSel
   if(m_infoSwitch.m_passSel) connectBranch<char>(tree,"passSel", &m_passSel);
+
+  // passOR
+  if(m_infoSwitch.m_passOR) connectBranch<char>(tree,"passOR", &m_passOR);
 
 }
 
@@ -1472,6 +1490,9 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
 
   // passSel
   if(m_infoSwitch.m_passSel) jet.passSel=m_passSel->at(idx);
+
+  // passOR
+  if(m_infoSwitch.m_passOR) jet.passOR=m_passOR->at(idx);
 
   if(m_debug) std::cout << "leave JetContainer::updateParticle " << std::endl;
   return;
@@ -1888,6 +1909,10 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<char>(tree,"passSel", m_passSel);
   }
 
+  if ( m_infoSwitch.m_passOR ) {
+    setBranch<char>(tree,"passOR", m_passOR);
+  }
+
   return;
 }
 
@@ -2294,6 +2319,10 @@ void JetContainer::clear()
 
   if( m_infoSwitch.m_passSel ) {
     m_passSel->clear();
+  }
+
+  if( m_infoSwitch.m_passOR ) {
+    m_passOR->clear();
   }
 
   return;
@@ -3480,6 +3509,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       m_passSel->push_back(passSel);
     }else{
       m_passSel->push_back(-99);
+    }
+  }
+
+  if ( m_infoSwitch.m_passOR ) {
+    char passOR;
+    bool status = jet->getAttribute<char>( "passOR", passOR );
+    if(status){
+      m_passOR->push_back(passOR);
+    }else{
+      m_passOR->push_back(-99);
     }
   }
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -447,11 +447,6 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_passOR  =new std::vector<char>();
   }
 
-  // custom chat decorations
-  if ( !m_infoSwitch.m_jetBTagCts.empty() ){ // Temporary
-    // Think what to do since technically I would like a separated branch for each of the requested decorations...
-  }
-
 }
 
 JetContainer::~JetContainer()

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -130,6 +130,13 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_PromptLeptonVeto                  = new std::vector<float> ();
   }
 
+  if ( m_infoSwitch.m_passSel ) {
+    m_passSel = new std::vector<char>();
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    m_passOR = new std::vector<char>();
+  }
+
 }
 
 MuonContainer::~MuonContainer()
@@ -254,6 +261,13 @@ MuonContainer::~MuonContainer()
     delete m_PromptLeptonVeto                  ;
   }
 
+  if ( m_infoSwitch.m_passSel ) {
+    delete m_passSel;
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    delete m_passOR;
+  }
+
 }
 
 void MuonContainer::setTree(TTree *tree)
@@ -376,6 +390,9 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "PromptLeptonVeto",                 &m_PromptLeptonVeto);
   }
 
+  if(m_infoSwitch.m_passSel) connectBranch<char>(tree,"passSel",&m_passSel);
+  if(m_infoSwitch.m_passOR) connectBranch<char>(tree,"passOR",&m_passOR);
+
 }
 
 void MuonContainer::updateParticle(uint idx, Muon& muon)
@@ -495,6 +512,11 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.PromptLeptonVeto                  = m_PromptLeptonVeto                  ->at(idx);
   }
 
+  // passSel
+  if(m_infoSwitch.m_passSel) muon.passSel = m_passSel->at(idx);
+  // passOR
+  if(m_infoSwitch.m_passOR) muon.passOR = m_passOR->at(idx);
+
 }
 
 
@@ -613,6 +635,13 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<float>(tree, "PromptLeptonVeto",                  m_PromptLeptonVeto);
   }
 
+  if ( m_infoSwitch.m_passSel ) {
+    setBranch<char>(tree,"passSel",m_passSel);
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    setBranch<char>(tree,"passOR",m_passOR);
+  }
+
   return;
 }
 
@@ -724,6 +753,13 @@ void MuonContainer::clear()
     m_ParamEnergyLossSigmaMinus->clear();
     m_ParamEnergyLossSigmaPlus->clear();
 
+  }
+
+  if(m_infoSwitch.m_passSel){
+    m_passSel->clear();
+  }
+  if(m_infoSwitch.m_passOR){
+    m_passOR->clear();
   }
 
 }
@@ -972,6 +1008,15 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     safeFill<float, float, xAOD::Muon>(muon, accMuon_ParamEnergyLossSigmaPlus, m_ParamEnergyLossSigmaPlus, -1);
 
   }
-  
+
+  if ( m_infoSwitch.m_passSel ) {
+    static SG::AuxElement::Accessor<char> accMuon_passSel( "passSel" );
+    safeFill<char, char, xAOD::Muon>(muon, accMuon_passSel, m_passSel, -99);
+  }
+  if ( m_infoSwitch.m_passOR ) {
+    static SG::AuxElement::Accessor<char> accMuon_passOR( "passOR" );
+    safeFill<char, char, xAOD::Muon>(muon, accMuon_passOR, m_passOR, -99);
+  }
+
   return;
 }

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -148,7 +148,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   const std::string selected_label = ( m_useSelected ) ? "passSel" : "";  // set with decoration flag you use for selected objects if want to consider only selected objects in OR, otherwise it will perform OR on all objects
 
   //Set Flags for recommended overlap procedures
-  ORUtils::ORFlags orFlags("OverlapRemovalTool", selected_label, "passOR");
+  ORUtils::ORFlags orFlags("OverlapRemovalTool", selected_label, m_decor);
 
   orFlags.outputPassValue     = true;
   orFlags.linkOverlapObjects  = m_linkOverlapObjects;
@@ -515,7 +515,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons)); // This line raises an exception
       ANA_MSG_DEBUG(  "Done Calling removeOverlaps()");
 
-      std::string ORdecor("passOR");
+      std::string ORdecor(m_decor);
       if(m_useCutFlow){
         // fill cutflow histograms
         //
@@ -629,7 +629,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         //
         ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons));
 
-        const std::string ORdecor("passOR");
+        const std::string ORdecor(m_decor);
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -734,7 +734,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         //
         ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons));
 
-        const std::string ORdecor("passOR");
+        const std::string ORdecor(m_decor);
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -840,7 +840,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         //
         ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons));
 
-        const std::string ORdecor("passOR");
+        const std::string ORdecor(m_decor);
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -946,7 +946,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons));
 
 
-        const std::string ORdecor("passOR");
+        const std::string ORdecor(m_decor);
         if(m_useCutFlow){
           // fill cutflow histograms
           //
@@ -1051,7 +1051,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         //
         ANA_CHECK( m_ORToolbox.masterTool->removeOverlaps(inElectrons, inMuons, inJets, inTaus, inPhotons));
 
-        const std::string ORdecor("passOR");
+        const std::string ORdecor(m_decor);
         if(m_useCutFlow){
           // fill cutflow histograms
           //

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -86,6 +86,11 @@ namespace xAH {
     float PromptLeptonIso;
     float PromptLeptonVeto;
 
+    // passSel
+    char passSel;
+    // passOR
+    char passOR;
+
   };
 
 }//xAH

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -108,6 +108,11 @@ namespace xAH {
       std::vector<float>* m_PromptLeptonIso;
       std::vector<float>* m_PromptLeptonVeto;
 
+      // passSel
+      std::vector<char>* m_passSel;
+      // passOR
+      std::vector<char>* m_passOR;
+
     };
 }
 #endif // xAODAnaHelpers_ElectronContainer_H

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -135,6 +135,7 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
+        m_noDataInfo     noDataInfo     exact
         m_eventCleaning  eventCleaning  exact
         m_bcidInfo       bcidInfo       exact
         m_pileup         pileup         exact
@@ -151,6 +152,7 @@ namespace HelperClasses {
    */
   class EventInfoSwitch : public InfoSwitch {
   public:
+    bool m_noDataInfo;
     bool m_eventCleaning;
     bool m_bcidInfo;
     bool m_pileup;
@@ -203,13 +205,14 @@ namespace HelperClasses {
     @rst
         The :cpp:class:`HelperClasses::InfoSwitch` struct for IParticle Information.
 
-        ============== ============ =======
-        Parameter      Pattern      Match
-        ============== ============ =======
-        m_kinematic    kinematic    exact
-        m_numLeading   NLeading     partial
-        m_useTheS      useTheS      exact
-        ============== ============ =======
+        ================ ============== =======
+        Parameter        Pattern        Match
+        ================ ============== =======
+        m_noMultiplicity noMultiplicity exact
+        m_kinematic      kinematic      exact
+        m_numLeading     NLeading       partial
+        m_useTheS        useTheS        exact
+        ================ ============== =======
 
         .. note::
             ``m_numLeading`` requires a number ``XX`` to follow it, defining the number of leading partiles and associate it with that variable.
@@ -225,6 +228,7 @@ namespace HelperClasses {
    */
   class IParticleInfoSwitch : public InfoSwitch {
   public:
+    bool m_noMultiplicity;
     bool m_kinematic;
     int  m_numLeading;
     bool m_useTheS;
@@ -255,6 +259,8 @@ namespace HelperClasses {
         m_isolWPs[""]          ISOL_NONE            exact
         m_isolWPs[XYZ]         ISOL_XYZ             pattern
         m_trigWPs[XYZ]         TRIG_XYZ             pattern
+        m_passSel              passSel              exact
+        m_passOR               passOR               exact
         ====================== ==================== =======
 
         .. note::
@@ -289,6 +295,9 @@ namespace HelperClasses {
     std::vector< std::string > m_isolWPs;
     std::vector< std::string > m_trigWPs;
 
+    bool m_passSel;
+    bool m_passOR;
+
     bool m_recoEff_sysNames;
     bool m_isoEff_sysNames;
     bool m_trigEff_sysNames;
@@ -321,6 +330,8 @@ namespace HelperClasses {
         m_isolWPs[""]         ISOL_NONE           exact
         m_isolWPs[XYZ]        ISOL_XYZ            pattern
         m_trigWPs[XYZ]        TRIG_XYZ            pattern
+        m_passSel             passSel             exact
+        m_passOR              passOR              exact
         ===================== =================== =======
 
         .. note::
@@ -355,6 +366,8 @@ namespace HelperClasses {
     std::vector< std::string > m_PIDSFWPs;
     std::vector< std::string > m_isolWPs;
     std::vector< std::string > m_trigWPs;
+    bool m_passSel;
+    bool m_passOR;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:
@@ -415,6 +428,7 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
+        m_noMultiplicity noMultiplicity exact
         m_kinematic      kinematic      exact
         m_trigger        trigger        exact
         m_substructure   substructure   exact
@@ -460,6 +474,7 @@ namespace HelperClasses {
         m_onlineBSTool   onlineBSTool   exact
         m_charge         charge         exact
         m_passSel        passSel        exact
+        m_passOR         passOR         exact
         m_vsLumiBlock    vsLumiBlock    exact
         m_vsActualMu     vsActualMu     exact
         m_lumiB_runN     lumiB_runN     exact
@@ -526,6 +541,7 @@ namespace HelperClasses {
     bool m_onlineBSTool;
     bool m_charge;
     bool m_passSel;
+    bool m_passOR;
     bool m_etaPhiMap;
     bool m_vsLumiBlock;
     bool m_vsActualMu;
@@ -554,6 +570,7 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
+        m_noMultiplicity noMultiplicity exact
         m_kinematic      kinematic      exact
         m_type           type           exact
         m_bVtx           bVtx           exact
@@ -586,6 +603,7 @@ namespace HelperClasses {
         ================ ============== =======
         Parameter        Pattern        Match
         ================ ============== =======
+        m_noMultiplicity noMultiplicity exact
         m_kinematic      kinematic      exact
         m_fitpars        fitpars        exact
         m_numbers        numbers        exact
@@ -598,6 +616,7 @@ namespace HelperClasses {
   */
   class TrackInfoSwitch : public InfoSwitch {
   public:
+    bool m_noMultiplicity;
     bool m_kinematic;
     bool m_fitpars;
     bool m_numbers;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -266,6 +266,9 @@ namespace xAH {
       // passSel
       char passSel;
 
+      // passOR
+      char passOR;
+
       const Muon* matchedMuon =nullptr; //!
       const Jet * matchedJet  =nullptr; //!
 

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -502,6 +502,9 @@ namespace xAH {
 
       // passSel
       std::vector<char> *m_passSel;
+
+      // passOR
+      std::vector<char> *m_passOR;
     };
 }
 

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -104,6 +104,11 @@ namespace xAH {
     float PromptLeptonIso;
     float PromptLeptonVeto;
 
+    // passSel
+    char passSel;
+    // passOR
+    char passOR;
+
   };
 
 }//xAH

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -111,6 +111,11 @@ namespace xAH {
       std::vector<float>* m_PromptLeptonIso;
       std::vector<float>* m_PromptLeptonVeto;
 
+      // passSel
+      std::vector<char>* m_passSel;
+      // passOR
+      std::vector<char>* m_passOR;
+
     };
 }
 #endif // xAODAnaHelpers_MuonContainer_H

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -91,8 +91,9 @@ class OverlapRemover : public xAH::Algorithm
   /** @brief Fill the cutflow histogram(s) for object counting */
   bool m_useCutFlow = true;
 
-  /** @brief Decorate selected objects (the default decoration string is `passSel`) */
+  /** @brief Decorate selected objects (the default decoration string is `passOR`) */
   bool     m_decorateSelectedObjects;
+  std::string m_decor = "passOR";
   /**
      @rst
         Make a copy of input container(s) with selected objects (using :cpp:any:`SG::VIEW_ELEMENTS` to be light weight)

--- a/xAODAnaHelpers/ParticleContainer.h
+++ b/xAODAnaHelpers/ParticleContainer.h
@@ -68,7 +68,7 @@ namespace xAH
 	}
 
 	tree->SetBranchStatus  (counterName.c_str() , 1);
-	tree->SetBranchAddress (counterName.c_str() , &m_n);
+	if(!m_infoSwitch.m_noMultiplicity) tree->SetBranchAddress (counterName.c_str() , &m_n);
 
         if(m_infoSwitch.m_kinematic)
           {
@@ -90,7 +90,7 @@ namespace xAH
 	std::string              counterName = "n"+m_name;
 	if (!m_suffix.empty()) { counterName += "_" + m_suffix; }
 
-	tree->Branch(counterName.c_str(),    &m_n, (counterName+"/I").c_str());
+	if(!m_infoSwitch.m_noMultiplicity) tree->Branch(counterName.c_str(),    &m_n, (counterName+"/I").c_str());
 
         if(m_infoSwitch.m_kinematic) {
 	  if(m_useMass)  setBranch<float>(tree,"m",                        m_M                );


### PR DESCRIPTION
News:

- Add option to save to TTrees passOR and passSel for electrons and muons
- Add option to save to TTrees passOR for jets
- Add possibility not to save data info in MC (runNumber, etc)
- Add possibility not to save object multiplicity to reduce TTree sizes
- Allow to choose OR decoration string

The backward compatibility is maintained.
