### PR TITLE
Add support for alternative schemes of NPs for FTAG systematics

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -256,6 +256,10 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EfficiencyLightCalibrations",  calibration));
       }
 
+    ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EigenvectorReductionB"        ,  m_EigenvectorReductionB) );
+    ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EigenvectorReductionC"        ,  m_EigenvectorReductionC) );
+    ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EigenvectorReductionLight"    ,  m_EigenvectorReductionLight) );
+
     ANA_CHECK( m_BJetEffSFTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_BJetEffSFTool_handle);
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -78,6 +78,11 @@ public:
   /// @brief Example: "410470;410250;410558;410464" (Pythia8,Sherpa22,Herwig7,MG)
   std::string m_EfficiencyCalibration = "";
 
+  /// @brief To change NP scheme for b-tagging systematics - Loose is the default value in athena
+  std::string m_EigenvectorReductionB = "Loose";
+  std::string m_EigenvectorReductionC = "Loose";
+  std::string m_EigenvectorReductionLight = "Loose";
+
 private:
 
   /// @brief The decoration key written to passing objects


### PR DESCRIPTION
Hi, 

as per the title, this PR is to allow the user to choose between different schemes of NPs for FTAG systematics. For more details please see https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#Systematics_strategy_and_further . 
For this we need to add the possibility to modify these properties
https://gitlab.cern.ch/atlas/athena/-/blob/main/PhysicsAnalysis/JetTagging/JetTagPerformanceCalibration/xAODBTaggingEfficiency/Root/BTaggingEfficiencyTool.cxx#L163-165

The default choice included in xAH is the same default of athena.

Best,
Guglielmo

fyi @SagarA17 