### PR TITLE
Fix-R22 Trigger Matching

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -355,9 +355,12 @@ EL::StatusCode ElectronSelector :: initialize ()
       ANA_CHECK( m_trigDecTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
+      ANA_CHECK( m_scoreTool.retrieve());
+
       //  everything went fine, let's initialise the tool!
       m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");;
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -332,9 +332,12 @@ EL::StatusCode JetSelector :: initialize ()
       ANA_CHECK( m_trigDecTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
+      ANA_CHECK( m_scoreTool.retrieve());
+
       //  everything went fine, let's initialise the tool!
       m_trigJetMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
       ANA_CHECK( m_trigJetMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+      ANA_CHECK( m_trigJetMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
       ANA_CHECK( m_trigJetMatchTool_handle.setProperty("OutputLevel", msg().level() ));
       ANA_CHECK( m_trigJetMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigJetMatchTool_handle);

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -299,9 +299,12 @@ EL::StatusCode MuonSelector :: initialize ()
       ANA_CHECK( m_trigDecTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
+      ANA_CHECK( m_scoreTool.retrieve());
+
       //  everything went fine, let's initialise the tool!
       m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
       ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -246,9 +246,12 @@ EL::StatusCode TauSelector :: initialize ()
       ANA_CHECK( m_trigDecTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
+      ANA_CHECK( m_scoreTool.retrieve());
+
       //  everything went fine, let's initialise the tool!
       m_trigTauMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
       ANA_CHECK( m_trigTauMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+      ANA_CHECK( m_trigTauMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
       ANA_CHECK( m_trigTauMatchTool_handle.setProperty("OutputLevel", msg().level() ));
       ANA_CHECK( m_trigTauMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigTauMatchTool_handle);

--- a/Root/TrigMatcher.cxx
+++ b/Root/TrigMatcher.cxx
@@ -95,11 +95,14 @@ EL::StatusCode TrigMatcher :: initialize ()
     }
   }
 
+  ANA_CHECK( m_scoreTool.retrieve());
+
   //  everything went fine, let's initialise the tool!
   //
   if( !isPHYS() ) {
     m_trigMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
     ANA_CHECK( m_trigMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+    ANA_CHECK( m_trigMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));    
   } else { // For DAOD_PHYS samples
     m_trigMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
   }

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -23,6 +23,7 @@
 #include "IsolationSelection/IIsolationSelectionTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
+#include "TriggerMatchingTool/IMatchScoringTool.h"
 
 // algorithm wrapper
 #include "xAODAnaHelpers/Algorithm.h"
@@ -264,6 +265,7 @@ private:
   CP::IsolationSelectionTool*                     m_isolationSelectionTool{nullptr};                                                                 //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>      m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                       }; //!
   asg::AnaToolHandle<Trig::IMatchingTool>         m_trigElectronMatchTool_handle; //!
+  asg::AnaToolHandle<Trig::IMatchScoringTool>     m_scoreTool                    {"Trig::DRScoringTool/DRScoringTool"                             }; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
   bool m_doTrigMatch = true;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -29,6 +29,7 @@
 #include "JetInterface/IJetModifier.h"
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
+#include "TriggerMatchingTool/IMatchScoringTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 
 class JetSelector : public xAH::Algorithm
@@ -304,6 +305,7 @@ private:
 
   asg::AnaToolHandle<Trig::IMatchingTool>    m_trigJetMatchTool_handle; //!
   asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"}; //!
+  asg::AnaToolHandle<Trig::IMatchScoringTool>  m_scoreTool{"Trig::DRScoringTool/DRScoringTool"}; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -20,6 +20,7 @@
 #include "IsolationSelection/IIsolationSelectionTool.h"
 #include "MuonAnalysisInterfaces/IMuonSelectionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
+#include "TriggerMatchingTool/IMatchScoringTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 
 // algorithm wrapper
@@ -157,6 +158,7 @@ private:
   asg::AnaToolHandle<CP::IMuonSelectionTool>       m_muonSelectionTool_handle     {"CP::MuonSelectionTool/MuonSelectionTool"          , this}; //!
   asg::AnaToolHandle<Trig::IMatchingTool>          m_trigMuonMatchTool_handle; //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>       m_trigDecTool_handle           {"Trig::TrigDecisionTool/TrigDecisionTool"                       }; //!
+  asg::AnaToolHandle<Trig::IMatchScoringTool>      m_scoreTool                    {"Trig::DRScoringTool/DRScoringTool"                             }; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -14,6 +14,7 @@
 #include "AsgTools/AnaToolHandle.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
+#include "TriggerMatchingTool/IMatchScoringTool.h"
 #include "TauAnalysisTools/ITauSelectionTool.h"
 
 //#include "TauAnalysisTools/TauOverlappingElectronLLHDecorator.h"
@@ -112,6 +113,7 @@ private:
   asg::AnaToolHandle<TauAnalysisTools::ITauSelectionTool> m_tauSelTool_handle{"TauAnalysisTools::TauSelectionTool/TauSelectionTool",     this}; //!
   asg::AnaToolHandle<Trig::TrigDecisionTool>              m_trigDecTool_handle{"Trig::TrigDecisionTool/TrigDecisionTool"    }; //!
   asg::AnaToolHandle<Trig::IMatchingTool>                 m_trigTauMatchTool_handle; //!
+  asg::AnaToolHandle<Trig::IMatchScoringTool>             m_scoreTool{"Trig::DRScoringTool/DRScoringTool"}; //!
 
   /// @brief This internal variable gets set to false if no triggers are defined or if TrigDecisionTool is missing
   bool m_doTrigMatch = true; //!

--- a/xAODAnaHelpers/TrigMatcher.h
+++ b/xAODAnaHelpers/TrigMatcher.h
@@ -13,6 +13,7 @@
 #include <AsgTools/AnaToolHandle.h>
 #include <TrigDecisionTool/TrigDecisionTool.h>
 #include <TriggerMatchingTool/IMatchingTool.h>
+#include "TriggerMatchingTool/IMatchScoringTool.h"
 
 #include <TH1D.h>
 
@@ -77,6 +78,7 @@ private:
   /* tools */
   asg::AnaToolHandle<Trig::TrigDecisionTool> m_trigDecTool_handle  {"Trig::TrigDecisionTool/TrigDecisionTool"             }; //!
   asg::AnaToolHandle<Trig::IMatchingTool>    m_trigMatchTool_handle; //!
+  asg::AnaToolHandle<Trig::IMatchScoringTool>  m_scoreTool {"Trig::DRScoringTool/DRScoringTool"}; //!
 
   std::vector<std::string> m_trigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_trigChains */
 


### PR DESCRIPTION
Since some R22 releases, a new tool (`Trig::DRScoringTool`) has to be set up to perform trigger matching (only needed for non-PHYS derivations). It was assumed that the existing trigger matching tool sets this up automatically, but this only works in AthAnalysis and not AnalysisBase (where we have to set it up manually ...):
https://twiki.cern.ch/twiki/bin/viewauth/Atlas/R22TriggerAnalysis

I've tried to catch `Trig::IMatchingTools` in the code and modify their initialization accordingly. Note: it seems that for the Run 3 trigger geometry we need a different matching tool ... so some further adjustments may be required later but this PR should fix things at least for R22 Run 2 data and mc20.