### PR TITLE
Clean up btaggers and add DL1dv00

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -122,11 +122,9 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     m_useContinuous = true;
     ANA_MSG_DEBUG(" Using continuous b-tagging"); }
 
-  // Only DL1, DL1r, DLr1mu and MV2c10 are calibrated
-  if (m_taggerName == "MV2c10") { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "DL1")    { taggerOK = true; m_getScaleFactors =  true; }
+  // No official calibrations in rel22 yet
   if (m_taggerName == "DL1r")   { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "DL1rmu") { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "DL1dv00")   { taggerOK = true; m_getScaleFactors =  true; }
 
   if( !opOK || !taggerOK ) {
     ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);
@@ -176,7 +174,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("TaggerName",          m_taggerName));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("OperatingPoint",      m_operatingPt));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("JetAuthor",           m_jetAuthor));
-  if(m_minPt!=-1) ANA_CHECK( m_BJetSelectTool_handle.setProperty("MinPt", m_minPt));
+  ANA_CHECK( m_BJetSelectTool_handle.setProperty("MinPt", m_minPt));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("ErrorOnTagWeightFailure", m_errorOnTagWeightFailure));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("OutputLevel", msg().level() ));
   ANA_CHECK( m_BJetSelectTool_handle.retrieve());
@@ -190,7 +188,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("SystematicsStrategy", m_systematicsStrategy));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("OperatingPoint",      m_operatingPtCDI     ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("JetAuthor",           m_jetAuthor          ));
-    if(m_minPt!=-1) ANA_CHECK( m_BJetEffSFTool_handle.setProperty("MinPt", m_minPt            ));
+    ANA_CHECK( m_BJetEffSFTool_handle.setProperty("MinPt", m_minPt            ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("ScaleFactorFileName", m_corrFileName       ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("UseDevelopmentFile",  m_useDevelopmentFile ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("ConeFlavourLabel",    m_coneFlavourLabel   ));

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -125,30 +125,6 @@ bool HelperFunctions::applyPrimaryVertexSelection( const xAOD::JetContainer* jet
   return true;
 }
 
-// compatible with starting with: 2015-PreRecomm-13TeV-MC12-CDI_August3-v1.root
-//https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingBenchmarks#MV2c20_tagger_AntiKt4EMTopoJets
-float HelperFunctions::GetBTagMV2c20_Cut( int efficiency ) {
-  if     ( efficiency == 85 ) { return -0.7887; }
-  else if( efficiency == 77 ) { return -0.4434; }
-  else if( efficiency == 70 ) { return -0.0436; }
-  else if( efficiency == 60 ) { return  0.4496; }
-  else { std::cout << "WARNING!! UNKNOWN BTAG EFFICIENCY POINT " << efficiency << std::endl; }
-  return -1; // no cut
-}
-
-std::string HelperFunctions::GetBTagMV2c20_CutStr( int efficiency ) {
-  float value = HelperFunctions::GetBTagMV2c20_Cut( efficiency );
-  std::string valueStr = std::to_string(value);
-  valueStr.replace(valueStr.find('.'),1,"_"); // replace period with underscore
-  // 7 characters long if start with a - and 6 otherwise
-  if( valueStr.find('-') != std::string::npos ) {
-    valueStr.resize(7,'0'); // cut to 7 or pad with 0s
-  } else {
-    valueStr.resize(6,'0'); // cut to 6 or pad with 0s
-  }
-  return valueStr;
-}
-
 std::string HelperFunctions::replaceString(std::string subject, const std::string& search, const std::string& replace)
 {
   size_t pos = 0;

--- a/Root/Jet.cxx
+++ b/Root/Jet.cxx
@@ -6,18 +6,6 @@ int Jet::is_btag(BTaggerOP op) const
 {
   switch(op)
     {
-    case Jet::BTaggerOP::DL1_FixedCutBEff_60:
-      return is_DL1_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_70:
-      return is_DL1_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_77:
-      return is_DL1_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_85:
-      return is_DL1_FixedCutBEff_85;
-      break;      
     case Jet::BTaggerOP::DL1r_FixedCutBEff_60:
       return is_DL1r_FixedCutBEff_60;
       break;
@@ -30,42 +18,24 @@ int Jet::is_btag(BTaggerOP op) const
     case Jet::BTaggerOP::DL1r_FixedCutBEff_85:
       return is_DL1r_FixedCutBEff_85;
       break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_60:
-      return is_DL1rmu_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_70:
-      return is_DL1rmu_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_77:
-      return is_DL1rmu_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_85:
-      return is_DL1rmu_FixedCutBEff_85;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_60:
-      return is_MV2c10_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_70:
-      return is_MV2c10_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_77:
-      return is_MV2c10_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_85:
-      return is_MV2c10_FixedCutBEff_85;
-      break;
-    case Jet::BTaggerOP::DL1_Continuous:
-      return is_DL1_Continuous;
-      break;
     case Jet::BTaggerOP::DL1r_Continuous:
       return is_DL1r_Continuous;
       break;
-    case Jet::BTaggerOP::DL1rmu_Continuous:
-      return is_DL1rmu_Continuous;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_60:
+      return is_DL1dv00_FixedCutBEff_60;
       break;
-    case Jet::BTaggerOP::MV2c10_Continuous:
-      return is_MV2c10_Continuous;
-      break;      
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_70:
+      return is_DL1dv00_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_77:
+      return is_DL1dv00_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_85:
+      return is_DL1dv00_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::DL1dv00_Continuous:
+      return is_DL1dv00_Continuous;
+      break;
     default:
       return 0;
       break;
@@ -76,18 +46,6 @@ const std::vector<float>& Jet::SF_btag(BTaggerOP op) const
 {
   switch(op)
     {
-    case Jet::BTaggerOP::DL1_FixedCutBEff_60:
-      return SF_DL1_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_70:
-      return SF_DL1_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_77:
-      return SF_DL1_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::DL1_FixedCutBEff_85:
-      return SF_DL1_FixedCutBEff_85;
-      break;      
     case Jet::BTaggerOP::DL1r_FixedCutBEff_60:
       return SF_DL1r_FixedCutBEff_60;
       break;
@@ -100,42 +58,24 @@ const std::vector<float>& Jet::SF_btag(BTaggerOP op) const
     case Jet::BTaggerOP::DL1r_FixedCutBEff_85:
       return SF_DL1r_FixedCutBEff_85;
       break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_60:
-      return SF_DL1rmu_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_70:
-      return SF_DL1rmu_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_77:
-      return SF_DL1rmu_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::DL1rmu_FixedCutBEff_85:
-      return SF_DL1rmu_FixedCutBEff_85;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_60:
-      return SF_MV2c10_FixedCutBEff_60;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_70:
-      return SF_MV2c10_FixedCutBEff_70;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_77:
-      return SF_MV2c10_FixedCutBEff_77;
-      break;
-    case Jet::BTaggerOP::MV2c10_FixedCutBEff_85:
-      return SF_MV2c10_FixedCutBEff_85;
-      break;
-    case Jet::BTaggerOP::DL1_Continuous:
-      return SF_DL1_Continuous;
-      break;
     case Jet::BTaggerOP::DL1r_Continuous:
       return SF_DL1r_Continuous;
       break;
-    case Jet::BTaggerOP::DL1rmu_Continuous:
-      return SF_DL1rmu_Continuous;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_60:
+      return SF_DL1dv00_FixedCutBEff_60;
       break;
-    case Jet::BTaggerOP::MV2c10_Continuous:
-      return SF_MV2c10_Continuous;
-      break;      
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_70:
+      return SF_DL1dv00_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_77:
+      return SF_DL1dv00_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::DL1dv00_FixedCutBEff_85:
+      return SF_DL1dv00_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::DL1dv00_Continuous:
+      return SF_DL1dv00_Continuous;
+      break;
     default:
       static const std::vector<float> dummySF = {1.};
       return dummySF;

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -226,35 +226,14 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
   // flavorTag
   if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
-    //m_MV1                               =new std::vector<float>();
-    m_MV2c00                            =new std::vector<float>();
-    m_MV2c10                            =new std::vector<float>();
-    m_MV2c10mu                          =new std::vector<float>();
-    m_MV2c10rnn                         =new std::vector<float>();
-    m_MV2rmu                            =new std::vector<float>();
-    m_MV2r                              =new std::vector<float>();
-    m_MV2c20                            =new std::vector<float>();
-    m_MV2c100                           =new std::vector<float>();
-    m_DL1                               =new std::vector<float>();
-    m_DL1_pu                            =new std::vector<float>();
-    m_DL1_pc                            =new std::vector<float>();
-    m_DL1_pb                            =new std::vector<float>();
-    m_DL1mu                             =new std::vector<float>();
-    m_DL1mu_pu                          =new std::vector<float>();
-    m_DL1mu_pc                          =new std::vector<float>();
-    m_DL1mu_pb                          =new std::vector<float>();
-    m_DL1rnn                            =new std::vector<float>();
-    m_DL1rnn_pu                         =new std::vector<float>();
-    m_DL1rnn_pc                         =new std::vector<float>();
-    m_DL1rnn_pb                         =new std::vector<float>();
-    m_DL1rmu                            =new std::vector<float>();
-    m_DL1rmu_pu                         =new std::vector<float>();
-    m_DL1rmu_pc                         =new std::vector<float>();
-    m_DL1rmu_pb                         =new std::vector<float>();
     m_DL1r                              =new std::vector<float>();
     m_DL1r_pu                           =new std::vector<float>();
     m_DL1r_pc                           =new std::vector<float>();
     m_DL1r_pb                           =new std::vector<float>();
+    m_DL1dv00                              =new std::vector<float>();
+    m_DL1dv00_pu                           =new std::vector<float>();
+    m_DL1dv00_pc                           =new std::vector<float>();
+    m_DL1dv00_pb                           =new std::vector<float>();
     m_HadronConeExclTruthLabelID        =new std::vector<int>();
     m_HadronConeExclExtendedTruthLabelID=new std::vector<int>();
 
@@ -666,35 +645,14 @@ JetContainer::~JetContainer()
   if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
     // flavorTag
 
-    //delete m_MV1;
-    delete m_MV2c00;
-    delete m_MV2c10;
-    delete m_MV2c10mu;
-    delete m_MV2c10rnn;
-    delete m_MV2rmu;
-    delete m_MV2r;
-    delete m_MV2c20;
-    delete m_MV2c100;
-    delete m_DL1;
-    delete m_DL1_pu;
-    delete m_DL1_pc;
-    delete m_DL1_pb;
-    delete m_DL1mu;
-    delete m_DL1mu_pu;
-    delete m_DL1mu_pc;
-    delete m_DL1mu_pb;
-    delete m_DL1rnn;
-    delete m_DL1rnn_pu;
-    delete m_DL1rnn_pc;
-    delete m_DL1rnn_pb;
-    delete m_DL1rmu;
-    delete m_DL1rmu_pu;
-    delete m_DL1rmu_pc;
-    delete m_DL1rmu_pb;
     delete m_DL1r;
     delete m_DL1r_pu;
     delete m_DL1r_pc;
     delete m_DL1r_pb;
+    delete m_DL1dv00;
+    delete m_DL1dv00_pu;
+    delete m_DL1dv00_pc;
+    delete m_DL1dv00_pb;
 
     delete m_HadronConeExclTruthLabelID;
     delete m_HadronConeExclExtendedTruthLabelID;
@@ -977,34 +935,14 @@ void JetContainer::setTree(TTree *tree)
 
   if(m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT)
     {
-      connectBranch<float>(tree,"MV2c00"                            ,&m_MV2c00);
-      connectBranch<float>(tree,"MV2c10"                            ,&m_MV2c10);
-      connectBranch<float>(tree,"MV2c10mu"                          ,&m_MV2c10mu);
-      connectBranch<float>(tree,"MV2c10rnn"                         ,&m_MV2c10rnn);
-      connectBranch<float>(tree,"MV2rmu"                            ,&m_MV2rmu);
-      connectBranch<float>(tree,"MV2r"                              ,&m_MV2r);
-      connectBranch<float>(tree,"MV2c20"                            ,&m_MV2c20);
-      connectBranch<float>(tree,"MV2c100"                           ,&m_MV2c100);
-      connectBranch<float>(tree,"DL1"                               ,&m_DL1      );
-      connectBranch<float>(tree,"DL1_pu"                            ,&m_DL1_pu   );
-      connectBranch<float>(tree,"DL1_pc"                            ,&m_DL1_pc   );
-      connectBranch<float>(tree,"DL1_pb"                            ,&m_DL1_pb   );
-      connectBranch<float>(tree,"DL1mu"                             ,&m_DL1mu    );
-      connectBranch<float>(tree,"DL1mu_pu"                          ,&m_DL1mu_pu );
-      connectBranch<float>(tree,"DL1mu_pc"                          ,&m_DL1mu_pc );
-      connectBranch<float>(tree,"DL1mu_pb"                          ,&m_DL1mu_pb );
-      connectBranch<float>(tree,"DL1rnn"                            ,&m_DL1rnn   );
-      connectBranch<float>(tree,"DL1rnn_pu"                         ,&m_DL1rnn_pu);
-      connectBranch<float>(tree,"DL1rnn_pc"                         ,&m_DL1rnn_pc);
-      connectBranch<float>(tree,"DL1rnn_pb"                         ,&m_DL1rnn_pb);
-      connectBranch<float>(tree,"DL1rmu"                            ,&m_DL1rmu   );
-      connectBranch<float>(tree,"DL1rmu_pu"                         ,&m_DL1rmu_pu);
-      connectBranch<float>(tree,"DL1rmu_pc"                         ,&m_DL1rmu_pc);
-      connectBranch<float>(tree,"DL1rmu_pb"                         ,&m_DL1rmu_pb);
       connectBranch<float>(tree,"DL1r"                              ,&m_DL1r     );
       connectBranch<float>(tree,"DL1r_pu"                           ,&m_DL1r_pu  );
       connectBranch<float>(tree,"DL1r_pc"                           ,&m_DL1r_pc  );
       connectBranch<float>(tree,"DL1r_pb"                           ,&m_DL1r_pb  );
+      connectBranch<float>(tree,"DL1dv00"                              ,&m_DL1dv00     );
+      connectBranch<float>(tree,"DL1dv00_pu"                           ,&m_DL1dv00_pu  );
+      connectBranch<float>(tree,"DL1dv00_pc"                           ,&m_DL1dv00_pc  );
+      connectBranch<float>(tree,"DL1dv00_pb"                           ,&m_DL1dv00_pb  );
       connectBranch<int>  (tree,"HadronConeExclTruthLabelID"        ,&m_HadronConeExclTruthLabelID);
       connectBranch<int>  (tree,"HadronConeExclExtendedTruthLabelID",&m_HadronConeExclExtendedTruthLabelID);
     }
@@ -1244,34 +1182,14 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
   if(m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT)
     {
       if(m_debug) std::cout << "updating flavorTag " << std::endl;
-      jet.MV2c00                    =m_MV2c00               ->at(idx);
-      jet.MV2c10                    =m_MV2c10               ->at(idx);
-      if(m_MV2c10mu)  jet.MV2c10mu  =m_MV2c10mu             ->at(idx);
-      if(m_MV2c10rnn) jet.MV2c10rnn =m_MV2c10rnn            ->at(idx);
-      if(m_MV2rmu)    jet.MV2rmu    =m_MV2rmu               ->at(idx);
-      if(m_MV2r)      jet.MV2r      =m_MV2r                 ->at(idx);
-      jet.MV2c20                    =m_MV2c20               ->at(idx);
-      jet.MV2c100                   =m_MV2c100              ->at(idx);
-      if(m_DL1)       jet.DL1       =m_DL1                  ->at(idx);
-      if(m_DL1_pu)    jet.DL1_pu    =m_DL1_pu               ->at(idx);
-      if(m_DL1_pc)    jet.DL1_pc    =m_DL1_pc               ->at(idx);
-      if(m_DL1_pb)    jet.DL1_pb    =m_DL1_pb               ->at(idx);
-      if(m_DL1mu)     jet.DL1mu     =m_DL1mu                ->at(idx);
-      if(m_DL1mu_pu)  jet.DL1mu_pu  =m_DL1mu_pu             ->at(idx);
-      if(m_DL1mu_pc)  jet.DL1mu_pc  =m_DL1mu_pc             ->at(idx);
-      if(m_DL1mu_pb)  jet.DL1mu_pb  =m_DL1mu_pb             ->at(idx);
-      if(m_DL1rnn)    jet.DL1rnn    =m_DL1rnn               ->at(idx);
-      if(m_DL1rnn_pu) jet.DL1rnn_pu =m_DL1rnn_pu            ->at(idx);
-      if(m_DL1rnn_pc) jet.DL1rnn_pc =m_DL1rnn_pc            ->at(idx);
-      if(m_DL1rnn_pb) jet.DL1rnn_pb =m_DL1rnn_pb            ->at(idx);
-      if(m_DL1rmu)    jet.DL1rmu    =m_DL1rmu               ->at(idx);
-      if(m_DL1rmu_pu) jet.DL1rmu_pu =m_DL1rmu_pu            ->at(idx);
-      if(m_DL1rmu_pc) jet.DL1rmu_pc =m_DL1rmu_pc            ->at(idx);
-      if(m_DL1rmu_pb) jet.DL1rmu_pb =m_DL1rmu_pb            ->at(idx);
       if(m_DL1r)      jet.DL1r      =m_DL1r                 ->at(idx);
       if(m_DL1r_pu)   jet.DL1r_pu   =m_DL1r_pu              ->at(idx);
       if(m_DL1r_pc)   jet.DL1r_pc   =m_DL1r_pc              ->at(idx);
       if(m_DL1r_pb)   jet.DL1r_pb   =m_DL1r_pb              ->at(idx);
+      if(m_DL1dv00)      jet.DL1dv00      =m_DL1dv00                 ->at(idx);
+      if(m_DL1dv00_pu)   jet.DL1dv00_pu   =m_DL1dv00_pu              ->at(idx);
+      if(m_DL1dv00_pc)   jet.DL1dv00_pc   =m_DL1dv00_pc              ->at(idx);
+      if(m_DL1dv00_pb)   jet.DL1dv00_pb   =m_DL1dv00_pb              ->at(idx);
       //std::cout << m_HadronConeExclTruthLabelID->size() << std::endl;
       if(m_HadronConeExclTruthLabelID)         jet.HadronConeExclTruthLabelID        =m_HadronConeExclTruthLabelID        ->at(idx);
       if(m_HadronConeExclExtendedTruthLabelID) jet.HadronConeExclExtendedTruthLabelID=m_HadronConeExclExtendedTruthLabelID->at(idx);
@@ -1384,22 +1302,6 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
     {
       switch(btag->m_op)
 	{
-	case Jet::BTaggerOP::DL1_FixedCutBEff_60:
-	  jet.is_DL1_FixedCutBEff_60=       btag->m_isTag->at(idx);
-	  jet.SF_DL1_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1_FixedCutBEff_70:
-	  jet.is_DL1_FixedCutBEff_70=       btag->m_isTag->at(idx);
-	  jet.SF_DL1_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1_FixedCutBEff_77:
-	  jet.is_DL1_FixedCutBEff_77=       btag->m_isTag->at(idx);
-	  jet.SF_DL1_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1_FixedCutBEff_85:
-	  jet.is_DL1_FixedCutBEff_85=       btag->m_isTag->at(idx);
-	  jet.SF_DL1_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
 	case Jet::BTaggerOP::DL1r_FixedCutBEff_60:
 	  jet.is_DL1r_FixedCutBEff_60=       btag->m_isTag->at(idx);
 	  jet.SF_DL1r_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
@@ -1416,53 +1318,29 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
 	  jet.is_DL1r_FixedCutBEff_85=       btag->m_isTag->at(idx);
 	  jet.SF_DL1r_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
-	case Jet::BTaggerOP::DL1rmu_FixedCutBEff_60:
-	  jet.is_DL1rmu_FixedCutBEff_60=       btag->m_isTag->at(idx);
-	  jet.SF_DL1rmu_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1rmu_FixedCutBEff_70:
-	  jet.is_DL1rmu_FixedCutBEff_70=       btag->m_isTag->at(idx);
-	  jet.SF_DL1rmu_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1rmu_FixedCutBEff_77:
-	  jet.is_DL1rmu_FixedCutBEff_77=       btag->m_isTag->at(idx);
-	  jet.SF_DL1rmu_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1rmu_FixedCutBEff_85:
-	  jet.is_DL1rmu_FixedCutBEff_85=       btag->m_isTag->at(idx);
-	  jet.SF_DL1rmu_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::MV2c10_FixedCutBEff_60:
-	  jet.is_MV2c10_FixedCutBEff_60=       btag->m_isTag->at(idx);
-	  jet.SF_MV2c10_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::MV2c10_FixedCutBEff_70:
-	  jet.is_MV2c10_FixedCutBEff_70=       btag->m_isTag->at(idx);
-	  jet.SF_MV2c10_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::MV2c10_FixedCutBEff_77:
-	  jet.is_MV2c10_FixedCutBEff_77=       btag->m_isTag->at(idx);
-	  jet.SF_MV2c10_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::MV2c10_FixedCutBEff_85:
-	  jet.is_MV2c10_FixedCutBEff_85=       btag->m_isTag->at(idx);
-	  jet.SF_MV2c10_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::MV2c10_Continuous:
-	  jet.is_MV2c10_Continuous=       btag->m_isTag->at(idx);
-	  jet.SF_MV2c10_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
-	case Jet::BTaggerOP::DL1_Continuous:
-	  jet.is_DL1_Continuous=       btag->m_isTag->at(idx);
-	  jet.SF_DL1_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
-	  break;
 	case Jet::BTaggerOP::DL1r_Continuous:
 	  jet.is_DL1r_Continuous=       btag->m_isTag->at(idx);
 	  jet.SF_DL1r_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
-	case Jet::BTaggerOP::DL1rmu_Continuous:
-	  jet.is_DL1rmu_Continuous=       btag->m_isTag->at(idx);
-	  jet.SF_DL1rmu_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	case Jet::BTaggerOP::DL1dv00_FixedCutBEff_60:
+	  jet.is_DL1dv00_FixedCutBEff_60=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv00_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv00_FixedCutBEff_70:
+	  jet.is_DL1dv00_FixedCutBEff_70=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv00_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv00_FixedCutBEff_77:
+	  jet.is_DL1dv00_FixedCutBEff_77=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv00_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv00_FixedCutBEff_85:
+	  jet.is_DL1dv00_FixedCutBEff_85=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv00_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv00_Continuous:
+	  jet.is_DL1dv00_Continuous=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv00_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
 	default:
 	  throw std::domain_error(
@@ -1716,34 +1594,14 @@ void JetContainer::setBranches(TTree *tree)
 
   if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
-    setBranch<float>(tree,"MV2c00",    m_MV2c00);
-    setBranch<float>(tree,"MV2c10",    m_MV2c10);
-    setBranch<float>(tree,"MV2c10mu",  m_MV2c10mu);
-    setBranch<float>(tree,"MV2c10rnn", m_MV2c10rnn);
-    setBranch<float>(tree,"MV2rmu",    m_MV2rmu);
-    setBranch<float>(tree,"MV2r",      m_MV2r);
-    setBranch<float>(tree,"MV2c20",    m_MV2c20);
-    setBranch<float>(tree,"MV2c100",   m_MV2c100);
-    setBranch<float>(tree,"DL1",       m_DL1);
-    setBranch<float>(tree,"DL1_pu",    m_DL1_pu);
-    setBranch<float>(tree,"DL1_pc",    m_DL1_pc);
-    setBranch<float>(tree,"DL1_pb",    m_DL1_pb);
-    setBranch<float>(tree,"DL1mu",     m_DL1mu);
-    setBranch<float>(tree,"DL1mu_pu",  m_DL1mu_pu);
-    setBranch<float>(tree,"DL1mu_pc",  m_DL1mu_pc);
-    setBranch<float>(tree,"DL1mu_pb",  m_DL1mu_pb);
-    setBranch<float>(tree,"DL1rnn",    m_DL1rnn);
-    setBranch<float>(tree,"DL1rnn_pu", m_DL1rnn_pu);
-    setBranch<float>(tree,"DL1rnn_pc", m_DL1rnn_pc);
-    setBranch<float>(tree,"DL1rnn_pb", m_DL1rnn_pb);
-    setBranch<float>(tree,"DL1rmu",     m_DL1rmu);
-    setBranch<float>(tree,"DL1rmu_pu",  m_DL1rmu_pu);
-    setBranch<float>(tree,"DL1rmu_pc",  m_DL1rmu_pc);
-    setBranch<float>(tree,"DL1rmu_pb",  m_DL1rmu_pb);
     setBranch<float>(tree,"DL1r",    m_DL1r);
     setBranch<float>(tree,"DL1r_pu", m_DL1r_pu);
     setBranch<float>(tree,"DL1r_pc", m_DL1r_pc);
     setBranch<float>(tree,"DL1r_pb", m_DL1r_pb);
+    setBranch<float>(tree,"DL1dv00",    m_DL1dv00);
+    setBranch<float>(tree,"DL1dv00_pu", m_DL1dv00_pu);
+    setBranch<float>(tree,"DL1dv00_pc", m_DL1dv00_pc);
+    setBranch<float>(tree,"DL1dv00_pb", m_DL1dv00_pb);
 
     setBranch<int  >(tree,"HadronConeExclTruthLabelID", m_HadronConeExclTruthLabelID);
     setBranch<int  >(tree,"HadronConeExclExtendedTruthLabelID", m_HadronConeExclExtendedTruthLabelID);
@@ -2135,34 +1993,14 @@ void JetContainer::clear()
   // flavor tag
   if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT  ) {
 
-    m_MV2c00                            ->clear();
-    m_MV2c10                            ->clear();
-    m_MV2c10mu                          ->clear();
-    m_MV2c10rnn                         ->clear();
-    m_MV2rmu                            ->clear();
-    m_MV2r                              ->clear();
-    m_MV2c20                            ->clear();
-    m_MV2c100                           ->clear();
-    m_DL1                               ->clear();
-    m_DL1_pu                            ->clear();
-    m_DL1_pc                            ->clear();
-    m_DL1_pb                            ->clear();
-    m_DL1mu                             ->clear();
-    m_DL1mu_pu                          ->clear();
-    m_DL1mu_pc                          ->clear();
-    m_DL1mu_pb                          ->clear();
-    m_DL1rnn                            ->clear();
-    m_DL1rnn_pu                         ->clear();
-    m_DL1rnn_pc                         ->clear();
-    m_DL1rnn_pb                         ->clear();
-    m_DL1rmu                            ->clear();
-    m_DL1rmu_pu                         ->clear();
-    m_DL1rmu_pc                         ->clear();
-    m_DL1rmu_pb                         ->clear();
     m_DL1r                              ->clear();
     m_DL1r_pu                           ->clear();
     m_DL1r_pc                           ->clear();
     m_DL1r_pb                           ->clear();
+    m_DL1dv00                              ->clear();
+    m_DL1dv00_pu                           ->clear();
+    m_DL1dv00_pc                           ->clear();
+    m_DL1dv00_pb                           ->clear();
     m_HadronConeExclTruthLabelID        ->clear();
     m_HadronConeExclExtendedTruthLabelID->clear();
 
@@ -2978,92 +2816,30 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       static SG::AuxElement::ConstAccessor<double> JetVertexCharge_discriminant("JetVertexCharge_discriminant");
       safeFill<double, double, xAOD::BTagging>(myBTag, JetVertexCharge_discriminant, m_JetVertexCharge_discriminant, -999);
     }
-
-    // MV2c taggers
-    float val;
-
-    val=-999;
-    myBTag->variable<float>("MV2c00"   , "discriminant", val);
-    m_MV2c00   ->push_back( val );
-
-    val=-999;
-    myBTag->variable<float>("MV2c10"   , "discriminant", val);
-    m_MV2c10   ->push_back( val );
-    val=-999;
-    myBTag->variable<float>("MV2c10mu" , "discriminant", val);
-    m_MV2c10mu ->push_back( val );
-
-    val=-999;
-    myBTag->variable<float>("MV2c10rnn", "discriminant", val);
-    m_MV2c10rnn->push_back( val );
-    val=-999;
-    myBTag->variable<float>("MV2c20"   , "discriminant", val);
-    m_MV2c20   ->push_back( val );
-
-    val=-999;
-    myBTag->variable<float>("MV2rmu" , "discriminant", val);
-    m_MV2rmu ->push_back( val );
-
-    val=-999;
-    myBTag->variable<float>("MV2r", "discriminant", val);
-    m_MV2r->push_back( val );
-
-    val=-999;
-    myBTag->variable<float>("MV2c100"  , "discriminant", val);
-    m_MV2c100  ->push_back( val );
-
-    // DL1 taggers
+    
     float pu, pb, pc, score;
-
-    pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1" , "pu", pu);
-    myBTag->variable<float>("DL1" , "pc", pc);
-    myBTag->variable<float>("DL1" , "pb", pb);
-    score=log( pb / (0.08*pc+0.92*pu) );
-    m_DL1_pu->push_back(pu);
-    m_DL1_pc->push_back(pc);
-    m_DL1_pb->push_back(pb);
-    m_DL1->push_back( score );
-
-    pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1mu" , "pu", pu);
-    myBTag->variable<float>("DL1mu" , "pc", pc);
-    myBTag->variable<float>("DL1mu" , "pb", pb);
-    score=log( pb / (0.08*pc+0.92*pu) );
-    m_DL1mu_pu->push_back(pu);
-    m_DL1mu_pc->push_back(pc);
-    m_DL1mu_pb->push_back(pb);
-    m_DL1mu->push_back( score );
-
-    pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1rnn" , "pu", pu);
-    myBTag->variable<float>("DL1rnn" , "pc", pc);
-    myBTag->variable<float>("DL1rnn" , "pb", pb);
-    score=log( pb / (0.03*pc+0.97*pu) );
-    m_DL1rnn_pu->push_back(pu);
-    m_DL1rnn_pc->push_back(pc);
-    m_DL1rnn_pb->push_back(pb);
-    m_DL1rnn->push_back( score );
-
-    pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1rmu" , "pu", pu);
-    myBTag->variable<float>("DL1rmu" , "pc", pc);
-    myBTag->variable<float>("DL1rmu" , "pb", pb);
-    score=log( pb / (0.08*pc+0.92*pu) );
-    m_DL1rmu_pu->push_back(pu);
-    m_DL1rmu_pc->push_back(pc);
-    m_DL1rmu_pb->push_back(pb);
-    m_DL1rmu->push_back( score );
 
     pu=0; pb=0; pc=0;
     myBTag->variable<float>("DL1r" , "pu", pu);
     myBTag->variable<float>("DL1r" , "pc", pc);
     myBTag->variable<float>("DL1r" , "pb", pb);
-    score=log( pb / (0.03*pc+0.97*pu) );
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.018*pc+0.982*pu) );
     m_DL1r_pu->push_back(pu);
     m_DL1r_pc->push_back(pc);
     m_DL1r_pb->push_back(pb);
     m_DL1r->push_back( score );
+    
+    pu=0; pb=0; pc=0;
+    myBTag->variable<float>("DL1dv00" , "pu", pu);
+    myBTag->variable<float>("DL1dv00" , "pc", pc);
+    myBTag->variable<float>("DL1dv00" , "pb", pb);
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.018*pc+0.982*pu) );
+    m_DL1dv00_pu->push_back(pu);
+    m_DL1dv00_pc->push_back(pc);
+    m_DL1dv00_pb->push_back(pb);
+    m_DL1dv00->push_back( score );
 
     // flavor groups truth definition
     static SG::AuxElement::ConstAccessor<int> hadConeExclTruthLabel("HadronConeExclTruthLabelID");

--- a/Root/JetHists.cxx
+++ b/Root/JetHists.cxx
@@ -210,36 +210,14 @@ StatusCode JetHists::initialize() {
   if( m_infoSwitch->m_flavorTag || m_infoSwitch->m_flavorTagHLT ) {
     if(m_debug) Info("JetHists::initialize()", "adding btagging plots");
 
-    m_MV2c00          = book(m_name, "MV2c00",            m_titlePrefix+"MV2c00" ,   100,    -1.1,   1.1);
-    m_MV2c10          = book(m_name, "MV2c10",            m_titlePrefix+"MV2c10" ,   100,    -1.1,   1.1);
-    m_MV2c10_l        = book(m_name, "MV2c10_l",          m_titlePrefix+"MV2c10" ,   500,    -1.1,   1.1);
-    m_MV2c20          = book(m_name, "MV2c20",            m_titlePrefix+"MV2c20" ,   100,    -1.1,   1.1);
     m_COMB            = book(m_name, "COMB",              m_titlePrefix+"COMB" ,     100,    -20,   40);
     m_JetFitter       = book(m_name, "JetFitter",         m_titlePrefix+"JetFitter" ,     100,    -10,   10);
-    //m_MV2           = book(m_name, "MV2",               m_titlePrefix+" jet MV2"          , 100,   -1  ,  1);
-    //m_IP3DvsMV2c20  = book(m_name, "IP3DvsMV2c20",      m_titlePrefix+" jet MV2c20"       , 100,   -1  ,  1,
 
     if(m_infoSwitch->m_vsActualMu){
-      m_frac_MV240_vs_actMu  = book(m_name, "frac_MV2c1040_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1040", 0, 1);
-      m_frac_MV250_vs_actMu  = book(m_name, "frac_MV2c1050_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1050", 0, 1);
-      m_frac_MV260_vs_actMu  = book(m_name, "frac_MV2c1060_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1060", 0, 1);
-      m_frac_MV270_vs_actMu  = book(m_name, "frac_MV2c1070_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1070", 0, 1);
-      m_frac_MV277_vs_actMu  = book(m_name, "frac_MV2c1077_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1077", 0, 1);
-      m_frac_MV285_vs_actMu  = book(m_name, "frac_MV2c1085_vs_actMu",  "actualMu",  50, 0, 100, "frac. pass MV2c1085", 0, 1);
-
       // counts (e.g. numbers of jets) vs. proton-proton Interactions
       m_actualMu = book(m_name, "actualMu", "number vs. actual #mu", 50, 0, 100);
-
     }
 
-    if(m_infoSwitch->m_vsLumiBlock){
-      m_frac_MV240_vs_lBlock  = book(m_name, "frac_MV2c1040_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1040", 0, 1);
-      m_frac_MV250_vs_lBlock  = book(m_name, "frac_MV2c1050_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1050", 0, 1);
-      m_frac_MV260_vs_lBlock  = book(m_name, "frac_MV2c1060_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1060", 0, 1);
-      m_frac_MV270_vs_lBlock  = book(m_name, "frac_MV2c1070_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1070", 0, 1);
-      m_frac_MV277_vs_lBlock  = book(m_name, "frac_MV2c1077_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1077", 0, 1);
-      m_frac_MV285_vs_lBlock  = book(m_name, "frac_MV2c1085_vs_lBlock",  "LumiBlock",  200, 0, 2000, "frac. pass MV2c1085", 0, 1);
-    }
   }
 
   if(m_infoSwitch->m_btag_jettrk) {
@@ -987,64 +965,6 @@ StatusCode JetHists::execute( const xAOD::IParticle* particle, float eventWeight
       btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
     }
 
-    double MV2c00 = -99;
-    double MV2c10 = -99;
-    double MV2c20 = -99;
-    btag_info->MVx_discriminant("MV2c00", MV2c00);
-    btag_info->MVx_discriminant("MV2c10", MV2c10);
-    btag_info->MVx_discriminant("MV2c20", MV2c20);
-    m_MV2c00   ->  Fill( MV2c00, eventWeight );
-    m_MV2c10   ->  Fill( MV2c10, eventWeight );
-    m_MV2c10_l ->  Fill( MV2c10, eventWeight );
-    m_MV2c20   ->  Fill( MV2c20, eventWeight );
-
-    if(m_infoSwitch->m_vsLumiBlock || m_infoSwitch->m_vsActualMu){
-
-
-      bool passMV2c1040 = (MV2c10 > 0.975);
-      bool passMV2c1050 = (MV2c10 > 0.95);
-      bool passMV2c1060 = (MV2c10 > 0.939);
-      bool passMV2c1070 = (MV2c10 > 0.831);
-      bool passMV2c1077 = (MV2c10 > 0.645);
-      bool passMV2c1085 = (MV2c10 > 0.11);
-
-
-      if(m_infoSwitch->m_flavorTagHLT){
-	passMV2c1040 = (MV2c10 >  0.978);
-	passMV2c1050 = (MV2c10 >  0.948);
-	passMV2c1060 = (MV2c10 >  0.847);
-	passMV2c1070 = (MV2c10 >  0.580);
-	passMV2c1077 = (MV2c10 >  0.162);
-	passMV2c1085 = (MV2c10 > -0.494);
-
-      }
-
-
-      if(m_infoSwitch->m_vsLumiBlock){
-	uint32_t lumiBlock = eventInfo->lumiBlock();
-
-	m_frac_MV240_vs_lBlock  -> Fill(lumiBlock, passMV2c1040,  eventWeight);
-	m_frac_MV250_vs_lBlock  -> Fill(lumiBlock, passMV2c1050,  eventWeight);
-	m_frac_MV260_vs_lBlock  -> Fill(lumiBlock, passMV2c1060,  eventWeight);
-	m_frac_MV270_vs_lBlock  -> Fill(lumiBlock, passMV2c1070,  eventWeight);
-	m_frac_MV277_vs_lBlock  -> Fill(lumiBlock, passMV2c1077,  eventWeight);
-	m_frac_MV285_vs_lBlock  -> Fill(lumiBlock, passMV2c1085,  eventWeight);
-      }
-
-
-      if(m_infoSwitch->m_vsActualMu){
-	float actualMu = eventInfo->actualInteractionsPerCrossing();
-
-	m_frac_MV240_vs_actMu  -> Fill(actualMu, passMV2c1040,  eventWeight);
-	m_frac_MV250_vs_actMu  -> Fill(actualMu, passMV2c1050,  eventWeight);
-	m_frac_MV260_vs_actMu  -> Fill(actualMu, passMV2c1060,  eventWeight);
-	m_frac_MV270_vs_actMu  -> Fill(actualMu, passMV2c1070,  eventWeight);
-	m_frac_MV277_vs_actMu  -> Fill(actualMu, passMV2c1077,  eventWeight);
-	m_frac_MV285_vs_actMu  -> Fill(actualMu, passMV2c1085,  eventWeight);
-      }
-
-    }
-
     static SG::AuxElement::ConstAccessor<double> SV0_significance3DAcc ("SV0_significance3D");
     if ( SV0_significance3DAcc.isAvailable(*btag_info) ) {
       m_COMB            ->  Fill( btag_info->SV1_loglikelihoodratio() + btag_info->IP3D_loglikelihoodratio() , eventWeight );
@@ -1735,64 +1655,10 @@ StatusCode JetHists::execute( const xAH::Particle* particle, float eventWeight, 
 //      h_SV1                       ->Fill(jet->SV1                  , eventWeight);
 //      h_IP3D                      ->Fill(jet->IP3D                 , eventWeight);
 
-      float MV2c10 = jet->MV2c10;
-
-      m_MV2c00                    ->Fill(jet->MV2c00               , eventWeight);
-      m_MV2c10                    ->Fill(jet->MV2c10               , eventWeight);
-      m_MV2c10_l                  ->Fill(jet->MV2c10               , eventWeight);
-      m_MV2c20                    ->Fill(jet->MV2c20               , eventWeight);
-
-      //      h_MV2                       ->Fill(jet->MV2                  , eventWeight);
-
-      if((m_infoSwitch->m_vsLumiBlock || m_infoSwitch->m_vsActualMu) && eventInfo){
-
-	bool passMV2c1040 = (MV2c10 > 0.975);
-	bool passMV2c1050 = (MV2c10 > 0.95);
-	bool passMV2c1060 = (MV2c10 > 0.939);
-	bool passMV2c1070 = (MV2c10 > 0.831);
-	bool passMV2c1077 = (MV2c10 > 0.645);
-	bool passMV2c1085 = (MV2c10 > 0.11);
-
-
-	if(m_infoSwitch->m_flavorTagHLT){
-	  passMV2c1040 = (MV2c10 >  0.978);
-	  passMV2c1050 = (MV2c10 >  0.948);
-	  passMV2c1060 = (MV2c10 >  0.847);
-	  passMV2c1070 = (MV2c10 >  0.580);
-	  passMV2c1077 = (MV2c10 >  0.162);
-	  passMV2c1085 = (MV2c10 > -0.494);
-	}
-
-	if(m_infoSwitch->m_vsLumiBlock){
-	  uint32_t lumiBlock = eventInfo->m_lumiBlock;
-
-	  m_frac_MV240_vs_lBlock  -> Fill(lumiBlock, passMV2c1040,  eventWeight);
-	  m_frac_MV250_vs_lBlock  -> Fill(lumiBlock, passMV2c1050,  eventWeight);
-	  m_frac_MV260_vs_lBlock  -> Fill(lumiBlock, passMV2c1060,  eventWeight);
-	  m_frac_MV270_vs_lBlock  -> Fill(lumiBlock, passMV2c1070,  eventWeight);
-	  m_frac_MV277_vs_lBlock  -> Fill(lumiBlock, passMV2c1077,  eventWeight);
-	  m_frac_MV285_vs_lBlock  -> Fill(lumiBlock, passMV2c1085,  eventWeight);
-	}
-
-	if(m_infoSwitch->m_vsActualMu){
-	  float actualMu = eventInfo->m_actualMu;
-
-	  m_frac_MV240_vs_actMu  -> Fill(actualMu, passMV2c1040,  eventWeight);
-	  m_frac_MV250_vs_actMu  -> Fill(actualMu, passMV2c1050,  eventWeight);
-	  m_frac_MV260_vs_actMu  -> Fill(actualMu, passMV2c1060,  eventWeight);
-	  m_frac_MV270_vs_actMu  -> Fill(actualMu, passMV2c1070,  eventWeight);
-	  m_frac_MV277_vs_actMu  -> Fill(actualMu, passMV2c1077,  eventWeight);
-	  m_frac_MV285_vs_actMu  -> Fill(actualMu, passMV2c1085,  eventWeight);
-	}
-
-      }
-
-
       m_COMB                      ->Fill(jet->SV1IP3D              , eventWeight);
       //m_JetFitter               ->Fill(jet->JetFitter            , eventWeight);
 
 //
-//      h_IP3DvsMV2c20->Fill(jet->MV2c20, jet->IP3D);
 
     }
 

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -1282,20 +1282,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   //
   if ( m_doHLTBTagCut ) {
     const xAOD::BTagging *btag_info = jet->auxdata< const xAOD::BTagging* >("HLTBTag");
-
     double tagValue = -99;
-    if(m_HLTBTagTaggerName=="MV2c00"){
-      btag_info->MVx_discriminant("MV2c00", tagValue);
-    }
-
-    if(m_HLTBTagTaggerName=="MV2c10"){
-      btag_info->MVx_discriminant("MV2c10", tagValue);
-    }
-
-    if(m_HLTBTagTaggerName=="MV2c20"){
-      btag_info->MVx_discriminant("MV2c20", tagValue);
-    }
-
     if(m_HLTBTagTaggerName=="COMB"){
       float wIP3D = btag_info->IP3D_loglikelihoodratio();
       float wSV1  = btag_info->SV1_loglikelihoodratio();

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -36,12 +36,11 @@ public:
   std::string m_outputSystName = "BJetEfficiency_Algo";
   bool        m_writeSystToMetadata = false;
 
-  std::string m_corrFileName = "xAODBTaggingEfficiency/13TeV/2016-20_7-13TeV-MC15-CDI-July12_v1.root";
-
-  std::string m_jetAuthor = "AntiKt4EMTopoJets";
+  std::string m_corrFileName = "xAODBTaggingEfficiency/13TeV/2021-22-13TeV-MC16-CDI-2021-12-02_v2.root";
+  std::string m_jetAuthor = "AntiKt4EMPFlowJets";
   /// @brief Minimum pT in MeV for taggable jets
-  float       m_minPt = -1;
-  std::string m_taggerName = "MV2c10";
+  float       m_minPt = 20e3;
+  std::string m_taggerName = "DL1r";
   bool        m_useDevelopmentFile = true;
   bool        m_coneFlavourLabel = true;
   std::string m_systematicsStrategy = "SFEigen";

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -479,10 +479,6 @@ namespace HelperClasses {
 
             ``jetBTag`` expects the format ``jetBTag_tagger_type_AABB..MM..YY.ZZ``. This will create a vector of working points (AA, BB, CC, ..., ZZ) associated with that tagger. Several entries can be given. For example::
 
-                m_configStr = "... jetBTag_MV2c10_FixedCutBEff_60707785 ..."
-
-            will define ``std::map<std::vector<std::pair<std::string,uint>>> m_jetBTag["MV2c10"] = {std::make_pair("FixedCutBEff",60), std::make_pair("FixedCutBEff",70) ,std::make_pair("FixedCutBEff",77), std::make_pair("FixedCutBEff",85)}``.
-
 	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames``
 	    to ``{"GhostAntiKt2TrackJet", "GhostVR30Rmax4Rmin02TrackJet"}``.
     @endrst

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -478,6 +478,8 @@ namespace HelperClasses {
                 m_configStr = "... sfJVTMedium ..."
 
             ``jetBTag`` expects the format ``jetBTag_tagger_type_AABB..MM..YY.ZZ``. This will create a vector of working points (AA, BB, CC, ..., ZZ) associated with that tagger. Several entries can be given. For example::
+           
+	        m_configStr = "... jetBTag_DL1r_FixedCutBEff_60707785 ..."
 
 	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames``
 	    to ``{"GhostAntiKt2TrackJet", "GhostVR30Rmax4Rmin02TrackJet"}``.

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -67,8 +67,6 @@ namespace HelperFunctions {
   int getPrimaryVertexLocation(const xAOD::VertexContainer* vertexContainer, MsgStream& msg);
   inline int getPrimaryVertexLocation(const xAOD::VertexContainer* vertexContainer){ return getPrimaryVertexLocation(vertexContainer, msg()); }
   bool applyPrimaryVertexSelection( const xAOD::JetContainer* jets, const xAOD::VertexContainer* vertices );
-  float GetBTagMV2c20_Cut( int efficiency );
-  std::string GetBTagMV2c20_CutStr( int efficiency );
   std::string replaceString(std::string subjet, const std::string& search, const std::string& replace);
   std::vector<TString> SplitString(TString& orig, const char separator);
   float dPhi(float phi1, float phi2);

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -12,11 +12,9 @@ namespace xAH {
     public:
       enum BTaggerOP {
 	None,
-	DL1_FixedCutBEff_60   , DL1_FixedCutBEff_70   , DL1_FixedCutBEff_77   , DL1_FixedCutBEff_85   ,
 	DL1r_FixedCutBEff_60  , DL1r_FixedCutBEff_70  , DL1r_FixedCutBEff_77  , DL1r_FixedCutBEff_85  ,
-        DL1rmu_FixedCutBEff_60, DL1rmu_FixedCutBEff_70, DL1rmu_FixedCutBEff_77, DL1rmu_FixedCutBEff_85,
-	MV2c10_FixedCutBEff_60, MV2c10_FixedCutBEff_70, MV2c10_FixedCutBEff_77, MV2c10_FixedCutBEff_85,
-	MV2c10_Continuous, DL1_Continuous, DL1r_Continuous, DL1rmu_Continuous // Continuous
+	DL1dv00_FixedCutBEff_60  , DL1dv00_FixedCutBEff_70  , DL1dv00_FixedCutBEff_77  , DL1dv00_FixedCutBEff_85  ,
+	DL1dv00_Continuous, DL1r_Continuous, // Continuous
       };
 
       float rapidity;
@@ -88,35 +86,14 @@ namespace xAH {
       float IP3D;
       float SV1IP3D;
       float COMBx;
-      float MV1;
-      float MV2c00;
-      float MV2c10;
-      float MV2c10mu;
-      float MV2c10rnn;
-      float MV2rmu;
-      float MV2r;
-      float MV2c20;
-      float MV2c100;
-      float DL1;
-      float DL1_pu;
-      float DL1_pc;
-      float DL1_pb;
-      float DL1mu;
-      float DL1mu_pu;
-      float DL1mu_pc;
-      float DL1mu_pb;
-      float DL1rnn;
-      float DL1rnn_pu;
-      float DL1rnn_pc;
-      float DL1rnn_pb;
-      float DL1rmu;
-      float DL1rmu_pu;
-      float DL1rmu_pc;
-      float DL1rmu_pb;
       float DL1r;
       float DL1r_pu;
       float DL1r_pc;
       float DL1r_pb;
+      float DL1dv00;
+      float DL1dv00_pu;
+      float DL1dv00_pc;
+      float DL1dv00_pb;
       int  HadronConeExclTruthLabelID;
       int  HadronConeExclExtendedTruthLabelID;
 
@@ -204,14 +181,6 @@ namespace xAH {
       std::vector<float> IP3D_weightUofTracks    ;
 
       // jetBTag
-      int is_DL1_FixedCutBEff_60;
-      std::vector<float> SF_DL1_FixedCutBEff_60;
-      int is_DL1_FixedCutBEff_70;
-      std::vector<float> SF_DL1_FixedCutBEff_70;
-      int is_DL1_FixedCutBEff_77;
-      std::vector<float> SF_DL1_FixedCutBEff_77;
-      int is_DL1_FixedCutBEff_85;
-      std::vector<float> SF_DL1_FixedCutBEff_85;
       
       int is_DL1r_FixedCutBEff_60;
       std::vector<float> SF_DL1r_FixedCutBEff_60;
@@ -221,38 +190,22 @@ namespace xAH {
       std::vector<float> SF_DL1r_FixedCutBEff_77;
       int is_DL1r_FixedCutBEff_85;
       std::vector<float> SF_DL1r_FixedCutBEff_85;
-
-      int is_DL1rmu_FixedCutBEff_60;
-      std::vector<float> SF_DL1rmu_FixedCutBEff_60;
-      int is_DL1rmu_FixedCutBEff_70;
-      std::vector<float> SF_DL1rmu_FixedCutBEff_70;
-      int is_DL1rmu_FixedCutBEff_77;
-      std::vector<float> SF_DL1rmu_FixedCutBEff_77;
-      int is_DL1rmu_FixedCutBEff_85;
-      std::vector<float> SF_DL1rmu_FixedCutBEff_85;
-
-      int is_MV2c10_FixedCutBEff_60;
-      std::vector<float> SF_MV2c10_FixedCutBEff_60;
-      int is_MV2c10_FixedCutBEff_70;
-      std::vector<float> SF_MV2c10_FixedCutBEff_70;
-      int is_MV2c10_FixedCutBEff_77;
-      std::vector<float> SF_MV2c10_FixedCutBEff_77;
-      int is_MV2c10_FixedCutBEff_85;
-      std::vector<float> SF_MV2c10_FixedCutBEff_85;
+      int is_DL1dv00_FixedCutBEff_60;
+      std::vector<float> SF_DL1dv00_FixedCutBEff_60;
+      int is_DL1dv00_FixedCutBEff_70;
+      std::vector<float> SF_DL1dv00_FixedCutBEff_70;
+      int is_DL1dv00_FixedCutBEff_77;
+      std::vector<float> SF_DL1dv00_FixedCutBEff_77;
+      int is_DL1dv00_FixedCutBEff_85;
+      std::vector<float> SF_DL1dv00_FixedCutBEff_85;
 
       // Continuous
-      int is_MV2c10_Continuous;
-      std::vector<float> SF_MV2c10_Continuous;
-      std::vector<float> inEffSF_MV2c10_Continuous;
-      int is_DL1_Continuous;
-      std::vector<float> SF_DL1_Continuous;
-      std::vector<float> inEffSF_DL1_Continuous;
       int is_DL1r_Continuous;
       std::vector<float> SF_DL1r_Continuous;
       std::vector<float> inEffSF_DL1r_Continuous;
-      int is_DL1rmu_Continuous;
-      std::vector<float> SF_DL1rmu_Continuous;
-      std::vector<float> inEffSF_DL1rmu_Continuous;
+      int is_DL1dv00_Continuous;
+      std::vector<float> SF_DL1dv00_Continuous;
+      std::vector<float> inEffSF_DL1dv00_Continuous;
 
 
       // truth

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -187,40 +187,17 @@ namespace xAH {
 
 
       // flavTag
-      std::vector<float> *m_MV2c00;
-      std::vector<float> *m_MV2c10;
-      std::vector<float> *m_MV2c10mu;
-      std::vector<float> *m_MV2c10rnn;
-      std::vector<float> *m_MV2rmu;
-      std::vector<float> *m_MV2r;
-      std::vector<float> *m_MV2c20;
-      std::vector<float> *m_MV2c100;
-      std::vector<float> *m_DL1;
-      std::vector<float> *m_DL1_pu;
-      std::vector<float> *m_DL1_pc;
-      std::vector<float> *m_DL1_pb;
-
-      std::vector<float> *m_DL1mu;
-      std::vector<float> *m_DL1mu_pu;
-      std::vector<float> *m_DL1mu_pc;
-      std::vector<float> *m_DL1mu_pb;
-
-      std::vector<float> *m_DL1rnn;
-      std::vector<float> *m_DL1rnn_pu;
-      std::vector<float> *m_DL1rnn_pc;
-      std::vector<float> *m_DL1rnn_pb;
       std::vector<int>   *m_HadronConeExclTruthLabelID;
       std::vector<int>   *m_HadronConeExclExtendedTruthLabelID;
-
-      std::vector<float> *m_DL1rmu;
-      std::vector<float> *m_DL1rmu_pu;
-      std::vector<float> *m_DL1rmu_pc;
-      std::vector<float> *m_DL1rmu_pb;
 
       std::vector<float> *m_DL1r;
       std::vector<float> *m_DL1r_pu;
       std::vector<float> *m_DL1r_pc;
       std::vector<float> *m_DL1r_pb;
+      std::vector<float> *m_DL1dv00;
+      std::vector<float> *m_DL1dv00_pu;
+      std::vector<float> *m_DL1dv00_pc;
+      std::vector<float> *m_DL1dv00_pb;
  
       // Jet Fitter
       std::vector<float>  *m_JetFitter_nVTX           ;
@@ -337,14 +314,6 @@ namespace xAH {
           if(m_isContinuous)
             m_ineffSf = new std::vector< std::vector<float> >();
 
-	  if(m_accessorName=="DL1_FixedCutBEff_60")
-	    m_op=Jet::BTaggerOP::DL1_FixedCutBEff_60;
-	  else if(m_accessorName=="DL1_FixedCutBEff_70")
-	    m_op=Jet::BTaggerOP::DL1_FixedCutBEff_70;
-	  else if(m_accessorName=="DL1_FixedCutBEff_77")
-	    m_op=Jet::BTaggerOP::DL1_FixedCutBEff_77;
-	  else if(m_accessorName=="DL1_FixedCutBEff_85")
-	    m_op=Jet::BTaggerOP::DL1_FixedCutBEff_85;     
 	  else if(m_accessorName=="DL1r_FixedCutBEff_60")
 	    m_op=Jet::BTaggerOP::DL1r_FixedCutBEff_60;
 	  else if(m_accessorName=="DL1r_FixedCutBEff_70")
@@ -353,30 +322,15 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::DL1r_FixedCutBEff_77;
 	  else if(m_accessorName=="DL1r_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::DL1r_FixedCutBEff_85;
-	  else if(m_accessorName=="DL1rmu_FixedCutBEff_60")
-	    m_op=Jet::BTaggerOP::DL1rmu_FixedCutBEff_60;
-	  else if(m_accessorName=="DL1rmu_FixedCutBEff_70")
-	    m_op=Jet::BTaggerOP::DL1rmu_FixedCutBEff_70;
-	  else if(m_accessorName=="DL1rmu_FixedCutBEff_77")
-	    m_op=Jet::BTaggerOP::DL1rmu_FixedCutBEff_77;
-	  else if(m_accessorName=="DL1rmu_FixedCutBEff_85")
-	    m_op=Jet::BTaggerOP::DL1rmu_FixedCutBEff_85;
-	  else if(m_accessorName=="MV2c10_FixedCutBEff_60")
-	    m_op=Jet::BTaggerOP::MV2c10_FixedCutBEff_60;
-	  else if(m_accessorName=="MV2c10_FixedCutBEff_70")
-	    m_op=Jet::BTaggerOP::MV2c10_FixedCutBEff_70;
-	  else if(m_accessorName=="MV2c10_FixedCutBEff_77")
-	    m_op=Jet::BTaggerOP::MV2c10_FixedCutBEff_77;
-	  else if(m_accessorName=="MV2c10_FixedCutBEff_85")
-	    m_op=Jet::BTaggerOP::MV2c10_FixedCutBEff_85;
-	  else if(m_accessorName=="DL1_Continuous")
-	    m_op=Jet::BTaggerOP::DL1_Continuous;
-          else if(m_accessorName=="DL1r_Continuous")
-	    m_op=Jet::BTaggerOP::DL1r_Continuous;
-          else if(m_accessorName=="DL1rmu_Continuous")
-	    m_op=Jet::BTaggerOP::DL1rmu_Continuous;
-	  else if(m_accessorName=="MV2c10_Continuous")
-	    m_op=Jet::BTaggerOP::MV2c10_Continuous;
+	  
+          else if(m_accessorName=="DL1dv00_FixedCutBEff_60")
+	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_60;
+	  else if(m_accessorName=="DL1dv00_FixedCutBEff_70")
+	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_70;
+	  else if(m_accessorName=="DL1dv00_FixedCutBEff_77")
+	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_77;
+	  else if(m_accessorName=="DL1dv00_FixedCutBEff_85")
+	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_85;
         }
 
         ~btagOpPoint()

--- a/xAODAnaHelpers/JetHists.h
+++ b/xAODAnaHelpers/JetHists.h
@@ -152,18 +152,9 @@ class JetHists : public IParticleHists
     TH1F* m_JVC; //!
 
     // Flavor Tag
-    TH1F* m_MV1   ; //!
-    TH1F* m_MV2c00   ; //!
-    TH1F* m_MV2c10   ; //!
-    TH1F* m_MV2c10_l ; //!
-    TH1F* m_MV2c20   ; //!
     TH1F* m_COMB   ; //!
     TH1F* m_SV0             ; //!
     TH1F* m_JetFitter       ; //!
-    //TH1F* m_MV2;
-    //TH2F* m_IP3DvsMV2c20;
-
-
 
     TProfile* m_vtxClass_vs_lBlock; //!
     TProfile* m_vtxEff10_vs_lBlock; //!
@@ -172,20 +163,6 @@ class JetHists : public IParticleHists
     TProfile* m_vtxEff1_raw_vs_lBlock; //!
     TProfile* m_vtxEff10_noDummy_vs_lBlock; //!
     TProfile* m_vtxEff1_noDummy_vs_lBlock; //!
-    TProfile* m_frac_MV240_vs_actMu; //!
-    TProfile* m_frac_MV250_vs_actMu; //!
-    TProfile* m_frac_MV260_vs_actMu; //!
-    TProfile* m_frac_MV270_vs_actMu; //!
-    TProfile* m_frac_MV277_vs_actMu; //!
-    TProfile* m_frac_MV285_vs_actMu; //!
-    TProfile* m_frac_MV240_vs_lBlock; //!
-    TProfile* m_frac_MV250_vs_lBlock; //!
-    TProfile* m_frac_MV260_vs_lBlock; //!
-    TProfile* m_frac_MV270_vs_lBlock; //!
-    TProfile* m_frac_MV277_vs_lBlock; //!
-    TProfile* m_frac_MV285_vs_lBlock; //!
-
-
 
     TH1F* m_trkSum_ntrk     ; //!
     TH1F* m_trkSum_sPt      ; //!

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -222,8 +222,8 @@ public:
   /// @brief Flag to apply btagging cut, if false just decorate decisions
   bool  m_doBTagCut = false;
   std::string m_corrFileName = "xAODBTaggingEfficiency/cutprofiles_22072015.root";
-  std::string m_jetAuthor = "AntiKt4EMTopoJets";
-  std::string m_taggerName = "MV2c20";
+  std::string m_jetAuthor = "AntiKt4EMPFlowJets";
+  std::string m_taggerName = "DL1r";
   std::string m_operatingPt = "FixedCutBEff_70";
   // for BTaggingSelectionTool -- doubles are needed or will crash
   // for the b-tagging tool - these are the b-tagging groups minimums
@@ -234,7 +234,7 @@ public:
 
   // HLT Btag quality
   bool m_doHLTBTagCut = false;
-  std::string m_HLTBTagTaggerName = "MV2c20";
+  std::string m_HLTBTagTaggerName = "DL1r";
   float m_HLTBTagCutValue = -0.4434;
   bool  m_requireHLTVtx = false;
   bool  m_requireNoHLTVtx = false;


### PR DESCRIPTION
Hello,

I tried to clean up the outdated b-taggers for the rel22 version: all MV2 tagger and DL1, DL1rnn, DL1rmu are removed

Also, the f_c values are updated to the latest value 0.018. In the future we may just want to retrieve this value from the CDI directly. I will follow this up.

New DL1dv00 tagger is added, which is the baseline rel22 btagger. This would allow the users to test it.

I am not sure whether in rell22, there will still be users considering btagging at the HLT though. If so, we may want to bring those MV2 taggers at the HLT back. They are currently removed as well.

I tested it on one rel22 PHYS sample for both DL1r and DL1dv00 taggers and everything ran fine with reasonable outputs.

Suggestions are welcome!

Thanks for your time!

Bing