### PR TITLE
Save beam spot weight 

### DIFF
--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -115,6 +115,10 @@ void EventInfo::setTree(TTree *tree)
     std::vector<float>*  m_caloCluster_e_addr = &m_caloCluster_e;
     HelperFunctions::connectBranch<float>("caloCluster", tree, "e",   &m_caloCluster_e_addr   );
   }
+
+  if ( m_infoSwitch.m_beamspotweight ) {
+    connectBranch<float>(tree, "beamSpotWeight",                    &m_beamspotweight);
+  }
 }
 
 
@@ -208,6 +212,10 @@ void EventInfo::setBranches(TTree *tree)
     tree->Branch("caloCluster_e",   &m_caloCluster_e);
   }
 
+  if ( m_infoSwitch.m_beamspotweight ) {
+    tree->Branch("beamSpotWeight",   &m_beamspotweight);
+  }
+
   return;
 }
 
@@ -260,6 +268,10 @@ void EventInfo::clear()
     m_caloCluster_eta.clear();
     m_caloCluster_phi.clear();
     m_caloCluster_e.clear();
+  }
+
+  if ( m_infoSwitch.m_beamspotweight ) {
+    m_beamspotweight = 1.;
   }
 
   return;
@@ -433,6 +445,9 @@ void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event
 
   }
 
+  if ( m_infoSwitch.m_beamspotweight ) {
+    m_beamspotweight = eventInfo->beamSpotWeight();
+  }
 
   return;
 }

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -129,6 +129,7 @@ namespace HelperClasses{
     m_truth         = has_exact("truth");
     m_caloClus      = has_exact("caloClusters");
     m_weightsSys    = has_exact("weightsSys");
+    m_beamspotweight= has_exact("beamspotweight");
   }
 
   void TriggerInfoSwitch::initialize(){

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -75,6 +75,9 @@ namespace xAH {
     double   m_rhoEMPFLOW;
     double   m_rhoLC;
 
+    // beam spot weight
+    float    m_beamspotweight;
+
     // truth
     int      m_pdgId1;
     int      m_pdgId2;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -145,6 +145,7 @@ namespace HelperClasses {
         m_truth          truth          exact
         m_caloClus       caloClusters   exact
         m_weightsSys     weightsSys     exact
+        m_beamspotweight beamspotweight exact
         ================ ============== =======
 
     @endrst
@@ -161,6 +162,7 @@ namespace HelperClasses {
     bool m_truth;
     bool m_caloClus;
     bool m_weightsSys;
+    bool m_beamspotweight;
     EventInfoSwitch(const std::string configStr) : InfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();


### PR DESCRIPTION
Add option to save beamSpotWeight into TTrees.

This will allow to follow the MC20 recommendations:
https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/MC20BeamSpotSizeReweighting