### PR TITLE
Adding notCorrectData_CB muon calib mode needed for AB 24.2.3 and higher

### DIFF
--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -131,6 +131,8 @@ EL::StatusCode MuonCalibrator :: initialize ()
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 1)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::correctData_IDMS
   } else if(m_calibrationMode == "notCorrectData_IDMS"){
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
+  } else if(m_calibrationMode == "notCorrectData_CB"){
+    ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 3)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_CB
   }
   // special corrections for muons with only 2 stations; to be switched on only for the muon highPt WP
   if (m_do2StationsHighPt){

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -132,6 +132,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   } else if(m_calibrationMode == "notCorrectData_IDMS"){
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
   } else if(m_calibrationMode == "notCorrectData_CB"){
+  # https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesR22#CP_MuonCalibTool_tool
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 3)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_CB
   }
   // special corrections for muons with only 2 stations; to be switched on only for the muon highPt WP

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -132,7 +132,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
   } else if(m_calibrationMode == "notCorrectData_IDMS"){
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 2)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_IDMS
   } else if(m_calibrationMode == "notCorrectData_CB"){
-  # https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesR22#CP_MuonCalibTool_tool
+  // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesR22#CP_MuonCalibTool_tool
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("calibMode", 3)); // i.e.: CP::MuonCalibrationPeriodTool::CalibMode::notCorrectData_CB
   }
   // special corrections for muons with only 2 stations; to be switched on only for the muon highPt WP


### PR DESCRIPTION
Adding the notCorrectData_CB muon calibration mode. From the latest [recommendations](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/MCPAnalysisGuidelinesR22#CP_MuonCalibTool_tool), this is needed in some cases for AnalysisBase >=24.2.3.