### PR TITLE
extend getMCShowerType() to work also for Sherpa 2.2.12 samples

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -562,6 +562,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
   else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
+  else if(tmp_name.Contains("SH_2212")) return Sherpa2210;
   else if(tmp_name.Contains("SHERPA")) return Sherpa22;
   else return Unknown;
 }


### PR DESCRIPTION
This is another small addition to getMCShowerType() so that also the new Shepra 2.2.12 samples can be processed