### PR TITLE
Change LLP stream and fix trigger matching for merged leptons

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -127,7 +127,7 @@ bool xAH::Algorithm::isPHYS(){
     TTree* metaData = dynamic_cast<TTree*>( wk()->inputFile()->Get("MetaData") );
     if(metaData){
       metaData->LoadTree(0);
-      return (metaData->GetBranch("StreamDAOD_PHYS") || metaData->GetBranch("StreamDAOD_PHYSLLP"));
+      return (metaData->GetBranch("StreamDAOD_PHYS") || metaData->GetBranch("StreamDAOD_LLP1"));
     } else {
       ANA_MSG_ERROR("MetaData tree missing from input file!");
       return 0;

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -364,6 +364,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
+      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
     }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -364,7 +364,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
+      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
     }
@@ -661,10 +661,15 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
           if ( !isTrigMatchedMapElDecor.isAvailable( *electron ) ) {
             isTrigMatchedMapElDecor( *electron ) = std::map<std::string,char>();
           }
-          static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::ElectronContainer>> originalElectronLink("originalElectronLink");
-          auto originalElectron = const_cast<xAOD::Electron*>(*originalElectronLink( *electron ));
-          char matched = ( m_trigElectronMatchTool_handle->match(*originalElectron, chain, m_minDeltaR) );
-          // char matched = ( m_trigElectronMatchTool_handle->match( *electron, chain, m_minDeltaR ) );
+
+          char matched = false;
+          if (!m_merged_electrons){
+            matched = ( m_trigElectronMatchTool_handle->match( *electron, chain, m_minDeltaR ) );
+          } else {
+            static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::ElectronContainer>> originalElectronLink("originalElectronLink");
+            auto originalElectron = const_cast<xAOD::Electron*>(*originalElectronLink( *electron ));
+            matched = ( m_trigElectronMatchTool_handle->match(*originalElectron, chain, m_minDeltaR) );
+          }
 
           ANA_MSG_DEBUG( "\t\t is electron trigger matched? " << matched);
 

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -661,8 +661,10 @@ bool ElectronSelector :: executeSelection ( const xAOD::ElectronContainer* inEle
           if ( !isTrigMatchedMapElDecor.isAvailable( *electron ) ) {
             isTrigMatchedMapElDecor( *electron ) = std::map<std::string,char>();
           }
-
-          char matched = ( m_trigElectronMatchTool_handle->match( *electron, chain, m_minDeltaR ) );
+          static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::ElectronContainer>> originalElectronLink("originalElectronLink");
+          auto originalElectron = const_cast<xAOD::Electron*>(*originalElectronLink( *electron ));
+          char matched = ( m_trigElectronMatchTool_handle->match(*originalElectron, chain, m_minDeltaR) );
+          // char matched = ( m_trigElectronMatchTool_handle->match( *electron, chain, m_minDeltaR ) );
 
           ANA_MSG_DEBUG( "\t\t is electron trigger matched? " << matched);
 

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -364,7 +364,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
+      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
     }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -364,7 +364,9 @@ EL::StatusCode ElectronSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+      if (!m_trigInputPrefix.empty()){
+        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+      }
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -307,6 +307,7 @@ EL::StatusCode MuonSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
+      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
       ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
     }
@@ -604,7 +605,10 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
             isTrigMatchedMapMuDecor( *muon ) = std::map<std::string,char>();
           }
 
-          char matched = ( m_trigMuonMatchTool_handle->match( *muon, chain, m_minDeltaR ) );
+          // char matched = ( m_trigMuonMatchTool_handle->match( *muon, chain, m_minDeltaR ) );
+          static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::MuonContainer>> originalMuonLink("originalMuonLink");
+          auto originalMuon = const_cast<xAOD::Muon*>(*originalMuonLink( *muon ));
+          char matched = ( m_trigMuonMatchTool_handle->match(*originalMuon, chain, m_minDeltaR) );
 
           ANA_MSG_DEBUG( "\t\t is muon trigger matched? " << matched);
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -307,7 +307,9 @@ EL::StatusCode MuonSelector :: initialize ()
     } else { // For DAOD_PHYS samples
       m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+      if (!m_trigInputPrefix.empty()){
+        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+      }
       ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -306,8 +306,8 @@ EL::StatusCode MuonSelector :: initialize ()
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
     } else { // For DAOD_PHYS samples
       m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
-      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("InputPrefix", "LRTTrigMatch_"));
+      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
+      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
       ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
     }
@@ -604,11 +604,14 @@ bool MuonSelector :: executeSelection ( const xAOD::MuonContainer* inMuons, floa
           if ( !isTrigMatchedMapMuDecor.isAvailable( *muon ) ) {
             isTrigMatchedMapMuDecor( *muon ) = std::map<std::string,char>();
           }
-
-          // char matched = ( m_trigMuonMatchTool_handle->match( *muon, chain, m_minDeltaR ) );
-          static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::MuonContainer>> originalMuonLink("originalMuonLink");
-          auto originalMuon = const_cast<xAOD::Muon*>(*originalMuonLink( *muon ));
-          char matched = ( m_trigMuonMatchTool_handle->match(*originalMuon, chain, m_minDeltaR) );
+          char matched = false;
+          if (!m_merged_muons){
+            matched = ( m_trigMuonMatchTool_handle->match( *muon, chain, m_minDeltaR ) );
+          } else {
+            static const SG::AuxElement::ConstAccessor<ElementLink<xAOD::MuonContainer>> originalMuonLink("originalMuonLink");
+            auto originalMuon = const_cast<xAOD::Muon*>(*originalMuonLink( *muon ));
+            matched = ( m_trigMuonMatchTool_handle->match(*originalMuon, chain, m_minDeltaR) );
+          }
 
           ANA_MSG_DEBUG( "\t\t is muon trigger matched? " << matched);
 

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -191,6 +191,11 @@ public:
   /// @brief Apply fix to EGamma Crack-Electron topocluster association bug for MET (PFlow) / false by default
   bool m_applyCrackVetoCleaning = false;
 
+  /// @brief Element links need to be updated if merged electrons are used (LRT + std) / false by default
+  bool           m_merged_electrons = false;
+  /// @brief Input prefix of trigger decision tool
+  std::string    m_trigInputPrefix = "TrigMatch_";
+
 private:
 
   /**

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -194,7 +194,7 @@ public:
   /// @brief Element links need to be updated if merged electrons are used (LRT + std) / false by default
   bool           m_merged_electrons = false;
   /// @brief Input prefix of trigger decision tool
-  std::string    m_trigInputPrefix = "TrigMatch_";
+  std::string    m_trigInputPrefix = "";
 
 private:
 

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -104,6 +104,10 @@ public:
   std::string    m_diMuTrigChains = "";
   /// @brief Recommended threshold for muon triggers: see https://svnweb.cern.ch/trac/atlasoff/browser/Trigger/TrigAnalysis/TriggerMatchingTool/trunk/src/TestMatchingToolAlg.cxx
   double         m_minDeltaR = 0.1;
+  /// @brief Element links need to be updated if merged muons are used (LRT + std) / false by default
+  bool           m_merged_muons = false;
+  /// @brief Input prefix of trigger decision tool
+  std::string    m_trigInputPrefix = "TrigMatch_";
 
 private:
 

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -107,7 +107,7 @@ public:
   /// @brief Element links need to be updated if merged muons are used (LRT + std) / false by default
   bool           m_merged_muons = false;
   /// @brief Input prefix of trigger decision tool
-  std::string    m_trigInputPrefix = "TrigMatch_";
+  std::string    m_trigInputPrefix = "";
 
 private:
 


### PR DESCRIPTION
Hello,

The LLP DAOD stream is now called `StreamDAOD_LLP1`.

We use `CP::ElectronLRTMergingAlg` and `CP::MuonLRTMergingAlg` to merge LRT and std electrons and muons on analysis level, more details about the muon merger are here: [link](https://indico.cern.ch/event/1188523/contributions/4994850/attachments/2490167/4276213/AMG_5Aug2022.pdf).
In the merged container, the trigger matching does not work anymore bc of broken links. I've updated the links in the electron (and muon selector) and added a flag `m_merged_electrons` (`m_merged_muons`) to use the updated links whenever merged leptons are used. We also needed to be able to configure the Input Prefix property of the trigger decision tool. I've added `m_trigInputPrefix = "TrigMatch_"` in both electron and muon selector to do this (the value we need is `"LRTTrigMatch_"`).

Pls let me know if you have any comments and if this can be merged in r22/master.

Cheers,
Christian