### PR TITLE
Remove VeryLooseNoPix and Fix LooseBL Electron WPs

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -815,17 +815,8 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
 
     for (auto& PID : m_infoSwitch.m_PIDWPs) {
       if (!PID.empty()) {
-        if (PID == "LHLooseBL") {
-          accPID.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( PID , SG::AuxElement::Accessor<char>( "LHLoose" ) ) );
-          if ( accPID.at( PID ).isAvailable( *elec ) && accBLayer.isAvailable( *elec ) ) {
-            m_PID->at( PID )->push_back( accBLayer( *elec ) == 1 && (accPID.at( PID ))( *elec ) == 1 );
-          } else {
-            m_PID->at( PID )->push_back( -1 );
-          }
-        } else {
-          accPID.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( PID , SG::AuxElement::Accessor<char>( PID ) ) );
-          safeFill<char, int, xAOD::Electron>( elec, accPID.at( PID ), m_PID->at( PID ), -1 );
-        }
+        accPID.insert( std::pair<std::string, SG::AuxElement::Accessor<char> > ( PID , SG::AuxElement::Accessor<char>( PID ) ) );
+        safeFill<char, int, xAOD::Electron>( elec, accPID.at( PID ), m_PID->at( PID ), -1 );
       }
     }
   }

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -27,6 +27,7 @@ namespace HelperClasses{
   {
     std::string VeryLoose("VeryLoose");         enumMap.insert(std::make_pair(VeryLoose  , LikeEnum::VeryLoose));
     std::string Loose("Loose");                 enumMap.insert(std::make_pair(Loose      , LikeEnum::Loose));
+    std::string LooseBL("LooseBL");             enumMap.insert(std::make_pair(LooseBL    , LikeEnum::LooseBL));
     std::string Medium("Medium");               enumMap.insert(std::make_pair(Medium     , LikeEnum::Medium));
     std::string Tight("Tight");                 enumMap.insert(std::make_pair(Tight      , LikeEnum::Tight));
   }

--- a/Root/ParticlePIDManager.cxx
+++ b/Root/ParticlePIDManager.cxx
@@ -3,7 +3,6 @@
 ANA_MSG_SOURCE(msgPIDManager, "PIDManager")
 
 ElectronLHPIDManager :: ElectronLHPIDManager ( std::string WP, bool debug ) :
-  m_asgElectronLikelihoodTool_VeryLooseNP(nullptr),
   m_asgElectronLikelihoodTool_VeryLoose(nullptr),
   m_asgElectronLikelihoodTool_Loose(nullptr),
   m_asgElectronLikelihoodTool_LooseBL(nullptr),
@@ -14,23 +13,20 @@ ElectronLHPIDManager :: ElectronLHPIDManager ( std::string WP, bool debug ) :
       m_debug      = debug;
 
       /*  fill the multimap with WPs and corresponding tools */
-      std::pair < std::string, AsgElectronLikelihoodTool* > veryloosenp = std::make_pair( std::string("VeryLooseNoPix"), m_asgElectronLikelihoodTool_VeryLooseNP );
       std::pair < std::string, AsgElectronLikelihoodTool* > veryloose   = std::make_pair( std::string("VeryLoose"), m_asgElectronLikelihoodTool_VeryLoose );
       std::pair < std::string, AsgElectronLikelihoodTool* > loose       = std::make_pair( std::string("Loose"),     m_asgElectronLikelihoodTool_Loose     );
       std::pair < std::string, AsgElectronLikelihoodTool* > loosebl     = std::make_pair( std::string("LooseBL"),     m_asgElectronLikelihoodTool_LooseBL     );
       std::pair < std::string, AsgElectronLikelihoodTool* > medium      = std::make_pair( std::string("Medium"),    m_asgElectronLikelihoodTool_Medium    );
       std::pair < std::string, AsgElectronLikelihoodTool* > tight       = std::make_pair( std::string("Tight"),     m_asgElectronLikelihoodTool_Tight     );
-      m_allWPTools.insert(veryloosenp); m_allWPAuxDecors.insert("VeryLooseNoPix");
       m_allWPTools.insert(veryloose);   m_allWPAuxDecors.insert("VeryLoose");
       m_allWPTools.insert(loose);       m_allWPAuxDecors.insert("Loose");
-      m_allWPTools.insert(loosebl);     m_allWPAuxDecors.insert("Loose"); //Not saved in DAODs, so use Loose decision
+      m_allWPTools.insert(loosebl);     m_allWPAuxDecors.insert("LooseBL");
       m_allWPTools.insert(medium);      m_allWPAuxDecors.insert("Medium");
       m_allWPTools.insert(tight);       m_allWPAuxDecors.insert("Tight");
 }
 
 ElectronLHPIDManager ::  ~ElectronLHPIDManager()
 {
-  if ( m_asgElectronLikelihoodTool_VeryLooseNP ) { delete m_asgElectronLikelihoodTool_VeryLooseNP; m_asgElectronLikelihoodTool_VeryLooseNP = nullptr; }
   if ( m_asgElectronLikelihoodTool_VeryLoose )   { delete m_asgElectronLikelihoodTool_VeryLoose; m_asgElectronLikelihoodTool_VeryLoose = nullptr; }
   if ( m_asgElectronLikelihoodTool_Loose )       { delete m_asgElectronLikelihoodTool_Loose;     m_asgElectronLikelihoodTool_Loose     = nullptr; }
   if ( m_asgElectronLikelihoodTool_LooseBL )     { delete m_asgElectronLikelihoodTool_LooseBL;   m_asgElectronLikelihoodTool_LooseBL   = nullptr; }
@@ -41,7 +37,7 @@ ElectronLHPIDManager ::  ~ElectronLHPIDManager()
 
 StatusCode ElectronLHPIDManager :: setupWPs( bool configTools, std::string selector_name) {
   using namespace msgPIDManager;
-  const std::string selectedWP = ( m_selectedWP == "LooseBL" ) ? "Loose" : m_selectedWP;
+  const std::string selectedWP = m_selectedWP;
   HelperClasses::EnumParser<LikeEnum::Menu> selectedWP_parser;
   unsigned int selectedWP_enum = static_cast<unsigned int>( selectedWP_parser.parseEnum(selectedWP) );
 
@@ -110,7 +106,7 @@ StatusCode ElectronLHPIDManager :: setDecorations( const xAOD::Electron* electro
 
 const std::string ElectronLHPIDManager :: getSelectedWP () {
 
-  const std::string WP = ( m_selectedWP == "LooseAndBLayer" ) ? "Loose" : m_selectedWP;
+  const std::string WP = m_selectedWP;
   return WP;
 
 }

--- a/xAODAnaHelpers/ParticlePIDManager.h
+++ b/xAODAnaHelpers/ParticlePIDManager.h
@@ -57,7 +57,6 @@ class ElectronLHPIDManager
     std::set<std::string> m_allWPAuxDecors;
     std::set<std::string> m_validWPs;
 
-    AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLooseNP;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_VeryLoose;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_Loose;
     AsgElectronLikelihoodTool*  m_asgElectronLikelihoodTool_LooseBL;


### PR DESCRIPTION
Removing the VeryLooseNoPix electron WP as this no longer seems to be supported. Fixing hard-coded overwrites of LooseBL to Loose that were missed in https://github.com/UCATLAS/xAODAnaHelpers/pull/1620.