### PR TITLE
Ftag update

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -126,7 +126,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if (m_taggerName == "DL1r")   { taggerOK = true; m_getScaleFactors =  false; }
   if (m_taggerName == "DL1dv00")   { taggerOK = true; m_getScaleFactors = false; }
   if (m_taggerName == "DL1dv01")   { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "GN120220509")   { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "GN120220509")   { taggerOK = true; m_getScaleFactors =  false; }
 
   if( !opOK || !taggerOK ) {
     ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -123,8 +123,10 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     ANA_MSG_DEBUG(" Using continuous b-tagging"); }
 
   // No official calibrations in rel22 yet
-  if (m_taggerName == "DL1r")   { taggerOK = true; m_getScaleFactors =  true; }
-  if (m_taggerName == "DL1dv00")   { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "DL1r")   { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "DL1dv00")   { taggerOK = true; m_getScaleFactors = false; }
+  if (m_taggerName == "DL1dv01")   { taggerOK = true; m_getScaleFactors =  true; }
+  if (m_taggerName == "GN120220509")   { taggerOK = true; m_getScaleFactors =  true; }
 
   if( !opOK || !taggerOK ) {
     ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);

--- a/Root/Jet.cxx
+++ b/Root/Jet.cxx
@@ -36,6 +36,36 @@ int Jet::is_btag(BTaggerOP op) const
     case Jet::BTaggerOP::DL1dv00_Continuous:
       return is_DL1dv00_Continuous;
       break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_60:
+      return is_DL1dv01_FixedCutBEff_60;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_70:
+      return is_DL1dv01_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_77:
+      return is_DL1dv01_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_85:
+      return is_DL1dv01_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::DL1dv01_Continuous:
+      return is_DL1dv01_Continuous;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_60:
+      return is_GN120220509_FixedCutBEff_60;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_70:
+      return is_GN120220509_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_77:
+      return is_GN120220509_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_85:
+      return is_GN120220509_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::GN120220509_Continuous:
+      return is_GN120220509_Continuous;
+      break;
     default:
       return 0;
       break;
@@ -75,6 +105,36 @@ const std::vector<float>& Jet::SF_btag(BTaggerOP op) const
       break;
     case Jet::BTaggerOP::DL1dv00_Continuous:
       return SF_DL1dv00_Continuous;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_60:
+      return SF_DL1dv01_FixedCutBEff_60;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_70:
+      return SF_DL1dv01_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_77:
+      return SF_DL1dv01_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::DL1dv01_FixedCutBEff_85:
+      return SF_DL1dv01_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::DL1dv01_Continuous:
+      return SF_DL1dv01_Continuous;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_60:
+      return SF_GN120220509_FixedCutBEff_60;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_70:
+      return SF_GN120220509_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_77:
+      return SF_GN120220509_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::GN120220509_FixedCutBEff_85:
+      return SF_GN120220509_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::GN120220509_Continuous:
+      return SF_GN120220509_Continuous;
       break;
     default:
       static const std::vector<float> dummySF = {1.};

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -230,10 +230,18 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_DL1r_pu                           =new std::vector<float>();
     m_DL1r_pc                           =new std::vector<float>();
     m_DL1r_pb                           =new std::vector<float>();
-    m_DL1dv00                              =new std::vector<float>();
-    m_DL1dv00_pu                           =new std::vector<float>();
-    m_DL1dv00_pc                           =new std::vector<float>();
-    m_DL1dv00_pb                           =new std::vector<float>();
+    m_DL1dv00                           =new std::vector<float>();
+    m_DL1dv00_pu                        =new std::vector<float>();
+    m_DL1dv00_pc                        =new std::vector<float>();
+    m_DL1dv00_pb                        =new std::vector<float>();
+    m_DL1dv01                           =new std::vector<float>();
+    m_DL1dv01_pu                        =new std::vector<float>();
+    m_DL1dv01_pc                        =new std::vector<float>();
+    m_DL1dv01_pb                        =new std::vector<float>();
+    m_GN1                               =new std::vector<float>();
+    m_GN1_pu                            =new std::vector<float>();
+    m_GN1_pc                            =new std::vector<float>();
+    m_GN1_pb                            =new std::vector<float>();
     m_HadronConeExclTruthLabelID        =new std::vector<int>();
     m_HadronConeExclExtendedTruthLabelID=new std::vector<int>();
 
@@ -653,6 +661,14 @@ JetContainer::~JetContainer()
     delete m_DL1dv00_pu;
     delete m_DL1dv00_pc;
     delete m_DL1dv00_pb;
+    delete m_DL1dv01;
+    delete m_DL1dv01_pu;
+    delete m_DL1dv01_pc;
+    delete m_DL1dv01_pb;
+    delete m_GN1;
+    delete m_GN1_pu;
+    delete m_GN1_pc;
+    delete m_GN1_pb;
 
     delete m_HadronConeExclTruthLabelID;
     delete m_HadronConeExclExtendedTruthLabelID;
@@ -939,10 +955,18 @@ void JetContainer::setTree(TTree *tree)
       connectBranch<float>(tree,"DL1r_pu"                           ,&m_DL1r_pu  );
       connectBranch<float>(tree,"DL1r_pc"                           ,&m_DL1r_pc  );
       connectBranch<float>(tree,"DL1r_pb"                           ,&m_DL1r_pb  );
-      connectBranch<float>(tree,"DL1dv00"                              ,&m_DL1dv00     );
-      connectBranch<float>(tree,"DL1dv00_pu"                           ,&m_DL1dv00_pu  );
-      connectBranch<float>(tree,"DL1dv00_pc"                           ,&m_DL1dv00_pc  );
-      connectBranch<float>(tree,"DL1dv00_pb"                           ,&m_DL1dv00_pb  );
+      connectBranch<float>(tree,"DL1dv00"                           ,&m_DL1dv00     );
+      connectBranch<float>(tree,"DL1dv00_pu"                        ,&m_DL1dv00_pu  );
+      connectBranch<float>(tree,"DL1dv00_pc"                        ,&m_DL1dv00_pc  );
+      connectBranch<float>(tree,"DL1dv00_pb"                        ,&m_DL1dv00_pb  );
+      connectBranch<float>(tree,"DL1dv01"                           ,&m_DL1dv01     );
+      connectBranch<float>(tree,"DL1dv01_pu"                        ,&m_DL1dv01_pu  );
+      connectBranch<float>(tree,"DL1dv01_pc"                        ,&m_DL1dv01_pc  );
+      connectBranch<float>(tree,"DL1dv01_pb"                        ,&m_DL1dv01_pb  );
+      connectBranch<float>(tree,"GN1"                               ,&m_GN1     );
+      connectBranch<float>(tree,"GN1_pu"                            ,&m_GN1_pu  );
+      connectBranch<float>(tree,"GN1_pc"                            ,&m_GN1_pc  );
+      connectBranch<float>(tree,"GN1_pb"                            ,&m_GN1_pb  );
       connectBranch<int>  (tree,"HadronConeExclTruthLabelID"        ,&m_HadronConeExclTruthLabelID);
       connectBranch<int>  (tree,"HadronConeExclExtendedTruthLabelID",&m_HadronConeExclExtendedTruthLabelID);
     }
@@ -1182,14 +1206,22 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
   if(m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT)
     {
       if(m_debug) std::cout << "updating flavorTag " << std::endl;
-      if(m_DL1r)      jet.DL1r      =m_DL1r                 ->at(idx);
-      if(m_DL1r_pu)   jet.DL1r_pu   =m_DL1r_pu              ->at(idx);
-      if(m_DL1r_pc)   jet.DL1r_pc   =m_DL1r_pc              ->at(idx);
-      if(m_DL1r_pb)   jet.DL1r_pb   =m_DL1r_pb              ->at(idx);
-      if(m_DL1dv00)      jet.DL1dv00      =m_DL1dv00                 ->at(idx);
-      if(m_DL1dv00_pu)   jet.DL1dv00_pu   =m_DL1dv00_pu              ->at(idx);
-      if(m_DL1dv00_pc)   jet.DL1dv00_pc   =m_DL1dv00_pc              ->at(idx);
-      if(m_DL1dv00_pb)   jet.DL1dv00_pb   =m_DL1dv00_pb              ->at(idx);
+      if(m_DL1r)        jet.DL1r        =m_DL1r        ->at(idx);
+      if(m_DL1r_pu)     jet.DL1r_pu     =m_DL1r_pu     ->at(idx);
+      if(m_DL1r_pc)     jet.DL1r_pc     =m_DL1r_pc     ->at(idx);
+      if(m_DL1r_pb)     jet.DL1r_pb     =m_DL1r_pb     ->at(idx);
+      if(m_DL1dv00)     jet.DL1dv00     =m_DL1dv00     ->at(idx);
+      if(m_DL1dv00_pu)  jet.DL1dv00_pu  =m_DL1dv00_pu  ->at(idx);
+      if(m_DL1dv00_pc)  jet.DL1dv00_pc  =m_DL1dv00_pc  ->at(idx);
+      if(m_DL1dv00_pb)  jet.DL1dv00_pb  =m_DL1dv00_pb  ->at(idx);
+      if(m_DL1dv01)     jet.DL1dv01     =m_DL1dv01     ->at(idx);
+      if(m_DL1dv01_pu)  jet.DL1dv01_pu  =m_DL1dv01_pu  ->at(idx);
+      if(m_DL1dv01_pc)  jet.DL1dv01_pc  =m_DL1dv01_pc  ->at(idx);
+      if(m_DL1dv01_pb)  jet.DL1dv01_pb  =m_DL1dv01_pb  ->at(idx);
+      if(m_GN1)         jet.GN1         =m_GN1         ->at(idx);
+      if(m_GN1_pu)      jet.GN1_pu      =m_GN1_pu      ->at(idx);
+      if(m_GN1_pc)      jet.GN1_pc      =m_GN1_pc      ->at(idx);
+      if(m_GN1_pb)      jet.GN1_pb      =m_GN1_pb      ->at(idx);
       //std::cout << m_HadronConeExclTruthLabelID->size() << std::endl;
       if(m_HadronConeExclTruthLabelID)         jet.HadronConeExclTruthLabelID        =m_HadronConeExclTruthLabelID        ->at(idx);
       if(m_HadronConeExclExtendedTruthLabelID) jet.HadronConeExclExtendedTruthLabelID=m_HadronConeExclExtendedTruthLabelID->at(idx);
@@ -1322,7 +1354,28 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
 	  jet.is_DL1r_Continuous=       btag->m_isTag->at(idx);
 	  jet.SF_DL1r_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
-	case Jet::BTaggerOP::DL1dv00_FixedCutBEff_60:
+	//DL1dv01 has preliminary rel22 pre-rec SF uncertainties   
+        case Jet::BTaggerOP::DL1dv01_FixedCutBEff_60:
+	  jet.is_DL1dv01_FixedCutBEff_60=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv01_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv01_FixedCutBEff_70:
+	  jet.is_DL1dv01_FixedCutBEff_70=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv01_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv01_FixedCutBEff_77:
+	  jet.is_DL1dv01_FixedCutBEff_77=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv01_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv01_FixedCutBEff_85:
+	  jet.is_DL1dv01_FixedCutBEff_85=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv01_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::DL1dv01_Continuous:
+	  jet.is_DL1dv01_Continuous=       btag->m_isTag->at(idx);
+	  jet.SF_DL1dv01_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+        case Jet::BTaggerOP::DL1dv00_FixedCutBEff_60:
 	  jet.is_DL1dv00_FixedCutBEff_60=       btag->m_isTag->at(idx);
 	  jet.SF_DL1dv00_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
@@ -1341,6 +1394,26 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
 	case Jet::BTaggerOP::DL1dv00_Continuous:
 	  jet.is_DL1dv00_Continuous=       btag->m_isTag->at(idx);
 	  jet.SF_DL1dv00_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+        case Jet::BTaggerOP::GN120220509_FixedCutBEff_60:
+	  jet.is_GN120220509_FixedCutBEff_60=       btag->m_isTag->at(idx);
+	  jet.SF_GN120220509_FixedCutBEff_60=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::GN120220509_FixedCutBEff_70:
+	  jet.is_GN120220509_FixedCutBEff_70=       btag->m_isTag->at(idx);
+	  jet.SF_GN120220509_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::GN120220509_FixedCutBEff_77:
+	  jet.is_GN120220509_FixedCutBEff_77=       btag->m_isTag->at(idx);
+	  jet.SF_GN120220509_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::GN120220509_FixedCutBEff_85:
+	  jet.is_GN120220509_FixedCutBEff_85=       btag->m_isTag->at(idx);
+	  jet.SF_GN120220509_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+	  break;
+	case Jet::BTaggerOP::GN120220509_Continuous:
+	  jet.is_GN120220509_Continuous=       btag->m_isTag->at(idx);
+	  jet.SF_GN120220509_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
 	default:
 	  throw std::domain_error(
@@ -1602,6 +1675,14 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"DL1dv00_pu", m_DL1dv00_pu);
     setBranch<float>(tree,"DL1dv00_pc", m_DL1dv00_pc);
     setBranch<float>(tree,"DL1dv00_pb", m_DL1dv00_pb);
+    setBranch<float>(tree,"DL1dv01",    m_DL1dv01);
+    setBranch<float>(tree,"DL1dv01_pu", m_DL1dv01_pu);
+    setBranch<float>(tree,"DL1dv01_pc", m_DL1dv01_pc);
+    setBranch<float>(tree,"DL1dv01_pb", m_DL1dv01_pb);
+    setBranch<float>(tree,"GN1",    m_GN1);
+    setBranch<float>(tree,"GN1_pu", m_GN1_pu);
+    setBranch<float>(tree,"GN1_pc", m_GN1_pc);
+    setBranch<float>(tree,"GN1_pb", m_GN1_pb);
 
     setBranch<int  >(tree,"HadronConeExclTruthLabelID", m_HadronConeExclTruthLabelID);
     setBranch<int  >(tree,"HadronConeExclExtendedTruthLabelID", m_HadronConeExclExtendedTruthLabelID);
@@ -1997,10 +2078,18 @@ void JetContainer::clear()
     m_DL1r_pu                           ->clear();
     m_DL1r_pc                           ->clear();
     m_DL1r_pb                           ->clear();
-    m_DL1dv00                              ->clear();
-    m_DL1dv00_pu                           ->clear();
-    m_DL1dv00_pc                           ->clear();
-    m_DL1dv00_pb                           ->clear();
+    m_DL1dv00                           ->clear();
+    m_DL1dv00_pu                        ->clear();
+    m_DL1dv00_pc                        ->clear();
+    m_DL1dv00_pb                        ->clear();
+    m_DL1dv01                           ->clear();
+    m_DL1dv01_pu                        ->clear();
+    m_DL1dv01_pc                        ->clear();
+    m_DL1dv01_pb                        ->clear();
+    m_GN1                               ->clear();
+    m_GN1_pu                            ->clear();
+    m_GN1_pc                            ->clear();
+    m_GN1_pb                            ->clear();
     m_HadronConeExclTruthLabelID        ->clear();
     m_HadronConeExclExtendedTruthLabelID->clear();
 
@@ -2840,6 +2929,34 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1dv00_pc->push_back(pc);
     m_DL1dv00_pb->push_back(pb);
     m_DL1dv00->push_back( score );
+    pu=0; pb=0; pc=0;
+    //pu = myBTag->auxdata<float>("DL1dv01_pu");
+    //pb = myBTag->auxdata<float>("DL1dv01_pb");
+    //pc = myBTag->auxdata<float>("DL1dv01_pc");
+    myBTag->variable<float>("DL1dv01" , "pu", pu);
+    myBTag->variable<float>("DL1dv01" , "pc", pc);
+    myBTag->variable<float>("DL1dv01" , "pb", pb);
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.018*pc+0.982*pu) );
+    m_DL1dv01_pu->push_back(pu);
+    m_DL1dv01_pc->push_back(pc);
+    m_DL1dv01_pb->push_back(pb);
+    m_DL1dv01->push_back( score );
+    
+    pu=0; pb=0; pc=0;
+    //pu = myBTag->auxdata<float>("GN120220509_pu");
+    //pb = myBTag->auxdata<float>("GN120220509_pb");
+    //pc = myBTag->auxdata<float>("GN120220509_pc");
+    myBTag->variable<float>("GN120220509" , "pu", pu);
+    myBTag->variable<float>("GN120220509" , "pc", pc);
+    myBTag->variable<float>("GN120220509" , "pb", pb);
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.05*pc+0.95*pu) ); // GN1 uses a different f_c value than DL1d which is 0.05
+    m_GN1_pu->push_back(pu);
+    m_GN1_pc->push_back(pc);
+    m_GN1_pb->push_back(pb);
+    m_GN1->push_back( score );
+    
 
     // flavor groups truth definition
     static SG::AuxElement::ConstAccessor<int> hadConeExclTruthLabel("HadronConeExclTruthLabelID");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -2930,9 +2930,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1dv00_pb->push_back(pb);
     m_DL1dv00->push_back( score );
     pu=0; pb=0; pc=0;
-    //pu = myBTag->auxdata<float>("DL1dv01_pu");
-    //pb = myBTag->auxdata<float>("DL1dv01_pb");
-    //pc = myBTag->auxdata<float>("DL1dv01_pc");
     myBTag->variable<float>("DL1dv01" , "pu", pu);
     myBTag->variable<float>("DL1dv01" , "pc", pc);
     myBTag->variable<float>("DL1dv01" , "pb", pb);
@@ -2944,9 +2941,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1dv01->push_back( score );
     
     pu=0; pb=0; pc=0;
-    //pu = myBTag->auxdata<float>("GN120220509_pu");
-    //pb = myBTag->auxdata<float>("GN120220509_pb");
-    //pc = myBTag->auxdata<float>("GN120220509_pc");
     myBTag->variable<float>("GN120220509" , "pu", pu);
     myBTag->variable<float>("GN120220509" , "pc", pc);
     myBTag->variable<float>("GN120220509" , "pb", pb);

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -14,7 +14,9 @@ namespace xAH {
 	None,
 	DL1r_FixedCutBEff_60  , DL1r_FixedCutBEff_70  , DL1r_FixedCutBEff_77  , DL1r_FixedCutBEff_85  ,
 	DL1dv00_FixedCutBEff_60  , DL1dv00_FixedCutBEff_70  , DL1dv00_FixedCutBEff_77  , DL1dv00_FixedCutBEff_85  ,
-	DL1dv00_Continuous, DL1r_Continuous, // Continuous
+	DL1dv01_FixedCutBEff_60  , DL1dv01_FixedCutBEff_70  , DL1dv01_FixedCutBEff_77  , DL1dv01_FixedCutBEff_85  ,
+	GN120220509_FixedCutBEff_60  , GN120220509_FixedCutBEff_70  , GN120220509_FixedCutBEff_77  , GN120220509_FixedCutBEff_85  ,
+	DL1dv00_Continuous, DL1r_Continuous, DL1dv01_Continuous, GN120220509_Continuous// Continuous
       };
 
       float rapidity;
@@ -94,6 +96,14 @@ namespace xAH {
       float DL1dv00_pu;
       float DL1dv00_pc;
       float DL1dv00_pb;
+      float DL1dv01;
+      float DL1dv01_pu;
+      float DL1dv01_pc;
+      float DL1dv01_pb;
+      float GN1;
+      float GN1_pu;
+      float GN1_pc;
+      float GN1_pb;
       int  HadronConeExclTruthLabelID;
       int  HadronConeExclExtendedTruthLabelID;
 
@@ -198,6 +208,22 @@ namespace xAH {
       std::vector<float> SF_DL1dv00_FixedCutBEff_77;
       int is_DL1dv00_FixedCutBEff_85;
       std::vector<float> SF_DL1dv00_FixedCutBEff_85;
+      int is_DL1dv01_FixedCutBEff_60;
+      std::vector<float> SF_DL1dv01_FixedCutBEff_60;
+      int is_DL1dv01_FixedCutBEff_70;
+      std::vector<float> SF_DL1dv01_FixedCutBEff_70;
+      int is_DL1dv01_FixedCutBEff_77;
+      std::vector<float> SF_DL1dv01_FixedCutBEff_77;
+      int is_DL1dv01_FixedCutBEff_85;
+      std::vector<float> SF_DL1dv01_FixedCutBEff_85;
+      int is_GN120220509_FixedCutBEff_60;
+      std::vector<float> SF_GN120220509_FixedCutBEff_60;
+      int is_GN120220509_FixedCutBEff_70;
+      std::vector<float> SF_GN120220509_FixedCutBEff_70;
+      int is_GN120220509_FixedCutBEff_77;
+      std::vector<float> SF_GN120220509_FixedCutBEff_77;
+      int is_GN120220509_FixedCutBEff_85;
+      std::vector<float> SF_GN120220509_FixedCutBEff_85;
 
       // Continuous
       int is_DL1r_Continuous;
@@ -206,6 +232,12 @@ namespace xAH {
       int is_DL1dv00_Continuous;
       std::vector<float> SF_DL1dv00_Continuous;
       std::vector<float> inEffSF_DL1dv00_Continuous;
+      int is_DL1dv01_Continuous;
+      std::vector<float> SF_DL1dv01_Continuous;
+      std::vector<float> inEffSF_DL1dv01_Continuous;
+      int is_GN120220509_Continuous;
+      std::vector<float> SF_GN120220509_Continuous;
+      std::vector<float> inEffSF_GN120220509_Continuous;
 
 
       // truth

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -198,6 +198,14 @@ namespace xAH {
       std::vector<float> *m_DL1dv00_pu;
       std::vector<float> *m_DL1dv00_pc;
       std::vector<float> *m_DL1dv00_pb;
+      std::vector<float> *m_DL1dv01;
+      std::vector<float> *m_DL1dv01_pu;
+      std::vector<float> *m_DL1dv01_pc;
+      std::vector<float> *m_DL1dv01_pb;
+      std::vector<float> *m_GN1;
+      std::vector<float> *m_GN1_pu;
+      std::vector<float> *m_GN1_pc;
+      std::vector<float> *m_GN1_pb;
  
       // Jet Fitter
       std::vector<float>  *m_JetFitter_nVTX           ;
@@ -331,6 +339,24 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_77;
 	  else if(m_accessorName=="DL1dv00_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_85;
+          
+          else if(m_accessorName=="DL1dv01_FixedCutBEff_60")
+	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_60;
+	  else if(m_accessorName=="DL1dv01_FixedCutBEff_70")
+	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_70;
+	  else if(m_accessorName=="DL1dv01_FixedCutBEff_77")
+	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_77;
+	  else if(m_accessorName=="DL1dv01_FixedCutBEff_85")
+	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_85;
+          
+          else if(m_accessorName=="GN120220509_FixedCutBEff_60")
+	    m_op=Jet::BTaggerOP::GN120220509_FixedCutBEff_60;
+	  else if(m_accessorName=="GN120220509_FixedCutBEff_70")
+	    m_op=Jet::BTaggerOP::GN120220509_FixedCutBEff_70;
+	  else if(m_accessorName=="GN120220509_FixedCutBEff_77")
+	    m_op=Jet::BTaggerOP::GN120220509_FixedCutBEff_77;
+	  else if(m_accessorName=="GN120220509_FixedCutBEff_85")
+	    m_op=Jet::BTaggerOP::GN120220509_FixedCutBEff_85;
         }
 
         ~btagOpPoint()


### PR DESCRIPTION
Added the new b-taggers: DL1dv01 and GN120220509
To btag selection tool needs to be updated in Athena in order to select jets based the OPs for GN120220509. For now, we only have its score outputs.
DL1dv01 should work and it has preliminary SFs available as well and it is currently the baseline rel22 tagger. 