### PR TITLE
Update Root/MuonCalibration.cxx: add momentum calibration mode property

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -188,6 +188,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
     ANA_MSG_WARNING("Overriding muon 2018 saggita release to " << m_overrideSagittaRelease18);
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("SagittaRelease18", m_overrideSagittaRelease18));
   }
+  ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibrationMode", m_calibrationMode));
   ANA_CHECK(m_muonCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_muonCalibrationTool_handle);
 

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -51,7 +51,8 @@ public:
   int m_sagittaCorrPhaseSpace17 = -1;
   /// @brief Set SagittaCorrPhaseSpace18 property if different than -1
   int m_sagittaCorrPhaseSpace18 = -1;
-
+  /// @brief Momentum calibration mode must be chosen: correctData_CB (0), correctData_IDMS (1) or notCorrectData_IDMS (2): https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC16#Details_on_using_the_MuonCalibra 
+  int m_calibrationMode = 0;
   // sort after calibration
   bool m_sort = true;
 


### PR DESCRIPTION
In line with the MCP precision recommendations from AAB 21.2.198 (https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC16#Details_on_using_the_MuonCalibra)
The `calibration mode' for the muon momentum calibration must be set explicitly by the user " via the calibrationMode property, that can be set to MuonCalibrationPeriodTool::correctData_CB (0), MuonCalibrationPeriodTool::correctData_IDMS (1) or MuonCalibrationPeriodTool::notCorrectData_IDMS (2). The current default option is "noOption", forcing all analyses are required to make an explicit choice."

I've defaulted it to set to 0 to avoid everyone's code crashing, and under the impression that most users of xAH don't use the highPt muon working point or are limited by muon systematics so should use 0, but details of which choice is best are in the twiki.