### PR TITLE
xAH updates for Trigger-Level Analyses

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -962,7 +962,19 @@ EL::StatusCode BasicEventSelection :: execute ()
 
     if ( m_applyTriggerCut ) {
 
-      if ( !triggerChainGroup->isPassed() ) {
+      // additional DEBUG logging to validate conditional logicss
+      ANA_MSG_DEBUG("Applying trigger cut corresponding to chain group " << m_triggerSelection);
+      ANA_MSG_DEBUG("Trigger chain group is NOT passed && is TLA data = " << int(!triggerChainGroup->isPassed(TrigDefs::requireDecision) && m_isTLAData));
+      ANA_MSG_DEBUG("Trigger chain group is NOT passed (no requireDecision) && is NOT TLA data = " << int(!triggerChainGroup->isPassed() && !m_isTLAData));
+
+      // different behaviour for isPassed depending on whether you are running on TLA data or not
+      // if running on TLA data, we only store the HLT part of the trigger decision i.e. the L1 part
+      // will always be "false", so we need to use TrigDefs::requireDecision to limit the decision 
+      // to being satisfied by the HLT leg(s) of the trigger chain
+      // TODO: check performance of this method when using trigger chains with the SAME HLT leg but different L1 seed
+      // e.g. HLT_j20_pf_ftf_L1J100 vs. HLT_j20_pf_ftf_L1HT190-J15s5pETA21
+      if ( (m_isTLAData && !triggerChainGroup->isPassed(TrigDefs::requireDecision)) || (!m_isTLAData && !triggerChainGroup->isPassed()) ) {
+      // if (!triggerChainGroup->isPassed(TrigDefs::requireDecision)) {
         wk()->skipEvent();
         return EL::StatusCode::SUCCESS;
       }
@@ -986,7 +998,7 @@ EL::StatusCode BasicEventSelection :: execute ()
       //
       for ( auto &trigName : triggerChainGroup->getListOfTriggers() ) {
         auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
-        if ( trigChain->isPassed() ) {
+        if ( (m_isTLAData && trigChain->isPassed(TrigDefs::requireDecision)) || (!m_isTLAData && trigChain->isPassed()) ) {
           passedTriggers.push_back( trigName );
           triggerPrescales.push_back( trigChain->getPrescale() );
 
@@ -1008,7 +1020,7 @@ EL::StatusCode BasicEventSelection :: execute ()
 
 	for ( const std::string &trigName : m_extraTriggerSelectionList ) {
 	  auto trigChain = m_trigDecTool_handle->getChainGroup( trigName );
-	  if ( trigChain->isPassed() ) {
+	  if ( (m_isTLAData && trigChain->isPassed(TrigDefs::requireDecision)) || (!m_isTLAData && trigChain->isPassed()) ) {
 	    passedTriggers.push_back( trigName );
 	    triggerPrescales.push_back( trigChain->getPrescale() );
 
@@ -1054,7 +1066,11 @@ EL::StatusCode BasicEventSelection :: execute ()
     }
     if ( m_storePassHLT ) {
       static SG::AuxElement::Decorator< int > passHLT("passHLT");
-      passHLT(*eventInfo) = ( m_triggerSelection.find("HLT_") != std::string::npos ) ? (int)m_trigDecTool_handle->isPassed(m_triggerSelection.c_str()) : -1;
+      if (!m_isTLAData) {
+        passHLT(*eventInfo) = ( m_triggerSelection.find("HLT_") != std::string::npos ) ? (int)m_trigDecTool_handle->isPassed(m_triggerSelection.c_str()) : -1;
+      } else {
+        passHLT(*eventInfo) = ( m_triggerSelection.find("HLT_") != std::string::npos ) ? (int)m_trigDecTool_handle->isPassed(m_triggerSelection.c_str(), TrigDefs::requireDecision) : -1;
+      }
     }
 
   } // if giving a specific list of triggers to look at

--- a/Root/HistogramManager.cxx
+++ b/Root/HistogramManager.cxx
@@ -243,8 +243,28 @@ void HistogramManager::fillHist(const std::string& histName, double valueX, doub
   histPointer->Fill(valueX, valueY, weight);
 }
 
-// void HistogramManager::fillProfile(const std::string& histName, double value, double bin) {
-//   TH1* profilePointer(NULL);
-//   histPointer = this->findHist(histName);
-//   histPointer->Fill(value, bin)
-// }
+void HistogramManager::fillHist(const std::string& histName, double valueX, double valueY, double valueZ, double weight) {
+  TH3* histPointer(NULL);
+  HistMap_t::const_iterator it = m_histMap.find( histName );
+  if ( it == m_histMap.end() ) {
+    ANA_MSG_ERROR("Histogram name " << histName << " not found");
+    return;
+  }
+  else {
+    histPointer = (TH3*)it->second;
+  }
+  histPointer->Fill(valueX, valueY, valueZ, weight);
+}
+
+void HistogramManager::fillProfile(const std::string& histName, double valueX, double valueY, double weight) {
+  TProfile* histPointer(NULL);
+  HistMap_t::const_iterator it = m_histMap.find( histName );
+  if ( it == m_histMap.end() ) {
+    ANA_MSG_ERROR("Histogram name " << histName << " not found");
+    return;
+  }
+  else {
+    histPointer = (TProfile*)it->second;
+  }
+  histPointer->Fill(valueX, valueY, weight);
+}

--- a/Root/HistogramManager.cxx
+++ b/Root/HistogramManager.cxx
@@ -242,3 +242,9 @@ void HistogramManager::fillHist(const std::string& histName, double valueX, doub
   }
   histPointer->Fill(valueX, valueY, weight);
 }
+
+// void HistogramManager::fillProfile(const std::string& histName, double value, double bin) {
+//   TH1* profilePointer(NULL);
+//   histPointer = this->findHist(histName);
+//   histPointer->Fill(value, bin)
+// }

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -232,7 +232,11 @@ EL::StatusCode JetCalibrator :: initialize ()
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("UseHLTEventShape", true) );
     // Note: PrimaryVerticesContainerName is actually a private ReadHandleKey, but we can set its value via the setProperty method
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("PrimaryVerticesContainerName", m_HLTVertexContainerName) );
-    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("averageInteractionsPerCrossingKey", m_HLTAvgMuLocation) );
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("averageInteractionsPerCrossingKey", m_HLTAvgMuDecor) );
+    if (m_EvtInfoHLTNPVDecor != "") {
+      ANA_CHECK( m_JetCalibrationTool_handle.setProperty("UseNPVFromEventInfo", true) );
+      ANA_CHECK( m_JetCalibrationTool_handle.setProperty("NPVKey", m_EvtInfoHLTNPVDecor) );
+    }
   }
   ANA_CHECK( m_JetCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_JetCalibrationTool_handle);

--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -227,6 +227,13 @@ EL::StatusCode JetCalibrator :: initialize ()
   if ( m_jetCalibToolsDEV ) {
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("DEVmode", m_jetCalibToolsDEV));
   }
+  // HLT jet re-calibration configuration
+  if (m_recalibrateHLTJets) {
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("UseHLTEventShape", true) );
+    // Note: PrimaryVerticesContainerName is actually a private ReadHandleKey, but we can set its value via the setProperty method
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("PrimaryVerticesContainerName", m_HLTVertexContainerName) );
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("averageInteractionsPerCrossingKey", m_HLTAvgMuLocation) );
+  }
   ANA_CHECK( m_JetCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_JetCalibrationTool_handle);
 

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -480,7 +480,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         }
       }
 
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
+      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) || m_store->contains<xAOD::JetContainer>(m_inContainerName_Jets) ) {
         ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) );
       } else {
         nomContainerNotFound = true;
@@ -488,7 +488,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) || m_store->contains<xAOD::PhotonContainer>(m_inContainerName_Photons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;

--- a/Root/OverlapRemover.cxx
+++ b/Root/OverlapRemover.cxx
@@ -463,7 +463,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       bool nomContainerNotFound(false);
 
       if( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) || m_store->contains<xAOD::ElectronContainer>(m_inContainerName_Electrons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -472,7 +472,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) || m_store->contains<xAOD::MuonContainer>(m_inContainerName_Muons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -497,7 +497,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) || m_store->contains<xAOD::TauJetContainer>(m_inContainerName_Taus) ) {
           ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -584,7 +584,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the electron syst loop ...
       if( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) || m_store->contains<xAOD::MuonContainer>(m_inContainerName_Muons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -592,7 +592,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         }
       }
 
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
+      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) || m_store->contains<xAOD::JetContainer>(m_inContainerName_Jets) ) {
         ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) );
       } else {
         nomContainerNotFound = true;
@@ -600,7 +600,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) || m_store->contains<xAOD::PhotonContainer>(m_inContainerName_Photons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -609,7 +609,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) || m_store->contains<xAOD::TauJetContainer>(m_inContainerName_Taus) ) {
           ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -689,7 +689,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the muon syst loop ...
       if( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) || m_store->contains<xAOD::ElectronContainer>(m_inContainerName_Electrons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -697,7 +697,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         }
       }
 
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
+      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) || m_store->contains<xAOD::JetContainer>(m_inContainerName_Jets) ) {
         ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) );
       } else {
         nomContainerNotFound = true;
@@ -705,7 +705,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) || m_store->contains<xAOD::PhotonContainer>(m_inContainerName_Photons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -714,7 +714,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) || m_store->contains<xAOD::TauJetContainer>(m_inContainerName_Taus) ) {
           ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -794,7 +794,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the jet syst loop ...
       if( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) || m_store->contains<xAOD::ElectronContainer>(m_inContainerName_Electrons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -803,7 +803,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) || m_store->contains<xAOD::MuonContainer>(m_inContainerName_Muons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -812,7 +812,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) || m_store->contains<xAOD::PhotonContainer>(m_inContainerName_Photons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -821,7 +821,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) || m_store->contains<xAOD::TauJetContainer>(m_inContainerName_Taus) ) {
           ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -901,7 +901,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the photon syst loop ...
       if( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) || m_store->contains<xAOD::ElectronContainer>(m_inContainerName_Electrons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -910,7 +910,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) || m_store->contains<xAOD::MuonContainer>(m_inContainerName_Muons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -918,7 +918,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         }
       }
 
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
+      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) || m_store->contains<xAOD::JetContainer>(m_inContainerName_Jets) ) {
         ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) );
       } else {
         nomContainerNotFound = true;
@@ -926,7 +926,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_useTaus ) {
-        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::TauJetContainer> >(m_inContainerName_Taus) || m_store->contains<xAOD::TauJetContainer>(m_inContainerName_Taus) ) {
           ANA_CHECK( HelperFunctions::retrieve(inTaus, m_inContainerName_Taus, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -1007,7 +1007,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
 
       // these input containers won't change in the tau syst loop ...
       if( m_useElectrons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::ElectronContainer> >(m_inContainerName_Electrons) || m_store->contains<xAOD::ElectronContainer>(m_inContainerName_Electrons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inElectrons, m_inContainerName_Electrons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -1016,7 +1016,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if( m_useMuons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::MuonContainer> >(m_inContainerName_Muons) || m_store->contains<xAOD::MuonContainer>(m_inContainerName_Muons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inMuons, m_inContainerName_Muons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;
@@ -1024,7 +1024,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
         }
       }
 
-      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) ) {
+      if ( m_store->contains<ConstDataVector<xAOD::JetContainer> >(m_inContainerName_Jets) || m_store->contains<xAOD::JetContainer>(m_inContainerName_Jets) ) {
         ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName_Jets, m_event, m_store, msg()) );
       } else {
         nomContainerNotFound = true;
@@ -1032,7 +1032,7 @@ EL::StatusCode OverlapRemover :: executeOR(  const xAOD::ElectronContainer* inEl
       }
 
       if ( m_usePhotons ) {
-        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) ) {
+        if ( m_store->contains<ConstDataVector<xAOD::PhotonContainer> >(m_inContainerName_Photons) || m_store->contains<xAOD::PhotonContainer>(m_inContainerName_Photons) ) {
           ANA_CHECK( HelperFunctions::retrieve(inPhotons, m_inContainerName_Photons, m_event, m_store, msg()) );
         } else {
           nomContainerNotFound = true;

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -48,6 +48,11 @@
 class BasicEventSelection : public xAH::Algorithm
 {
   public:
+
+  // Dijet+ISR TLA specific options
+    /// @brief Flag to determine when running on TLA data for different handling of TDT
+    bool m_isTLAData = false;
+
   // Sample type settings
     /// @brief Protection when running on truth xAOD
     bool m_truthLevelOnly = false;

--- a/xAODAnaHelpers/HistogramManager.h
+++ b/xAODAnaHelpers/HistogramManager.h
@@ -243,7 +243,8 @@ class HistogramManager {
      */
     void fillHist(const std::string& histName, double value, double weight);
     void fillHist(const std::string& histName, double valueX, double valueY, double weight);
-
+    void fillHist(const std::string& histName, double valueX, double valueY, double valueZ, double weight);
+    void fillProfile(const std::string& histName, double valueX, double valueY, double weight);
 
   private:
     /**

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -57,6 +57,14 @@ public:
   /// @brief Write systematics names to metadata
   bool        m_writeSystToMetadata = false;
 
+
+  /// @brief whether to run HLT jet re-calibration
+  bool        m_recalibrateHLTJets = false;
+  /// @brief vertex container name to use for HLT jet re-calibration
+  std::string m_HLTVertexContainerName = "HLT_IDVertex_FS";
+  /// @brief HLT average mu location on EventInfo after formatting
+  std::string m_HLTAvgMuLocation = "EventInfo.AvgMu";
+
   /// @brief config for JetCalibrationTool ConfigDir, set it to override tool defaults
   std::string m_calibConfigDir = "";
   /// @brief config for JetCalibrationTool for Data

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -62,8 +62,12 @@ public:
   bool        m_recalibrateHLTJets = false;
   /// @brief vertex container name to use for HLT jet re-calibration
   std::string m_HLTVertexContainerName = "HLT_IDVertex_FS";
-  /// @brief HLT average mu location on EventInfo after formatting
-  std::string m_HLTAvgMuLocation = "EventInfo.AvgMu";
+  /// @brief HLT average mu decoration on EventInfo after formatting
+  std::string m_HLTAvgMuDecor = "EventInfo.AvgMu";
+  /// @brief location of the HLT NPV on EventInfo object (e.g. EventInfo.NPV)
+  /// this defaults to an empty string and is only configured in JetCalibrationTool
+  /// when a non-empty string is provided
+  std::string m_EvtInfoHLTNPVDecor = "";
 
   /// @brief config for JetCalibrationTool ConfigDir, set it to override tool defaults
   std::string m_calibConfigDir = "";


### PR DESCRIPTION
Adds various modifications including:
- changes to `JetCalibrator`  for correcting HLT jets (new options for setting up `JetCalibrationTool`, yet to be upstreamed in Athena but planned)
- more functionality for filling `TProfile` & `TH3` objects with `HistogramManager`
- changes to handling of photon containers in `OverlapRemover`, only for checking existence in TStore when deep/shallow copies exist
- changes to `BasicEventSelection` adding a TLA data flag to control how trigger decisions are checked (from some differences between trigger decisions stored in 2022 TLA data & the primary physics data stream)

NOTE: for `BasicEventSelection` trigger decision changes we may need a follow up PR after checking if the modified TLA data logic is required for 2023 TLA data (if not, then we will need a 2022 TLA data flag)