### PR TITLE
Bump lxml from 4.6.5 to 4.9.1 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ exhale==0.2.3
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.11.3
-lxml==4.6.5
+lxml==4.9.1
 MarkupSafe==1.1.1
 packaging==19.2
 Pygments==2.7.4


### PR DESCRIPTION
Reimplements this after master->main change: 
https://github.com/UCATLAS/xAODAnaHelpers/pull/1549