### PR TITLE
add option to copy b-tagging links to JetCalibrator

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -409,6 +409,12 @@ EL::StatusCode JetCalibrator :: execute ()
   // ConstDataVector<xAOD::JetContainer>* calibJetsCDV = new ConstDataVector<xAOD::JetContainer>(SG::VIEW_ELEMENTS);
   // calibJetsCDV->reserve( calibJetsSC.first->size() );
 
+  // bend b-tagging links
+  if (m_bendBTaggingLinks){
+    ANA_MSG_DEBUG("Copying b-tagging links from " << m_btaggingContainerName << " to " << m_outContainerName);
+    ANA_CHECK( bendBTaggingLinks(calibJetsSC.first) );
+  }
+
   if ( m_addGhostMuonsToJets ) {
     ANA_MSG_VERBOSE("Run muon-to-jet ghost association");
     const xAOD::MuonContainer* muons(nullptr);
@@ -688,5 +694,24 @@ EL::StatusCode JetCalibrator::initializeUncertaintiesTool(asg::AnaToolHandle<ICP
   ANA_CHECK( uncToolHandle.retrieve());
   ANA_MSG_DEBUG("Retrieved JetUncertaintiesTool: " << uncToolHandle);
 
+  return EL::StatusCode::SUCCESS;
+}
+
+EL::StatusCode JetCalibrator::bendBTaggingLinks(xAOD::JetContainer* to_container){
+  // shamelessly copied from SUSYTools: https://gitlab.cern.ch/atlas/athena/-/blob/21.2/PhysicsAnalysis/SUSYPhys/SUSYTools/Root/Jets.cxx#L1077
+  const xAOD::JetContainer* b_tag_jets = nullptr;
+  HelperFunctions::retrieve(b_tag_jets, m_btaggingContainerName, m_event, m_store, msg());
+  if (b_tag_jets->size() != to_container->size()) {
+    ATH_MSG_FATAL("Size of the original jet container and of the btag container do not match");
+    return EL::StatusCode::FAILURE;
+  }
+  xAOD::JetContainer::const_iterator btag_begin = b_tag_jets->begin();
+  xAOD::JetContainer::const_iterator btag_end   = b_tag_jets->end();
+
+  xAOD::JetContainer::iterator to_begin = to_container->begin();
+  xAOD::JetContainer::iterator to_end   = to_container->end();
+  for (  ; to_begin != to_end && btag_begin != btag_end ; ++to_begin, ++btag_begin) {
+    (*to_begin)->setBTaggingLink((*btag_begin)->btaggingLink());
+  }
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -126,6 +126,12 @@ EL::StatusCode JetCalibrator :: initialize ()
     return EL::StatusCode::FAILURE;
   }
 
+  // Check if a source container of the b-tagging links was specified
+  if (m_bendBTaggingLinks && m_btaggingContainerName.empty()){
+    ANA_MSG_ERROR( "Please specify a source container to copy the b-tagging links from such as AntiKt4EMPFlowJets_BTagging201903 via m_btaggingContainerName. Exiting.");
+    return EL::StatusCode::FAILURE;
+  }
+
   if ( m_outputAlgo.empty() ) {
     m_outputAlgo = m_jetAlgo + "_Calib_Algo";
   }

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -131,6 +131,11 @@ public:
   std::string m_truthBosonContainerName = "TruthBosonsWithDecayParticles";
   /// @brief Name of the truth top quark container if using TRUTH3 containers
   std::string m_truthTopQuarkContainerName = "TruthTopQuarkWithDecayParticles";
+  
+  /// @brief Copy b-tagging links to "default" jet container a la SUSYTools in order to allow running b-tagging tools on these
+  bool m_bendBTaggingLinks = false;
+  /// @brief Name of the source container of the b-tagging links
+  std::string m_btaggingContainerName = "AntiKt4EMPFlowJets_BTagging201903";
 
 // systematics
   /// @brief jet tile correction
@@ -171,6 +176,7 @@ private:
                                    std::pair<xAOD::JetContainer*, xAOD::ShallowAuxContainer*>& calibJetsSC,
                                    std::vector<std::string>& vecOutContainerNames, bool isPDCopy);
   EL::StatusCode initializeUncertaintiesTool(asg::AnaToolHandle<ICPJetUncertaintiesTool>& uncToolHandle, bool isData);
+  EL::StatusCode bendBTaggingLinks(xAOD::JetContainer* to_container);
 
 public:
 

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -134,8 +134,8 @@ public:
   
   /// @brief Copy b-tagging links to "default" jet container a la SUSYTools in order to allow running b-tagging tools on these
   bool m_bendBTaggingLinks = false;
-  /// @brief Name of the source container of the b-tagging links
-  std::string m_btaggingContainerName = "AntiKt4EMPFlowJets_BTagging201903";
+  /// @brief Name of the source container of the b-tagging links, e.g. AntiKt4EMPFlowJets_BTagging201903
+  std::string m_btaggingContainerName = "";
 
 // systematics
   /// @brief jet tile correction


### PR DESCRIPTION
This PR adds the possibility to copy b-tagging links to the "default" jet collection in the JetCalibrator (as this is the algorithm that should run first on the input jet collection). This allows to allow run the b-tagging tools also on these jet collections and one doesn't have to set up a new shallow copy of jets for the METMaker.