### PR TITLE
Correct MetContainer, branches incorrectly created

### DIFF
--- a/Root/MetContainer.cxx
+++ b/Root/MetContainer.cxx
@@ -122,10 +122,10 @@ void MetContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_sigClus ) {
-    setBranch(tree, "FinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt,  "/F");
-    setBranch(tree, "FinalClusOverSqrtHt",     &m_metFinalClusOverSqrtHt,     "/F");
-    setBranch(tree, "FinalClusSignificance",   &m_metFinalClusSignificance,   "/F");
-    setBranch(tree, "FinalClusSigDirectional", &m_metFinalClusSigDirectional, "/F");
+    setBranch(tree, "FinalClusOverSqrtSumEt",  &m_metFinalClusOverSqrtSumEt,  "F");
+    setBranch(tree, "FinalClusOverSqrtHt",     &m_metFinalClusOverSqrtHt,     "F");
+    setBranch(tree, "FinalClusSignificance",   &m_metFinalClusSignificance,   "F");
+    setBranch(tree, "FinalClusSigDirectional", &m_metFinalClusSigDirectional, "F");
   }
 
   if ( m_infoSwitch.m_sigResolutionClus ) {


### PR DESCRIPTION
The SigClus branches are being created with type tag `/F` which should be `F`. At present
```
TBranch::TBranch          WARNING Extra characters after type tag '/F' for branch 'metFinalClusOverSqrtSumEt'; must be one character.
TBranch::TLeaf            ERROR   Illegal data type for metFinalClusOverSqrtSumEt/metFinalClusOverSqrtSumEt//F
```
 is produced when you try to add the branches to the tree. 

Removes the `/` which also makes it consistent with the other lines in the file. With this change applied the branches are added.