### PR TITLE
MET TST Pre-Recs

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -129,9 +129,11 @@ EL::StatusCode METConstructor :: initialize ()
   ANA_MSG_DEBUG("Retrieved tool: " << m_metmaker_handle);
 
   ///////////// IMETSystematicsTool ///////////////////
-  if ( m_doPFlow ) { // do TST
-    ANA_CHECK(m_metSyst_handle.setProperty("ConfigPrefix", "METUtilities/run2_13TeV/"));
-    ANA_CHECK(m_metSyst_handle.setProperty("ConfigSoftTrkFile", "TrackSoftTerms-pflow.config"));
+  if (!m_systConfigPrefix.empty()) {
+    ANA_CHECK(m_metSyst_handle.setProperty("ConfigPrefix", m_systConfigPrefix));
+  }
+  if (!m_systConfigSoftTrkFile.empty()) {
+    ANA_CHECK(m_metSyst_handle.setProperty("ConfigSoftTrkFile", m_systConfigSoftTrkFile));
   }
   ANA_CHECK(m_metSyst_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_metSyst_handle);

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -31,6 +31,8 @@ public:
   std::string m_mapName = "METAssoc_AntiKt4LCTopo";
   std::string m_coreName = "MET_Core_AntiKt4LCTopo";
   std::string m_outputContainer = "NewRefFinal";
+  std::string m_systConfigPrefix = "METUtilities/R22_PreRecs";
+  std::string m_systConfigSoftTrkFile = "TrackSoftTerms-pflow.config";
   std::string m_inputJets = "";
   std::string m_inputElectrons = "";
   std::string m_inputPhotons = "";


### PR DESCRIPTION
This MR makes the inputs to the METSystematicsTool and points them to the files corresponding to the R22 pre-recs (which will be announced shortly :) ).

Side remark: if the new m_systConfigPrefix` and `m_systConfigSoftTrkFile` fields would be left blank, the defaults in the METSystematicsTool are used which would be the nominally preferred behavior. But these defaults are super outdated until the next Analysis release so in order not to break anything for older releases I set them by hand.