### PR TITLE
R22 Jet Pile-up tagging and MET pre-recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 22.2.88
+          - 22.2.97
 
     steps:
     - uses: actions/checkout@master

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -289,6 +289,7 @@ namespace HelperClasses{
     m_trackAll      = has_exact("trackAll");
     m_chargedPFOPV  = has_exact("chargedPFOPV");
     m_jvt           = has_exact("JVT");
+    m_fJvt          = has_exact("fJvt");
     m_NNJvt         = has_exact("NNJvt");
     m_allTrack      = has_exact("allTrack");
     m_allTrackPVSel = has_exact("allTrackPVSel");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -164,6 +164,18 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
       m_JvtEff_SF_Tight  = new std::vector< std::vector<float> > ();
     }
   }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "FixedEffPt" ) {
+    m_JvtPass_FixedEffPt   = new std::vector<int>();
+    if ( m_mc ) {
+      m_JvtEff_SF_FixedEffPt = new std::vector< std::vector<float> > ();
+    }
+  }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "TightFwd" ) {
+    m_JvtPass_TightFwd    = new std::vector<int>();
+    if ( m_mc ) {
+      m_JvtEff_SF_TightFwd  = new std::vector< std::vector<float> > ();
+    }
+  }  
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sffJVTName == "Loose" ) {
     m_fJvtPass_Loose   = new std::vector<int>();
     if ( m_mc ) {
@@ -613,6 +625,18 @@ JetContainer::~JetContainer()
       delete m_JvtEff_SF_Tight;
     }
   }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "FixedEffPt" ) {
+    delete m_JvtPass_FixedEffPt;
+    if ( m_mc ) {
+      delete m_JvtEff_SF_FixedEffPt;
+    }
+  }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "TightFwd" ) {
+    delete m_JvtPass_TightFwd;
+    if ( m_mc ) {
+      delete m_JvtEff_SF_TightFwd;
+    }
+  }  
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sffJVTName == "Loose" ) {
     delete m_fJvtPass_Loose;
     if ( m_mc ) {
@@ -1657,6 +1681,18 @@ void JetContainer::setBranches(TTree *tree)
       setBranch<std::vector<float> >(tree,"JvtEff_SF_Tight",     m_JvtEff_SF_Tight );
     }
   }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "FixedEffPt" ) {
+    setBranch<int>(tree,"JvtPass_FixedEffPt",       m_JvtPass_FixedEffPt );
+    if ( m_mc ) {
+      setBranch<std::vector<float> >(tree,"JvtEff_SF_FixedEffPt",    m_JvtEff_SF_FixedEffPt );
+    }
+  }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "TightFwd" ) {
+    setBranch<int>(tree,"JvtPass_TightFwd",        m_JvtPass_TightFwd );
+    if ( m_mc ) {
+      setBranch<std::vector<float> >(tree,"JvtEff_SF_TightFwd",     m_JvtEff_SF_TightFwd );
+    }
+  }  
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sffJVTName == "Loose" ) {
     setBranch<int>(tree,"fJvtPass_Loose",       m_fJvtPass_Loose );
     if ( m_mc ) {
@@ -2089,6 +2125,18 @@ void JetContainer::clear()
       m_JvtEff_SF_Tight ->clear();
     }
   }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "FixedEffPt" ) {
+    m_JvtPass_FixedEffPt    ->clear();
+    if ( m_mc ) {
+      m_JvtEff_SF_FixedEffPt->clear();
+    }
+  }
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "TightFwd" ) {
+    m_JvtPass_TightFwd     ->clear();
+    if ( m_mc ) {
+      m_JvtEff_SF_TightFwd ->clear();
+    }
+  }  
   if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sffJVTName == "Loose" ) {
     m_fJvtPass_Loose    ->clear();
     if ( m_mc ) {
@@ -2790,12 +2838,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
   static SG::AuxElement::ConstAccessor< char > jvtPass_Loose("JetJVT_Passed_Loose");
   static SG::AuxElement::ConstAccessor< char > jvtPass_Medium("JetJVT_Passed_Medium");
   static SG::AuxElement::ConstAccessor< char > jvtPass_Tight("JetJVT_Passed_Tight");
+  static SG::AuxElement::ConstAccessor< char > jvtPass_FixedEffPt("JetJVT_Passed_FixedEffPt");
+  static SG::AuxElement::ConstAccessor< char > jvtPass_TightFwd("JetJVT_Passed_TightFwd");    
   static SG::AuxElement::ConstAccessor< char > fjvtPass_Loose("JetfJVT_Passed_Loose");
   static SG::AuxElement::ConstAccessor< char > fjvtPass_Medium("JetfJVT_Passed_Medium");
   static SG::AuxElement::ConstAccessor< char > fjvtPass_Tight("JetfJVT_Passed_Tight");
   static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Loose("JetJvtEfficiency_JVTSyst_JVT_Loose");
   static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Medium("JetJvtEfficiency_JVTSyst_JVT_Medium");
   static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_Tight("JetJvtEfficiency_JVTSyst_JVT_Tight");
+  static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_FixedEffPt("JetJvtEfficiency_JVTSyst_JVT_FixedEffPt");
+  static SG::AuxElement::ConstAccessor< std::vector< float > > jvtSF_TightFwd("JetJvtEfficiency_JVTSyst_JVT_TightFwd");  
   static SG::AuxElement::ConstAccessor< std::vector< float > > fjvtSF_Loose("JetJvtEfficiency_fJVTSyst_fJVT_Loose");
   static SG::AuxElement::ConstAccessor< std::vector< float > > fjvtSF_Medium("JetJvtEfficiency_fJVTSyst_fJVT_Medium");
   static SG::AuxElement::ConstAccessor< std::vector< float > > fjvtSF_Tight("JetJvtEfficiency_fJVTSyst_fJVT_Tight");
@@ -2831,6 +2883,28 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
         m_JvtEff_SF_Tight->push_back( jvtSF_Tight( *jet ) );
       } else {
         m_JvtEff_SF_Tight->push_back( junkSF );
+      }
+    }
+  }
+
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "FixedEffPt" ) {
+    safeFill<char, int, xAOD::Jet>(jet, jvtPass_FixedEffPt, m_JvtPass_FixedEffPt, -1);
+    if ( m_mc ) {
+      if ( jvtSF_FixedEffPt.isAvailable( *jet ) ) {
+        m_JvtEff_SF_FixedEffPt->push_back( jvtSF_FixedEffPt( *jet ) );
+      } else {
+        m_JvtEff_SF_FixedEffPt->push_back( junkSF );
+      }
+    }
+  }
+
+  if ( m_infoSwitch.m_trackPV || m_infoSwitch.m_sfJVTName == "TightFwd" ) {
+    safeFill<char, int, xAOD::Jet>(jet, jvtPass_TightFwd, m_JvtPass_TightFwd, -1);
+    if ( m_mc ) {
+      if ( jvtSF_TightFwd.isAvailable( *jet ) ) {
+        m_JvtEff_SF_TightFwd->push_back( jvtSF_TightFwd( *jet ) );
+      } else {
+        m_JvtEff_SF_TightFwd->push_back( junkSF );
       }
     }
   }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -272,6 +272,7 @@ EL::StatusCode JetSelector :: initialize ()
   // initialize the CP::JetJvtEfficiency Tool for JVT
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JVT_tool_handle, CP::JetJvtEfficiency));
   ANA_CHECK( m_JVT_tool_handle.setProperty("WorkingPoint", m_WorkingPointJVT ));
+  ANA_CHECK( m_JVT_tool_handle.setProperty("TaggingAlg", CP::JvtTagger::Jvt ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("SFFile",       m_SFFileJVT ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("OutputLevel",  msg().level()));
   ANA_CHECK( m_JVT_tool_handle.retrieve());

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -252,10 +252,10 @@ EL::StatusCode JetSelector :: initialize ()
 
     CP::SystematicSet affectSystsfJVT = m_fJVT_eff_tool_handle->affectingSystematics();
     for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
-    
+
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
-    
+
     const CP::SystematicSet recSystsfJVT = m_fJVT_eff_tool_handle->recommendedSystematics();
     m_systListfJVT = HelperFunctions::getListofSystematics( recSystsfJVT, m_systNamefJVT, m_systValfJVT, msg() );
 
@@ -616,7 +616,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
         // if made it to the end with no duplicates, then we're done
         if(i_etaPair==int(etaPairs.size())-1)
-          allChecked = true; 
+          allChecked = true;
       }
     }
 
@@ -648,7 +648,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
       }
       i_jet++;
     }
-      
+
     // if only looking at a subset of jets make sure all are decorated
     if ( m_nToProcess > 0 && nObj >= m_nToProcess ) {
       if ( m_decorateSelectedObjects ) {

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -236,28 +236,28 @@ EL::StatusCode JetSelector :: initialize ()
   //init fJVT
   if (m_dofJVT) {
     // initialize the CP::JetJvtEfficiency Tool for fJVT
-    // ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("UseMuSFFormat",       m_UseMuSFFormatfJVT ));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("ScaleFactorDecorationName", "fJVTSF"));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("OutputLevel",  msg().level()));
-    // ANA_CHECK( m_fJVT_eff_tool_handle.retrieve());
-    // ANA_MSG_DEBUG("Retrieved tool: " << m_fJVT_eff_tool_handle);
+    ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("TaggingAlg", CP::JvtTagger::fJvt ));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("ScaleFactorDecorationName", "fJVTSF"));
+    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("OutputLevel",  msg().level()));
+    ANA_CHECK( m_fJVT_eff_tool_handle.retrieve());
+    ANA_MSG_DEBUG("Retrieved tool: " << m_fJVT_eff_tool_handle);
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
     m_outputSystNamesfJVT = m_outputSystNamesfJVT + "_fJVT_" + m_WorkingPointfJVT;
     //  Create a passed label for JVT cut
     m_outputfJVTPassed = m_outputfJVTPassed + "_" + m_WorkingPointfJVT;
 
-    // CP::SystematicSet affectSystsfJVT = m_fJVT_eff_tool_handle->affectingSystematics();
-    // for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
-    //
+    CP::SystematicSet affectSystsfJVT = m_fJVT_eff_tool_handle->affectingSystematics();
+    for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
+    
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
-    //
-    // const CP::SystematicSet recSystsfJVT = m_fJVT_eff_tool_handle->recommendedSystematics();
-    // m_systListfJVT = HelperFunctions::getListofSystematics( recSystsfJVT, m_systNamefJVT, m_systValfJVT, msg() );
+    
+    const CP::SystematicSet recSystsfJVT = m_fJVT_eff_tool_handle->recommendedSystematics();
+    m_systListfJVT = HelperFunctions::getListofSystematics( recSystsfJVT, m_systNamefJVT, m_systValfJVT, msg() );
 
     ANA_MSG_INFO("Will be using JetJvtEfficiency tool fJVT efficiency systematic:");
     for ( const auto& syst_it : m_systListfJVT ) {
@@ -272,7 +272,7 @@ EL::StatusCode JetSelector :: initialize ()
   // initialize the CP::JetJvtEfficiency Tool for JVT
   ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JVT_tool_handle, CP::JetJvtEfficiency));
   ANA_CHECK( m_JVT_tool_handle.setProperty("WorkingPoint", m_WorkingPointJVT ));
-  ANA_CHECK( m_JVT_tool_handle.setProperty("TaggingAlg", CP::JvtTagger::Jvt ));
+  ANA_CHECK( m_JVT_tool_handle.setProperty("TaggingAlg", CP::JvtTagger::NNJvt ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("SFFile",       m_SFFileJVT ));
   ANA_CHECK( m_JVT_tool_handle.setProperty("OutputLevel",  msg().level()));
   ANA_CHECK( m_JVT_tool_handle.retrieve());
@@ -287,7 +287,7 @@ EL::StatusCode JetSelector :: initialize ()
   for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by JVT efficiency systematic: " << syst_it.name()); }
 
   // Make a list of systematics to be used, based on configuration input
-  //Use HelperFunctions::getListofSystematics() for this!
+  // Use HelperFunctions::getListofSystematics() for this!
 
   const CP::SystematicSet recSystsJVT = m_JVT_tool_handle->recommendedSystematics();
   m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, msg() );
@@ -633,6 +633,9 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
       m_count_events_with_duplicates++;
   }
 
+  // recalculate the NNJvt scores and decisions
+  ANA_CHECK(m_JVT_tool_handle->recalculateScores(*inJets));
+
   i_jet = 0;
   for ( auto jet_itr : *inJets ) { // duplicated of basic loop
 
@@ -827,99 +830,111 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
     // Do it only if a tool with *this* name hasn't already been used
     //
-    if (false) {
-    // if ( m_fJVT_eff_tool_handle.isInitialized() && !m_fjvtUsedBefore) {
+    if (m_fJVT_eff_tool_handle.isInitialized() && !m_fjvtUsedBefore)
+    {
       //
       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* jet)
       //
-      static const SG::AuxElement::Decorator< std::vector<float> > dec_sffJVT( m_outputSystNamesfJVT );
+      static const SG::AuxElement::Decorator<std::vector<float>> dec_sffJVT(m_outputSystNamesfJVT);
 
       // Create the name of the SF weight to be recorded
       //   template:  SYSNAME_fJVTEff_SF
       //   Only need to do it once per call of executeSelection()
-      for ( const auto& syst_it : m_systListfJVT ) {
+      for (const auto &syst_it : m_systListfJVT)
+      {
         std::string sfName = "fJVTEff_SF";
-        if ( !syst_it.name().empty() ) {
-           std::string prepend = syst_it.name() + "_";
-           sfName.insert( 0, prepend );
+        if (!syst_it.name().empty())
+        {
+          std::string prepend = syst_it.name() + "_";
+          sfName.insert(0, prepend);
         }
         ANA_MSG_DEBUG("fJVT SF sys name (to be recorded in xAOD::TStore) is: " << sfName);
         sysVariationNamesfJVT->push_back(sfName);
       }
 
       unsigned int idx(0);
-      for ( auto jet : *(selectedJets) ) {
-	// Create Scale Factor aux for all jets
-	std::vector<float > sfVecfJVT;
+      for (auto jet : *(selectedJets))
+      {
+        // Create Scale Factor aux for all jets
+        std::vector<float> sfVecfJVT;
 
-	for ( const auto& syst_it : m_systListfJVT ) {
-	  // we do not need all SF for non-nominal trees
-	  if ( !syst_it.name().empty() && !isNominal )
+        for (const auto &syst_it : m_systListfJVT)
+        {
+          // we do not need all SF for non-nominal trees
+          if (!syst_it.name().empty() && !isNominal)
             continue;
 
-	  // apply syst
-	  //
-	  // if ( m_fJVT_eff_tool_handle->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS ) {
-	  //   ANA_MSG_ERROR( "Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
-	  //   return EL::StatusCode::FAILURE;
-	  // }
-	  ANA_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());
+          // apply syst
+          //
+          if (m_fJVT_eff_tool_handle->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS)
+          {
+            ANA_MSG_ERROR("Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
+            return EL::StatusCode::FAILURE;
+          }
+          ANA_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());
 
-	  // and now apply fJVT SF!
-	  //
-          ANA_MSG_DEBUG("Applying fJVT SF" );
+          // and now apply fJVT SF!
+          //
+          ANA_MSG_DEBUG("Applying fJVT SF");
 
-          static const SG::AuxElement::Decorator<char> passedfJVT( m_outputfJVTPassed );
-          if ( syst_it.name().empty() ) {
-            passedfJVT( *jet ) = jet->auxdata<char>("passFJVT");
+          static const SG::AuxElement::Decorator<char> passedfJVT(m_outputfJVTPassed);
+          if (syst_it.name().empty())
+          {
+            passedfJVT(*jet) = m_fJVT_eff_tool_handle->passesJvtCut(*jet);
           }
 
           float fjvtSF(1.0);
-          // if ( m_fJVT_eff_tool_handle->isInRange(*jet) ) {
-          //   // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
-          //   if ( !m_dofJVTVeto && jet->auxdata<char>("passFJVT") != 1 ) {
-          //     if ( m_fJVT_eff_tool_handle->getInefficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
-          //       ANA_MSG_ERROR( "Error in fJVT Tool getInefficiencyScaleFactor");
-          //       return EL::StatusCode::FAILURE;
-          //     }
-          //   } else { // otherwise classic efficiency scale factor
-          //     // if ( m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
-          //     //   ANA_MSG_ERROR( "Error in fJVT Tool getEfficiencyScaleFactor");
-          //     //   return EL::StatusCode::FAILURE;
-          //     // }
-          //   }
-          // }
-          sfVecfJVT.push_back( fjvtSF );
+          if ( m_fJVT_eff_tool_handle->isInRange(*jet) ) {
+            // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
+            if ( !m_dofJVTVeto && !m_fJVT_eff_tool_handle->passesJvtCut(*jet)) {
+              if ( m_fJVT_eff_tool_handle->getInefficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
+                ANA_MSG_ERROR( "Error in fJVT Tool getInefficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
+              }
+            } else { // otherwise classic efficiency scale factor
+              if ( m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
+                ANA_MSG_ERROR( "Error in fJVT Tool getEfficiencyScaleFactor");
+                return EL::StatusCode::FAILURE;
+              }
+            }
+          }
+          sfVecfJVT.push_back(fjvtSF);
 
-          ANA_MSG_DEBUG( "===>>>");
-          ANA_MSG_DEBUG( "Jet " << idx << ", pt = " << jet->pt()*1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) );
-          ANA_MSG_DEBUG( "fJVT SF decoration: " << m_outputSystNamesfJVT );
-          ANA_MSG_DEBUG( "Systematic: " << syst_it.name() );
-          ANA_MSG_DEBUG( "fJVT SF:");
-          ANA_MSG_DEBUG( "\t " << fjvtSF << " (from getEfficiencyScaleFactor())" );
-          ANA_MSG_DEBUG( "--------------------------------------");
-	}
-	++idx;
-	//
-	// Add it to decoration vector
-	//
-	dec_sffJVT( *jet )= sfVecfJVT;
+          ANA_MSG_DEBUG("===>>>");
+          ANA_MSG_DEBUG("Jet " << idx << ", pt = " << jet->pt() * 1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()));
+          ANA_MSG_DEBUG("fJVT SF decoration: " << m_outputSystNamesfJVT);
+          ANA_MSG_DEBUG("Systematic: " << syst_it.name());
+          ANA_MSG_DEBUG("fJVT SF:");
+          ANA_MSG_DEBUG("\t " << fjvtSF << " (from getEfficiencyScaleFactor())");
+          ANA_MSG_DEBUG("--------------------------------------");
+        }
+        ++idx;
+        //
+        // Add it to decoration vector
+        //
+        dec_sffJVT(*jet) = sfVecfJVT;
+      }
+
+      // Add list of fJVT systematics names to TStore
+      //
+      // NB: we need to make sure that this is not pushed more than once in TStore!
+      // This will be the case when this executeSelection() function gets called for every syst varied input container,
+      // e.g. the different SC containers w/ calibration systematics upstream.
+      //
+      if (!m_store->contains<std::vector<std::string>>(m_outputSystNamesfJVT))
+      {
+        ANA_CHECK(m_store->record(std::move(sysVariationNamesfJVT), m_outputSystNamesfJVT));
       }
     }
-
-    // Add list of fJVT systematics names to TStore
-    //
-    // NB: we need to make sure that this is not pushed more than once in TStore!
-    // This will be the case when this executeSelection() function gets called for every syst varied input container,
-    // e.g. the different SC containers w/ calibration systematics upstream.
-    //
-    if ( !m_store->contains<std::vector<std::string> >(m_outputSystNamesfJVT) ) { ANA_CHECK( m_store->record( std::move(sysVariationNamesfJVT), m_outputSystNamesfJVT)); }
-  } else if ( !isMC() && m_dofJVT ) {
-    // Loop over selected jets and decorate with fJVT passed status
-    for ( auto jet : *(selectedJets) ) {
-      // create passed fJVT decorator
-      static const SG::AuxElement::Decorator<char> passedfJVT( m_outputfJVTPassed );
-      passedfJVT( *jet ) = jet->auxdata<char>("passFJVT");
+    else if (!isMC() && m_dofJVT)
+    {
+      // Loop over selected jets and decorate with fJVT passed status
+      for (auto jet : *(selectedJets))
+      {
+        // create passed fJVT decorator
+        static const SG::AuxElement::Decorator<char> passedfJVT(m_outputfJVTPassed);
+        passedfJVT(*jet) = m_fJVT_eff_tool_handle->passesJvtCut(*jet);
+      }
     }
   }
 
@@ -1245,7 +1260,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   } // m_doJVF
 
   if(m_dofJVT){
-    if(jet->auxdata<char>("passFJVT")!=1){
+    if (!m_fJVT_eff_tool_handle->passesJvtCut(*jet)){
       ANA_MSG_DEBUG("jet pt = "<<jetPt<<",eta = "<<jetEta<<",phi = "<<jetPhi);
       ANA_MSG_DEBUG("Failed forward JVT");
       if(m_dofJVTVeto)return 0;

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -120,7 +120,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   m_store = wk()->xaodStore();
 
   ANA_MSG_INFO( "Number of events in file: " << m_event->getEntries() );
-  
+
 
   if ( m_inContainerName_Jets.empty() ) {
     ANA_MSG_ERROR( "InputContainerJets is empty! Must have it to perform Overlap Removal! Exiting.");
@@ -131,19 +131,19 @@ EL::StatusCode OverlapRemover :: initialize ()
   if ( !m_inContainerName_Muons.empty() )     { m_useMuons     = true; }
   if ( !m_inContainerName_Taus.empty() )      { m_useTaus      = true; }
   if ( !m_inContainerName_Photons.empty() )   { m_usePhotons   = true; }
-  
+
   m_outAuxContainerName_Electrons   = m_outContainerName_Electrons + "Aux."; // the period is very important!
   m_outAuxContainerName_Muons       = m_outContainerName_Muons + "Aux.";     // the period is very important!
   m_outAuxContainerName_Jets        = m_outContainerName_Jets + "Aux.";      // the period is very important!
   m_outAuxContainerName_Photons     = m_outContainerName_Photons + "Aux.";   // the period is very important!
   m_outAuxContainerName_Taus        = m_outContainerName_Taus + "Aux.";      // the period is very important!
 
-  
+
   if ( setCounters() == EL::StatusCode::FAILURE ) {
     ANA_MSG_ERROR( "Failed to properly set event/object counters. Exiting." );
     return EL::StatusCode::FAILURE;
   }
-  
+
   // initialize ASG overlap removal tool
   const std::string selected_label = ( m_useSelected ) ? "passSel" : "";  // set with decoration flag you use for selected objects if want to consider only selected objects in OR, otherwise it will perform OR on all objects
 
@@ -162,7 +162,6 @@ EL::StatusCode OverlapRemover :: initialize ()
   orFlags.doTaus      = m_useTaus;
   orFlags.doPhotons   = m_usePhotons;
   orFlags.doFatJets   = false;
-  orFlags.doMuPFJetOR = m_doMuPFJetOR;
 
   ANA_CHECK( ORUtils::recommendedTools(orFlags, m_ORToolbox));
   if(m_applyRelPt) ANA_CHECK( m_ORToolbox.muJetORT.setProperty("ApplyRelPt", true) );

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -496,7 +496,7 @@ namespace HelperClasses {
                 m_configStr = "... sfJVTMedium ..."
 
             ``jetBTag`` expects the format ``jetBTag_tagger_type_AABB..MM..YY.ZZ``. This will create a vector of working points (AA, BB, CC, ..., ZZ) associated with that tagger. Several entries can be given. For example::
-           
+
 	        m_configStr = "... jetBTag_DL1r_FixedCutBEff_60707785 ..."
 
 	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames``
@@ -529,6 +529,7 @@ namespace HelperClasses {
     bool m_trackAll;
     bool m_chargedPFOPV;
     bool m_jvt;
+    bool m_fJvt;
     bool m_NNJvt;
     bool m_allTrack;
     bool m_allTrackDetail;

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -20,7 +20,6 @@
 #include "JetCalibTools/IJetCalibrationTool.h"
 #include "JetCPInterfaces/ICPJetUncertaintiesTool.h"
 #include "JetInterface/IJetSelector.h"
-#include "JetInterface/IJetUpdateJvt.h"
 #include "JetCPInterfaces/IJetTileCorrectionTool.h"
 // #include "ParticleJetTools/JetTruthLabelingTool.h"
 #include "xAODCore/ShallowCopy.h"
@@ -99,18 +98,7 @@ public:
   bool m_saveAllCleanDecisions = false;
   /// @brief Do Ugly cleaning ( i.e. TileGap 3 )
   bool m_jetCleanUgly = false;
-  /// @brief Recalculate JVT using the calibrated jet pT
-  bool m_redoJVT = false;
 
-  /// @brief Calculate fJVT using the calibrated jet pT
-  bool m_calculatefJVT = false;
-  /// @brief Maximum pT of central jets used to compute fJVT decision
-  double m_fJVTCentralMaxPt = -1;
-  /// @brief fJVT working point
-  std::string m_fJVTWorkingPoint = "Medium";
-
-  /// @brief Name of Jvt aux decoration.  Was "JvtJvfcorr" in Rel 20.7, is now "JVFCorr" in Rel 21. Leave empty to use JetMomentTools default.
-  std::string m_JvtAuxName = "";
   /// @brief Sort the processed container elements by transverse momentum
   bool    m_sort = true;
   /// @brief Apply jet cleaning to parent jet
@@ -157,8 +145,6 @@ private:
   asg::AnaToolHandle<IJetCalibrationTool>        m_JetCalibrationTool_handle   {"JetCalibrationTool"   , this}; //!
   asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_JetUncertaintiesTool_handle {"JetUncertaintiesTool" , this}; //!
   asg::AnaToolHandle<ICPJetUncertaintiesTool>    m_pseudodataJERTool_handle    {"PseudodataJERTool"    , this}; //!
-  asg::AnaToolHandle<IJetUpdateJvt>              m_JVTUpdateTool_handle        {"JetVertexTaggerTool"  , this}; //!
-  asg::AnaToolHandle<IJetModifier>               m_fJVTTool_handle             {"JetForwardJvtTool"    , this}; //!
   asg::AnaToolHandle<IJetSelector>               m_JetCleaningTool_handle      {"JetCleaningTool"      , this}; //!
   // asg::AnaToolHandle<CP::IJetTileCorrectionTool> m_JetTileCorrectionTool_handle{"JetTileCorrectionTool", this}; //!
   // asg::AnaToolHandle<JetTruthLabelingTool>       m_JetTruthLabelingTool_handle {"JetTruthLabelingTool" , this}; //!

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -51,7 +51,7 @@ namespace xAH {
       std::vector<int>               *m_isTrigMatched;
       std::vector<std::vector<int> > *m_isTrigMatchedToChain;
       std::vector<std::string>       *m_listTrigChains;
-      
+
       // clean
       std::vector<float> *m_Timing;
       std::vector<float> *m_LArQuality;
@@ -144,6 +144,7 @@ namespace xAH {
       std::vector< std::vector<float> > *m_JvtEff_SF_Tight;
       std::vector<float> *m_JvtJvfcorr;
       std::vector<float> *m_JvtRpt;
+      std::vector<float> *m_fJvt;
       std::vector<int> *m_fJvtPass_Loose;
       std::vector< std::vector<float> > *m_fJvtEff_SF_Loose;
       std::vector<int> *m_fJvtPass_Medium;
@@ -159,7 +160,7 @@ namespace xAH {
       std::vector<int> *m_JvtPass_TightFwd;
       std::vector< std::vector<float> > *m_JvtEff_SF_TightFwd;
 
-      // chargedPFOPV 
+      // chargedPFOPV
       std::vector<float> *m_SumPtChargedPFOPt500PV;
       std::vector<float> *m_fCharged;
 
@@ -216,7 +217,7 @@ namespace xAH {
       std::vector<float> *m_GN1_pu;
       std::vector<float> *m_GN1_pc;
       std::vector<float> *m_GN1_pb;
- 
+
       // Jet Fitter
       std::vector<float>  *m_JetFitter_nVTX           ;
       std::vector<float>  *m_JetFitter_nSingleTracks  ;
@@ -340,7 +341,7 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::DL1r_FixedCutBEff_77;
 	  else if(m_accessorName=="DL1r_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::DL1r_FixedCutBEff_85;
-	  
+
           else if(m_accessorName=="DL1dv00_FixedCutBEff_60")
 	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_60;
 	  else if(m_accessorName=="DL1dv00_FixedCutBEff_70")
@@ -349,7 +350,7 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_77;
 	  else if(m_accessorName=="DL1dv00_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::DL1dv00_FixedCutBEff_85;
-          
+
           else if(m_accessorName=="DL1dv01_FixedCutBEff_60")
 	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_60;
 	  else if(m_accessorName=="DL1dv01_FixedCutBEff_70")
@@ -358,7 +359,7 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_77;
 	  else if(m_accessorName=="DL1dv01_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::DL1dv01_FixedCutBEff_85;
-          
+
           else if(m_accessorName=="GN120220509_FixedCutBEff_60")
 	    m_op=Jet::BTaggerOP::GN120220509_FixedCutBEff_60;
 	  else if(m_accessorName=="GN120220509_FixedCutBEff_70")

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -154,6 +154,10 @@ namespace xAH {
       // NNJvt
       std::vector<float> *m_NNJvt;
       std::vector<bool> *m_NNJvtPass;
+      std::vector<int> *m_JvtPass_FixedEffPt;
+      std::vector< std::vector<float> > *m_JvtEff_SF_FixedEffPt;
+      std::vector<int> *m_JvtPass_TightFwd;
+      std::vector< std::vector<float> > *m_JvtEff_SF_TightFwd;
 
       // chargedPFOPV 
       std::vector<float> *m_SumPtChargedPFOPt500PV;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -179,7 +179,7 @@ public:
      See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration for latest recommendation.
      @endrst
   */
-  std::string m_SFFileJVT = "JetJvtEfficiency/Moriond2018/JvtSFFile_EMPFlow.root";
+  std::string m_SFFileJVT = ""; // JetJvtEfficiency tool will use latest recommendation per default
   std::string m_outputSystNamesJVT = "JetJvtEfficiency_JVTSyst";
 
   float         m_systValJVT = 0.0;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -168,7 +168,7 @@ public:
 
     @endrst
   */
-  std::string m_WorkingPointJVT = "Tight";
+  std::string m_WorkingPointJVT = "FixedEffPt";
 
   /**
      @brief Configuration containting JVT scale factors.
@@ -214,8 +214,7 @@ public:
   */
 
   // Set the correct SF file and format
-  std::string m_SFFilefJVT = "JetJvtEfficiency/May2020/fJvtSFFile.EMPFlow.root";
-  bool m_UseMuSFFormatfJVT = true; // To account for new SF binning
+  std::string m_SFFilefJVT = ""; // JetJvtEfficiency tool will use latest recommendation per default
 
   std::string m_outputSystNamesfJVT = "JetJvtEfficiency_fJVTSyst";
 
@@ -300,7 +299,7 @@ private:
   std::vector<std::string>            m_diJetTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diJetTrigChains */
   
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::IJetJvtEfficiency/JVT"}; //!
-  // asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency/fJVT"}; //!
+  asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency/fJVT"}; //!
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
 
   asg::AnaToolHandle<Trig::IMatchingTool>    m_trigJetMatchTool_handle; //!

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -181,6 +181,10 @@ public:
   */
   std::string m_SFFileJVT = ""; // JetJvtEfficiency tool will use latest recommendation per default
   std::string m_outputSystNamesJVT = "JetJvtEfficiency_JVTSyst";
+  /// @brief Tagging algorithm to be used to veto PU jets in central region - default in R22 is NNJvt
+  int m_JvtTaggingAlg = CP::JvtTagger::NNJvt;
+  /// @brief Do re-calculation of NNJvt - scores need to be re-evaluated in case jet pt changed w.r.t. derivation
+  bool m_recalculateJvtScores = true;
 
   float         m_systValJVT = 0.0;
   std::string   m_systNameJVT = "";
@@ -297,7 +301,7 @@ private:
 
   std::vector<std::string>            m_singleJetTrigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_singleJetTrigChains */
   std::vector<std::string>            m_diJetTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diJetTrigChains */
-  
+
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::IJetJvtEfficiency/JVT"}; //!
   asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency/fJVT"}; //!
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -145,10 +145,6 @@ class OverlapRemover : public xAH::Algorithm
   std::string  m_outContainerName_Taus = "";
   std::string  m_inputAlgoTaus = "";
 
-  /** @brief To remove muons reconstructed as p-flow jets
-  https://twiki.cern.ch/twiki/bin/view/AtlasProtected/HowToCleanJetsR21#Muons_Reconstructed_as_Jets_in_P */
-  bool m_doMuPFJetOR = false;
-
  protected:
 
   /** @brief A counter for the number of processed events */


### PR DESCRIPTION
This MR implements recommendations that have become available with AnalysisBase 22.2.97 (releases before that are not compatible). In particular NNJvt is now used as successor of Jvt.

This mostly affects the setup of the tools which apply the NNJvt and fJvt requirements and retrieve the SFs.  The MR also adds back the fJvt which has been commented out so far in R22.

In addition, some additional features/changes have been implemented:
* remove the doEMPFlow flag of the analysis OR, as this was removed (no bug in PFlow building w.r.t. to muons in R22 anymore) in this release
* add functionality to write out the fJvt scores to the output