### PR TITLE
adding do2StationsHighPt property for MuonCalibrator

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -132,6 +132,10 @@ EL::StatusCode MuonCalibrator :: initialize ()
   } else if(m_calibrationMode == "notCorrectData_IDMS"){
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibrationMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
   }
+  // special corrections for muons with only 2 stations; to be switched on only for the muon highPt WP
+  if (m_do2StationsHighPt){
+    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("do2StationsHighPt", m_do2StationsHighPt));
+  }  
   ANA_CHECK(m_muonCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_muonCalibrationTool_handle);
 

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -22,6 +22,9 @@ public:
   /// @brief Set calibrationMode property if different than noOption
   std::string m_calibrationMode = "noOption";
 
+  //// @brief Set Perform special resolution corrections for two-station muons passing the HighPt selection criteria, switch on only when using the HighPt WP
+  bool m_do2StationsHighPt = false;
+
   // sort after calibration
   bool m_sort = true;
 


### PR DESCRIPTION
This PR adds an additional property to the MuonCalibrator algorithm to switch on the do2StationsHighPt flag which is recommended by MCP for the muon HighPt WP (see [here](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesMC16#Momentum_corrections_Precision_R)).