### PR TITLE
Use b-tagging efficiency maps from Sherpa 2.2.10 for Sherpa 2.2.11

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -239,6 +239,9 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	      case HelperFunctions::Sherpa22:
 		calibration="410250";
 		break;
+	      case HelperFunctions::Sherpa2210:
+		calibration="700122";
+		break;
 	      case HelperFunctions::Unknown:
 		ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
 		return EL::StatusCode::FAILURE;
@@ -627,6 +630,9 @@ unsigned int BJetEfficiencyCorrector :: getMCIndex (int dsid)
 
     // Sherpa 2.2.10
     if ((name.find("Sh_2210") != std::string::npos)){ return m_MCIndexes["Sherpa2210"]; }
+
+    // Sherpa 2.2.11
+    if ((name.find("Sh_2211") != std::string::npos)){ return m_MCIndexes["Sherpa2210"]; } // MC-MC SFs from Sherpa 2.2.10 is the best we can use for Sherpa 2.2.11 (for now)
 
     // Sherpa 2.2
     if ((name.find("Sh_22") != std::string::npos) ||

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -560,6 +560,8 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
   else if(tmp_name.Contains("HERWIG")) return Herwig7;
   else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
+  else if(tmp_name.Contains("SHERPA_2210")) return Sherpa2210;
+  else if(tmp_name.Contains("SHERPA_2211")) return Sherpa2210;
   else if(tmp_name.Contains("SHERPA")) return Sherpa22;
   else return Unknown;
 }

--- a/data/DSIDtoGenerator.txt
+++ b/data/DSIDtoGenerator.txt
@@ -819,7 +819,7 @@
 410065 PwPyEG_P2012_Wt_DS_dilepton_antitop
 410642 PhPy8EG_A14_tchan_lept_top
 410643 PhPy8EG_A14_tchan_lept_antitop
-410644 PowhegPythiaEvtGen_P2012_SingleTopSchan_noAllHad_top
+410644 PowhegPythia8EvtGen_A14_singletop_schan_lept_top
 410645 PowhegPythia8EvtGen_A14_singletop_schan_lept_antitop
 410646 PowhegPythia8EvtGen_A14_Wt_DR_inclusive_top
 410647 PowhegPythia8EvtGen_A14_Wt_DR_inclusive_antitop
@@ -2677,4 +2677,10 @@
 700128 Sh_2210
 700129 Sh_2210
 700130 Sh_2210
-
+700100 Sh_2210
+700320 Sh_2211
+700321 Sh_2211
+700322 Sh_2211
+700323 Sh_2211
+700324 Sh_2211
+700325 Sh_2211

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -520,7 +520,7 @@ namespace HelperFunctions {
   }
 
   /// @brief The different supported shower types
-  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22};
+  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22, Sherpa2210};
 
   /**
     @brief Determines the type of generator used for the shower from the sample name


### PR DESCRIPTION
Also correctly recognize Sherpa 2.2.10 when m_EfficiencyCalibration=="auto"