### PR TITLE
Update lepton isolation variables

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -31,16 +31,14 @@ ElectronContainer::ElectronContainer(const std::string& name, const std::string&
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_etcone20                               = new std::vector<float> ();
-    m_ptcone20                               = new std::vector<float> ();
-    m_ptcone30                               = new std::vector<float> ();
-    m_ptcone40                               = new std::vector<float> ();
     m_ptvarcone20                            = new std::vector<float> ();
-    m_ptvarcone30                            = new std::vector<float> ();
-    m_ptvarcone40                            = new std::vector<float> ();
     m_topoetcone20                           = new std::vector<float> ();
-    m_topoetcone30                           = new std::vector<float> ();
     m_topoetcone40                           = new std::vector<float> ();
+    m_neflowisol20                           = new std::vector<float> ();
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500            = new std::vector<float> ();
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000           = new std::vector<float> ();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500         = new std::vector<float> ();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000        = new std::vector<float> ();
   }
 
   if ( m_infoSwitch.m_PID ) {
@@ -155,16 +153,14 @@ ElectronContainer::~ElectronContainer()
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    delete m_etcone20                               ;
-    delete m_ptcone20                               ;
-    delete m_ptcone30                               ;
-    delete m_ptcone40                               ;
     delete m_ptvarcone20                            ;
-    delete m_ptvarcone30                            ;
-    delete m_ptvarcone40                            ;
     delete m_topoetcone20                           ;
-    delete m_topoetcone30                           ;
     delete m_topoetcone40                           ;
+    delete m_neflowisol20                           ;
+    delete m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500                 ;
+    delete m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000                ;
+    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500              ;
+    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000             ;
   }
 
   if ( m_infoSwitch.m_PID ) {
@@ -279,16 +275,14 @@ void ElectronContainer::setTree(TTree *tree)
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    connectBranch<float>(tree, "etcone20",         &m_etcone20);
-    connectBranch<float>(tree, "ptcone20",         &m_ptcone20);
-    connectBranch<float>(tree, "ptcone30",         &m_ptcone30);
-    connectBranch<float>(tree, "ptcone40",         &m_ptcone40);
     connectBranch<float>(tree, "ptvarcone20",      &m_ptvarcone20);
-    connectBranch<float>(tree, "ptvarcone30",      &m_ptvarcone30);
-    connectBranch<float>(tree, "ptvarcone40",      &m_ptvarcone40);
     connectBranch<float>(tree, "topoetcone20",     &m_topoetcone20);
-    connectBranch<float>(tree, "topoetcone30",     &m_topoetcone30);
     connectBranch<float>(tree, "topoetcone40",     &m_topoetcone40);
+    connectBranch<float>(tree, "neflowisol20",     &m_neflowisol20);    
+    connectBranch<float>(tree, "ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500",     &m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500);
+    connectBranch<float>(tree, "ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000",    &m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000);
+    connectBranch<float>(tree, "ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500",  &m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500);
+    connectBranch<float>(tree, "ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000", &m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000);
   }
 
   if ( m_infoSwitch.m_PID ) {
@@ -400,16 +394,14 @@ void ElectronContainer::updateParticle(uint idx, Electron& elec)
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    elec.etcone20                                 =     m_etcone20                                   ->at(idx);
-    elec.ptcone20                                 =     m_ptcone20                                   ->at(idx);
-    elec.ptcone30                                 =     m_ptcone30                                   ->at(idx);
-    elec.ptcone40                                 =     m_ptcone40                                   ->at(idx);
     elec.ptvarcone20                              =     m_ptvarcone20                                ->at(idx);
-    elec.ptvarcone30                              =     m_ptvarcone30                                ->at(idx);
-    elec.ptvarcone40                              =     m_ptvarcone40                                ->at(idx);
     elec.topoetcone20                             =     m_topoetcone20                               ->at(idx);
-    elec.topoetcone30                             =     m_topoetcone30                               ->at(idx);
     elec.topoetcone40                             =     m_topoetcone40                               ->at(idx);
+    elec.neflowisol20                             =     m_neflowisol20                               ->at(idx);
+    elec.ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500             =     m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500         ->at(idx);
+    elec.ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000            =     m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000        ->at(idx);
+    elec.ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500          =     m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500      ->at(idx);
+    elec.ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000         =     m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000     ->at(idx);
   }
 
   // quality
@@ -521,16 +513,14 @@ void ElectronContainer::setBranches(TTree *tree)
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    setBranch<float>(tree, "etcone20",         m_etcone20);
-    setBranch<float>(tree, "ptcone20",         m_ptcone20);
-    setBranch<float>(tree, "ptcone30",         m_ptcone30);
-    setBranch<float>(tree, "ptcone40",         m_ptcone40);
     setBranch<float>(tree, "ptvarcone20",      m_ptvarcone20);
-    setBranch<float>(tree, "ptvarcone30",      m_ptvarcone30);
-    setBranch<float>(tree, "ptvarcone40",      m_ptvarcone40);
     setBranch<float>(tree, "topoetcone20",     m_topoetcone20);
-    setBranch<float>(tree, "topoetcone30",     m_topoetcone30);
     setBranch<float>(tree, "topoetcone40",     m_topoetcone40);
+    setBranch<float>(tree, "neflowisol20",     m_neflowisol20);
+    setBranch<float>(tree, "ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500",     m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500);
+    setBranch<float>(tree, "ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000",    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000);
+    setBranch<float>(tree, "ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500",  m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500);
+    setBranch<float>(tree, "ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000", m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000);
   }
 
   if ( m_infoSwitch.m_PID ) {
@@ -640,16 +630,14 @@ void ElectronContainer::clear()
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_etcone20                               ->clear();
-    m_ptcone20                               ->clear();
-    m_ptcone30                               ->clear();
-    m_ptcone40                               ->clear();
     m_ptvarcone20                            ->clear();
-    m_ptvarcone30                            ->clear();
-    m_ptvarcone40                            ->clear();
     m_topoetcone20                           ->clear();
-    m_topoetcone30                           ->clear();
     m_topoetcone40                           ->clear();
+    m_neflowisol20                           ->clear();
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500        ->clear();
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000       ->clear();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500     ->clear();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000    ->clear();
   }
 
   if ( m_infoSwitch.m_PID ) {
@@ -797,16 +785,14 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_etcone20    ->push_back( elec->isolation( xAOD::Iso::etcone20 )    /m_units );
-    m_ptcone20    ->push_back( elec->isolation( xAOD::Iso::ptcone20 )    /m_units );
-    m_ptcone30    ->push_back( elec->isolation( xAOD::Iso::ptcone30 )    /m_units );
-    m_ptcone40    ->push_back( elec->isolation( xAOD::Iso::ptcone40 )    /m_units );
     m_ptvarcone20 ->push_back( elec->isolation( xAOD::Iso::ptvarcone20 ) /m_units );
-    m_ptvarcone30 ->push_back( elec->isolation( xAOD::Iso::ptvarcone30 ) /m_units );
-    m_ptvarcone40 ->push_back( elec->isolation( xAOD::Iso::ptvarcone40 ) /m_units );
     m_topoetcone20->push_back( elec->isolation( xAOD::Iso::topoetcone20 )/m_units );
-    m_topoetcone30->push_back( elec->isolation( xAOD::Iso::topoetcone30 )/m_units );
     m_topoetcone40->push_back( elec->isolation( xAOD::Iso::topoetcone40 )/m_units );
+    m_neflowisol20->push_back( elec->isolation( xAOD::Iso::neflowisol20 )/m_units );
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500    ->push_back( elec->isolation( xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500 )    /m_units );
+    m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000   ->push_back( elec->isolation( xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 )   /m_units );
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ->push_back( elec->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ) /m_units );
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000->push_back( elec->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 )/m_units );
   }
 
   if ( m_infoSwitch.m_PID ) {

--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -13,12 +13,25 @@ namespace HelperClasses{
   EnumParser<xAOD::Iso::IsolationType>::EnumParser()
   {
     std::string etcone20("etcone20");         enumMap.insert(std::make_pair(etcone20,      xAOD::Iso::etcone20));
+    std::string etcone30("etcone30");         enumMap.insert(std::make_pair(etcone30,      xAOD::Iso::etcone30));
+    std::string etcone40("etcone40");         enumMap.insert(std::make_pair(etcone40,      xAOD::Iso::etcone40));
     std::string topoetcone20("topoetcone20"); enumMap.insert(std::make_pair(topoetcone20,  xAOD::Iso::topoetcone20));
     std::string topoetcone30("topoetcone30"); enumMap.insert(std::make_pair(topoetcone30,  xAOD::Iso::topoetcone30));
+    std::string topoetcone40("topoetcone40"); enumMap.insert(std::make_pair(topoetcone40,  xAOD::Iso::topoetcone40));
     std::string ptcone20("ptcone20");         enumMap.insert(std::make_pair(ptcone20,      xAOD::Iso::ptcone20));
     std::string ptcone30("ptcone30");         enumMap.insert(std::make_pair(ptcone30,      xAOD::Iso::ptcone30));
+    std::string ptcone40("ptcone40");         enumMap.insert(std::make_pair(ptcone40,      xAOD::Iso::ptcone40));
+    std::string ptcone50("ptcone50");         enumMap.insert(std::make_pair(ptcone50,      xAOD::Iso::ptcone50));
     std::string ptvarcone20("ptvarcone20");   enumMap.insert(std::make_pair(ptvarcone20,   xAOD::Iso::ptvarcone20));
     std::string ptvarcone30("ptvarcone30");   enumMap.insert(std::make_pair(ptvarcone30,   xAOD::Iso::ptvarcone30));
+    std::string ptvarcone40("ptvarcone40");   enumMap.insert(std::make_pair(ptvarcone40,   xAOD::Iso::ptvarcone40));
+    std::string neflowisol20("neflowisol20"); enumMap.insert(std::make_pair(neflowisol20,  xAOD::Iso::neflowisol20));
+    std::string ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 ("ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500");                      enumMap.insert(std::make_pair(ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500,             xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500));
+    std::string ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000("ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000");                     enumMap.insert(std::make_pair(ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000,            xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000));
+    std::string ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ("ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500");          enumMap.insert(std::make_pair(ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500,       xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500));
+    std::string ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000("ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000");         enumMap.insert(std::make_pair(ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000,      xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000));
+    std::string ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ("ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500");    enumMap.insert(std::make_pair(ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500,    xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500));
+    std::string ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000("ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000");   enumMap.insert(std::make_pair(ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000,   xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000));
   }
 
   /* parser for electron likelihood PID enum */

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -32,17 +32,18 @@ MuonContainer::MuonContainer(const std::string& name, const std::string& detailS
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_ptcone20                                   = new  vector<float> ();
-    m_ptcone30                                   = new  vector<float> ();
-    m_ptcone40                                   = new  vector<float> ();
-    m_ptvarcone20                                = new  vector<float> ();
-    m_ptvarcone30                                = new  vector<float> ();
-    m_ptvarcone40                                = new  vector<float> ();
-    m_topoetcone20                               = new  vector<float> ();
-    m_topoetcone30                               = new  vector<float> ();
-    m_topoetcone40                               = new  vector<float> ();
-    m_neflowisol20                               = new  vector<float> ();
-    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 = new vector<float> ();
+    m_ptcone20                                       = new  vector<float> ();
+    m_ptcone30                                       = new  vector<float> ();
+    m_ptcone40                                       = new  vector<float> ();
+    m_ptvarcone20                                    = new  vector<float> ();
+    m_ptvarcone30                                    = new  vector<float> ();
+    m_ptvarcone40                                    = new  vector<float> ();
+    m_topoetcone20                                   = new  vector<float> ();
+    m_topoetcone30                                   = new  vector<float> ();
+    m_topoetcone40                                   = new  vector<float> ();
+    m_neflowisol20                                   = new  vector<float> ();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500  = new vector<float> ();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000 = new vector<float> ();
   }
 
   // quality
@@ -180,7 +181,8 @@ MuonContainer::~MuonContainer()
     delete m_topoetcone30                               ;
     delete m_topoetcone40                               ;
     delete m_neflowisol20                               ;                               
-    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
+    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 ;
+    delete m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000;
   }
   
   // quality
@@ -320,7 +322,8 @@ void MuonContainer::setTree(TTree *tree)
     connectBranch<float>(tree,"topoetcone30",   &m_topoetcone30);
     connectBranch<float>(tree,"topoetcone40",   &m_topoetcone40);
     connectBranch<float>(tree,"neflowisol20",   &m_neflowisol20);
-    connectBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500", &m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
+    connectBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500",  &m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
+    connectBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000", &m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000);
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -449,8 +452,9 @@ void MuonContainer::updateParticle(uint idx, Muon& muon)
     muon.topoetcone20                             =     m_topoetcone20                               ->at(idx);
     muon.topoetcone30                             =     m_topoetcone30                               ->at(idx);
     muon.topoetcone40                             =     m_topoetcone40                               ->at(idx);
-    muon.neflowisol20 = m_neflowisol20->at(idx);
-    muon.ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 = m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 -> at(idx);
+    muon.neflowisol20                             =     m_neflowisol20                               ->at(idx);
+    muon.ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 = m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500   -> at(idx);
+    muon.ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000 = m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000 -> at(idx);
   }
   
   // quality
@@ -584,7 +588,8 @@ void MuonContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"topoetcone30",   m_topoetcone30);
     setBranch<float>(tree,"topoetcone40",   m_topoetcone40);
     setBranch<float>(tree,"neflowisol20",   m_neflowisol20);
-    setBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500", m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
+    setBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500",  m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500);
+    setBranch<float>(tree,"ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000", m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000);
   }
 
   if ( m_infoSwitch.m_effSF && m_mc ) {
@@ -714,6 +719,7 @@ void MuonContainer::clear()
     m_topoetcone40->clear();
     m_neflowisol20->clear();
     m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500->clear();
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000->clear();
   }
 
   if ( m_infoSwitch.m_quality ) {
@@ -875,7 +881,8 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
     m_topoetcone30->push_back( muon->isolation( xAOD::Iso::topoetcone30 )/m_units );
     m_topoetcone40->push_back( muon->isolation( xAOD::Iso::topoetcone40 )/m_units );
     m_neflowisol20->push_back( muon->isolation( xAOD::Iso::neflowisol20 )/m_units );
-    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500->push_back( muon->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 )/m_units );
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 ->push_back( muon->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500 ) /m_units );
+    m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000->push_back( muon->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000 )/m_units );
   }
 
   if ( m_infoSwitch.m_quality ) {

--- a/xAODAnaHelpers/Electron.h
+++ b/xAODAnaHelpers/Electron.h
@@ -29,8 +29,13 @@ namespace xAH {
     float ptvarcone30;
     float ptvarcone40;
     float topoetcone20;
+    float ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500;
+    float ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000;
+    float ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500;
+    float ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000;
     float topoetcone30;
     float topoetcone40;
+    float neflowisol20;
 
     // PID
     std::map< std::string, int > PID;

--- a/xAODAnaHelpers/ElectronContainer.h
+++ b/xAODAnaHelpers/ElectronContainer.h
@@ -45,16 +45,14 @@ namespace xAH {
 
       // isolation
       std::map< std::string, std::vector< int >* >* m_isIsolated;
-      std::vector<float>* m_etcone20;
-      std::vector<float>* m_ptcone20;
-      std::vector<float>* m_ptcone30;
-      std::vector<float>* m_ptcone40;
       std::vector<float>* m_ptvarcone20;
-      std::vector<float>* m_ptvarcone30;
-      std::vector<float>* m_ptvarcone40;
       std::vector<float>* m_topoetcone20;
-      std::vector<float>* m_topoetcone30;
       std::vector<float>* m_topoetcone40;
+      std::vector<float>* m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500;
+      std::vector<float>* m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000;
+      std::vector<float>* m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500;
+      std::vector<float>* m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000;
+      std::vector<float>* m_neflowisol20;
 
       // PID
       std::map< std::string, std::vector< int >* >* m_PID;

--- a/xAODAnaHelpers/Muon.h
+++ b/xAODAnaHelpers/Muon.h
@@ -34,6 +34,7 @@ namespace xAH {
     float topoetcone40;
     float neflowisol20;
     float ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
+    float ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000;
     
     // quality
     std::map< std::string, int > quality;

--- a/xAODAnaHelpers/MuonContainer.h
+++ b/xAODAnaHelpers/MuonContainer.h
@@ -55,6 +55,7 @@ namespace xAH {
       std::vector<float> *m_topoetcone40;
       std::vector<float> *m_neflowisol20;
       std::vector<float> *m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt500;
+      std::vector<float> *m_ptvarcone30_Nonprompt_All_MaxWeightTTVA_pt1000;
 
 
       // quality


### PR DESCRIPTION
Hello,

This MR adds the latest supported lepton isolation variables, and removes some old ones which are no longer added to the derivations. The variables added will be used to apply the recommended isolation WPs (https://twiki.cern.ch/twiki/bin/view/AtlasProtected/RecommendedIsolationWPsRel22) for release 22 analyses.

Thanks,
Sagar and @gfrattar