### PR TITLE
improve lepton efficiency systematics implementation

### DIFF
--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -29,7 +29,7 @@ using std::vector;
 #pragma link C++ class vector<float>+;
 #endif
 
-HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store):
+HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store, std::string nominalTreeName):
   m_trigInfoSwitch(nullptr),
   m_trigConfTool(nullptr),
   m_trigDecTool(nullptr),
@@ -40,7 +40,8 @@ HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const 
   m_debug = debug;
   m_tree = tree;
   m_tree->SetDirectory( file );
-  m_nominalTree = strcmp(m_tree->GetName(), "nominal") == 0;
+  m_nominalTreeName = nominalTreeName;
+  m_nominalTree = strcmp(m_tree->GetName(), nominalTreeName.c_str()) == 0;
   m_event = event;
   m_store = store;
   Info("HelpTreeBase()", "HelpTreeBase setup");
@@ -109,8 +110,8 @@ HelpTreeBase::~HelpTreeBase() {
 }
 
 
-HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent* event, xAOD::TStore* store, const float units, bool debug):
-  HelpTreeBase(event, tree, file, units, debug, store)
+HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent* event, xAOD::TStore* store, const float units, bool debug, std::string nominalTreeName):
+  HelpTreeBase(event, tree, file, units, debug, store, nominalTreeName)
 {
   // use the other constructor for everything
 }
@@ -337,9 +338,7 @@ void HelpTreeBase::AddMuons(const std::string& detailStr, const std::string& muo
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = thisMuon->m_infoSwitch;
 
-  std::string tname = m_tree->GetName();
-
-  if ( tname == "nominal" ) {
+  if (m_nominalTree) {
 
      if ( muonInfoSwitch.m_recoEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
        for (auto& reco : muonInfoSwitch.m_recoWPs) {
@@ -357,8 +356,10 @@ void HelpTreeBase::AddMuons(const std::string& detailStr, const std::string& muo
 
      if ( muonInfoSwitch.m_trigEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
        for (auto& trig : muonInfoSwitch.m_trigWPs) {
-         std::string trigEffSF_sysNames = "muon_TrigEff_SF_" + trig + "_sysNames";
-         m_tree->Branch( trigEffSF_sysNames.c_str() , & (m_MuonTrigEff_SF_sysNames)[ trig ] );
+         for (auto& reco : muonInfoSwitch.m_recoWPs) {
+           std::string trigEffSF_sysNames = "muon_TrigEff_SF_" + trig + "_" + reco + "_sysNames";
+           m_tree->Branch( trigEffSF_sysNames.c_str() , & (m_MuonTrigEff_SF_sysNames)[ trig ][ reco ] );
+         }
        }
      }
 
@@ -378,14 +379,12 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
   this->ClearMuons(muonName);
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = m_muons[muonName]->m_infoSwitch;
 
-  std::string tname = m_tree->GetName();
-
-  if ( tname == "nominal" ) {
+  if (m_nominalTree) {
 
     if ( muonInfoSwitch.m_recoEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& reco : muonInfoSwitch.m_recoWPs ) {
         std::vector< std::string >* tmp_reco_sys(nullptr);
-        if ( m_store->retrieve(tmp_reco_sys, "MuonEfficiencyCorrector_RecoSyst_" + reco).isSuccess() ) {
+        if ( m_store->retrieve(tmp_reco_sys, "MuonEfficiencyCorrector_RecoSyst_Reco" + reco).isSuccess() ) {
           (m_MuonRecoEff_SF_sysNames)[ reco ] = *tmp_reco_sys;
         }
       }
@@ -394,7 +393,7 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
     if ( muonInfoSwitch.m_isoEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& isol : muonInfoSwitch.m_isolWPs ) {
         std::vector< std::string >* tmp_iso_sys(nullptr);
-        if ( m_store->retrieve(tmp_iso_sys, "MuonEfficiencyCorrector_IsoSyst_" + isol).isSuccess() ) {
+        if ( m_store->retrieve(tmp_iso_sys, "MuonEfficiencyCorrector_IsoSyst_Iso" + isol).isSuccess() ) {
           (m_MuonIsoEff_SF_sysNames)[ isol ] = *tmp_iso_sys;
         }
       }
@@ -402,9 +401,11 @@ void HelpTreeBase::FillMuons( const xAOD::MuonContainer* muons, const xAOD::Vert
 
     if ( muonInfoSwitch.m_trigEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& trig : muonInfoSwitch.m_trigWPs ) {
-        std::vector< std::string >* tmp_trig_sys(nullptr);
-        if ( m_store->retrieve(tmp_trig_sys, "MuonEfficiencyCorrector_TrigSyst_" + trig).isSuccess() ) {
-          (m_MuonTrigEff_SF_sysNames)[ trig ] = *tmp_trig_sys;
+        for ( auto& reco : muonInfoSwitch.m_recoWPs ) {
+          std::vector< std::string >* tmp_trig_sys(nullptr);
+          if ( m_store->retrieve(tmp_trig_sys, "MuonEfficiencyCorrector_TrigSyst_" + trig + "_Reco" + reco).isSuccess() ) {
+            (m_MuonTrigEff_SF_sysNames)[ trig ][ reco ] = *tmp_trig_sys;
+          }
         }
       }
     }
@@ -437,28 +438,29 @@ void HelpTreeBase::FillMuon( const xAOD::Muon* muon, const xAOD::Vertex* primary
 
 void HelpTreeBase::ClearMuons(const std::string& muonName) {
 
-  std::string tname = m_tree->GetName();
   xAH::MuonContainer* thisMuon = m_muons[muonName];
   HelperClasses::MuonInfoSwitch& muonInfoSwitch = thisMuon->m_infoSwitch;
 
-  if ( tname == "nominal" ) {
+  if (m_nominalTree) {
 
     if ( muonInfoSwitch.m_recoEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& reco : muonInfoSwitch.m_recoWPs ) {
           (m_MuonRecoEff_SF_sysNames)[ reco ].clear();
-        }
+      }
     }
 
     if ( muonInfoSwitch.m_isoEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& isol : muonInfoSwitch.m_isolWPs ) {
           (m_MuonIsoEff_SF_sysNames)[ isol ].clear();
-        }
+      }
     }
 
     if ( muonInfoSwitch.m_trigEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
       for ( auto& trig : muonInfoSwitch.m_trigWPs ) {
-          (m_MuonTrigEff_SF_sysNames)[ trig ].clear();
+        for ( auto& reco : muonInfoSwitch.m_recoWPs ) {
+            (m_MuonTrigEff_SF_sysNames)[ trig ][ reco ].clear();
         }
+      }
     }
 
     if ( muonInfoSwitch.m_ttvaEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -357,7 +357,7 @@ void HelpTreeBase::AddMuons(const std::string& detailStr, const std::string& muo
      if ( muonInfoSwitch.m_trigEff_sysNames && muonInfoSwitch.m_effSF && m_isMC ) {
        for (auto& trig : muonInfoSwitch.m_trigWPs) {
          for (auto& reco : muonInfoSwitch.m_recoWPs) {
-           std::string trigEffSF_sysNames = "muon_TrigEff_SF_" + trig + "_" + reco + "_sysNames";
+           std::string trigEffSF_sysNames = (muonInfoSwitch.m_recoWPs.size()>1) ? "muon_TrigEff_SF_" + trig + "_" + reco + "_sysNames" : "muon_TrigEff_SF_" + trig + "_sysNames";
            m_tree->Branch( trigEffSF_sysNames.c_str() , & (m_MuonTrigEff_SF_sysNames)[ trig ][ reco ] );
          }
        }

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -91,6 +91,7 @@ private:
   int m_numEvent;         //!
   int m_numObject;        //!
 
+  // To include the nominal in the Recp/Iso/Trig/TTVA efficiency SFs output, use "All", or include "Nominal" in the list
   std::vector<CP::SystematicSet> m_systListPID;  //!
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListReco; //!

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -67,8 +67,8 @@ class HelpTreeBase {
 
 public:
 
-  HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, xAOD::TStore* store = nullptr );
-  HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false );
+  HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, xAOD::TStore* store = nullptr, std::string nominalTreeName = "nominal" );
+  HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false, std::string nominalTreeName = "nominal" );
   virtual ~HelpTreeBase();
 
   void AddEvent         (const std::string& detailStr = "");
@@ -184,7 +184,7 @@ public:
   void ClearJets          (const std::string& jetName = "jet");
   void ClearL1Jets        (const std::string& jetName = "L1Jet");
   void ClearTruth         (const std::string& truthName);
-  void ClearTracks	      (const std::string& trackName);
+  void ClearTracks	  (const std::string& trackName);
   void ClearFatJets       (const std::string& fatjetName, const std::string& suffix="");
   void ClearTruthFatJets  (const std::string& truthFatJetName = "truth_fatjet");
   void ClearTaus          (const std::string& tauName = "tau" );
@@ -327,6 +327,7 @@ protected:
 
   bool m_debug;
   bool m_isMC;
+  std::string m_nominalTreeName;
   bool m_nominalTree;
 
   // event
@@ -386,7 +387,7 @@ protected:
   std::map<std::string, xAH::MuonContainer*> m_muons;
   std::map<std::string, std::vector<std::string> > m_MuonRecoEff_SF_sysNames;
   std::map<std::string, std::vector<std::string> > m_MuonIsoEff_SF_sysNames;
-  std::map<std::string, std::vector<std::string> > m_MuonTrigEff_SF_sysNames;
+  std::map<std::string, std::map<std::string, std::vector<std::string> > > m_MuonTrigEff_SF_sysNames;
   std::vector<std::string>  m_MuonTTVAEff_SF_sysNames;
 
   //

--- a/xAODAnaHelpers/MuonEfficiencyCorrector.h
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector.h
@@ -87,6 +87,7 @@ private:
   int m_numEvent;         //!
   int m_numObject;        //!
 
+  // To include the nominal in the Recp/Iso/Trig/TTVA efficiency SFs output, use "All", or include "Nominal" in the list
   std::vector<CP::SystematicSet> m_systListReco; //!
   std::vector<CP::SystematicSet> m_systListIso;  //!
   std::vector<CP::SystematicSet> m_systListTrig; //!


### PR DESCRIPTION
- fix names of muon efficiency systematics in HelpTreeBase to match those in the MuonEfficiencyCorrector
- Make muon trigger efficiency systs reco-WP dependent in HelpTreeBase, to match MuonEfficiencyCorrector
- remove a couple of whitespaces for neatness
- add comments to the Muon/ElectronEfficiencyCorrector headers to note that the syst list needs to include "All" or "Nominal" explicitly to ensure the nominal SFs are stored in the ttree as well as the systematics varied list. 
- add an option to HelpTreeBase to specify the nominal tree name, which defaults to "nominal" for backward compatibility. Perhaps this is unnecessary but at least it draws attention to the fact it is set to nominal unless explicitly changed to avoid other people having the same problem I did with muon efficiency systs.
- make use of the m_nominalTree bool variable in HelpTreeBase::AddMuons  and HelpTreeBase::FillMuons rather than re-checking the name of the input tree and whether that matches a hard-coded string for the nominal tree name.