### PR TITLE
do not try to access btagging SFs for jets with eta > 2.5

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -408,6 +408,8 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   //
   for( const xAOD::Jet* jet_itr : *(inJets)){
 
+    if(abs(jet_itr->eta()) > 2.5) continue;
+
     if(!m_useContinuous){
       // get tagging decision
       ANA_MSG_DEBUG(" Getting tagging decision ");
@@ -471,6 +473,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
           for( const xAOD::Jet* jet_itr : *(inJets))
 	    {
+              if(abs(jet_itr->eta()) > 2.5) continue;
               if(m_setMapIndex){ // select an efficiency map for use in MC/MC and inefficiency scale factors, based on user specified selection of efficiency maps
                 auto FlavLabel = getFlavorLabel(*jet_itr);
                 auto DSID      = eventInfo->mcChannelNumber();


### PR DESCRIPTION
Hi,

this MR introduces a check on the eta of the jets when trying to access the b-tagging information, limiting to abs(eta) < 2.5 as per detector constraints. This is needed because of the recent modification to Athena, in which an error message is spammed if this action is tried, see https://gitlab.cern.ch/atlas/athena/-/blob/release/22.2.99/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/CalibrationDataInterface/Root/CalibrationDataInterfaceROOT.cxx#L805-808 .

Cheers,
Guglielmo