### PR TITLE
Update photon variable correction to be in line with R22 recommendations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ atlas_add_library( xAODAnaHelpersLib xAODAnaHelpers/*.h Root/*.h Root/*.cxx ${xA
                    ElectronEfficiencyCorrectionLib ElectronPhotonSelectorToolsLib
                    IsolationSelectionLib IsolationCorrectionsLib
                    ElectronPhotonShowerShapeFudgeToolLib
+                   EGammaVariableCorrectionLib
                    FTagAnalysisInterfacesLib JetAnalysisInterfacesLib MuonAnalysisInterfacesLib
                    PhotonEfficiencyCorrectionLib METUtilitiesLib METInterface
                    TauAnalysisToolsLib AsgTools xAODMissingET

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -14,7 +14,7 @@
 #include "IsolationCorrections/IIsolationCorrectionTool.h"
 
 class AsgPhotonIsEMSelector;
-class ElectronPhotonShowerShapeFudgeTool;
+class ElectronPhotonVariableCorrectionTool;
 
 namespace CP {
   class EgammaCalibrationAndSmearingTool;
@@ -78,7 +78,7 @@ private:
   CP::EgammaCalibrationAndSmearingTool* m_EgammaCalibrationAndSmearingTool = nullptr; //!
   asg::AnaToolHandle<CP::IIsolationCorrectionTool> m_isolationCorrectionTool_handle  {"CP::IsolationCorrectionTool/IsolationCorrectionTool", this}; //!
 
-  ElectronPhotonShowerShapeFudgeTool*   m_photonFudgeMCTool = nullptr; //!
+  ElectronPhotonVariableCorrectionTool* m_photonVarCorrectionTool = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonTightIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonMediumIsEMSelector = nullptr; //!
   AsgPhotonIsEMSelector*                m_photonLooseIsEMSelector = nullptr; //!


### PR DESCRIPTION
The tool used to shift photon shower shape variables for MC has changed for release 22 from ElectronPhotonShowerShapeFudgeTool to EGammaVariableCorrection (see [here](https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/EGammaIdentificationRun2#Shifting_the_photon_shower_shape)).

This pull request replaces the old tool with the new tool for use in the PhotonCalibrator, and uses the fudge factors in TUNE23 as a configuration file, in line with current recommendations.