### PR TITLE
Bugfix: LHCut not updated if multiple instances of ElectronSelector are called

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -1011,7 +1011,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
       if ( m_doLHPIDcut ) {
 
         bool passSelID(false);
-        static SG::AuxElement::ConstAccessor< char > LHDecision( "DFCommonElectronsLH" + m_LHOperatingPoint );
+        SG::AuxElement::ConstAccessor< char > LHDecision( "DFCommonElectronsLH" + m_LHOperatingPoint );
         if( LHDecision.isAvailable( *electron ) ){
 	  if (m_doModifiedEleId){
 	    if(m_LHOperatingPoint == "Tight"){


### PR DESCRIPTION
Fixes a bug in the electron selector which affects the LH decision cut if multiple instances of the selector are called with different WPs due to a static ConstAccessor.

For e.g. if you have

Presel -> OverlapRemoval -> FinalSel

with different LH WPs in Presel and FinalSel, the WP in Presel will be used for FinalSel. This should now be fixed.