### PR TITLE
Adding AF3 support

### DIFF
--- a/Root/Algorithm.cxx
+++ b/Root/Algorithm.cxx
@@ -130,6 +130,11 @@ bool xAH::Algorithm::isAF3(){
       return m_isAF3;
     }
 
+    if (m_setAF3){
+      m_setAF3 = true;
+      return m_isAF3;
+    }
+
     std::string SimulationFlavour;
     const xAOD::FileMetaData* fmd = nullptr;
     if( wk()->xaodEvent()->retrieveMetaInput(fmd, "FileMetaData") != StatusCode::SUCCESS){

--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1122,7 +1122,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
   ANA_CHECK( m_event->retrieve( eventInfo, "EventInfo" ) );
 
   // Determine simulation flavour
-  std::string SimulationFlavour = isFastSim() ? "AFII" : "FS";
+  std::string SimulationFlavour = isFastSim() ? ( isAF3() ? "AF3" : "AFII" ) : "FS";
 
   // Extract campaign automatically from Run Number
   std::string mcCampaignMD = "";

--- a/Root/PhotonCalibrator.cxx
+++ b/Root/PhotonCalibrator.cxx
@@ -154,7 +154,7 @@ EL::StatusCode PhotonCalibrator :: initialize ()
   if(m_randomRunNumber>0) ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("randomRunNumber", m_randomRunNumber));
 
   //Backwards compatibility
-  if (m_useAFII)
+  if (m_useAFII || m_useAF3)
     m_forceFastSim = true;
   if ( isFastSim() )
     ANA_CHECK( m_EgammaCalibrationAndSmearingTool->setProperty("useAFII", 1));
@@ -255,7 +255,7 @@ EL::StatusCode PhotonCalibrator :: initialize ()
     } else {
       dataType = PATCore::ParticleDataType::Full;
     }
-    ANA_MSG_DEBUG("isSimulation=" << ( isMC() ? "Y" : "N") << " isAFII=" << ( isFastSim() ? "Y" : "N" ) << " selected dataType=" << dataType );
+    ANA_MSG_DEBUG("isSimulation=" << ( isMC() ? "Y" : "N") << " Simulation type: " << ( isFastSim() ? ( isAF3() ? "AF3" : "AFII") : "FullSim" ) << " selected dataType=" << dataType );
 
 
     // photon efficiency correction tool

--- a/python/cli_options.py
+++ b/python/cli_options.py
@@ -62,6 +62,12 @@ standard = {
         "default": False,
         "help": "Running on AFII",
     },
+    "isAF3": {
+        "action": "store_true",
+        "dest": "is_AF3",
+        "default": False,
+        "help": "Running on AF3",
+    },
     "extraOptions": {
         "dest": "extra_options",
         "metavar": "[param=val]",

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -165,6 +165,22 @@ namespace xAH {
          */
         int m_isFastSim = -1;
 
+        /**
+            @rst
+                This stores the isAF3 decision, and can also be used to override at the algorithm level to force analyzing FastSim with AF3 or not.
+
+                ===== ========================================================
+                Value Meaning
+                ===== ========================================================
+                -1    Default, use Metadata object to determine if AF3 FastSim or not
+                0     Treat the input as FullSim or AFII
+                1     Treat the input as FastSim with AF3
+                ===== ========================================================
+
+            @endrst
+         */
+        int m_isAF3 = -1;
+
         /** Flag to use Run 3 trigger navigation (true), or Run 2 navigation (false)*/
         bool m_useRun3navigation = false;
 
@@ -180,6 +196,7 @@ namespace xAH {
 
         /** Backwards compatibility, same as m_forceFastSim */
         bool m_setAFII = false;
+        bool m_setAF3 = false;
 
 
       protected:
@@ -231,6 +248,9 @@ namespace xAH {
             @endrst
          */
         bool isFastSim();
+
+        /** If the name includes ATLFASTII or ATLFAST3 then set to AFII or AF3, if deemed fullSim then FS else leave as empty string and complain */
+        bool isAF3();
 
 	/** Determines if using DAOD_PHYS or not. */
 	bool isPHYS();

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -56,6 +56,7 @@ class BasicEventSelection : public xAH::Algorithm
       SimulationFlavour will be determined from the sample MetaData, unless AFII or FS is explicitely requested with the following flags.
       @endrst */
     bool m_setAFII = false;
+    bool m_setAF3 = false;
     bool m_setFS = false;
 
   // GRL

--- a/xAODAnaHelpers/PhotonCalibrator.h
+++ b/xAODAnaHelpers/PhotonCalibrator.h
@@ -55,6 +55,7 @@ public:
   std::string m_outputAlgoSystNames = "PhotonCalibrator_Syst";
 
   bool        m_useAFII = false; //For backwards compatibility
+  bool        m_useAF3 = false; //For backwards compatibility
   float       m_systVal = 0.0;
   std::string m_systName = "";
 

--- a/xAODAnaHelpers/TauCalibrator.h
+++ b/xAODAnaHelpers/TauCalibrator.h
@@ -26,6 +26,7 @@ public:
   std::string m_generator = "";
   std::string m_campaign = "";
   bool m_setAFII = false;
+  bool m_setAF3 = false;
 
   bool m_skipTruthMatchCheck = false;
 


### PR DESCRIPTION
- Adds new function in Algorithm.cxx to tell from the metadata if isAF3() is true.
- AF3 will also set 'isFastSim()' to be true.
- "AF3" string will be set if isAF3() is true, rather than "AFII" or "FS" for the autoconfigured PRW filenames
- added variables to set AF3 in config akin to those for AFII in photon and tau calibrators. 
- At the moment assuming that any CP recommendations for AF3 are the same as AFII but this could be changed if needed in the future.
- Also added isAF3 override to python options, akin to current AFII override.