### PR TITLE
MCType not needed when no jet uncert are requested

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -135,7 +135,7 @@ EL::StatusCode ElectronSelector :: initialize ()
 
     // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -158,7 +158,7 @@ EL::StatusCode JetCalibrator :: initialize ()
     }
   }
 
-  if(!isFastSim() && m_uncertMCType.empty()){
+  if(!isFastSim() && m_uncertMCType.empty() && !m_uncertConfig.empty()){
     ANA_MSG_ERROR("MCType not provided, please set m_uncertMCType (MC20 or MC21) when running on FullSim samples.  Exiting.");
     return EL::StatusCode::FAILURE;
   }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -124,7 +124,7 @@ EL::StatusCode JetSelector :: initialize ()
 
    // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -133,7 +133,7 @@ EL::StatusCode MuonSelector :: initialize ()
 
     // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -1115,7 +1115,7 @@ EL::StatusCode OverlapRemover :: setCutFlowHist( )
 
     // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the object cutflow
     //

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -118,7 +118,7 @@ EL::StatusCode PhotonSelector :: initialize ()
 
     // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -139,7 +139,7 @@ EL::StatusCode TauSelector :: initialize ()
 
     // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/Root/TrackSelector.cxx
+++ b/Root/TrackSelector.cxx
@@ -98,7 +98,7 @@ EL::StatusCode TrackSelector :: initialize ()
   // input events.
 
   if(m_useCutFlow) {
-    TFile *file = wk()->getOutputFile ("cutflow");
+    TFile *file = wk()->getOutputFile (m_cutFlowStreamName);
     m_cutflowHist  = (TH1D*)file->Get("cutflow");
     m_cutflowHistW = (TH1D*)file->Get("cutflow_weighted");
     m_cutflow_bin  = m_cutflowHist->GetXaxis()->FindBin(m_name.c_str());

--- a/Root/TruthSelector.cxx
+++ b/Root/TruthSelector.cxx
@@ -89,7 +89,7 @@ EL::StatusCode TruthSelector :: initialize ()
 
    // retrieve the file in which the cutflow hists are stored
     //
-    TFile *file     = wk()->getOutputFile ("cutflow");
+    TFile *file     = wk()->getOutputFile (m_cutFlowStreamName);
 
     // retrieve the event cutflows
     //

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -102,6 +102,9 @@ namespace xAH {
         /** debug level */
         MSG::Level m_msgLevel = MSG::INFO;
 
+        // output stream name for cutflow
+        std::string m_cutFlowStreamName = "cutflow";
+
         /** If running systematics, the name of the systematic */
         std::string m_systName = "";
         /** If running systematics, the value to set the systematic to

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -187,7 +187,6 @@ class BasicEventSelection : public xAH::Algorithm
 
     // output stream names
     std::string m_metaDataStreamName = "metadata";
-    std::string m_cutFlowStreamName = "cutflow";
     std::string m_duplicatesStreamName = "duplicates_tree";
 
     /** Check for duplicated events in data */


### PR DESCRIPTION
Also set common stream name for the cutflows in Algorithm. This fixes the hard-coding of the cutflow in BasicEventSelection

Fixes: https://github.com/UCATLAS/xAODAnaHelpers/issues/1608
Implements: https://github.com/UCATLAS/xAODAnaHelpers/issues/598