### PR TITLE
adding functionality to add NNJvt branches to output

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -289,6 +289,7 @@ namespace HelperClasses{
     m_trackAll      = has_exact("trackAll");
     m_chargedPFOPV  = has_exact("chargedPFOPV");
     m_jvt           = has_exact("JVT");
+    m_NNJvt         = has_exact("NNJvt");
     m_allTrack      = has_exact("allTrack");
     m_allTrackPVSel = has_exact("allTrackPVSel");
     m_allTrackDetail= has_exact("allTrackDetail");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -183,6 +183,11 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     }
   }
 
+  if (m_infoSwitch.m_NNJvt) {
+    m_NNJvt = new std::vector<float>();
+    m_NNJvtPass = new std::vector<bool>();
+  }
+
   // chargedPFOPV
   if ( m_infoSwitch.m_chargedPFOPV ) {
     m_SumPtChargedPFOPt500PV = new std::vector<float> ();
@@ -583,6 +588,11 @@ JetContainer::~JetContainer()
       delete m_JvtRpt;
     }
     delete m_Jvt;
+  }
+
+  if (m_infoSwitch.m_NNJvt){
+    delete m_NNJvt;
+    delete m_NNJvtPass;
   }
 
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Loose" ) {
@@ -1624,6 +1634,11 @@ void JetContainer::setBranches(TTree *tree)
     //setBranch<float>(tree,"GhostTrackAssociationFraction", m_ghostTrackAssFrac);
   }
 
+  if (m_infoSwitch.m_NNJvt) {
+    setBranch<float>(tree, "NNJvt", m_NNJvt);
+    setBranch<bool>(tree, "NNJvtPass", m_NNJvtPass);
+  }
+
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Loose" ) {
     setBranch<int>(tree,"JvtPass_Loose",        m_JvtPass_Loose );
     if ( m_mc ) {
@@ -2049,6 +2064,11 @@ void JetContainer::clear()
       m_JvtRpt            ->clear();
     }
     m_Jvt               ->clear();
+  }
+
+  if (m_infoSwitch.m_NNJvt){
+    m_NNJvt->clear();
+    m_NNJvtPass->clear();
   }
 
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "Loose" ) {
@@ -2739,6 +2759,13 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       //      } else { m_ghostTrackAssFrac->push_back( -999 ) ; }
 
     } // trackPV || chargedPFOPV || JVT
+
+    if (m_infoSwitch.m_NNJvt) {
+      static SG::AuxElement::ConstAccessor< float > NNJvt ("NNJvt");
+      static SG::AuxElement::ConstAccessor< char > NNJvtPass ("NNJvtPass");
+      safeFill<float, float, xAOD::Jet>(jet, NNJvt, m_NNJvt, -999);
+      safeFill<char, bool, xAOD::Jet>(jet, NNJvtPass, m_NNJvtPass, 0);
+    }
 
     if ( m_infoSwitch.m_clean && pvLocation >= 0 ) {
 

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -456,6 +456,7 @@ namespace HelperClasses {
         m_trackAll       trackAll       exact
         m_chargedPFOPV   chargedPFOPV   exact
         m_jvt            JVT            exact
+        m_NNJvt          NNJvt          exact
         m_sfJVTName      sfJVT          partial
         m_sffJVTName     sffJVT         partial
         m_allTrack       allTrack       exact
@@ -528,6 +529,7 @@ namespace HelperClasses {
     bool m_trackAll;
     bool m_chargedPFOPV;
     bool m_jvt;
+    bool m_NNJvt;
     bool m_allTrack;
     bool m_allTrackDetail;
     bool m_allTrackPVSel;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -151,6 +151,10 @@ namespace xAH {
       std::vector<int> *m_fJvtPass_Tight;
       std::vector< std::vector<float> > *m_fJvtEff_SF_Tight;
 
+      // NNJvt
+      std::vector<float> *m_NNJvt;
+      std::vector<bool> *m_NNJvtPass;
+
       // chargedPFOPV 
       std::vector<float> *m_SumPtChargedPFOPt500PV;
       std::vector<float> *m_fCharged;


### PR DESCRIPTION
This PR adds the functionality to add the NNJvt (successor of Jvt for jet pile-up tagging in R22) scores and decisions (automatically stored in all R22 derivations) to the output. This is triggered by adding the keyword "NNJvt" to the detail string for jets.

Tagging also @hollypacey.