### PR TITLE
Add more releases to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           - analysisbase
         release_version:
           - 22.2.97
+          - 22.2.98
+          - 22.2.99
+          - 22.2.100
+          - 22.2.101
+          - 22.2.102
+          - 22.2.103
+          - 22.2.104
+          - 22.2.105
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
xAH seems to be working fine up to 22.2.105, and there are fixes affecting analyzers in releases above 22.2.97, so adding newer releases to CI tests.