### PR TITLE
feat: Change base repo for docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       RELEASE_TYPE: ${{ matrix.release_type }}
       RELEASE_VERSION: ${{ matrix.release_version }}
-      DOCKER_BASE_REPO: atlas
+      DOCKER_BASE_REPO: gitlab-registry.cern.ch/atlas/athena
       DOCKER_TARGET_REPO: ucatlas
       RELEASE: ${{ format('{0}@{1}', matrix.release_type, matrix.release_version) }}
     strategy:


### PR DESCRIPTION
Migrate from [DockerHub](https://hub.docker.com/u/atlas) to [GitLab Registry](https://gitlab.cern.ch/atlas/athena/container_registry/8439).
