### PR TITLE
Fixing MET Systematics

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -122,9 +122,6 @@ EL::StatusCode METConstructor :: initialize ()
   if ( m_doPFlow ) {
     ANA_CHECK(m_metmaker_handle.setProperty("DoPFlow", true));
   }
-  if ( m_doMuonPFlowBugfix ) {
-    ANA_CHECK(m_metmaker_handle.setProperty("DoMuonPFlowBugfix", true));
-  }
   if ( !m_METWorkingPoint.empty() ){
     ANA_CHECK(m_metmaker_handle.setProperty("JetSelection", m_METWorkingPoint));
   }

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -148,7 +148,7 @@ EL::StatusCode METConstructor :: initialize ()
     ANA_CHECK( m_metSignificance_handle.setProperty("SoftTermReso", m_significanceSoftTermReso) );
 
     // For AFII samples
-    if ( isFastSim() ){ 
+    if ( isFastSim() ){
       ANA_MSG_INFO( "Setting simulation flavour to AFII");
       ANA_CHECK( m_metSignificance_handle.setProperty("IsAFII", true));
     }
@@ -207,8 +207,6 @@ EL::StatusCode METConstructor :: execute ()
    const xAOD::MissingETAssociationMap* metMap = 0;
    ANA_CHECK( HelperFunctions::retrieve(metMap, m_mapName, m_event, m_store, msg()));
    xAOD::MissingETAssociationHelper metHelper(metMap);
-   // Reset all the met map associations
-   metHelper.resetObjSelectionFlags();
 
    std::vector<CP::SystematicSet>::const_iterator sysListItr;
    auto vecOutContainerNames = std::make_unique< std::vector< std::string > >();
@@ -227,8 +225,10 @@ EL::StatusCode METConstructor :: execute ()
      ANA_CHECK( HelperFunctions::retrieve(sysJetsNames, m_jetSystematics, 0, m_store, msg()));
 
      for ( auto systName : *sysJetsNames ) {
-       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) m_sysList.push_back(CP::SystematicSet(systName));
-       ANA_MSG_DEBUG("jet syst added is = "<< systName);
+       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) {
+         m_sysList.push_back(CP::SystematicSet(systName));
+         ANA_MSG_DEBUG("jet syst added is = "<< systName);
+       }
      }
    }
 
@@ -238,8 +238,10 @@ EL::StatusCode METConstructor :: execute ()
      ANA_CHECK( HelperFunctions::retrieve(sysElectronsNames, m_eleSystematics, 0, m_store, msg()));
 
      for ( auto systName : *sysElectronsNames ) {
-       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())  ) m_sysList.push_back(CP::SystematicSet(systName));
-       ANA_MSG_DEBUG("ele syst added is = "<< systName);
+       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) {
+         m_sysList.push_back(CP::SystematicSet(systName));
+         ANA_MSG_DEBUG("ele syst added is = "<< systName);
+       }
      }
    }
 
@@ -249,8 +251,10 @@ EL::StatusCode METConstructor :: execute ()
      ANA_CHECK( HelperFunctions::retrieve(sysMuonsNames, m_muonSystematics, 0, m_store, msg()));
 
      for ( auto systName : *sysMuonsNames ) {
-       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) m_sysList.push_back(CP::SystematicSet(systName));
-       ANA_MSG_DEBUG("muon syst added is = "<< systName);
+       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) {
+         m_sysList.push_back(CP::SystematicSet(systName));
+         ANA_MSG_DEBUG("muon syst added is = "<< systName);
+       }
      }
    }
 
@@ -260,8 +264,10 @@ EL::StatusCode METConstructor :: execute ()
      ANA_CHECK( HelperFunctions::retrieve(sysTausNames, m_tauSystematics, 0, m_store, msg()));
 
      for ( auto systName : *sysTausNames ) {
-       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) m_sysList.push_back(CP::SystematicSet(systName));
-       ANA_MSG_DEBUG("tau syst added is = "<< systName);
+       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) {
+         m_sysList.push_back(CP::SystematicSet(systName));
+         ANA_MSG_DEBUG("tau syst added is = "<< systName);
+       }
      }
    }
 
@@ -271,8 +277,10 @@ EL::StatusCode METConstructor :: execute ()
      ANA_CHECK( HelperFunctions::retrieve(sysPhotonsNames, m_phoSystematics, 0, m_store, msg()));
 
      for ( auto systName : *sysPhotonsNames ) {
-       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) m_sysList.push_back(CP::SystematicSet(systName));
-       ANA_MSG_DEBUG("photon syst added is = "<< systName);
+       if (systName != "" && !(std::find(m_sysList.begin(), m_sysList.end(), CP::SystematicSet(systName)) != m_sysList.end())) {
+         m_sysList.push_back(CP::SystematicSet(systName));
+         ANA_MSG_DEBUG("photon syst added is = "<< systName);
+       }
      }
    }
 
@@ -295,6 +303,9 @@ EL::StatusCode METConstructor :: execute ()
 
       vecOutContainerNames->push_back( systName );
 
+      // Reset all the met map associations
+      metHelper.resetObjSelectionFlags();
+
       //create a met container, one for each syst
       auto newMet = std::make_unique<xAOD::MissingETContainer>();
       auto metAuxCont = std::make_unique<xAOD::MissingETAuxContainer>();
@@ -311,7 +322,7 @@ EL::StatusCode METConstructor :: execute ()
          const xAOD::ElectronContainer* eleCont(0);
          std::string suffix = "";
          if (sysElectronsNames && std::find(std::begin(*sysElectronsNames), std::end(*sysElectronsNames), systName) != std::end(*sysElectronsNames)) {
-           ANA_MSG_DEBUG("doing electron systematics");
+           if (systName != "") ANA_MSG_DEBUG("doing electron systematics");
            suffix = systName;
          }
 
@@ -342,7 +353,7 @@ EL::StatusCode METConstructor :: execute ()
          const xAOD::PhotonContainer* phoCont(0);
          std::string suffix = "";
          if (sysPhotonsNames && std::find(std::begin(*sysPhotonsNames), std::end(*sysPhotonsNames), systName) != std::end(*sysPhotonsNames)) {
-           ANA_MSG_DEBUG("doing photon systematics");
+           if (systName != "") ANA_MSG_DEBUG("doing photon systematics");
            suffix = systName;
          }
 
@@ -389,7 +400,7 @@ EL::StatusCode METConstructor :: execute ()
         const xAOD::TauJetContainer* tauCont(0);
         std::string suffix = "";
         if (sysTausNames && std::find(std::begin(*sysTausNames), std::end(*sysTausNames), systName) != std::end(*sysTausNames)) {
-          ANA_MSG_DEBUG("doing tau systematics");
+          if (systName != "") ANA_MSG_DEBUG("doing tau systematics");
           suffix = systName;
         }
 
@@ -426,7 +437,7 @@ EL::StatusCode METConstructor :: execute ()
         const xAOD::MuonContainer* muonCont(0);
         std::string suffix = "";
         if (sysMuonsNames && std::find(std::begin(*sysMuonsNames), std::end(*sysMuonsNames), systName) != std::end(*sysMuonsNames)) {
-          ANA_MSG_DEBUG("doing muon systematics");
+          if (systName != "") ANA_MSG_DEBUG("doing muon systematics");
           suffix = systName;
         }
 
@@ -460,7 +471,7 @@ EL::StatusCode METConstructor :: execute ()
      const xAOD::JetContainer* jetCont(0);
      std::string suffix = "";
      if (sysJetsNames && std::find(std::begin(*sysJetsNames), std::end(*sysJetsNames), systName) != std::end(*sysJetsNames)) {
-       ANA_MSG_DEBUG("doing muon systematics");
+       if (systName != "") ANA_MSG_DEBUG("doing jet systematics");
        suffix = systName;
      }
 
@@ -566,28 +577,6 @@ EL::StatusCode METConstructor :: execute ()
      ANA_MSG_DEBUG(" FinalTrk met, for syst " << systName << " is = " << (*newMet->find("FinalTrk"))->met());
      ANA_MSG_DEBUG("storing met container :  " << (m_outputContainer + systName));
      ANA_MSG_DEBUG("storing  Aux met container :  "<< (m_outputContainer + systName + "Aux."));
-
-     // Debug compare reference and recomputed MET
-     if ( m_msgLevel <= MSG::DEBUG ) {
-       const xAOD::MissingETContainer* oldMet(0);
-       ANA_CHECK( HelperFunctions::retrieve(oldMet, m_referenceMETContainer, m_event, m_store, msg()) );
-
-       ANA_MSG_DEBUG( ">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-       if ( !m_inputElectrons.empty() ) ANA_MSG_DEBUG( "RefEle:       old=" << (*oldMet->find("RefEle"))->met() << " \tnew" << (*newMet->find("RefEle"))->met());
-       if ( !m_inputPhotons.empty() )   ANA_MSG_DEBUG( "RefPhoton:    old=" << (*oldMet->find("RefGamma"))->met() << " \tnew" << (*newMet->find("RefGamma"))->met());
-       if ( !m_inputTaus.empty() )      ANA_MSG_DEBUG( "RefTau:       old=" << (*oldMet->find("RefTau"))->met() << " \tnew" << (*newMet->find("RefTau"))->met());
-       if ( !m_inputMuons.empty() )     ANA_MSG_DEBUG( "RefMuon:      old=" << (*oldMet->find("Muons"))->met() << " \tnew" << (*newMet->find("Muons"))->met());
-       ANA_MSG_DEBUG( "RefJet:       old=" << (*oldMet->find("RefJet"))->met() << " \tnew" << (*newMet->find("RefJet"))->met());
-       if ( m_addSoftClusterTerms ) {
-         ANA_MSG_DEBUG( "SoftClus:     old=" << (*oldMet->find("SoftClus"))->met() << " \tnew" << (*newMet->find("SoftClus"))->met());
-       }
-       ANA_MSG_DEBUG( "PVSoftTrk:    old=" << (*oldMet->find("PVSoftTrk"))->met() << " \tnew" << (*newMet->find("PVSoftTrk"))->met());
-       ANA_MSG_DEBUG( "  ");
-       ANA_MSG_DEBUG( "FinalClus:    old=" << (*oldMet->find("FinalClus"))->met() << " \tnew" << (*newMet->find("FinalClus"))->met());
-       ANA_MSG_DEBUG( "       >>>>> R=" << (*oldMet->find("FinalClus"))->met()/ (*newMet->find("FinalClus"))->met());
-       ANA_MSG_INFO( "FinalTrk:     old=" << (*oldMet->find("FinalTrk"))->met() << " \tnew" << (*newMet->find("FinalTrk"))->met());
-       ANA_MSG_INFO( "       >>>>> R=" << (*oldMet->find("FinalTrk"))->met()/ (*newMet->find("FinalTrk"))->met());
-     }
 
      // Store MET
      ANA_CHECK( m_store->record( std::move(newMet), (m_outputContainer + systName) ));

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -28,7 +28,6 @@ class METConstructor : public xAH::Algorithm
 public:
 
   // configuration variables
-  std::string m_referenceMETContainer = "MET_Reference_AntiKt4LCTopo";
   std::string m_mapName = "METAssoc_AntiKt4LCTopo";
   std::string m_coreName = "MET_Core_AntiKt4LCTopo";
   std::string m_outputContainer = "NewRefFinal";

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -51,10 +51,7 @@ public:
   std::string m_fJVTdecorName = "passFJVT";
 
   /// @brief To turn on p-flow MET calculation set m_doPFlow to true
-  bool    m_doPFlow = false;
-
-  /// @brief Set DoMuonPFlowBugfix property
-  bool    m_doMuonPFlowBugfix = false;
+  bool    m_doPFlow = true;
 
   /// @brief Name of MET Working Point (defines the JetSelection applied in METMaker)
   std::string m_METWorkingPoint = "";


### PR DESCRIPTION
This PR fixes a bug in the current implementation of the METConstructor. So far the MET associations have been reset only at the start of each event but not for each systematic. This resulted in all objects which have been added already in the nominal "run", wouldn't have been added in any of the systematics to the MET calculation because the METMaker doesn't add objects which it already had seen before.

I've already adjusted the debug output a bit to be a bit less confusing because some of the "doing systematic X" statements have been also printed during when processing the nominal run. I've also completely dropped some debug output which compares the reconstructed MET against some reference. A reference MET doesn't exist anymore in any of the common input derivations, hence it leads to crashes when the debug output in turned on.

Finally, I've made some adjustments in the members: switched doPFlow to true as default and also dropped a property which doesn't exist anymore for the R22 METMaker