### PR TITLE
adding option to change MET working point

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -124,7 +124,9 @@ EL::StatusCode METConstructor :: initialize ()
   if ( m_doMuonPFlowBugfix ) {
     ANA_CHECK(m_metmaker_handle.setProperty("DoMuonPFlowBugfix", true));
   }
-  ANA_CHECK(m_metmaker_handle.setProperty("JetSelection", m_METWorkingPoint));
+  if ( !m_METWorkingPoint.empty() ){
+    ANA_CHECK(m_metmaker_handle.setProperty("JetSelection", m_METWorkingPoint));
+  }
   ANA_CHECK(m_metmaker_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_metmaker_handle);
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -124,6 +124,7 @@ EL::StatusCode METConstructor :: initialize ()
   if ( m_doMuonPFlowBugfix ) {
     ANA_CHECK(m_metmaker_handle.setProperty("DoMuonPFlowBugfix", true));
   }
+  ANA_CHECK(m_metmaker_handle.setProperty("JetSelection", m_METWorkingPoint));
   ANA_CHECK(m_metmaker_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_metmaker_handle);
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -49,7 +49,7 @@ public:
   bool    m_dofJVTCut = false;
 
   /// @brief Name of MET Working Point (defines the JetSelection applied in METMaker)
-  std::string m_METWorkingPoint = "Tight";
+  std::string m_METWorkingPoint = "";
 
   /// @brief Name of fJVT decoration
   std::string m_fJVTdecorName = "passFJVT";

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -48,6 +48,9 @@ public:
   bool    m_doJVTCut = false;
   bool    m_dofJVTCut = false;
 
+  /// @brief Name of MET Working Point (defines the JetSelection applied in METMaker)
+  std::string m_METWorkingPoint = "Tight";
+
   /// @brief Name of fJVT decoration
   std::string m_fJVTdecorName = "passFJVT";
 


### PR DESCRIPTION
As described here https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EtmissRecommendationsFullRun2#Working_Points, the MET Run2 recommendations support several MET Working points that each place different selections on the Jets passed into METMaker. 

By default, the code and recommendation uses the Tight working point, but we should be able to alter this line https://gitlab.cern.ch/atlas/athena/-/blob/21.2/Reconstruction/MET/METUtilities/Root/METMaker.cxx#L111 when initiating the METMaker too so analyses (and mainly the METPerformance code) can change working points. 

The code change is just to add the option to set this property in METConstructor, with a variable called m_METWorkingPoint (I think this is a bit clearer than e.g. m_JetSelection to users). 