### PR TITLE
Adding new option to specify ShowerModel to JetCalibTool

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -217,6 +217,9 @@ EL::StatusCode JetCalibrator :: initialize ()
   }
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("ConfigFile",m_calibConfig));
   ANA_CHECK( m_JetCalibrationTool_handle.setProperty("CalibSequence",m_calibSequence));
+  if( !m_showerModel.empty() ) {
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("ShowerModel",m_showerModel));
+  }
   if ( !m_overrideCalibArea.empty() ) {
     ANA_MSG_WARNING("Overriding jet calibration area to " << m_overrideCalibArea);
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("CalibArea", m_overrideCalibArea));

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -68,6 +68,8 @@ public:
   std::string m_calibConfigAFII = "JES_MC16Recommendation_AFII_EMTopo_April2018_rel21.config";
   /// @brief List of calibration steps. Auto-configured to the Jet/Etmiss recommendation if left blank.
   std::string m_calibSequence = "";
+  /// @brief The shower model used in MC, for MC-2-MC corrections
+  std::string m_showerModel = "";
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
   /// @brief MC type for Jet Uncertainty Tool


### PR DESCRIPTION
This is a simple PR that adds a new option to `JetCalibrator` that specifies the `ShowerModel` of the MC you're running on. This is necessary for the new MC2MC calibrations for precision analyses, outlined on the recommendations twiki:

https://twiki.cern.ch/twiki/bin/view/AtlasProtected/ApplyJetCalibrationR21#MC_to_MC_calibrations

🍻 MLB