### PR TITLE
Add the support for a lepton favored OR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           - 24.2.4
           - 24.2.5
           - 24.2.6
+          - 24.2.7
+          - 24.2.8
+          - 24.2.9
 
     steps:
     - uses: actions/checkout@master

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -165,6 +165,11 @@ EL::StatusCode OverlapRemover :: initialize ()
 
   ANA_CHECK( ORUtils::recommendedTools(orFlags, m_ORToolbox));
   if(m_applyRelPt) ANA_CHECK( m_ORToolbox.muJetORT.setProperty("ApplyRelPt", true) );
+  if (m_lepFavWP) {
+    ANA_CHECK( m_ORToolbox.eleEleORT.setProperty("UseClusterMatch", true) );
+    ANA_CHECK( m_ORToolbox.muJetORT.setProperty("OuterDR", 0.) );
+    ANA_CHECK( m_ORToolbox.eleJetORT.setProperty("OuterDR", 0.) );
+  }
   ANA_CHECK( m_ORToolbox.initialize());
   ANA_MSG_INFO( "OverlapRemover Interface succesfully initialized!" );
 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -154,7 +154,7 @@ EL::StatusCode OverlapRemover :: initialize ()
   orFlags.linkOverlapObjects  = m_linkOverlapObjects;
   orFlags.bJetLabel           = m_bTagWP;
   orFlags.boostedLeptons      = m_useBoostedLeptons;
-  orFlags.doEleEleOR          = m_doEleEleOR;
+  orFlags.doEleEleOR          = m_doEleEleOR || m_lepFavWP;
 
   orFlags.doJets      = true;
   orFlags.doMuons     = m_useMuons;

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -113,7 +113,7 @@ class OverlapRemover : public xAH::Algorithm
   bool m_doEleEleOR = false;
   /** @brief Turn ON ApplyRelPt in MuJetOverlapTool (default is false) */
   bool m_applyRelPt = false;
-  /** @brief Turn ON Lepton favored working point (default is false) */
+  /** @brief Turn ON Lepton favored working point (HSG2 prescription)  */
   bool m_lepFavWP = false;
 
   /** @brief Output systematics list container name */

--- a/xAODAnaHelpers/OverlapRemover.h
+++ b/xAODAnaHelpers/OverlapRemover.h
@@ -113,6 +113,8 @@ class OverlapRemover : public xAH::Algorithm
   bool m_doEleEleOR = false;
   /** @brief Turn ON ApplyRelPt in MuJetOverlapTool (default is false) */
   bool m_applyRelPt = false;
+  /** @brief Turn ON Lepton favored working point (default is false) */
+  bool m_lepFavWP = false;
 
   /** @brief Output systematics list container name */
   std::string  m_outputAlgoSystNames = "ORAlgo_Syst";


### PR DESCRIPTION
This MR adds the support for lepton favored overlap removal configuration. Within this, the electron-electron OR is enabled and uses cluster matching, and the leptons which overlap with jets are not removed (which is done by setting the outer cone DR to 0). This OR was developed and supported by HSG2.

Tagging @gfrattar.

Cheers,
Sagar