### PR TITLE
adding support for Sherpa 2.2.14 to HelperFunctions::getMCShowerType()

### DIFF
--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -539,6 +539,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2212")) return Sherpa2210;
+  else if(tmp_name.Contains("SH_2214")) return Sherpa2210;
   else if(tmp_name.Contains("SHERPA")) return Sherpa22;
   else return Unknown;
 }


### PR DESCRIPTION
This MR adds support for Sherpa 2.2.14 samples (used in mc23) to the "auto" mode of HelperFunctions::getMCShowerType().