### PR TITLE
Use MuonCalibTool to support 22.2.88+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 22.2.74
-          - 22.2.75
-          - 22.2.77
-          - 22.2.78
-          - 22.2.79
-          - 22.2.80
-          - 22.2.81
-          - 22.2.82
-          - 22.2.83
-          - 22.2.84
-          - 22.2.85
-          - 22.2.86
-          - 22.2.87
+          - 22.2.88
 
     steps:
     - uses: actions/checkout@master

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -126,11 +126,11 @@ EL::StatusCode MuonCalibrator :: initialize ()
   // Initialize the CP::MuonCalibrationPeriodTool
   // set calibrationMode (the default is "noOption", forcing analyses to make an explicit choice)
   if(m_calibrationMode == "correctData_CB"){
-    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibrationMode", 0)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::correctData_CB
+    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 0)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::correctData_CB
   } else if(m_calibrationMode == "correctData_IDMS"){
-    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibrationMode", 1)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::correctData_IDMS
+    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 1)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::correctData_IDMS
   } else if(m_calibrationMode == "notCorrectData_IDMS"){
-    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibrationMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
+    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
   }
   // special corrections for muons with only 2 stations; to be switched on only for the muon highPt WP
   if (m_do2StationsHighPt){

--- a/Root/MuonInFatJetCorrector.cxx
+++ b/Root/MuonInFatJetCorrector.cxx
@@ -10,7 +10,6 @@
 #include "xAODTruth/TruthParticleContainer.h"
 
 #include "MuonSelectorTools/MuonSelectionTool.h"
-#include "MuonMomentumCorrections/MuonCalibrationPeriodTool.h"
 
 #include "xAODAnaHelpers/MuonInFatJetCorrector.h"
 #include "xAODAnaHelpers/HelperClasses.h"

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -7,7 +7,7 @@
 // external tools include(s):
 #include <AsgTools/AnaToolHandle.h>
 #include <AsgAnalysisInterfaces/IPileupReweightingTool.h>
-#include <MuonAnalysisInterfaces/IMuonCalibrationAndSmearingTool.h>
+#include "MuonMomentumCorrections/MuonCalibTool.h"
 
 class MuonCalibrator : public xAH::Algorithm
 {
@@ -63,7 +63,7 @@ private:
   std::vector<CP::SystematicSet> m_systList; //!
 
   // tools
-  asg::AnaToolHandle<CP::IMuonCalibrationAndSmearingTool> m_muonCalibrationTool_handle{"CP::MuonCalibrationPeriodTool/MuonCalibrationAndSmearingTool", this}; //!
+  asg::AnaToolHandle<CP::MuonCalibTool> m_muonCalibrationTool_handle{"CP::MuonCalibTool/MuonCalibrationTool", this}; //!
 
   // variables that don't get filled at submission time should be
   // protected from being send from the submission node to the worker


### PR DESCRIPTION
The tool now expects ```calibMode``` to be set instead of ```calibrationMode``` but I decided not to change the name of ```m_calibrationMode``` (in MuonCalibrator) so people don't need to make any change.