### PR TITLE
Configure GSCDepth option for JetCalibrator

### DIFF
--- a/Root/JetCalibrator.cxx
+++ b/Root/JetCalibrator.cxx
@@ -227,6 +227,10 @@ EL::StatusCode JetCalibrator :: initialize ()
   if ( m_jetCalibToolsDEV ) {
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("DEVmode", m_jetCalibToolsDEV));
   }
+  if (!m_calibGSCDepth.empty() && m_calibSequence.find("GSC") != std::string::npos) {
+    ANA_MSG_WARNING("Using modified GSCDepth property for jet calibration '" << m_calibGSCDepth << "' which will override config file value");
+    ANA_CHECK( m_JetCalibrationTool_handle.setProperty("GSCDepth", m_calibGSCDepth));
+  }
   // HLT jet re-calibration configuration
   if (m_recalibrateHLTJets) {
     ANA_CHECK( m_JetCalibrationTool_handle.setProperty("UseHLTEventShape", true) );

--- a/xAODAnaHelpers/JetCalibrator.h
+++ b/xAODAnaHelpers/JetCalibrator.h
@@ -69,6 +69,10 @@ public:
   /// when a non-empty string is provided
   std::string m_EvtInfoHLTNPVDecor = "";
 
+  /// @brief GSCDepth property to override GSCDepth in config file when set to 
+  /// a non-empty string and GSC is in the calibration sequence
+  std::string m_calibGSCDepth = "";
+
   /// @brief config for JetCalibrationTool ConfigDir, set it to override tool defaults
   std::string m_calibConfigDir = "";
   /// @brief config for JetCalibrationTool for Data


### PR DESCRIPTION
Adding an additional option in `JetCalibrator` to allow the `GSCDepth` specified in a calibration config file to be overwritten with a user-specified value via `m_calibGSCDepth`. Implemented to only override `GSCDepth` when `m_calibGSCDepth` is not empty and `GSC` exists as a substring in the calibration sequence string.