### PR TITLE
fix: Use PR target instead

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,9 +1,10 @@
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for security considerations
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - r22/master
-    types: ["closed"]
+    types: ["closed", "labeled"]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -29,6 +29,7 @@ jobs:
             cherry-pick
           reviewers: |
             jbossios
+          author: xAH-bot <xAH-bot@users.noreply.github.com>
 
   cherry_pick_release_r21:
     runs-on: ubuntu-latest
@@ -49,3 +50,4 @@ jobs:
             cherry-pick
           reviewers: |
             kratsg
+          author: xAH-bot <xAH-bot@users.noreply.github.com>


### PR DESCRIPTION
Actions triggered by forked repositories only have read-only permissions (even for actions triggered by post-PR merging).

See `pull_request_target` information here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests
