### PR TITLE
Addition of very loose nopix WP to electron ID options

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -408,6 +408,8 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   //
   for( const xAOD::Jet* jet_itr : *(inJets)){
 
+    if(abs(jet_itr->eta()) > 2.5) continue;
+
     if(!m_useContinuous){
       // get tagging decision
       ANA_MSG_DEBUG(" Getting tagging decision ");
@@ -471,6 +473,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 
           for( const xAOD::Jet* jet_itr : *(inJets))
 	    {
+              if(abs(jet_itr->eta()) > 2.5) continue;
               if(m_setMapIndex){ // select an efficiency map for use in MC/MC and inefficiency scale factors, based on user specified selection of efficiency maps
                 auto FlavLabel = getFlavorLabel(*jet_itr);
                 auto DSID      = eventInfo->mcChannelNumber();

--- a/Root/ParticlePIDManager.cxx
+++ b/Root/ParticlePIDManager.cxx
@@ -3,6 +3,7 @@
 ANA_MSG_SOURCE(msgPIDManager, "PIDManager")
 
 ElectronLHPIDManager :: ElectronLHPIDManager ( std::string WP, bool debug ) :
+  m_asgElectronLikelihoodTool_VeryLooseNP(nullptr),
   m_asgElectronLikelihoodTool_VeryLoose(nullptr),
   m_asgElectronLikelihoodTool_Loose(nullptr),
   m_asgElectronLikelihoodTool_LooseBL(nullptr),
@@ -13,25 +14,28 @@ ElectronLHPIDManager :: ElectronLHPIDManager ( std::string WP, bool debug ) :
       m_debug      = debug;
 
       /*  fill the multimap with WPs and corresponding tools */
-      std::pair < std::string, AsgElectronLikelihoodTool* > veryloose = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
-      std::pair < std::string, AsgElectronLikelihoodTool* > loose     = std::make_pair( std::string("Loose"),     m_asgElectronLikelihoodTool_Loose     );
-      std::pair < std::string, AsgElectronLikelihoodTool* > loosebl   = std::make_pair( std::string("LooseBL"),     m_asgElectronLikelihoodTool_LooseBL     );
-      std::pair < std::string, AsgElectronLikelihoodTool* > medium    = std::make_pair( std::string("Medium"),    m_asgElectronLikelihoodTool_Medium    );
-      std::pair < std::string, AsgElectronLikelihoodTool* > tight     = std::make_pair( std::string("Tight"),     m_asgElectronLikelihoodTool_Tight     );
-      m_allWPTools.insert(veryloose); m_allWPAuxDecors.insert("VeryLoose");
-      m_allWPTools.insert(loose);     m_allWPAuxDecors.insert("Loose");
-      m_allWPTools.insert(loosebl);   m_allWPAuxDecors.insert("Loose"); //Not saved in DAODs, so use Loose decision
-      m_allWPTools.insert(medium);    m_allWPAuxDecors.insert("Medium");
-      m_allWPTools.insert(tight);     m_allWPAuxDecors.insert("Tight");
+      std::pair < std::string, AsgElectronLikelihoodTool* > veryloosenp = std::make_pair( std::string("VeryLooseNoPix"), m_asgElectronLikelihoodTool_VeryLooseNP );
+      std::pair < std::string, AsgElectronLikelihoodTool* > veryloose   = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
+      std::pair < std::string, AsgElectronLikelihoodTool* > loose       = std::make_pair( std::string("Loose"),     m_asgElectronLikelihoodTool_Loose     );
+      std::pair < std::string, AsgElectronLikelihoodTool* > loosebl     = std::make_pair( std::string("LooseBL"),     m_asgElectronLikelihoodTool_LooseBL     );
+      std::pair < std::string, AsgElectronLikelihoodTool* > medium      = std::make_pair( std::string("Medium"),    m_asgElectronLikelihoodTool_Medium    );
+      std::pair < std::string, AsgElectronLikelihoodTool* > tight       = std::make_pair( std::string("Tight"),     m_asgElectronLikelihoodTool_Tight     );
+      m_allWPTools.insert(veryloosenp); m_allWPAuxDecors.insert("VeryLooseNoPix");
+      m_allWPTools.insert(veryloose);   m_allWPAuxDecors.insert("VeryLoose");
+      m_allWPTools.insert(loose);       m_allWPAuxDecors.insert("Loose");
+      m_allWPTools.insert(loosebl);     m_allWPAuxDecors.insert("Loose"); //Not saved in DAODs, so use Loose decision
+      m_allWPTools.insert(medium);      m_allWPAuxDecors.insert("Medium");
+      m_allWPTools.insert(tight);       m_allWPAuxDecors.insert("Tight");
 }
 
 ElectronLHPIDManager ::  ~ElectronLHPIDManager()
 {
-  if ( m_asgElectronLikelihoodTool_VeryLoose ) { delete m_asgElectronLikelihoodTool_VeryLoose; m_asgElectronLikelihoodTool_VeryLoose = nullptr; }
-  if ( m_asgElectronLikelihoodTool_Loose )     { delete m_asgElectronLikelihoodTool_Loose;     m_asgElectronLikelihoodTool_Loose     = nullptr; }
-  if ( m_asgElectronLikelihoodTool_LooseBL )   { delete m_asgElectronLikelihoodTool_LooseBL;   m_asgElectronLikelihoodTool_LooseBL   = nullptr; }
-  if ( m_asgElectronLikelihoodTool_Medium )    { delete m_asgElectronLikelihoodTool_Medium;    m_asgElectronLikelihoodTool_Medium    = nullptr; }
-  if ( m_asgElectronLikelihoodTool_Tight )     { delete m_asgElectronLikelihoodTool_Tight;     m_asgElectronLikelihoodTool_Tight     = nullptr; }
+  if ( m_asgElectronLikelihoodTool_VeryLooseNP ) { delete m_asgElectronLikelihoodTool_VeryLooseNP; m_asgElectronLikelihoodTool_VeryLooseNP = nullptr; }
+  if ( m_asgElectronLikelihoodTool_VeryLoose )   { delete m_asgElectronLikelihoodTool_VeryLoose; m_asgElectronLikelihoodTool_VeryLoose = nullptr; }
+  if ( m_asgElectronLikelihoodTool_Loose )       { delete m_asgElectronLikelihoodTool_Loose;     m_asgElectronLikelihoodTool_Loose     = nullptr; }
+  if ( m_asgElectronLikelihoodTool_LooseBL )     { delete m_asgElectronLikelihoodTool_LooseBL;   m_asgElectronLikelihoodTool_LooseBL   = nullptr; }
+  if ( m_asgElectronLikelihoodTool_Medium )      { delete m_asgElectronLikelihoodTool_Medium;    m_asgElectronLikelihoodTool_Medium    = nullptr; }
+  if ( m_asgElectronLikelihoodTool_Tight )       { delete m_asgElectronLikelihoodTool_Tight;     m_asgElectronLikelihoodTool_Tight     = nullptr; }
 }
 
 

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -57,6 +57,7 @@ class ElectronLHPIDManager
     std::set<std::string> m_allWPAuxDecors;
     std::set<std::string> m_validWPs;
 
+    AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLooseNP;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLoose;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_LooseBL;


### PR DESCRIPTION
Hi,

this MR adds the possibility to select the ```DFCommonElectronsLHVeryLooseNoPix``` WP for electron ID, used in LLP searches.

Cheers,
Guglielmo & Sagar