### PR TITLE
Add additional AnalysisBase versions to ci.yml configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           - 22.2.103
           - 22.2.104
           - 22.2.105
+	  - 22.2.108
+	  - 22.2.109
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
Add additional AnalysisBase versions to the `ci.yml` configuration file to support AnalysisBase 22.2.108 and 22.2.109, which support the latest offline (`AntiKtEMPFlowJets`) jet calibration pre-recommendations.