### PR TITLE
Add string support for vectors and update isolation WPs

### DIFF
--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -41,6 +41,8 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
     m_topoetcone20                               = new  vector<float> ();
     m_topoetcone30                               = new  vector<float> ();
     m_topoetcone40                               = new  vector<float> ();
+    m_neflowisol20                               = new  vector<float> ();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 = new vector<float> ();
   }
 
   // quality
@@ -177,6 +179,8 @@ MuonContainer::~MuonContainer()
     delete m_topoetcone20                               ;
     delete m_topoetcone30                               ;
     delete m_topoetcone40                               ;
+    delete m_neflowisol20                               ;                               
+    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
   }
   
   // quality
@@ -315,6 +319,8 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<float>(tree,"topoetcone20",   &m_topoetcone20);
     connectBranch<float>(tree,"topoetcone30",   &m_topoetcone30);
     connectBranch<float>(tree,"topoetcone40",   &m_topoetcone40);
+    connectBranch<float>(tree,"neflowisol20",   &m_neflowisol20);
+    connectBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500", &m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -443,6 +449,8 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.topoetcone20                             =     m_topoetcone20                               ->at(idx);
     muon.topoetcone30                             =     m_topoetcone30                               ->at(idx);
     muon.topoetcone40                             =     m_topoetcone40                               ->at(idx);
+    muon.neflowisol20 = m_neflowisol20->at(idx);
+    muon.ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 = m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 -> at(idx);
   }
   
   // quality
@@ -575,6 +583,8 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"topoetcone20",   m_topoetcone20);
     setBranch<float>(tree,"topoetcone30",   m_topoetcone30);
     setBranch<float>(tree,"topoetcone40",   m_topoetcone40);
+    setBranch<float>(tree,"neflowisol20",   m_neflowisol20);
+    setBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500", m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -702,6 +712,8 @@ void MuonContainer::clear()
     m_topoetcone20->clear();
     m_topoetcone30->clear();
     m_topoetcone40->clear();
+    m_neflowisol20->clear();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500->clear();
   }
 
   if ( m_infoSwitch.m_quality ) {
@@ -862,7 +874,8 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     m_topoetcone20->push_back( muon->isolation( xAOD::Iso::topoetcone20 )/m_units );
     m_topoetcone30->push_back( muon->isolation( xAOD::Iso::topoetcone30 )/m_units );
     m_topoetcone40->push_back( muon->isolation( xAOD::Iso::topoetcone40 )/m_units );
-    
+    m_neflowisol20->push_back( muon->isolation( xAOD::Iso::neflowisol20 )/m_units );
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500->push_back( muon->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 )/m_units );
   }
 
   if ( m_infoSwitch.m_quality ) {

--- a/python/utils.py
+++ b/python/utils.py
@@ -126,17 +126,17 @@ def update_clioption_defaults(argdict, newvalues):
 
 # helper function to deal with type madness in vector(...)
 def _find_element_type(iterable, element_type):
-  supported = (int, float)
+  supported = (int, float, str)
 
   if element_type is None:
     try:
       element_type = type(iterable[0])
-    except IndexError: 
-      # for empty iterables, c++ still needs a type, 
+    except IndexError:
+      # for empty iterables, c++ still needs a type,
       raise ValueError(
           '`vector` cannot determine the element type of an empty input iterable.'
           ' Please specify the expected type using the element_type argument.')
-    
+
     if element_type not in supported:
       raise NotImplementedError(
           '`vector` recieved iterable with elements of '
@@ -151,7 +151,7 @@ def _find_element_type(iterable, element_type):
         + ' is not supported. The following types are supported: "'
         + '", "'.join([s.__name__ for s in supported])
         + '"')
-    
+
     if iterable and not isinstance(iterable[0], element_type):
       raise ValueError(
           'The specified element_type ("{}") '.format(element_type.__name__)
@@ -175,20 +175,21 @@ def vector(iterable, element_type = None):
 
   Inputs may be empty (specify element_type to avoid type mismatches).
   >>> my_vector = vector([], element_type = float) # an empty vector of floats
-  
+
   Arguments:
      - iterable : a list or tuple of numbers, to be converted into a vector
      - element_type : type of the vector elements. With non-empty
-                      iterables, the element type is deduced, so 
+                      iterables, the element type is deduced, so
                       this argument is optional. On empty iterables,
                       you need to specify it.
   Returns:
     A new vector containing the elements of the input iterable.
-  
+
   Raises an exception if the element types are not matching, or not supported.
   """
-  
+
   element_type = _find_element_type(iterable, element_type)
+  if (element_type == str): element_type = ROOT.std.string
   vector = ROOT.std.vector(element_type.__name__)()
   for element in iterable:
     vector.push_back(element)

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -32,6 +32,8 @@ namespace xAH {
     float topoetcone20;
     float topoetcone30;
     float topoetcone40;
+    float neflowisol20;
+    float ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
     
     // quality
     std::map< std::string, int > quality;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -53,6 +53,9 @@ namespace xAH {
       std::vector<float> *m_topoetcone20;
       std::vector<float> *m_topoetcone30;
       std::vector<float> *m_topoetcone40;
+      std::vector<float> *m_neflowisol20;
+      std::vector<float> *m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
+
 
       // quality
       std::map< std::string, std::vector< int >* >* m_quality;


### PR DESCRIPTION
Hello,

This MR aims to add support for vectors of strings in xAH. There's a subtle conversion from python `str` to `ROOT.std.string` which is needed to make this happen for a meaningful pass to c++.

Further, there are updates to the lepton iso WP based on the latest rel 22 run 2 recommendations.

Thanks,
Sagar and @gfrattar 