### PR TITLE
Fix default MCType for FullSim in JetCalibrator

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -158,7 +158,10 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
-  if(m_uncertMCType.empty()) m_uncertMCType = isFastSim() ? "AFII" : "MC16";
+  if(!isFastSim() && m_uncertMCType.empty()){
+    ANA_MSG_ERROR("MCType not provided, please set m_uncertMCType (MC20 or MC21) when running on FullSim samples.  Exiting.");
+    return EL::StatusCode::FAILURE;
+  }
 
   // Autoconfigure calibration sequence if the user didn't do it.
   // Recommended strings taken from ApplyJetCalibrationR21 Twiki.

--- a/docs/Algorithms.rst
+++ b/docs/Algorithms.rst
@@ -68,7 +68,7 @@ Outputs new containers for each systematic variation.
 For JES: Uses JetUncertaintiesTool. JES is different for AFII, so
 m\_setAFII may be required if metadata isn't working. 1. JESUncertConfig
 - Configuration file for JES 2. JESUncertMCType - Type of JES
-Uncertainty to use, MC15 or MC12
+Uncertainty to use, MC20 or MC21
 
 For JER: Uses JERSmearingTool 1. JERUncertConfig - Configuration file
 for JER 2. JERFullSys - Run full list of systematics for data and MC.

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -69,7 +69,7 @@ public:
   std::string m_calibSequence = "";
   /// @brief config for Jet Uncertainty Tool
   std::string m_uncertConfig = "";
-  /// @brief MC type for Jet Uncertainty Tool
+  /// @brief MC type for Jet Uncertainty Tool (need to be set for FullSim)
   std::string m_uncertMCType = "";
   /// @brief Override CalibArea tag (default recommended)
   std::string m_overrideCalibArea = "";


### PR DESCRIPTION
JetUncertainties has now two options in R22: MC20 or MC21. Hence, we shouldn't be using MC16 as the default FullSim MCType. Instead, I propose to force users to choose the MCType when using FullSim samples. The default is kept empty and it would have to be set by the user to MC20 or MC21.