### PR TITLE
add precedent '/' to fix scanXRD option

### DIFF
--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -354,7 +354,7 @@ if __name__ == "__main__":
         elif args.use_scanXRD:
           # assume format like root://someserver//path/to/files/*pattern*.root
           server, path = fname.replace('root://', '').split('//')
-          sh_list = ROOT.SH.DiskListXRD(server, os.path.join(path, ''), True)
+          sh_list = ROOT.SH.DiskListXRD(server, os.path.join("/", path, ''), True)
           ROOT.SH.ScanDir().scan(sh_all, sh_list)
         else:
           # need to parse and split it up


### PR DESCRIPTION
I think a leading '/' is missing when running with the `--scanXRD` flag. After adding this, it was possible for me to run when supplying inputs via e.g. `--files "root://eosuser.cern.ch//eos/user/h/higgsino/SusySkimHiggsino/CI/DAODs/mc16_13TeV.511724.MGPy8EG_LO_LQ_S1T_ResProd_lam11_2000_1p0.deriv.DAOD_PHYS.e8371_a875_r10201_p5001"` while I got a crash before.