### PR TITLE
Add isRun3Geo option to MuonSelector and MuonCalibrator

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -136,6 +136,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   if (m_do2StationsHighPt){
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("do2StationsHighPt", m_do2StationsHighPt));
   }  
+  ANA_CHECK(m_muonCalibrationTool_handle.setProperty( "IsRun3Geo", m_isRun3Geo ));
   ANA_CHECK(m_muonCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_muonCalibrationTool_handle);
 

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -236,6 +236,7 @@ EL::StatusCode MuonSelector :: initialize ()
 
   ANA_CHECK( m_muonSelectionTool_handle.setProperty( "MaxEta", static_cast<double>(m_eta_max) ));
   ANA_CHECK( m_muonSelectionTool_handle.setProperty( "MuQuality", m_muonQuality ));
+  ANA_CHECK( m_muonSelectionTool_handle.setProperty( "IsRun3Geo", m_isRun3Geo ));
   ANA_CHECK( m_muonSelectionTool_handle.setProperty( "OutputLevel", msg().level() ));
   ANA_CHECK( m_muonSelectionTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_muonSelectionTool_handle);

--- a/xAODAnaHelpers/MuonCalibrator.h
+++ b/xAODAnaHelpers/MuonCalibrator.h
@@ -22,6 +22,9 @@ public:
   /// @brief Set calibrationMode property if different than noOption
   std::string m_calibrationMode = "noOption";
 
+  /** @brief Switch on Run3 geometry for muon selector tool */
+  bool           m_isRun3Geo = false;
+
   //// @brief Set Perform special resolution corrections for two-station muons passing the HighPt selection criteria, switch on only when using the HighPt WP
   bool m_do2StationsHighPt = false;
 

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -65,6 +65,8 @@ public:
   float          m_pT_min = 1e8;
   /** require quality */
   std::string    m_muonQualityStr = "Medium";
+  /** @brief Switch on Run3 geometry for muon selector tool */
+  bool           m_isRun3Geo = false;
   /** require type */
   //std::string    m_muonType;
   /** require |eta| < eta_max */


### PR DESCRIPTION
Adds new member variable m_isRun3Geo to MuonSelector.cxx which sets the IsRun3Geo property in muonSelectionTool - required to be set to true to avoid a crash when running on Run3.

Defaults to false for Run2 setting.
