### PR TITLE
Use `asg::AnaToolHandle<ToolInterface>` to  store efficiency scale factor tools in `xAH::MuonEfficiencyCorrector`

### DIFF
--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -15,6 +15,7 @@
 #include "PATInterfaces/SystematicVariation.h"
 #include "PATInterfaces/ISystematicsTool.h"
 #include "MuonAnalysisInterfaces/IMuonEfficiencyScaleFactors.h"
+#include "MuonAnalysisInterfaces/IMuonTriggerScaleFactors.h"
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
@@ -99,8 +100,8 @@ private:
   std::string m_recoEffSF_tool_name; //!
   asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muIsoSF_tool; //!
   std::string m_isoEffSF_tool_name; //!
-  CP::MuonTriggerScaleFactors* m_muTrigSF_tool = nullptr;                  //!
-  std::string m_trigEffSF_tool_name;                                       //!
+  asg::AnaToolHandle<CP::IMuonTriggerScaleFactors> m_muTrigSF_tool; //!
+  std::string m_trigEffSF_tool_name; //!
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool = nullptr;               //!
   std::string m_TTVAEffSF_tool_name;                                       //!
   std::map<std::string, std::string> m_SingleMuTriggerMap; //!

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -97,8 +97,8 @@ private:
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool/Pileup"}; //!
   asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muRecoSF_tool; //!
   std::string m_recoEffSF_tool_name; //!
-  CP::MuonEfficiencyScaleFactors* m_muIsoSF_tool = nullptr;                //!
-  std::string m_isoEffSF_tool_name;                                        //!
+  asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muIsoSF_tool; //!
+  std::string m_isoEffSF_tool_name; //!
   CP::MuonTriggerScaleFactors* m_muTrigSF_tool = nullptr;                  //!
   std::string m_trigEffSF_tool_name;                                       //!
   CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool = nullptr;               //!

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -14,6 +14,7 @@
 #include "PATInterfaces/SystematicsUtil.h"
 #include "PATInterfaces/SystematicVariation.h"
 #include "PATInterfaces/ISystematicsTool.h"
+#include "MuonAnalysisInterfaces/IMuonEfficiencyScaleFactors.h"
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
@@ -94,8 +95,8 @@ private:
 
   // tools
   asg::AnaToolHandle<CP::IPileupReweightingTool> m_pileup_tool_handle{"CP::PileupReweightingTool/Pileup"}; //!
-  CP::MuonEfficiencyScaleFactors* m_muRecoSF_tool = nullptr;               //!
-  std::string m_recoEffSF_tool_name;                                       //!
+  asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muRecoSF_tool; //!
+  std::string m_recoEffSF_tool_name; //!
   CP::MuonEfficiencyScaleFactors* m_muIsoSF_tool = nullptr;                //!
   std::string m_isoEffSF_tool_name;                                        //!
   CP::MuonTriggerScaleFactors* m_muTrigSF_tool = nullptr;                  //!

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -102,8 +102,8 @@ private:
   std::string m_isoEffSF_tool_name; //!
   asg::AnaToolHandle<CP::IMuonTriggerScaleFactors> m_muTrigSF_tool; //!
   std::string m_trigEffSF_tool_name; //!
-  CP::MuonEfficiencyScaleFactors* m_muTTVASF_tool = nullptr;               //!
-  std::string m_TTVAEffSF_tool_name;                                       //!
+  asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors> m_muTTVASF_tool; //!
+  std::string m_TTVAEffSF_tool_name; //!
   std::map<std::string, std::string> m_SingleMuTriggerMap; //!
 
   // variables that don't get filled at submission time should be


### PR DESCRIPTION
The sharing-tools-across-algo-instances logic is preserved by using the "public" `asg::AnaToolHandle<ToolInterface>` c'tor (i.e. calling with only a string). As far as I understand, that should make the  `AnaToolHandle` use a `std::shared_ptr` under the hood. Thus it fixes #1508 along the lines suggested by @kratsg. 

NB: In the current master, the systematics for each of the tools would only be set up in the first algorithm instance which requested that tool instance, except for the trigger efficiency correction, where the systematics evaluation would be set up for every algo, leading to duplications. 
This seemed to be a  bug to me, so I also aligned the muon trigger eff. systematics treatment with the other tool's systematics (only set up once, for the first algo to configure the tool.)