### PR TITLE
add check for NaN pT values to the muon selector

### DIFF
--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -150,6 +150,7 @@ EL::StatusCode MuonSelector :: initialize ()
     m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_1->GetXaxis()->FindBin("eta_and_quality_cut");
     m_mu_cutflow_ptmax_cut            = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_mu_cutflow_ptmin_cut            = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
+    m_mu_cutflow_ptnan_check          = m_mu_cutflowHist_1->GetXaxis()->FindBin("ptNaN_check");
     m_mu_cutflow_type_cut             = m_mu_cutflowHist_1->GetXaxis()->FindBin("type_cut");
     m_mu_cutflow_z0sintheta_cut       = m_mu_cutflowHist_1->GetXaxis()->FindBin("z0sintheta_cut");
     m_mu_cutflow_d0_cut               = m_mu_cutflowHist_1->GetXaxis()->FindBin("d0_cut");
@@ -166,6 +167,7 @@ EL::StatusCode MuonSelector :: initialize ()
       m_mu_cutflow_eta_and_quaility_cut = m_mu_cutflowHist_2->GetXaxis()->FindBin("eta_and_quality_cut");
       m_mu_cutflow_ptmax_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
       m_mu_cutflow_ptmin_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
+      m_mu_cutflow_ptnan_check   = m_mu_cutflowHist_2->GetXaxis()->FindBin("ptNaN_check");
       m_mu_cutflow_type_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("type_cut");
       m_mu_cutflow_z0sintheta_cut	 = m_mu_cutflowHist_2->GetXaxis()->FindBin("z0sintheta_cut");
       m_mu_cutflow_d0_cut		 = m_mu_cutflowHist_2->GetXaxis()->FindBin("d0_cut");
@@ -842,6 +844,19 @@ int MuonSelector :: passCuts( const xAOD::Muon* muon, const xAOD::Vertex *primar
   }
   if (!m_isUsedBefore && m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_ptmin_cut, 1 );
   if ( m_isUsedBefore && m_useCutFlow ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_ptmin_cut, 1 ); }
+
+  // *********************************************************************************************************************************************************************
+  //
+  // pT NaN check
+  //
+  if ( m_pT_NaNcheck ) {
+    if ( muon->pt() != muon->pt() ) {
+      ANA_MSG_DEBUG( "Muon failed pT NaN check.");
+      return 0;
+    }
+  }
+  if (!m_isUsedBefore && m_useCutFlow) m_mu_cutflowHist_1->Fill( m_mu_cutflow_ptnan_check, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_mu_cutflowHist_2->Fill( m_mu_cutflow_ptnan_check, 1 ); }
 
   // *********************************************************************************************************************************************************************
   //

--- a/xAODAnaHelpers/MuonSelector.h
+++ b/xAODAnaHelpers/MuonSelector.h
@@ -64,6 +64,8 @@ public:
   float          m_pT_max = 1e8;
   /** require pT > pt_min */
   float          m_pT_min = 1e8;
+  /** check if pT is NaN */
+  bool          m_pT_NaNcheck = false;
   /** require quality */
   std::string    m_muonQualityStr = "Medium";
   /** @brief Switch on Run3 geometry for muon selector tool */
@@ -142,6 +144,7 @@ private:
   int   m_mu_cutflow_eta_and_quaility_cut;  //!
   int   m_mu_cutflow_ptmax_cut;  	    //!
   int   m_mu_cutflow_ptmin_cut;  	    //!
+  int   m_mu_cutflow_ptnan_check;  	    //!
   int   m_mu_cutflow_type_cut;		    //!
   int   m_mu_cutflow_z0sintheta_cut;	    //!
   int   m_mu_cutflow_d0_cut;		    //!


### PR DESCRIPTION
In some mc samples of processes with high-mass resonances and very high-pT muons, the calibration tool sometimes outputs a -nan pt value. To veto those events, I added a flag for the config of the MuonSelector.