### PR TITLE
Adding first implementation of access to Phase1 L1Calo jet containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 22.2.59
+          - 22.2.74
 
     steps:
     - uses: actions/checkout@master

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -627,13 +627,13 @@ void HelpTreeBase::AddL1Jets( const std::string& jetName)
 
 }
 
-void HelpTreeBase::FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName, bool sortL1Jets ) {
+void HelpTreeBase::FillLegacyL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName, bool sortL1Jets ) {
 
   this->ClearL1Jets(jetName);
 
   xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
   
-  thisL1Jet->FillL1Jets(jets,sortL1Jets);
+  thisL1Jet->FillLegacyL1Jets(jets,sortL1Jets);
 
 }
 

--- a/Root/L1JetContainer.cxx
+++ b/Root/L1JetContainer.cxx
@@ -6,7 +6,7 @@ using namespace xAH;
 L1JetContainer::L1JetContainer(const std::string& name, float units, bool mc)
   : ParticleContainer(name,"",units,mc)
 {
-  m_l1Jet_et8x8             =new std::vector<float>();
+  m_l1Jet_et                =new std::vector<float>();
   m_l1Jet_eta               =new std::vector<float>();
   m_l1Jet_phi               =new std::vector<float>();
 }
@@ -14,7 +14,7 @@ L1JetContainer::L1JetContainer(const std::string& name, float units, bool mc)
 L1JetContainer::~L1JetContainer()
 {
   if(m_debug) std::cout << " Deleting L1JetContainer "  << std::endl;
-  delete m_l1Jet_et8x8;
+  delete m_l1Jet_et;
   delete m_l1Jet_eta;
   delete m_l1Jet_phi;
 }
@@ -22,7 +22,7 @@ L1JetContainer::~L1JetContainer()
 void L1JetContainer::setTree(TTree *tree)
 {
   ParticleContainer::setTree(tree);
-  connectBranch<float>(tree,"et8x8",&m_l1Jet_et8x8);
+  connectBranch<float>(tree,"et",&m_l1Jet_et);
   connectBranch<float>(tree,"eta",  &m_l1Jet_eta);
   connectBranch<float>(tree,"phi",  &m_l1Jet_phi);
 }
@@ -35,7 +35,7 @@ void L1JetContainer::updateParticle(uint idx, Jet& jet)
 void L1JetContainer::setBranches(TTree *tree)
 {
   ParticleContainer::setBranches(tree);
-  setBranch<float>(tree,"et8x8",m_l1Jet_et8x8);
+  setBranch<float>(tree,"et",m_l1Jet_et); // et8x8 for the case of Legacy L1 jet RoIs
   setBranch<float>(tree,"eta",  m_l1Jet_eta);
   setBranch<float>(tree,"phi",  m_l1Jet_phi);
   return;
@@ -44,16 +44,16 @@ void L1JetContainer::setBranches(TTree *tree)
 void L1JetContainer::clear()
 {
   ParticleContainer::clear();
-  m_l1Jet_et8x8->clear();
+  m_l1Jet_et->clear();
   m_l1Jet_eta  ->clear();
   m_l1Jet_phi  ->clear();
   return;
 }
 
-void L1JetContainer::FillL1Jets( const xAOD::JetRoIContainer* jets, bool sort){
+void L1JetContainer::FillLegacyL1Jets( const xAOD::JetRoIContainer* jets, bool sort){
   if(!sort) {
     for( auto jet_itr : *jets ) {
-      m_l1Jet_et8x8->push_back ( jet_itr->et8x8() / m_units );
+      m_l1Jet_et->push_back ( jet_itr->et8x8() / m_units );
       m_l1Jet_eta->push_back( jet_itr->eta() );
       m_l1Jet_phi->push_back( jet_itr->phi() );
     }
@@ -70,7 +70,7 @@ void L1JetContainer::FillL1Jets( const xAOD::JetRoIContainer* jets, bool sort){
     
     std::sort(vec.begin(), vec.end(), [&](const std::vector<float> a, const std::vector<float> b) { return a.at(0) < b.at(0);});
     for (int i = int(vec.size())-1; i >= 0; i--) {
-      m_l1Jet_et8x8->push_back((vec.at(i)).at(0) / m_units);
+      m_l1Jet_et->push_back((vec.at(i)).at(0) / m_units);
       m_l1Jet_eta->push_back((vec.at(i)).at(1));
       m_l1Jet_phi->push_back((vec.at(i)).at(2));
     }

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -473,13 +473,43 @@ EL::StatusCode TreeAlgo :: execute ()
     if ( !m_l1JetContainerName.empty() ){
       bool reject = false;
       for ( unsigned int ll = 0; ll < m_l1JetContainers.size(); ++ll ) {
-        const xAOD::JetRoIContainer* inL1Jets(nullptr);
-        if ( !HelperFunctions::isAvailable<xAOD::JetRoIContainer>(m_l1JetContainers.at(ll), m_event, m_store, msg()) ){
-          ANA_MSG_DEBUG( "The L1 jet container " + m_l1JetContainers.at(ll) + " is not available. Skipping all remaining L1 jet collections");
-          reject = true;
-	}
-        ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainers.at(ll), m_event, m_store, msg()) );
-        helpTree->FillL1Jets( inL1Jets, m_l1JetBranches.at(ll), m_sortL1Jets );
+        if(m_l1JetContainers.at(ll).find("Fex")== std::string::npos){ // Legacy L1 jets
+          const xAOD::JetRoIContainer* inL1Jets(nullptr); 
+          if ( !HelperFunctions::isAvailable<xAOD::JetRoIContainer>(m_l1JetContainers.at(ll), m_event, m_store, msg()) ){
+            ANA_MSG_DEBUG( "The L1 jet container " + m_l1JetContainers.at(ll) + " is not available. Skipping all remaining L1 jet collections");
+            reject = true;
+          }
+          ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainers.at(ll), m_event, m_store, msg()) );
+          helpTree->FillLegacyL1Jets( inL1Jets, m_l1JetBranches.at(ll), m_sortL1Jets );
+        }else{ // Phase 1 L1 jets
+          if(m_l1JetContainers.at(ll).find("jFexSR")!= std::string::npos){ // jFEX small-R
+            const xAOD::jFexSRJetRoIContainer* inL1Jets(nullptr);
+            if ( !HelperFunctions::isAvailable<xAOD::jFexSRJetRoIContainer>(m_l1JetContainers.at(ll), m_event, m_store, msg()) ){
+              ANA_MSG_DEBUG( "The L1 jet container " + m_l1JetContainers.at(ll) + " is not available. Skipping all remaining L1 jet collections");
+              reject = true;
+            }
+            ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainers.at(ll), m_event, m_store, msg()) );
+            helpTree->FillPhase1L1Jets( inL1Jets, m_l1JetBranches.at(ll), m_sortL1Jets );
+          }else if(m_l1JetContainers.at(ll).find("jFexLR")!= std::string::npos){ // jFEX large-R
+            const xAOD::jFexLRJetRoIContainer* inL1Jets(nullptr);
+            if ( !HelperFunctions::isAvailable<xAOD::jFexLRJetRoIContainer>(m_l1JetContainers.at(ll), m_event, m_store, msg()) ){
+              ANA_MSG_DEBUG( "The L1 jet container " + m_l1JetContainers.at(ll) + " is not available. Skipping all remaining L1 jet collections");
+              reject = true;
+            }
+            ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainers.at(ll), m_event, m_store, msg()) );
+            helpTree->FillPhase1L1Jets( inL1Jets, m_l1JetBranches.at(ll), m_sortL1Jets );            
+          }else if(m_l1JetContainers.at(ll).find("gFex")!= std::string::npos){ // gFEX small-R/large-R jets
+            const xAOD::gFexJetRoIContainer* inL1Jets(nullptr);
+            if ( !HelperFunctions::isAvailable<xAOD::gFexJetRoIContainer>(m_l1JetContainers.at(ll), m_event, m_store, msg()) ){
+              ANA_MSG_DEBUG( "The L1 jet container " + m_l1JetContainers.at(ll) + " is not available. Skipping all remaining L1 jet collections");
+              reject = true;
+            }
+            ANA_CHECK( HelperFunctions::retrieve(inL1Jets, m_l1JetContainers.at(ll), m_event, m_store, msg()) );
+            helpTree->FillPhase1L1Jets( inL1Jets, m_l1JetBranches.at(ll), m_sortL1Jets ); 
+          }else{
+            ANA_MSG_DEBUG( "Phase 1 L1 jet container " + m_l1JetContainers.at(ll) + " is not known." );
+          }
+        } 
       }
 
       if ( reject ) {

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -143,7 +143,17 @@ public:
 
   void FillJets( const xAOD::JetContainer* jets, int pvLocation = -1, const std::string& jetName = "jet" );
   void FillJet( const xAOD::Jet* jet_itr, const xAOD::Vertex* pv, int pvLocation, const std::string& jetName = "jet" );
-  void FillL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName = "L1Jet", bool sortL1Jets = false );
+  void FillLegacyL1Jets( const xAOD::JetRoIContainer* jets, const std::string& jetName = "L1Jet", bool sortL1Jets = false );
+
+  template <typename T>
+  void FillPhase1L1Jets(T*& jets, const std::string& jetName = "L1Jet", bool sortL1Jets = false){
+    
+    this->ClearL1Jets(jetName);
+
+    xAH::L1JetContainer* thisL1Jet = m_l1Jets[jetName];
+  
+    thisL1Jet->FillPhase1L1Jets(jets,sortL1Jets);
+  }
 
   void FillTruth( const xAOD::TruthParticleContainer* truth, const std::string& truthName = "xAH_truth" );
   void FillTruth( const xAOD::TruthParticle* truthPart, const std::string& truthName );


### PR DESCRIPTION
Adding first implementation of access to Phase1 L1Calo jet containers. Separated functions for Legacy and Phase1 L1Calo containers, since the name of the ET variable is different.

Templated the function for Phase1 L1Calo jets, since the access to et, eta and phi is done the same way.

Harmonised the "ET" variable name at the output, mentioning that the variable names are different in the base EDMs.

Any further suggestions to clean up the code are welcome.

Tagging @jbossios.