### PR TITLE
Proper initialization of flag to include or not cleaning LLP information

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -261,6 +261,7 @@ namespace HelperClasses{
     m_clean         = has_exact("clean");
     m_cleanLight    = has_exact("cleanLight");
     m_cleanTrig     = has_exact("cleanTrig");
+    m_cleanLLP      = has_exact("cleanLLP");
     m_energy        = has_exact("energy");
     m_energyLight   = has_exact("energyLight");
     m_scales        = has_exact("scales");


### PR DESCRIPTION
Ntuple production from AODs was including the jet cleaning information when not asking for it. This was leading to having files with different numbers of branches which was leading to merging problems on the Grid (smaller number of events than in the base sample).

This MR aims to fix that.