### PR TITLE
Adding LRT muons information

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -250,8 +250,6 @@ namespace HelperClasses{
     m_passSel = has_exact("passSel");
     // passOR
     m_passOR = has_exact("passOR");
-
-    m_doLRT = has_exact("doLRTelectrons");
   }
 
   void PhotonInfoSwitch::initialize(){
@@ -289,6 +287,7 @@ namespace HelperClasses{
     m_truth         = has_exact("truth");
     m_truthDetails  = has_exact("truth_details");
     m_layer         = has_exact("layer");
+    m_fJVT          = has_exact("fJVT");
     m_trackPV       = has_exact("trackPV");
     m_trackAll      = has_exact("trackAll");
     m_chargedPFOPV  = has_exact("chargedPFOPV");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -201,6 +201,8 @@ namespace HelperClasses{
     m_trigEff_sysNames = has_exact("trigEff_sysNames");
     m_ttvaEff_sysNames = has_exact("ttvaEff_sysNames");
 
+    m_doLRT = has_exact("doLRTmuons");
+
   }
 
   void ElectronInfoSwitch::initialize(){
@@ -248,6 +250,8 @@ namespace HelperClasses{
     m_passSel = has_exact("passSel");
     // passOR
     m_passOR = has_exact("passOR");
+
+    m_doLRT = has_exact("doLRTelectrons");
   }
 
   void PhotonInfoSwitch::initialize(){
@@ -289,7 +293,6 @@ namespace HelperClasses{
     m_trackAll      = has_exact("trackAll");
     m_chargedPFOPV  = has_exact("chargedPFOPV");
     m_jvt           = has_exact("JVT");
-    m_fJvt          = has_exact("fJvt");
     m_NNJvt         = has_exact("NNJvt");
     m_allTrack      = has_exact("allTrack");
     m_allTrackPVSel = has_exact("allTrackPVSel");

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -287,7 +287,7 @@ namespace HelperClasses{
     m_truth         = has_exact("truth");
     m_truthDetails  = has_exact("truth_details");
     m_layer         = has_exact("layer");
-    m_fJVT          = has_exact("fJVT");
+    m_fJvt          = has_exact("fJvt");
     m_trackPV       = has_exact("trackPV");
     m_trackAll      = has_exact("trackAll");
     m_chargedPFOPV  = has_exact("chargedPFOPV");

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -130,6 +130,9 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_PromptLeptonVeto                  = new std::vector<float> ();
   }
 
+  m_isLRT = new std::vector<char>();
+  m_passIDcuts = new std::vector<char>();
+
   if ( m_infoSwitch.m_passSel ) {
     m_passSel = new std::vector<char>();
   }
@@ -261,6 +264,9 @@ MuonContainer::~MuonContainer()
     delete m_PromptLeptonVeto                  ;
   }
 
+  delete m_isLRT;
+  delete m_passIDcuts;
+
   if ( m_infoSwitch.m_passSel ) {
     delete m_passSel;
   }
@@ -390,6 +396,8 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "PromptLeptonVeto",                 &m_PromptLeptonVeto);
   }
 
+  connectBranch<char>(tree,"isLRT",&m_isLRT);
+  connectBranch<char>(tree,"passIDcuts",&m_passIDcuts);
   if(m_infoSwitch.m_passSel) connectBranch<char>(tree,"passSel",&m_passSel);
   if(m_infoSwitch.m_passOR) connectBranch<char>(tree,"passOR",&m_passOR);
 
@@ -511,6 +519,9 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.PromptLeptonIso                   = m_PromptLeptonIso                   ->at(idx);
     muon.PromptLeptonVeto                  = m_PromptLeptonVeto                  ->at(idx);
   }
+
+  muon.isLRT = m_isLRT->at(idx);
+  muon.passIDcuts = m_passIDcuts->at(idx);
 
   // passSel
   if(m_infoSwitch.m_passSel) muon.passSel = m_passSel->at(idx);
@@ -635,6 +646,9 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<float>(tree, "PromptLeptonVeto",                  m_PromptLeptonVeto);
   }
 
+  setBranch<char>(tree,"isLRT",m_isLRT);
+  setBranch<char>(tree,"passIDcuts",m_passIDcuts);
+
   if ( m_infoSwitch.m_passSel ) {
     setBranch<char>(tree,"passSel",m_passSel);
   }
@@ -754,6 +768,9 @@ void MuonContainer::clear()
     m_ParamEnergyLossSigmaPlus->clear();
 
   }
+
+  m_isLRT->clear();
+  m_passIDcuts->clear();
 
   if(m_infoSwitch.m_passSel){
     m_passSel->clear();
@@ -1009,6 +1026,12 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
 
   }
 
+  static SG::AuxElement::Accessor<char> accMuon_isLRT( "isLRT" );
+  safeFill<char, char, xAOD::Muon>(muon, accMuon_isLRT, m_isLRT, -1);
+
+  static SG::AuxElement::Accessor<char> accMuon_passIDcuts( "passIDcuts" );
+  safeFill<char, char, xAOD::Muon>(muon, accMuon_passIDcuts, m_passIDcuts, -1);
+  
   if ( m_infoSwitch.m_passSel ) {
     static SG::AuxElement::Accessor<char> accMuon_passSel( "passSel" );
     safeFill<char, char, xAOD::Muon>(muon, accMuon_passSel, m_passSel, -99);

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -130,8 +130,10 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_PromptLeptonVeto                  = new std::vector<float> ();
   }
 
-  m_isLRT = new std::vector<char>();
-  m_passIDcuts = new std::vector<char>();
+  if ( m_infoSwitch.m_doLRT ){
+    m_isLRT = new std::vector<char>();
+    m_passIDcuts = new std::vector<char>();
+  }
 
   if ( m_infoSwitch.m_passSel ) {
     m_passSel = new std::vector<char>();
@@ -264,8 +266,10 @@ MuonContainer::~MuonContainer()
     delete m_PromptLeptonVeto                  ;
   }
 
-  delete m_isLRT;
-  delete m_passIDcuts;
+  if ( m_infoSwitch.m_doLRT ){
+    delete m_isLRT;
+    delete m_passIDcuts;
+  }
 
   if ( m_infoSwitch.m_passSel ) {
     delete m_passSel;
@@ -396,8 +400,10 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<float>(tree, "PromptLeptonVeto",                 &m_PromptLeptonVeto);
   }
 
-  connectBranch<char>(tree,"isLRT",&m_isLRT);
-  connectBranch<char>(tree,"passIDcuts",&m_passIDcuts);
+  if ( m_infoSwitch.m_doLRT ){
+    connectBranch<char>(tree,"isLRT",&m_isLRT);
+    connectBranch<char>(tree,"passIDcuts",&m_passIDcuts);
+  }
   if(m_infoSwitch.m_passSel) connectBranch<char>(tree,"passSel",&m_passSel);
   if(m_infoSwitch.m_passOR) connectBranch<char>(tree,"passOR",&m_passOR);
 
@@ -520,8 +526,10 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.PromptLeptonVeto                  = m_PromptLeptonVeto                  ->at(idx);
   }
 
-  muon.isLRT = m_isLRT->at(idx);
-  muon.passIDcuts = m_passIDcuts->at(idx);
+  if ( m_infoSwitch.m_doLRT ){
+    muon.isLRT = m_isLRT->at(idx);
+    muon.passIDcuts = m_passIDcuts->at(idx);
+  }
 
   // passSel
   if(m_infoSwitch.m_passSel) muon.passSel = m_passSel->at(idx);
@@ -646,8 +654,10 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<float>(tree, "PromptLeptonVeto",                  m_PromptLeptonVeto);
   }
 
-  setBranch<char>(tree,"isLRT",m_isLRT);
-  setBranch<char>(tree,"passIDcuts",m_passIDcuts);
+  if ( m_infoSwitch.m_doLRT ){
+    setBranch<char>(tree,"isLRT",m_isLRT);
+    setBranch<char>(tree,"passIDcuts",m_passIDcuts);
+  }
 
   if ( m_infoSwitch.m_passSel ) {
     setBranch<char>(tree,"passSel",m_passSel);
@@ -769,8 +779,10 @@ void MuonContainer::clear()
 
   }
 
-  m_isLRT->clear();
-  m_passIDcuts->clear();
+  if ( m_infoSwitch.m_doLRT ){
+    m_isLRT->clear();
+    m_passIDcuts->clear();
+  }
 
   if(m_infoSwitch.m_passSel){
     m_passSel->clear();
@@ -1026,12 +1038,14 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
 
   }
 
-  static SG::AuxElement::Accessor<char> accMuon_isLRT( "isLRT" );
-  safeFill<char, char, xAOD::Muon>(muon, accMuon_isLRT, m_isLRT, -1);
+  if ( m_infoSwitch.m_doLRT ){
+    static SG::AuxElement::Accessor<char> accMuon_isLRT( "isLRT" );
+    safeFill<char, char, xAOD::Muon>(muon, accMuon_isLRT, m_isLRT, -1);
 
-  static SG::AuxElement::Accessor<char> accMuon_passIDcuts( "passIDcuts" );
-  safeFill<char, char, xAOD::Muon>(muon, accMuon_passIDcuts, m_passIDcuts, -1);
-  
+    static SG::AuxElement::Accessor<char> accMuon_passIDcuts( "passIDcuts" );
+    safeFill<char, char, xAOD::Muon>(muon, accMuon_passIDcuts, m_passIDcuts, -1);
+  }
+
   if ( m_infoSwitch.m_passSel ) {
     static SG::AuxElement::Accessor<char> accMuon_passSel( "passSel" );
     safeFill<char, char, xAOD::Muon>(muon, accMuon_passSel, m_passSel, -99);

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -300,6 +300,8 @@ namespace HelperClasses {
     bool m_passSel;
     bool m_passOR;
 
+    bool m_doLRT;
+
     bool m_recoEff_sysNames;
     bool m_isoEff_sysNames;
     bool m_trigEff_sysNames;
@@ -370,6 +372,7 @@ namespace HelperClasses {
     std::vector< std::string > m_trigWPs;
     bool m_passSel;
     bool m_passOR;
+    bool m_doLRT;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:
@@ -496,7 +499,7 @@ namespace HelperClasses {
                 m_configStr = "... sfJVTMedium ..."
 
             ``jetBTag`` expects the format ``jetBTag_tagger_type_AABB..MM..YY.ZZ``. This will create a vector of working points (AA, BB, CC, ..., ZZ) associated with that tagger. Several entries can be given. For example::
-
+           
 	        m_configStr = "... jetBTag_DL1r_FixedCutBEff_60707785 ..."
 
 	    ``trackJetName`` expects one or more track jet container names separated by an underscore. For example, the string ``trackJetName_GhostAntiKt2TrackJet_GhostVR30Rmax4Rmin02TrackJet`` will set the attriubte ``m_trackJetNames``
@@ -529,7 +532,6 @@ namespace HelperClasses {
     bool m_trackAll;
     bool m_chargedPFOPV;
     bool m_jvt;
-    bool m_fJvt;
     bool m_NNJvt;
     bool m_allTrack;
     bool m_allTrackDetail;

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -372,7 +372,6 @@ namespace HelperClasses {
     std::vector< std::string > m_trigWPs;
     bool m_passSel;
     bool m_passOR;
-    bool m_doLRT;
     ElectronInfoSwitch(const std::string configStr) : IParticleInfoSwitch(configStr) { initialize(); };
     virtual ~ElectronInfoSwitch() {}
   protected:
@@ -530,6 +529,7 @@ namespace HelperClasses {
     bool m_layer;
     bool m_trackPV;
     bool m_trackAll;
+    bool m_fJvt;
     bool m_chargedPFOPV;
     bool m_jvt;
     bool m_NNJvt;

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -104,6 +104,9 @@ namespace xAH {
     float PromptLeptonIso;
     float PromptLeptonVeto;
 
+    char isLRT;
+    char passIDcuts;
+
     // passSel
     char passSel;
     // passOR

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -111,6 +111,9 @@ namespace xAH {
       std::vector<float>* m_PromptLeptonIso;
       std::vector<float>* m_PromptLeptonVeto;
 
+      std::vector<char>* m_isLRT;
+      std::vector<char>* m_passIDcuts;
+     
       // passSel
       std::vector<char>* m_passSel;
       // passOR

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -112,6 +112,9 @@ public:
   /// @brief Input prefix of trigger decision tool
   std::string    m_trigInputPrefix = "";
 
+  /** add LRT muon information */
+  bool       	 m_doLRT = false;
+
 private:
 
   int            m_muonQuality; //!


### PR DESCRIPTION
Hi, 

for dHNL analysis we would like to slightly modify the code such that in the case of LRT muons no ID cuts are checked. Additionally, the boolean used in this step (checking if the muon is LRT and if it passes ID cuts) are stored in the output ntuples.

In attachment one useful plot that shows that for LRT muons you can have both cases in which ID cuts are passed or not, while for prompt muons these are always satisfied since the ID cuts is intrinsic in the accept method.

[c1.pdf](https://github.com/UCATLAS/xAODAnaHelpers/files/10175616/c1.pdf)

Thank you, cheers.
Guglielmo & Sagar
