### PR TITLE
feat: Add workflow for sweeping changes from master to r22

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -11,7 +11,9 @@ jobs:
   cherry_pick_release_r22:
     runs-on: ubuntu-latest
     name: Cherry pick into r22/master
-    if: contains(github.event.pull_request.labels.*.name, 'sweep-r22')
+    if: >-
+      github.event.pull_request.merged
+      && contains(github.event.pull_request.labels.*.name, 'sweep-r22')
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+    branches:
+      - master
+    types: ["closed"]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  cherry_pick_release_r22:
+    runs-on: ubuntu-latest
+    name: Cherry pick into r22/master
+    if: contains(github.event.pull_request.labels.*.name, 'sweep-r22')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into release-v1.0
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: r22/master
+          labels: |
+            cherry-pick
+          reviewers: |
+            jbossios
+
+


### PR DESCRIPTION
This workflow depends on [github-cherry-pick-action](https://github.com/carloscastrojumo/github-cherry-pick-action). PRs labeled with `sweep-r22` will be swept into the r22 branch once the PR is merged.
