### PR TITLE
Fixing tau initializations

### DIFF
--- a/xAODAnaHelpers/TauSelector.h
+++ b/xAODAnaHelpers/TauSelector.h
@@ -94,15 +94,15 @@ private:
   int m_numObjectPass;      //!
 
   // cutflow
-  TH1D* m_cutflowHist;      //!
-  TH1D* m_cutflowHistW;     //!
+  TH1D* m_cutflowHist = nullptr;      //!
+  TH1D* m_cutflowHistW = nullptr;     //!
   int   m_cutflow_bin;      //!
 
-  bool  m_isUsedBefore;     //!
+  bool  m_isUsedBefore = false;     //!
 
   // object cutflow
-  TH1D* m_tau_cutflowHist_1;                //!
-  TH1D* m_tau_cutflowHist_2;                //!
+  TH1D* m_tau_cutflowHist_1 = nullptr;                //!
+  TH1D* m_tau_cutflowHist_2 = nullptr;                //!
 
   int   m_tau_cutflow_all;		    //!
   int   m_tau_cutflow_selected;             //!


### PR DESCRIPTION
Fixing initializations in TauSelector to match ElectronSelector and MuonSelector. This should fix the following error seen by a user:

`/usatlas/u/rmcgov/Public/Analysis/2023-11_RPV_Chargino/BLCharginoHlWorkspace/source/xAODAnaHelpers/Root/TauSelector.cxx:796:8: runtime error: load of value 153, which is not a valid value for type 'bool'`
