### PR TITLE
throw if TTree::Fill() reports a failure to write

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -1,5 +1,7 @@
 // c++ include(s):
 #include <iostream>
+#include <exception>
+#include <sstream>
 
 // EDM include(s):
 #include "xAODBTagging/BTagging.h"
@@ -115,7 +117,14 @@ HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent* event, xAOD::
 
 
 void HelpTreeBase::Fill() {
-  m_tree->Fill();
+  // code_or_nbytes is the number of bytes written, or -1 if an error occured
+  const int code_or_nbytes = m_tree->Fill();
+  if(code_or_nbytes < 0) // 0 can be OK if all branches are disabled and thus no data is written
+  {
+    auto msg = std::stringstream();
+    msg << "HelpTreeBase::Fill(): error in TTree::Fill() : returned " << code_or_nbytes;
+    throw std::runtime_error(msg.str());
+  }
 }
 
 /*********************


### PR DESCRIPTION
fixes #1511 by throwing an informative `std::runtime_error` if the `TTree::Fill()` call fails and reports it in its return value.
The reasons to throw rather than pass through the returrn value:
  * throwing leaves the signature of `void HelpTreeBase::Fill()` unchanged
  * the exception alerts users to the error unless they explicitly anticipate & handle it in a try/catch block. Conversely it is easy to forget to check the returned value for the special value `-1`