### PR TITLE
Support CP algorithms in xAH_config.algorithm() (through AnaAlgSequence)

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -39,75 +39,63 @@ class Config(object):
     assert len(args) == 1 or len(args) == 2
 
     if isinstance(args[0], AnaAlgSequence): # add non-xAH (CP or not) algorithms from an AnaAlgSequence
+      if len(args) > 1:
+        logger.warning("algorithm() expects one argument when using AnaAlgSequence, {} were provided".format(len(args)))
       for alg in args[0]:
         self._algorithms.append(alg)
-    else: # add xAH algorithms
-      className = args[0]
-      options = args[1]
-      if not isinstance(options, dict):
-        raise TypeError("Must pass in a dictionary of options")
+      return
 
-      # if m_name not set, randomly generate it
-      algName = options.get("m_name", None)
-      if algName is None:
-        algName = str(NameGenerator())
-        logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
-        options['m_name'] = algName
-      # if not isinstance(algName, str) and not isinstance(algName, unicode):
-      #   raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
+    className = args[0]
+    options = args[1]
+    if not isinstance(options, dict):
+      raise TypeError("Must pass in a dictionary of options")
 
-      # handle deprecation of m_debug, m_verbose
-      if 'm_debug' in options:
-        logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='debug'")
-      if 'm_verbose' in options:
-        logger.warning("m_verbose is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='verbose'.")
+    # if m_name not set, randomly generate it
+    algName = options.get("m_name", None)
+    if algName is None:
+      algName = str(NameGenerator())
+      logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
+      options['m_name'] = algName
+    # if not isinstance(algName, str) and not isinstance(algName, unicode):
+    #   raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 
-      # handle msgLevels, can be string or integer
-      msgLevel = options.get("m_msgLevel", "info")
-      # if isinstance(msgLevel, unicode): msgLevel = msgLevel.encode('utf-8')
-      if not isinstance(msgLevel, str) and not isinstance(msgLevel, int):
-        raise TypeError("m_msgLevel must be a string or integer for instance of {0:s}".format(className))
-      if isinstance(msgLevel, str):
-        if not hasattr(ROOT.MSG, msgLevel.upper()):
-          raise ValueError("m_msgLevel must be a valid MSG::level: {0:s}".format(msgLevel))
-        msgLevel = getattr(ROOT.MSG, msgLevel.upper())
-      options['m_msgLevel'] = msgLevel
+    # handle deprecation of m_debug, m_verbose
+    if 'm_debug' in options:
+      logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='debug'")
+    if 'm_verbose' in options:
+      logger.warning("m_verbose is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='verbose'.")
 
-      # Construct the given constructor
-      #    (complicated b/c we have to deal nesting of namespaces)
-      alg = reduce(lambda x,y: getattr(x, y, None), className.split('::'), ROOT)
-      if alg is None:
-        raise AttributeError(className)
+    # handle msgLevels, can be string or integer
+    msgLevel = options.get("m_msgLevel", "info")
+    # if isinstance(msgLevel, unicode): msgLevel = msgLevel.encode('utf-8')
+    if not isinstance(msgLevel, str) and not isinstance(msgLevel, int):
+      raise TypeError("m_msgLevel must be a string or integer for instance of {0:s}".format(className))
+    if isinstance(msgLevel, str):
+      if not hasattr(ROOT.MSG, msgLevel.upper()):
+        raise ValueError("m_msgLevel must be a valid MSG::level: {0:s}".format(msgLevel))
+      msgLevel = getattr(ROOT.MSG, msgLevel.upper())
+    options['m_msgLevel'] = msgLevel
 
-      # get a list of parent classes
-      parents = inspect.getmro(alg)
-      if ROOT.EL.Algorithm in parents:
-        # Construct an instance of the alg and set its attributes
-        alg_obj = alg()
-        alg_obj.SetName(algName)
-        self._log.append((className,algName))
-        alg_obj.setMsgLevel(msgLevel)
-        for k,v in options.items():
-          # only crash on algorithm configurations that aren't m_msgLevel and m_name (xAH specific)
-          if not hasattr(alg_obj, k) and k not in ['m_msgLevel', 'm_name']:
-            raise AttributeError(k)
-          elif hasattr(alg_obj, k):
-            #handle unicode from json
-            # if isinstance(v, unicode): v = v.encode('utf-8')
-            self._log.append((algName, k, v))
-            try:
-              setattr(alg_obj, k, v)
-            except:
-              logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
-              raise
-      elif ROOT.EL.AnaAlgorithm in parents:
-        alg_obj = AnaAlgorithmConfig(className)
-        alg_obj.setName(algName)
-        self._log.append((className, algName))
-        # TODO
-        #setattr(alg_obj, "OutputLevel", msgLevel)
-        for k,v in options.items():
-          if k in ['m_msgLevel', 'm_name']: continue
+    # Construct the given constructor
+    #    (complicated b/c we have to deal nesting of namespaces)
+    alg = reduce(lambda x,y: getattr(x, y, None), className.split('::'), ROOT)
+    if alg is None:
+      raise AttributeError(className)
+
+    # get a list of parent classes
+    parents = inspect.getmro(alg)
+    if ROOT.EL.Algorithm in parents:
+      # Construct an instance of the alg and set its attributes
+      alg_obj = alg()
+      alg_obj.SetName(algName)
+      self._log.append((className,algName))
+      alg_obj.setMsgLevel(msgLevel)
+      for k,v in options.items():
+        # only crash on algorithm configurations that aren't m_msgLevel and m_name (xAH specific)
+        if not hasattr(alg_obj, k) and k not in ['m_msgLevel', 'm_name']:
+          raise AttributeError(k)
+        elif hasattr(alg_obj, k):
+          #handle unicode from json
           # if isinstance(v, unicode): v = v.encode('utf-8')
           self._log.append((algName, k, v))
           try:
@@ -115,11 +103,26 @@ class Config(object):
           except:
             logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
             raise
-      else:
-        raise TypeError("Algorithm {0:s} is not an EL::Algorithm or EL::AnaAlgorithm. I do not know how to configure it. {1}".format(className, parents))
+    elif ROOT.EL.AnaAlgorithm in parents:
+      alg_obj = AnaAlgorithmConfig(className)
+      alg_obj.setName(algName)
+      self._log.append((className, algName))
+      # TODO
+      #setattr(alg_obj, "OutputLevel", msgLevel)
+      for k,v in options.items():
+        if k in ['m_msgLevel', 'm_name']: continue
+        # if isinstance(v, unicode): v = v.encode('utf-8')
+        self._log.append((algName, k, v))
+        try:
+          setattr(alg_obj, k, v)
+        except:
+          logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
+          raise
+    else:
+      raise TypeError("Algorithm {0:s} is not an EL::Algorithm or EL::AnaAlgorithm. I do not know how to configure it. {1}".format(className, parents))
 
-      # Add the constructed algo to the list of algorithms to run
-      self._algorithms.append(alg_obj)
+    # Add the constructed algo to the list of algorithms to run
+    self._algorithms.append(alg_obj)
 
   # set based on patterns
   def sample(self, pattern, **kwargs):

--- a/python/config.py
+++ b/python/config.py
@@ -21,6 +21,7 @@ class Config(object):
     self._samples    = {}
     self._outputs    = set([])
     self._log        = []
+    self._cp_sequence = {}
 
   def setalg(self, className, options):
     logger.warning("Config::setalg is being renamed to Config::algorithm.")
@@ -28,6 +29,9 @@ class Config(object):
     frame, path, lineno, source, lines, _ = inspect.stack()[1]
     logger.warning("\tPossible call stack: {0:s}({1:d}): {2:s}".format(path, lineno, lines[0].strip()))
     return self.algorithm(className, options)
+
+  def cp_sequence(self, sequence):
+    self._cp_sequence[len(self._algorithms)-1 if len(self._algorithms) else "initial"] = sequence
 
   def algorithm(self, className, options):
     # check first argument

--- a/python/config.py
+++ b/python/config.py
@@ -12,6 +12,7 @@ ROOT.gROOT.SetBatch(True)
 
 import inspect
 from AnaAlgorithm.AnaAlgorithmConfig import AnaAlgorithmConfig
+from AnaAlgorithm.AnaAlgSequence import AnaAlgSequence
 
 from .utils import NameGenerator
 
@@ -21,7 +22,6 @@ class Config(object):
     self._samples    = {}
     self._outputs    = set([])
     self._log        = []
-    self._cp_sequence = {}
 
   def setalg(self, className, options):
     logger.warning("Config::setalg is being renamed to Config::algorithm.")
@@ -30,64 +30,84 @@ class Config(object):
     logger.warning("\tPossible call stack: {0:s}({1:d}): {2:s}".format(path, lineno, lines[0].strip()))
     return self.algorithm(className, options)
 
-  def cp_sequence(self, sequence):
-    self._cp_sequence[len(self._algorithms)-1 if len(self._algorithms) else "initial"] = sequence
-
-  def algorithm(self, className, options):
+  def algorithm(self, *args):
     # check first argument
     # if isinstance(className, unicode):
     # if not isinstance(className, str):
     #   raise TypeError("className must be a string")
 
-    if not isinstance(options, dict):
-      raise TypeError("Must pass in a dictionary of options")
+    assert len(args) == 1 or len(args) == 2
 
-    # if m_name not set, randomly generate it
-    algName = options.get("m_name", None)
-    if algName is None:
-      algName = str(NameGenerator())
-      logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
-      options['m_name'] = algName
-    # if not isinstance(algName, str) and not isinstance(algName, unicode):
-    #   raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
+    if isinstance(args[0], AnaAlgSequence): # add non-xAH (CP or not) algorithms from an AnaAlgSequence
+      for alg in args[0]:
+        self._algorithms.append(alg)
+    else: # add xAH algorithms
+      className = args[0]
+      options = args[1]
+      if not isinstance(options, dict):
+        raise TypeError("Must pass in a dictionary of options")
 
-    # handle deprecation of m_debug, m_verbose
-    if 'm_debug' in options:
-      logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='debug'")
-    if 'm_verbose' in options:
-      logger.warning("m_verbose is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='verbose'.")
+      # if m_name not set, randomly generate it
+      algName = options.get("m_name", None)
+      if algName is None:
+        algName = str(NameGenerator())
+        logger.warning("Setting missing m_name={0:s} for instance of {1:s}".format(algName, className))
+        options['m_name'] = algName
+      # if not isinstance(algName, str) and not isinstance(algName, unicode):
+      #   raise TypeError("'m_name' must be a string for instance of {0:s}".format(className))
 
-    # handle msgLevels, can be string or integer
-    msgLevel = options.get("m_msgLevel", "info")
-    # if isinstance(msgLevel, unicode): msgLevel = msgLevel.encode('utf-8')
-    if not isinstance(msgLevel, str) and not isinstance(msgLevel, int):
-      raise TypeError("m_msgLevel must be a string or integer for instance of {0:s}".format(className))
-    if isinstance(msgLevel, str):
-      if not hasattr(ROOT.MSG, msgLevel.upper()):
-        raise ValueError("m_msgLevel must be a valid MSG::level: {0:s}".format(msgLevel))
-      msgLevel = getattr(ROOT.MSG, msgLevel.upper())
-    options['m_msgLevel'] = msgLevel
+      # handle deprecation of m_debug, m_verbose
+      if 'm_debug' in options:
+        logger.warning("m_debug is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='debug'")
+      if 'm_verbose' in options:
+        logger.warning("m_verbose is being deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882 . Set m_msgLevel='verbose'.")
 
-    # Construct the given constructor
-    #    (complicated b/c we have to deal nesting of namespaces)
-    alg = reduce(lambda x,y: getattr(x, y, None), className.split('::'), ROOT)
-    if alg is None:
-      raise AttributeError(className)
+      # handle msgLevels, can be string or integer
+      msgLevel = options.get("m_msgLevel", "info")
+      # if isinstance(msgLevel, unicode): msgLevel = msgLevel.encode('utf-8')
+      if not isinstance(msgLevel, str) and not isinstance(msgLevel, int):
+        raise TypeError("m_msgLevel must be a string or integer for instance of {0:s}".format(className))
+      if isinstance(msgLevel, str):
+        if not hasattr(ROOT.MSG, msgLevel.upper()):
+          raise ValueError("m_msgLevel must be a valid MSG::level: {0:s}".format(msgLevel))
+        msgLevel = getattr(ROOT.MSG, msgLevel.upper())
+      options['m_msgLevel'] = msgLevel
 
-    # get a list of parent classes
-    parents = inspect.getmro(alg)
-    if ROOT.EL.Algorithm in parents:
-      # Construct an instance of the alg and set its attributes
-      alg_obj = alg()
-      alg_obj.SetName(algName)
-      self._log.append((className,algName))
-      alg_obj.setMsgLevel(msgLevel)
-      for k,v in options.items():
-        # only crash on algorithm configurations that aren't m_msgLevel and m_name (xAH specific)
-        if not hasattr(alg_obj, k) and k not in ['m_msgLevel', 'm_name']:
-          raise AttributeError(k)
-        elif hasattr(alg_obj, k):
-          #handle unicode from json
+      # Construct the given constructor
+      #    (complicated b/c we have to deal nesting of namespaces)
+      alg = reduce(lambda x,y: getattr(x, y, None), className.split('::'), ROOT)
+      if alg is None:
+        raise AttributeError(className)
+
+      # get a list of parent classes
+      parents = inspect.getmro(alg)
+      if ROOT.EL.Algorithm in parents:
+        # Construct an instance of the alg and set its attributes
+        alg_obj = alg()
+        alg_obj.SetName(algName)
+        self._log.append((className,algName))
+        alg_obj.setMsgLevel(msgLevel)
+        for k,v in options.items():
+          # only crash on algorithm configurations that aren't m_msgLevel and m_name (xAH specific)
+          if not hasattr(alg_obj, k) and k not in ['m_msgLevel', 'm_name']:
+            raise AttributeError(k)
+          elif hasattr(alg_obj, k):
+            #handle unicode from json
+            # if isinstance(v, unicode): v = v.encode('utf-8')
+            self._log.append((algName, k, v))
+            try:
+              setattr(alg_obj, k, v)
+            except:
+              logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
+              raise
+      elif ROOT.EL.AnaAlgorithm in parents:
+        alg_obj = AnaAlgorithmConfig(className)
+        alg_obj.setName(algName)
+        self._log.append((className, algName))
+        # TODO
+        #setattr(alg_obj, "OutputLevel", msgLevel)
+        for k,v in options.items():
+          if k in ['m_msgLevel', 'm_name']: continue
           # if isinstance(v, unicode): v = v.encode('utf-8')
           self._log.append((algName, k, v))
           try:
@@ -95,26 +115,11 @@ class Config(object):
           except:
             logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
             raise
-    elif ROOT.EL.AnaAlgorithm in parents:
-      alg_obj = AnaAlgorithmConfig(className)
-      alg_obj.setName(algName)
-      self._log.append((className, algName))
-      # TODO
-      #setattr(alg_obj, "OutputLevel", msgLevel)
-      for k,v in options.items():
-        if k in ['m_msgLevel', 'm_name']: continue
-        # if isinstance(v, unicode): v = v.encode('utf-8')
-        self._log.append((algName, k, v))
-        try:
-          setattr(alg_obj, k, v)
-        except:
-          logger.error("There was a problem setting {0:s} to {1} for {2:s}::{3:s}".format(k, v, className, algName))
-          raise
-    else:
-      raise TypeError("Algorithm {0:s} is not an EL::Algorithm or EL::AnaAlgorithm. I do not know how to configure it. {1}".format(className, parents))
+      else:
+        raise TypeError("Algorithm {0:s} is not an EL::Algorithm or EL::AnaAlgorithm. I do not know how to configure it. {1}".format(className, parents))
 
-    # Add the constructed algo to the list of algorithms to run
-    self._algorithms.append(alg_obj)
+      # Add the constructed algo to the list of algorithms to run
+      self._algorithms.append(alg_obj)
 
   # set based on patterns
   def sample(self, pattern, **kwargs):

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -497,9 +497,17 @@ if __name__ == "__main__":
         if isinstance(alg, ROOT.EL.NTupleSvc) and not job.outputHas(alg.GetName()):
           job.outputAdd(ROOT.EL.OutputStream(alg.GetName()))
 
-    # Add the algorithms to the job
-    for alg in configurator._algorithms:
+    # Add sequence of CP algorithms scheduled before any xAH algorithm
+    if "initial" in configurator._cp_sequence:
+      for alg in configurator._cp_sequence["initial"]:
+        job.algsAdd(alg)
+
+    # Add any other requested algorithm to the job
+    for index, alg in enumerate(configurator._algorithms):
       job.algsAdd(alg)
+      if index in configurator._cp_sequence: # add CP algorithms requested b/w this xAH alg and the next one
+        for alg in configurator._cp_sequence[index]:
+          job.algsAdd(alg)
     
     for configLog in configurator._log:
       # this is when we have just the algorithm name

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
         if isinstance(alg, ROOT.EL.NTupleSvc) and not job.outputHas(alg.GetName()):
           job.outputAdd(ROOT.EL.OutputStream(alg.GetName()))
 
-    # Add the algorithms the job
+    # Add the algorithms to the job
     for alg in configurator._algorithms:
       job.algsAdd(alg)
     

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -497,17 +497,9 @@ if __name__ == "__main__":
         if isinstance(alg, ROOT.EL.NTupleSvc) and not job.outputHas(alg.GetName()):
           job.outputAdd(ROOT.EL.OutputStream(alg.GetName()))
 
-    # Add sequence of CP algorithms scheduled before any xAH algorithm
-    if "initial" in configurator._cp_sequence:
-      for alg in configurator._cp_sequence["initial"]:
-        job.algsAdd(alg)
-
-    # Add any other requested algorithm to the job
-    for index, alg in enumerate(configurator._algorithms):
+    # Add the algorithms the job
+    for alg in configurator._algorithms:
       job.algsAdd(alg)
-      if index in configurator._cp_sequence: # add CP algorithms requested b/w this xAH alg and the next one
-        for alg in configurator._cp_sequence[index]:
-          job.algsAdd(alg)
     
     for configLog in configurator._log:
       # this is when we have just the algorithm name


### PR DESCRIPTION
This PR adds the possibility of scheduling CP algorithms b/w the xAH algorithms (before/after).

For example, you could write a python module named xAODAnaHelpers/python/makeMuonAnalysisSequence.py containing what is on the following example:

https://atlassoftwaredocs.web.cern.ch/ABtutorial/cpalg_example_jobs/

Then, you need to add the following to your python config:

```
from xAODAnaHelpers import Config as xAH_config
from xAODAnaHelpers.makeMuonAnalysisSequence import makeMuonAnalysisSequence
c = xAH_config()
c.algorithm(makeMuonAnalysisSequence("mc"))
```