### PR TITLE
Draft: Jinja compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 Babel==2.9.1
 beautifulsoup4==4.8.1
-breathe==4.14.1
+breathe==4.35.0
 bs4==0.0.1
 certifi==2023.7.22
 chardet==3.0.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,7 +26,7 @@ sphinx-argparse==0.2.5
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-applehelp==1.0.1
 sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 Babel==2.9.1
 beautifulsoup4==4.8.1
-breathe==4.13.1
+breathe==4.14.1
 bs4==0.0.1
 certifi==2023.7.22
 chardet==3.0.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,5 +29,5 @@ sphinxcontrib-devhelp==1.0.1
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
+sphinxcontrib-serializinghtml==1.1.5
 urllib3==1.26.18

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,7 +21,7 @@ requests==2.31.0
 six==1.13.0
 snowballstemmer==2.0.0
 soupsieve==1.9.5
-Sphinx==2.2.1
+Sphinx==4.5.0
 sphinx-argparse==0.2.5
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-applehelp==1.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.15.2
 exhale==0.2.3
 idna==2.8
 imagesize==1.1.0
-Jinja2==2.11.3
+Jinja2==3.1.3
 lxml==4.9.1
 MarkupSafe==1.1.1
 packaging==19.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ idna==2.8
 imagesize==1.1.0
 Jinja2==3.1.3
 lxml==4.9.1
-MarkupSafe==1.1.1
+MarkupSafe==2.1.3
 packaging==19.2
 Pygments==2.15.0
 pyparsing==2.4.5


### PR DESCRIPTION
Update jinja (see https://github.com/UCATLAS/xAODAnaHelpers/pull/1668), update MarkupSafe to work with jinja update.