### PR TITLE
fixing getMCShowerType() for Sherpa 2.2.10 and Sherpa 2.2.11 samples

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -560,8 +560,8 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
   else if(tmp_name.Contains("HERWIG")) return Herwig7;
   else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
-  else if(tmp_name.Contains("SHERPA_2210")) return Sherpa2210;
-  else if(tmp_name.Contains("SHERPA_2211")) return Sherpa2210;
+  else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
+  else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
   else if(tmp_name.Contains("SHERPA")) return Sherpa22;
   else return Unknown;
 }


### PR DESCRIPTION
As far as I can tell, the physics short tag for the new Sherpa samples contains "Sh" instead of "Sherpa", hence the getMCShowerType() function fails when processing these, see for example

> mc16_13TeV.700340.Sh_2211_Wenu_maxHTpTV2_CVetoBVeto.deriv.DAOD_PHYS.e8351_s3126_r9364_p5001

This PR only adjust the associated lines.