### PR TITLE
add support for trigger matching for Run 3 data and MC

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -340,35 +340,47 @@ EL::StatusCode ElectronSelector :: initialize ()
   //     do not initialise if there are no input trigger chains
   if(  !( m_singleElTrigChains.empty() && m_diElTrigChains.empty() ) ) {
 
-    if( !isPHYS() ) {
-      // Grab the TrigDecTool from the ToolStore
-      if(!m_trigDecTool_handle.isUserConfigured()){
-        ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
-        return EL::StatusCode::FAILURE;
-      }
-      ANA_CHECK( m_trigDecTool_handle.retrieve());
-      ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
+    // grab the TrigDecTool from the ToolStore
+    if(!m_trigDecTool_handle.isUserConfigured()){
+      ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
+      return EL::StatusCode::FAILURE;
+    }
+    ANA_CHECK( m_trigDecTool_handle.retrieve());
+    ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
-      ANA_CHECK( m_scoreTool.retrieve());
+    // in AB we need to explicitly retrieve this tool, see https://twiki.cern.ch/twiki/bin/viewauth/Atlas/R22TriggerAnalysis
+    ANA_CHECK( m_scoreTool.retrieve());
 
-      //  everything went fine, let's initialise the tool!
-      m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");;
+    // Run3 got a new trigger navigation
+    if (m_useRun3navigation) {
+      m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::R3MatchingTool/TrigR3MatchingTool");
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
       ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
-      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
-      ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
-    } else { // For DAOD_PHYS samples
-      m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
-      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      if (!m_trigInputPrefix.empty()){
-        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
-	ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "RemapBrokenLinks", true) );
-      }
+      ANA_CHECK( m_trigElectronMatchTool_handle.setProperty("OutputLevel", msg().level() ));
       ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
     }
-
+    // otherwise we have to configure the Run2-style navigation
+    else {
+      if( !isPHYS() ) {
+        m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");;
+        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
+        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
+        ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
+        ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
+      }
+      else { // For DAOD_PHYS samples
+        m_trigElectronMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");;
+        ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
+        if (!m_trigInputPrefix.empty()){
+          ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+          ANA_CHECK( m_trigElectronMatchTool_handle.setProperty( "RemapBrokenLinks", true) );
+        }
+        ANA_CHECK( m_trigElectronMatchTool_handle.retrieve());
+        ANA_MSG_DEBUG("Retrieved tool: " << m_trigElectronMatchTool_handle);
+      }
+    }
   } else {
 
     m_doTrigMatch = false;

--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -141,7 +141,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   ANA_CHECK(checkToolStore<CP::IMuonEfficiencyScaleFactors>(m_recoEffSF_tool_name));
   const bool recoEffSFInstanceExists = asg::ToolStore::contains<CP::IMuonEfficiencyScaleFactors>(m_recoEffSF_tool_name);
-  
+
 
   // calling with only the first arg causes AnaToolHandle to use std::shared_ptr and return any already existing instance (aka making the tool "public")
   m_muRecoSF_tool = asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors>("CP::MuonEfficiencyScaleFactors/"+m_recoEffSF_tool_name);
@@ -155,7 +155,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   assert(m_muRecoSF_tool.isInitialized());
 
   // only process systematics once per efficiency SF/WP
-  if(not recoEffSFInstanceExists) { 
+  if(not recoEffSFInstanceExists) {
     //  Add the chosen WP to the string labelling the vector<SF> decoration
     //
     m_outputSystNamesReco = m_outputSystNamesReco + "_Reco" + m_WorkingPointReco;
@@ -190,7 +190,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   ANA_CHECK( checkToolStore<CP::IMuonEfficiencyScaleFactors>(m_isoEffSF_tool_name));
   const bool isoEffSFInstanceExists = asg::ToolStore::contains<CP::IMuonEfficiencyScaleFactors>(m_isoEffSF_tool_name);
-  
+
   // calling with only the first arg causes AnaToolHandle to use std::shared_ptr and return any already existing instance (aka making the tool "public")
   m_muIsoSF_tool = asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors>("CP::MuonEfficiencyScaleFactors/"+m_isoEffSF_tool_name);
   // setProperty is ignored if tool is already configured (i.e. for isoEffSFInstanceExists == true)
@@ -201,7 +201,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   }
   ANA_CHECK(m_muIsoSF_tool.retrieve());
   assert(m_muIsoSF_tool.isInitialized());
-  
+
   // only process systematics once per efficiency SF/WP
   if(not isoEffSFInstanceExists){
 
@@ -241,7 +241,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   // calling with only the first arg causes AnaToolHandle to use std::shared_ptr and return any already existing instance (aka making the tool "public")
   m_muTrigSF_tool = asg::AnaToolHandle<CP::IMuonTriggerScaleFactors>("CP::MuonTriggerScaleFactors/"+m_trigEffSF_tool_name );
-  // setProperty is ignored if tool is already configured 
+  // setProperty is ignored if tool is already configured
   if ( m_AllowZeroSF ) {
     ANA_MSG_WARNING( "m_AllowZeroSF is set to True. No errors will arise for runs missing required triggers!!!");
     ANA_CHECK( m_muTrigSF_tool.setProperty("AllowZeroSF", m_AllowZeroSF ));
@@ -249,7 +249,7 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
   ANA_CHECK(m_muTrigSF_tool.setProperty("MuonQuality", m_WorkingPointReco ));
   ANA_CHECK(m_muTrigSF_tool.retrieve());
   assert(m_muTrigSF_tool.isInitialized());
- 
+
   std::string token;
   std::istringstream ss(m_MuTrigLegs);
   while ( std::getline(ss, token, ',') ) {
@@ -292,10 +292,10 @@ EL::StatusCode MuonEfficiencyCorrector :: initialize ()
 
   ANA_CHECK( checkToolStore<CP::IMuonEfficiencyScaleFactors>(m_TTVAEffSF_tool_name));
   const bool TTVASFInstanceExists = asg::ToolStore::contains<CP::IMuonEfficiencyScaleFactors>(m_TTVAEffSF_tool_name);
- 
+
   // calling with only the first arg causes AnaToolHandle to use std::shared_ptr and return any already existing instance (aka making the tool "public")
   m_muTTVASF_tool = asg::AnaToolHandle<CP::IMuonEfficiencyScaleFactors>("CP::MuonEfficiencyScaleFactors/"+m_TTVAEffSF_tool_name);
-  // setProperty is ignored if tool is already configured (i.e. for TTVASFInstanceExists == true) 
+  // setProperty is ignored if tool is already configured (i.e. for TTVASFInstanceExists == true)
   ANA_CHECK( m_muTTVASF_tool.setProperty("WorkingPoint", m_WorkingPointTTVA ));
   if ( !m_overrideCalibRelease.empty() ) {
     ANA_MSG_WARNING("Overriding muon efficiency calibration release to " << m_overrideCalibRelease);
@@ -703,7 +703,8 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
 
       auto trig_it = trig.second;
       if (trig.first.find("2015")!=std::string::npos && run>284484) continue;
-      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos || trig.first.find("2018")!=std::string::npos) && run<=284484) continue;
+      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos || trig.first.find("2018")!=std::string::npos) && (run<=284484 || run >400000) ) continue;
+      else if (trig.first.find("2022")!=std::string::npos && run< 400000) continue;
 
       std::unique_ptr< std::vector< std::string > > sysVariationNamesTrig = nullptr;
       if ( writeSystNames ) sysVariationNamesTrig = std::make_unique< std::vector< std::string > >();
@@ -839,7 +840,7 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
            ++idx;
 
         } // close muon loop
-	
+
 	// Get global trigger efficiency SF (using all muons)
 	if(!m_usePerMuonTriggerSFs){
            // Get SF

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -290,35 +290,48 @@ EL::StatusCode MuonSelector :: initialize ()
   //
   // **************************************
   if( !( m_singleMuTrigChains.empty() && m_diMuTrigChains.empty() ) ) {
-    if( !isPHYS() ) {
-      // Grab the TrigDecTool from the ToolStore
-      if(!m_trigDecTool_handle.isUserConfigured()){
-        ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
-        return EL::StatusCode::FAILURE;
-      }
-      ANA_CHECK( m_trigDecTool_handle.retrieve());
-      ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
-      ANA_CHECK( m_scoreTool.retrieve());
+    // grab the TrigDecTool from the ToolStore
+    if(!m_trigDecTool_handle.isUserConfigured()){
+      ANA_MSG_FATAL("A configured " << m_trigDecTool_handle.typeAndName() << " must have been previously created! Are you creating one in xAH::BasicEventSelection?" );
+      return EL::StatusCode::FAILURE;
+    }
+    ANA_CHECK( m_trigDecTool_handle.retrieve());
+    ANA_MSG_DEBUG("Retrieved tool: " << m_trigDecTool_handle);
 
-      //  everything went fine, let's initialise the tool!
-      m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
+    // in AB we need to explicitly retrieve this tool, see https://twiki.cern.ch/twiki/bin/viewauth/Atlas/R22TriggerAnalysis
+    ANA_CHECK( m_scoreTool.retrieve());
+
+    // Run3 got a new trigger navigation
+    if (m_useRun3navigation) {
+      m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::R3MatchingTool/TrigR3MatchingTool");
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
       ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
       ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
       ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
-    } else { // For DAOD_PHYS samples
-      m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
-      ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
-      if (!m_trigInputPrefix.empty()){
-        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
-	ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "RemapBrokenLinks", true) );
-      }
-      ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
-      ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
     }
-
+    // otherwise we have to configure the Run2-style navigation
+    else {
+      if( !isPHYS() ) {
+        m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchingTool/MatchingTool");
+        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "TrigDecisionTool", m_trigDecTool_handle ));
+        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "ScoringTool", m_scoreTool ));
+        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty("OutputLevel", msg().level() ));
+        ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
+        ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
+      }
+      else { // For DAOD_PHYS samples
+        m_trigMuonMatchTool_handle = asg::AnaToolHandle<Trig::IMatchingTool>("Trig::MatchFromCompositeTool/MatchFromCompositeTool");
+        ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "OutputLevel", msg().level() ));
+        if (!m_trigInputPrefix.empty()){
+          ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "InputPrefix", m_trigInputPrefix ));
+          ANA_CHECK( m_trigMuonMatchTool_handle.setProperty( "RemapBrokenLinks", true) );
+        }
+        ANA_CHECK( m_trigMuonMatchTool_handle.retrieve());
+        ANA_MSG_DEBUG("Retrieved tool: " << m_trigMuonMatchTool_handle);
+      }
+    }
   } else {
 
     m_doTrigMatch = false;


### PR DESCRIPTION
This PR adds support of trigger matching for electron- and muon triggers for Run3 data and MC. As these have a new trigger navigation a dedicated matching tool has to be set up (following the [R22TriggerAnalysis](https://twiki.cern.ch/twiki/bin/viewauth/Atlas/R22TriggerAnalysis) twiki). In contrast to "Run2 samples", no distinction seems to be required between PHYS and non-PHYS samples though.

As small additional adjustment was also required to `MuonEfficiencyCorrector.cxx` in order to allow for a proper retrieval of muon trigger SFs for 2022.