### PR TITLE
Add support to electron LooseBL PID

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -127,6 +127,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
   //
   if ( !m_WorkingPointPID.empty() ) {
 
+    // Loose working point saved as DFCommonElectronsLHLooseBL in derivations
+    // but SFs provided for LooseBLayer instead (naming mismatch)
+    if (m_WorkingPointPID == "LooseBL") m_WorkingPointPID = "LooseBLayer"; // protection
+
     ANA_MSG_INFO("Electron ID working point: " << m_WorkingPointPID);
 
     m_pidEffSF_tool_name = "ElectronEfficiencyCorrectionTool_effSF_PID_" + m_WorkingPointPID;

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -268,7 +268,6 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   if( m_doLHPID ){
     // if not using LH PID, make sure all the decorations will be set ... by choosing the loosest WP!
-    //std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "Loose";
     std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "LooseBL";
     m_el_LH_PIDManager = new ElectronLHPIDManager( likelihoodWP, msgLvl(MSG::DEBUG) );
 
@@ -281,8 +280,6 @@ EL::StatusCode ElectronSelector :: initialize ()
     }
 
     if ( m_readIDFlagsFromDerivation ) {
-      // LooseBL is not in Derivations, so choose Loose and do BLayer cut locally
-
       ANA_MSG_INFO( "Reading Electron LH ID from DAODs ..." );
       ANA_CHECK( m_el_LH_PIDManager->setupWPs( false ));
     } else {
@@ -1028,7 +1025,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 	      passThisID = acc_EG_Medium( *electron ) && acc_EG_Tight( *electron );
 	    } else if(decorWP == "LHMedium"){
 	      passThisID = ( acc_EG_Loose( *electron ) && acc_EG_Medium( *electron ) ) || acc_EG_Tight( *electron );
-	    } else if (decorWP == "LHLooseBL") {
+	    } else if (decorWP == "LHLooseBL" || decorWP == "LHLoose") {
 	      passThisID = acc_EG_Medium( *electron ) || acc_EG_Loose( *electron );
 	    } else { passThisID = LHDecisionAll( *electron ); }
 	  }

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -268,7 +268,8 @@ EL::StatusCode ElectronSelector :: initialize ()
 
   if( m_doLHPID ){
     // if not using LH PID, make sure all the decorations will be set ... by choosing the loosest WP!
-    std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "Loose";
+    //std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "Loose";
+    std::string likelihoodWP = ( m_doLHPIDcut ) ? m_LHOperatingPoint : "LooseBL";
     m_el_LH_PIDManager = new ElectronLHPIDManager( likelihoodWP, msgLvl(MSG::DEBUG) );
 
 
@@ -281,10 +282,6 @@ EL::StatusCode ElectronSelector :: initialize ()
 
     if ( m_readIDFlagsFromDerivation ) {
       // LooseBL is not in Derivations, so choose Loose and do BLayer cut locally
-      if( m_LHOperatingPoint == "LooseBL" ){
-        m_LHOperatingPoint = "Loose";
-        m_doBLTrackQualityCut = true;
-      }
 
       ANA_MSG_INFO( "Reading Electron LH ID from DAODs ..." );
       ANA_CHECK( m_el_LH_PIDManager->setupWPs( false ));
@@ -991,7 +988,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 
     if ( m_readIDFlagsFromDerivation ) {
 
-      const static SG::AuxElement::ConstAccessor<char> acc_EG_Loose("DFCommonElectronsLHLoose");
+      const static SG::AuxElement::ConstAccessor<char> acc_EG_Loose("DFCommonElectronsLHLooseBL");
       const static SG::AuxElement::ConstAccessor<char> acc_EG_Medium("DFCommonElectronsLHMedium");
       const static SG::AuxElement::ConstAccessor<char> acc_EG_Tight("DFCommonElectronsLHTight");
 
@@ -1005,7 +1002,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 	      passSelID = acc_EG_Medium( *electron ) && acc_EG_Tight( *electron );
 	    } else if(m_LHOperatingPoint == "Medium"){
 	      passSelID = ( acc_EG_Loose( *electron ) && acc_EG_Medium( *electron ) ) || acc_EG_Tight( *electron );
-	    } else if (m_LHOperatingPoint == "Loose") {
+	    } else if (m_LHOperatingPoint == "LooseBL") {
 	      passSelID = acc_EG_Medium( *electron ) || acc_EG_Loose( *electron );
 	    } else { passSelID = LHDecision( *electron ); }
 	  }
@@ -1031,7 +1028,7 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
 	      passThisID = acc_EG_Medium( *electron ) && acc_EG_Tight( *electron );
 	    } else if(decorWP == "LHMedium"){
 	      passThisID = ( acc_EG_Loose( *electron ) && acc_EG_Medium( *electron ) ) || acc_EG_Tight( *electron );
-	    } else if (decorWP == "LHLoose") {
+	    } else if (decorWP == "LHLooseBL") {
 	      passThisID = acc_EG_Medium( *electron ) || acc_EG_Loose( *electron );
 	    } else { passThisID = LHDecisionAll( *electron ); }
 	  }


### PR DESCRIPTION
News:
- Electron LooseBL ID working point is now saved in derivations (no need to use Loose instead)
- The only electron loose ID working point for which SFs are provided is LooseBLayer [1]
  - AFAICT: LooseBLayer corresponds to the LooseBL working point

NOTE: This MR breaks backward compatibility when:

- m_readIDFlagsFromDerivation and m_doLHPID and m_doLHPIDcut are all true in ElectronSelector: Loose -> LooseBL
- m_doLHPIDcut is false in ElectronSelector: new lowest working point: Loose -> LooseBL

I don't see the point of maintaining the current functionality since Loose do not have SFs, but I'm open for suggestions.

[1] https://atlas-groupdata.web.cern.ch/atlas-groupdata/ElectronEfficiencyCorrection/2015_2018/rel21.2/Precision_Summer2020_v1/map4.txt