### PR TITLE
fix typo to allow processing of MET CST term again

### DIFF
--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -517,7 +517,7 @@ EL::StatusCode METConstructor :: execute ()
 
      if(!m_rebuildUsingTracksInJets && m_addSoftClusterTerms){
        //get the soft cluster term, and applyCorrection
-       xAOD::MissingET * softClusMet = (*newMet)["SoftClusCore"];
+       xAOD::MissingET * softClusMet = (*newMet)["SoftClus"];
        //assert( softClusMet != 0); //check we retrieved the clust term
        if( isMC() && m_metSyst_handle->applyCorrection(*softClusMet, metHelper) != CP::CorrectionCode::Ok) {
          ANA_MSG_ERROR( "Could not apply correction to soft clus met !!!! ");


### PR DESCRIPTION
Tiny fix to allow the processing of the calo-soft term (CST) for the MET again. The additional "Core" suffix is probably a remnant of the very early R22 days to match some (now adjusted) typos in the METMaker.

The CST term is officially not supplied with recommendations so far, but for studies with the MET group studying this kind of soft term can be helpful.