### PR TITLE
Allow to decorate jets with JVT decision when truth jets are not available

### DIFF
--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2659,7 +2659,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
           m_JVFPV->push_back( jvf( *jet )[pvLocation] );
         } else { m_JVFPV->push_back( -999 ); }
 
-        static SG::AuxElement::ConstAccessor< float > jvtJvfcorr ("JvtJvfcorr");
+        static SG::AuxElement::ConstAccessor< float > jvtJvfcorr ("JVFCorr");
         safeFill<float, float, xAOD::Jet>(jet, jvtJvfcorr, m_JvtJvfcorr, -999);
 
         static SG::AuxElement::ConstAccessor< float > jvtRpt ("JvtRpt");

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -693,7 +693,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   // Loop over selected jets and decorate with JVT efficiency SF
   // Do it only for MC
   //
-  if ( !m_haveTruthJets && m_getJVTSF) {
+  if ( !m_haveTruthJets && m_getJVTSF && m_doJVT) {
     ANA_MSG_ERROR("Truth jets are needed to retrieve JVT SFs (set m_haveTruthJets to True to retrieve SFs OR set m_getJVTSF to False not to retrieve SFs");
     return EL::StatusCode::FAILURE;
   }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -693,7 +693,11 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   // Loop over selected jets and decorate with JVT efficiency SF
   // Do it only for MC
   //
-  if ( isMC() && m_doJVT && m_haveTruthJets ) {
+  if ( !m_haveTruthJets && m_getJVTSF) {
+    ANA_MSG_ERROR("Truth jets are needed to retrieve JVT SFs (set m_haveTruthJets to True to retrieve SFs OR set m_getJVTSF to False not to retrieve SFs");
+    return EL::StatusCode::FAILURE;
+  }
+  if ( isMC() && m_doJVT) {
 
     auto sysVariationNamesJVT = std::make_unique< std::vector< std::string > >();
 
@@ -755,7 +759,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               if ( syst_it.name().empty() ) {
                 passedJVT( *jet ) = 0; // mark as not passed
               }
-              if ( m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+              if ( m_getJVTSF && m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_ERROR( "Error in JVT Tool getInefficiencyScaleFactor");
                 return EL::StatusCode::FAILURE;
               }
@@ -763,7 +767,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               if ( syst_it.name().empty() ) {
                 passedJVT( *jet ) = 1;
               }
-              if ( m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
+              if ( m_getJVTSF && m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF ) != CP::CorrectionCode::Ok ) {
                 ANA_MSG_ERROR( "Error in JVT Tool getEfficiencyScaleFactor");
                 return EL::StatusCode::FAILURE;
               }

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -139,6 +139,8 @@ public:
   bool m_jvtUsedBefore=false;
   /// @brief Does the input have truth jets? If not, cannot decorate with true hard scatter / pileup info
   bool m_haveTruthJets = true;
+  /// @brief Retrieve JVT SFs (true by default, when false: allows to get JVT decision w/o needing truth jets)
+  bool m_getJVTSF = true;
 
   /**
     @brief Minimum value of JVT for selecting jets.


### PR DESCRIPTION
Cherry-pick the following commits from r22/master:
https://github.com/UCATLAS/xAODAnaHelpers/commit/8de1d72d0f29f8057c13d96ba2bb238b9a9a6c99
https://github.com/UCATLAS/xAODAnaHelpers/commit/9ca075b9b840a7afb0d800793ba93356abe8cb37

This allows to decorate jets with JVT decision even when truth jets are not available (in this case, user should set m_getJVTSF to False).