### PR TITLE
Fix LRT muon selection and PRW

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -1228,7 +1228,7 @@ StatusCode BasicEventSelection::autoconfigurePileupRWTool()
   std::vector<std::string> prwConfigFiles;
   for(const auto& mcCampaign : mcCampaignList)
     {
-      std::string prwConfigFile = PathResolverFindCalibFile("/dev/PileupReweighting/share/DSID" + std::to_string(DSID_INT/1000) +"xxx/pileup_" + mcCampaign + "_dsid" + std::to_string(DSID_INT) + "_" + SimulationFlavour + ".root");
+      std::string prwConfigFile = PathResolverFindCalibFile("dev/PileupReweighting/share/DSID" + std::to_string(DSID_INT/1000) +"xxx/pileup_" + mcCampaign + "_dsid" + std::to_string(DSID_INT) + "_" + SimulationFlavour + ".root");
       TFile testF(prwConfigFile.data(),"read");
       if(testF.IsZombie())
 	{

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -798,7 +798,8 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
   bool LRTdecorIsAvailable = false;
   bool muonIsLRT = false;
-  bool AcceptPromptMuon = (bool)m_muonSelectionTool_handle->accept( *muon );
+  bool AcceptStdMuon = (bool)m_muonSelectionTool_handle->accept( *muon );
+  bool AcceptLRTMuon = this_quality <= m_muonQuality; //LRT WP do not have the ID cuts applied so use getQuality()
 
   if ( m_doLRT ){
     static SG::AuxElement::Decorator< char > passIDcuts("passIDcuts");
@@ -810,13 +811,19 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
   ANA_MSG_DEBUG( "Doing muon quality" );
   if ( !m_doLRT ){
-    if( !AcceptPromptMuon ){
+    if( !AcceptStdMuon ){
       ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
       return 0;
     }
   }
   else {
-    if ( (!LRTdecorIsAvailable && !AcceptPromptMuon) || (LRTdecorIsAvailable && !muonIsLRT && !AcceptPromptMuon) ) {
+    if ( (!LRTdecorIsAvailable && !AcceptStdMuon) || (LRTdecorIsAvailable && !muonIsLRT && !AcceptStdMuon) ) {
+      // Checking if a muon is from the standard container, and if it fails the WP using the MST->accept() method.
+      ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
+      return 0;
+    }
+    else if (LRTdecorIsAvailable && muonIsLRT && !AcceptLRTMuon) {
+      // Checking if a muon is from the LRT container, and if it fails the WP using the MST->getQuality() method.
       ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
       return 0;
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -817,13 +817,10 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
     }
   }
   else {
-    if ( (!LRTdecorIsAvailable && !AcceptStdMuon) || (LRTdecorIsAvailable && !muonIsLRT && !AcceptStdMuon) ) {
-      // Checking if a muon is from the standard container, and if it fails the WP using the MST->accept() method.
-      ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
-      return 0;
-    }
-    else if (LRTdecorIsAvailable && muonIsLRT && !AcceptLRTMuon) {
-      // Checking if a muon is from the LRT container, and if it fails the WP using the MST->getQuality() method.
+    if ( (!LRTdecorIsAvailable && !AcceptStdMuon) || //If decor is not available, the muon is standard
+         (LRTdecorIsAvailable && !muonIsLRT && !AcceptStdMuon) || //If decor is available and is 0, the muon is standard. Use accept() method for standard muons.
+         (LRTdecorIsAvailable && muonIsLRT && !AcceptLRTMuon) //If decor is available and is 1, the muon is LRT. Use getQuality() method for LRT muons.
+       ) {
       ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
       return 0;
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -809,9 +809,8 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
 
   ANA_MSG_DEBUG( "Doing muon quality" );
   if ( !acceptMuon ) {
-      ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
-      return 0;
-    }
+    ANA_MSG_DEBUG( "Muon failed requirements of MuonSelectionTool.");
+    return 0;
   }
 
   if (!m_isUsedBefore && m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_eta_and_quaility_cut, 1 );


### PR DESCRIPTION
Hi,
We make improvements to MuonSelector to act correctly on LRT muons. Earlier, they were just being ignored and the logic was convoluted and dirty.
After an update to PathResolver, there are problems looking for files if the path has a leading forward slash. Fixing it to get the PRW file automatically. This change was reverted in AB,24.2.26, but I still suggest removing the leading slash to not make it look like its an absolute path.
Tagging @kratsg to merge. Thanks!