### PR TITLE
Add protection for isolation variables if using LRT leptons

### DIFF
--- a/Root/ElectronContainer.cxx
+++ b/Root/ElectronContainer.cxx
@@ -785,10 +785,16 @@ void ElectronContainer::FillElectron( const xAOD::IParticle* particle, const xAO
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_ptvarcone20 ->push_back( elec->isolation( xAOD::Iso::ptvarcone20 ) /m_units );
+    if ( m_infoSwitch.m_doLRT ) {
+      m_ptvarcone20 ->push_back(-1.);
+      m_neflowisol20->push_back(-1.);
+    }
+    else {
+      m_ptvarcone20 ->push_back( elec->isolation( xAOD::Iso::ptvarcone20 ) /m_units );
+      m_neflowisol20->push_back( elec->isolation( xAOD::Iso::neflowisol20 )/m_units );
+    }
     m_topoetcone20->push_back( elec->isolation( xAOD::Iso::topoetcone20 )/m_units );
     m_topoetcone40->push_back( elec->isolation( xAOD::Iso::topoetcone40 )/m_units );
-    m_neflowisol20->push_back( elec->isolation( xAOD::Iso::neflowisol20 )/m_units );
     m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500    ->push_back( elec->isolation( xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt500 )    /m_units );
     m_ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000   ->push_back( elec->isolation( xAOD::Iso::ptcone20_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 )   /m_units );
     m_ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ->push_back( elec->isolation( xAOD::Iso::ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt500 ) /m_units );

--- a/Root/MuonContainer.cxx
+++ b/Root/MuonContainer.cxx
@@ -871,12 +871,22 @@ void MuonContainer::FillMuon( const xAOD::IParticle* particle, const xAOD::Verte
   }
 
   if ( m_infoSwitch.m_isolationKinematics ) {
-    m_ptcone20    ->push_back( muon->isolation( xAOD::Iso::ptcone20 )    /m_units );
-    m_ptcone30    ->push_back( muon->isolation( xAOD::Iso::ptcone30 )    /m_units );
-    m_ptcone40    ->push_back( muon->isolation( xAOD::Iso::ptcone40 )    /m_units );
-    m_ptvarcone20 ->push_back( muon->isolation( xAOD::Iso::ptvarcone20 ) /m_units );
-    m_ptvarcone30 ->push_back( muon->isolation( xAOD::Iso::ptvarcone30 ) /m_units );
-    m_ptvarcone40 ->push_back( muon->isolation( xAOD::Iso::ptvarcone40 ) /m_units );
+    if ( m_infoSwitch.m_doLRT ) {
+      m_ptcone20    ->push_back(-1.);
+      m_ptcone30    ->push_back(-1.);
+      m_ptcone40    ->push_back(-1.);
+      m_ptvarcone20 ->push_back(-1.);
+      m_ptvarcone30 ->push_back(-1.);
+      m_ptvarcone40 ->push_back(-1.);
+    }
+    else {
+      m_ptcone20    ->push_back( muon->isolation( xAOD::Iso::ptcone20 )    /m_units );
+      m_ptcone30    ->push_back( muon->isolation( xAOD::Iso::ptcone30 )    /m_units );
+      m_ptcone40    ->push_back( muon->isolation( xAOD::Iso::ptcone40 )    /m_units );
+      m_ptvarcone20 ->push_back( muon->isolation( xAOD::Iso::ptvarcone20 ) /m_units );
+      m_ptvarcone30 ->push_back( muon->isolation( xAOD::Iso::ptvarcone30 ) /m_units );
+      m_ptvarcone40 ->push_back( muon->isolation( xAOD::Iso::ptvarcone40 ) /m_units );
+    }
     m_topoetcone20->push_back( muon->isolation( xAOD::Iso::topoetcone20 )/m_units );
     m_topoetcone30->push_back( muon->isolation( xAOD::Iso::topoetcone30 )/m_units );
     m_topoetcone40->push_back( muon->isolation( xAOD::Iso::topoetcone40 )/m_units );


### PR DESCRIPTION
Hello,

This MR adds a protection for some isolation variables in case on is using LRT leptons. These variables are only there for historical reasons, hence aren't calculated for LRT leptons. In case an analysis does use LRT leptons, the branches would just be filled with a default -1. 

Kind regards,
Sagar and @gfrattar 