### PR TITLE
Save particleType to Trees and allow multiple type-based selections

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -416,6 +416,7 @@ namespace HelperClasses{
     m_children      = has_exact("children");
     m_dressed       = has_exact("dressed");
     m_origin        = has_exact("origin");
+    m_particleType  = has_exact("particleType");
   }
 
   void TrackInfoSwitch::initialize(){

--- a/Root/TruthContainer.cxx
+++ b/Root/TruthContainer.cxx
@@ -51,6 +51,10 @@ TruthContainer::TruthContainer(const std::string& name, const std::string& detai
     m_origin = new std::vector<unsigned int>();
   }
 
+  if(m_infoSwitch.m_particleType){
+    m_particleType = new std::vector<unsigned int>();
+  }
+
 }
 
 TruthContainer::~TruthContainer()
@@ -96,6 +100,10 @@ TruthContainer::~TruthContainer()
 
   if(m_infoSwitch.m_origin){
     delete m_origin;
+  }
+
+  if(m_infoSwitch.m_particleType){
+    delete m_particleType;
   }
 
 }
@@ -146,6 +154,10 @@ void TruthContainer::setTree(TTree *tree)
     connectBranch<unsigned int> (tree,"origin",  &m_origin);
   }
 
+  if(m_infoSwitch.m_particleType){
+    connectBranch<unsigned int> (tree,"type",  &m_particleType);
+  }
+
 }
 
 void TruthContainer::updateParticle(uint idx, TruthPart& truth)
@@ -193,6 +205,10 @@ void TruthContainer::updateParticle(uint idx, TruthPart& truth)
 
   if(m_infoSwitch.m_origin){
     truth.origin = m_origin->at(idx);
+  }
+
+  if(m_infoSwitch.m_particleType){
+    truth.type = m_particleType->at(idx);
   }
 
   if(m_debug) std::cout << "leave TruthContainer::updateParticle " << std::endl;
@@ -246,6 +262,10 @@ void TruthContainer::setBranches(TTree *tree)
     setBranch<unsigned int> (tree,"origin",m_origin);
   }
 
+  if(m_infoSwitch.m_particleType){
+    setBranch<unsigned int> (tree,"type",m_particleType);
+  }
+
   return;
 }
 
@@ -293,6 +313,10 @@ void TruthContainer::clear()
 
   if(m_infoSwitch.m_origin){
     m_origin->clear();
+  }
+
+  if(m_infoSwitch.m_particleType){
+    m_particleType->clear();
   }
 
   return;
@@ -413,6 +437,15 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
       m_origin->push_back(origin);
     } else {
       m_origin->push_back(0); // Non-defined
+    }
+  }
+
+  if(m_infoSwitch.m_particleType){
+    if( truth->isAvailable<unsigned int>("classifierParticleType") ){
+      unsigned int type = truth->auxdata<unsigned int>("classifierParticleType");
+      m_particleType->push_back(type);
+    } else {
+      m_particleType->push_back(0); // Unknown
     }
   }
 

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -329,7 +329,26 @@ int TruthSelector :: PassCuts( const xAOD::TruthParticle* truthPart ) {
   // selections for particles from MCTruthClassifier
 
   // type
-  if ( m_type != 1000 ) {
+  if ( !m_typeOptions.empty() ) { // check w.r.t. multiple possible type values
+    if ( m_type != 1000 ) { ANA_MSG_WARNING( "single and multiple type conditions were selected, only the former will be used" );
+    } else {
+      std::string token;
+      std::vector<unsigned int> typeVec;
+      std::istringstream ss(m_typeOptions);
+      while ( std::getline(ss, token, '|') ) typeVec.push_back(std::stoi(token));
+      bool found = false;
+      if( truthPart->isAvailable<unsigned int>("classifierParticleType") ){
+        unsigned int type = truthPart->auxdata<unsigned int>("classifierParticleType");
+        for (unsigned int i=0;i<typeVec.size();++i){
+          if (type == typeVec.at(i)) found = true;
+        }
+        if (!found) { return 0; }
+      } else {
+        ANA_MSG_WARNING( "classifierParticleType is not available" );
+      }
+    }
+  }
+  if ( m_type != 1000 ) { // single type value
     if( truthPart->isAvailable<unsigned int>("classifierParticleType") ){
       unsigned int type = truthPart->auxdata<unsigned int>("classifierParticleType");
       if ( type != m_type ) { return 0; }

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -578,6 +578,7 @@ namespace HelperClasses {
         m_children       children       exact
         m_dressed        dressed        exact
         m_origin         origin         exact
+        m_particleType   particleType   exact
         ================ ============== =======
 
 
@@ -591,6 +592,7 @@ namespace HelperClasses {
     bool m_children;
     bool m_dressed;
     bool m_origin;
+    bool m_particleType;
     TruthInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
   protected:
     void initialize();

--- a/xAODAnaHelpers/TruthContainer.h
+++ b/xAODAnaHelpers/TruthContainer.h
@@ -76,6 +76,9 @@ namespace xAH {
       // origin
       std::vector<unsigned int>* m_origin;
 
+      // particle type
+      std::vector<unsigned int>* m_particleType;
+
     };
 }
 

--- a/xAODAnaHelpers/TruthPart.h
+++ b/xAODAnaHelpers/TruthPart.h
@@ -45,6 +45,9 @@ namespace xAH {
       // Origin
       unsigned int origin;
 
+      // Type
+      unsigned int type;
+
     };
 
 }//xAH

--- a/xAODAnaHelpers/TruthSelector.h
+++ b/xAODAnaHelpers/TruthSelector.h
@@ -56,6 +56,8 @@ public:
   float m_rapidity_min = 1e8;
   /// @brief require classifierParticleType == type (defined by TruthClassifier: https://gitlab.cern.ch/atlas/athena/blob/21.2/PhysicsAnalysis/MCTruthClassifier/MCTruthClassifier/MCTruthClassifierDefs.h)
   unsigned int m_type = 1000; // this will apply no selection
+  /// @brief require classifierParticleType to match any of the "|" separated type values (e.g. "1|2|3|4")
+  std::string m_typeOptions; // this will apply no selection
   /// @brief require classifierParticleOrigin == origin (defined by TruthClassifier: https://gitlab.cern.ch/atlas/athena/blob/21.2/PhysicsAnalysis/MCTruthClassifier/MCTruthClassifier/MCTruthClassifierDefs.h)
   unsigned int m_origin = 1000; // this will apply no selection
   /// @brief require classifierParticleOrigin to match any of the "|" separated origin values (e.g. "10|12|13")


### PR DESCRIPTION
News:

- Add possibility in TruthContainer to save ParticleType (infoswitch option: particleType, saved as type)
- Add possibility to select truth particles based on their type (added variable: m_typeOptions, works similarly to previously added m_originOptions)