### PR TITLE
Add isRun3 flag and configure TDT properly

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -134,6 +134,19 @@ bool xAH::Algorithm::isPHYS(){
     }
 }
 
+bool xAH::Algorithm::isRun3(){
+  /**
+   * Maybe there is a way to do this on-the-fly
+  */
+
+  if (m_isRun3 == -1) {
+    ANA_MSG_ERROR("isRun3 is can't be determined on-the-fly.  Please configure it.");
+    return 0;
+  } else {
+    return m_isRun3 == 1;
+  }
+}
+
 void xAH::Algorithm::registerInstance(){
     if(m_registered) return;
     m_instanceRegistry[m_className]++;

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -521,6 +521,12 @@ EL::StatusCode BasicEventSelection :: initialize ()
     ANA_CHECK( m_trigDecTool_handle.setProperty( "ConfigTool", m_trigConfTool_handle ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "TrigDecisionKey", "xTrigDecision" ));
     ANA_CHECK( m_trigDecTool_handle.setProperty( "OutputLevel", msg().level() ));
+
+    if ( isRun3() )
+    {
+      ANA_CHECK( m_trigDecTool_handle.setProperty( "NavigationFormat", "TrigComposite") );
+      ANA_CHECK( m_trigDecTool_handle.setProperty( "HLTSummary", "HLTNav_Summary_DAODSlimmed") );
+    }
     ANA_CHECK( m_trigDecTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -162,6 +162,22 @@ namespace xAH {
          */
         int m_isFastSim = -1;
 
+        /**
+            @rst
+                This stores the isRun3 decision, and can also be used to override at the algorithm level to force analyzing Run3 or not.
+
+                ===== ========================================================
+                Value Meaning
+                ===== ========================================================
+                -1    Default, use Metadata object to determine if Run2 or Run 3
+                0     Treat the input as Run2
+                1     Treat the input as Run3
+                ===== ========================================================
+
+            @endrst
+         */
+        int m_isRun3 = -1;
+
         /** Flags to force a specific data-type, even if it disagrees with your input */
         bool m_forceFastSim = false;
         bool m_forceFullSim = false;
@@ -223,6 +239,9 @@ namespace xAH {
 
 	/** Determines if using DAOD_PHYS or not. */
 	bool isPHYS();
+
+        /** Determines if using Run 2 or Run 3 samples */
+        bool isRun3();
 
         /**
             @rst


### PR DESCRIPTION
Add a flag to control Run 3 vs Run 2 behavior and use it to configure the trigger decision tool properly for Run 3.  Addresses part of #1572 