### PR TITLE
add timing cuts to JetSelector

### DIFF
--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -1304,9 +1304,6 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   }
   if ( m_useCutFlow ) m_jet_cutflowHist_1->Fill( m_jet_cutflow_jvt_cut, 1 );
 
-  //
-  //  Timing (same for offline and HLT for the time being)
-  //
   if ( m_doJetTimingCut ) {
     ANA_MSG_DEBUG("Doing Jet Timing cut");
     float jet_timing;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -144,6 +144,7 @@ EL::StatusCode JetSelector :: initialize ()
     m_jet_cutflow_etmin_cut       = m_jet_cutflowHist_1->GetXaxis()->FindBin("etmin_cut");
     m_jet_cutflow_eta_cut         = m_jet_cutflowHist_1->GetXaxis()->FindBin("eta_cut");
     m_jet_cutflow_jvt_cut         = m_jet_cutflowHist_1->GetXaxis()->FindBin("JVT_cut");
+    m_jet_cutflow_timing_cut      = m_jet_cutflowHist_1->GetXaxis()->FindBin("timing_cut");
     m_jet_cutflow_btag_cut        = m_jet_cutflowHist_1->GetXaxis()->FindBin("BTag_cut");
     m_jet_cutflow_cleaning_cut    = m_jet_cutflowHist_1->GetXaxis()->FindBin("cleaning_cut");
 
@@ -1282,6 +1283,21 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
     if ( !m_noJVTVeto && !result ) return 0;
   }
   if ( m_useCutFlow ) m_jet_cutflowHist_1->Fill( m_jet_cutflow_jvt_cut, 1 );
+
+  //
+  //  Timing (same for offline and HLT for the time being)
+  //
+  if ( m_doJetTimingCut ) {
+    ANA_MSG_DEBUG("Doing Jet Timing cut");
+    float jet_timing;
+    if (jet->getAttribute("Timing", jet_timing)) {
+      if ( std::fabs(jet_timing) > m_jetTiming_max) { return 0; }
+      if ( m_useCutFlow ) m_jet_cutflowHist_1->Fill( m_jet_cutflow_timing_cut, 1 );
+    } else {
+      ANA_MSG_ERROR("Jet timing decoration doesn't exist for this jet collection!");
+      return 0;
+    }
+  }
 
   //
   //  BTagging

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -224,6 +224,10 @@ public:
   /// @brief was fJVT already run in an earlier instance of JetSelector?
   bool m_fjvtUsedBefore=false;
 
+  /// @brief Timing cut
+  bool          n_doJetTimingCut = false;
+  float         m_jetTiming_max = -1;
+
   /// @brief Flag to apply btagging cut, if false just decorate decisions
   bool  m_doBTagCut = false;
   std::string m_corrFileName = "xAODBTaggingEfficiency/cutprofiles_22072015.root";
@@ -291,6 +295,7 @@ private:
   int   m_jet_cutflow_etmin_cut;     //!
   int   m_jet_cutflow_eta_cut;       //!
   int   m_jet_cutflow_jvt_cut;       //!
+  int   m_jet_cutflow_timing_cut;    //!
   int   m_jet_cutflow_btag_cut;      //!
 
   std::vector<CP::SystematicSet> m_systListJVT; //!

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -225,7 +225,7 @@ public:
   bool m_fjvtUsedBefore=false;
 
   /// @brief Timing cut
-  bool          n_doJetTimingCut = false;
+  bool          m_doJetTimingCut = false;
   float         m_jetTiming_max = -1;
 
   /// @brief Flag to apply btagging cut, if false just decorate decisions


### PR DESCRIPTION
Add timing cuts to JetSelector tested in release 22.2.97. Modifications include support for cutflow histograms and adding an option to set an abs(timing) > X selection for the input jet collection. Returns from JetSelector::PassCuts when no "Timing" decoration is included on the jet.