### PR TITLE
More updates for Trigger-Level Analysis (TLA)

### DIFF
--- a/Root/HelperClasses.cxx
+++ b/Root/HelperClasses.cxx
@@ -333,6 +333,7 @@ namespace HelperClasses{
     m_constituentAll    = has_exact("constituentAll");
     m_flavorTag         = has_exact("flavorTag");
     m_flavorTagHLT      = has_exact("flavorTagHLT");
+    m_flavorTagTLA      = has_exact("flavorTagTLA");
     m_btag_jettrk       = has_exact("btag_jettrk");
     m_jetFitterDetails  = has_exact("jetFitterDetails");
     m_svDetails         = has_exact("svDetails");

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -254,6 +254,11 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
   }
 
   // flavorTag
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA ) {
+    m_HadronConeExclTruthLabelID        =new std::vector<int>();
+    m_HadronConeExclExtendedTruthLabelID=new std::vector<int>();
+  }
+  
   if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
     m_DL1r                              =new std::vector<float>();
@@ -280,8 +285,6 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_GN2v00NewAliasWP_pu               =new std::vector<float>();
     m_GN2v00NewAliasWP_pc               =new std::vector<float>();
     m_GN2v00NewAliasWP_pb               =new std::vector<float>();
-    m_HadronConeExclTruthLabelID        =new std::vector<int>();
-    m_HadronConeExclExtendedTruthLabelID=new std::vector<int>();
 
     // Jet Fitter
     if( m_infoSwitch.m_jetFitterDetails){
@@ -390,6 +393,13 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_vtx_online_bkg_x0  = new  std::vector<float>();
     m_vtx_online_bkg_y0  = new  std::vector<float>();
     m_vtx_online_bkg_z0  = new  std::vector<float>();
+  }
+
+  if( m_infoSwitch.m_flavorTagTLA  ) {
+    m_fastDIPS     =new std::vector<float>();
+    m_fastDIPS_pu  =new std::vector<float>();
+    m_fastDIPS_pc  =new std::vector<float>();
+    m_fastDIPS_pb  =new std::vector<float>();
   }
 
   if( !m_infoSwitch.m_jetBTag.empty() ) {
@@ -723,7 +733,12 @@ JetContainer::~JetContainer()
 
 
   // flavorTag
-  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA ) {
+    delete m_HadronConeExclTruthLabelID;
+    delete m_HadronConeExclExtendedTruthLabelID;
+  }
+
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT ) {
     // flavorTag
 
     delete m_DL1r;
@@ -750,9 +765,6 @@ JetContainer::~JetContainer()
     delete m_GN2v00NewAliasWP_pu;
     delete m_GN2v00NewAliasWP_pc;
     delete m_GN2v00NewAliasWP_pb;
-
-    delete m_HadronConeExclTruthLabelID;
-    delete m_HadronConeExclExtendedTruthLabelID;
 
     // Jet Fitter
     if( m_infoSwitch.m_jetFitterDetails){
@@ -859,6 +871,13 @@ JetContainer::~JetContainer()
     delete m_vtx_online_bkg_x0  ;
     delete m_vtx_online_bkg_y0  ;
     delete m_vtx_online_bkg_z0  ;
+  }
+
+  if( m_infoSwitch.m_flavorTagTLA ) {
+    delete m_fastDIPS;
+    delete m_fastDIPS_pu;
+    delete m_fastDIPS_pc;
+    delete m_fastDIPS_pb;
   }
 
   for(auto btag : m_btags)
@@ -1038,6 +1057,12 @@ void JetContainer::setTree(TTree *tree)
       connectBranch<double>(tree,"JetVertexCharge_discriminant", &m_JetVertexCharge_discriminant);
     }
 
+  if(m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA)
+    {
+      connectBranch<int>  (tree,"HadronConeExclTruthLabelID"        ,&m_HadronConeExclTruthLabelID);
+      connectBranch<int>  (tree,"HadronConeExclExtendedTruthLabelID",&m_HadronConeExclExtendedTruthLabelID);
+    }
+
   if(m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT)
     {
       connectBranch<float>(tree,"DL1r"                              ,&m_DL1r     );
@@ -1064,8 +1089,6 @@ void JetContainer::setTree(TTree *tree)
       connectBranch<float>(tree,"GN2v00NewAliasWP_pu"               ,&m_GN2v00NewAliasWP_pu  );
       connectBranch<float>(tree,"GN2v00NewAliasWP_pc"               ,&m_GN2v00NewAliasWP_pc  );
       connectBranch<float>(tree,"GN2v00NewAliasWP_pb"               ,&m_GN2v00NewAliasWP_pb  );
-      connectBranch<int>  (tree,"HadronConeExclTruthLabelID"        ,&m_HadronConeExclTruthLabelID);
-      connectBranch<int>  (tree,"HadronConeExclExtendedTruthLabelID",&m_HadronConeExclExtendedTruthLabelID);
     }
 
   if(m_infoSwitch.m_flavorTagHLT)
@@ -1086,6 +1109,13 @@ void JetContainer::setTree(TTree *tree)
       connectBranch<float>(tree,"vtx_online_bkg_x0",  &m_vtx_online_bkg_x0);
       connectBranch<float>(tree,"vtx_online_bkg_y0",  &m_vtx_online_bkg_y0);
       connectBranch<float>(tree,"vtx_online_bkg_z0",  &m_vtx_online_bkg_z0);
+    }
+  if(m_infoSwitch.m_flavorTagTLA)
+    {
+      connectBranch<float>(tree,"fastDIPS",    &m_fastDIPS);
+      connectBranch<float>(tree,"fastDIPS_pu", &m_fastDIPS_pu);
+      connectBranch<float>(tree,"fastDIPS_pc", &m_fastDIPS_pc);
+      connectBranch<float>(tree,"fastDIPS_pb", &m_fastDIPS_pb);
     }
 
   if(m_infoSwitch.m_jetFitterDetails)
@@ -1305,6 +1335,12 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
     jet.JVC = m_JetVertexCharge_discriminant->at(idx);
   }
 
+  if(m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA)
+    {
+      if(m_HadronConeExclTruthLabelID)         jet.HadronConeExclTruthLabelID        =m_HadronConeExclTruthLabelID        ->at(idx);
+      if(m_HadronConeExclExtendedTruthLabelID) jet.HadronConeExclExtendedTruthLabelID=m_HadronConeExclExtendedTruthLabelID->at(idx);
+    }
+
   if(m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT)
     {
       if(m_debug) std::cout << "updating flavorTag " << std::endl;
@@ -1334,8 +1370,6 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
       if(m_GN2v00NewAliasWP_pb) jet.GN2v00NewAliasWP_pb =m_GN2v00NewAliasWP_pb ->at(idx);
 
       //std::cout << m_HadronConeExclTruthLabelID->size() << std::endl;
-      if(m_HadronConeExclTruthLabelID)         jet.HadronConeExclTruthLabelID        =m_HadronConeExclTruthLabelID        ->at(idx);
-      if(m_HadronConeExclExtendedTruthLabelID) jet.HadronConeExclExtendedTruthLabelID=m_HadronConeExclExtendedTruthLabelID->at(idx);
       if(m_debug) std::cout << "leave flavorTag " << std::endl;
     }
 
@@ -1373,6 +1407,16 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
       jet.JetFitter_deltaphi              =m_JetFitter_deltaphi       ->at(idx);
       jet.JetFitter_N2Tpar                =m_JetFitter_N2Tpar         ->at(idx);
 
+    }
+  
+  if(m_infoSwitch.m_flavorTagTLA)
+    {
+      if(m_debug) std::cout << "updating flavorTagTLA " << std::endl;
+      if(m_fastDIPS)    jet.fastDIPS      =m_fastDIPS     ->at(idx);
+      if(m_fastDIPS_pu) jet.fastDIPS_pu   =m_fastDIPS_pu  ->at(idx);
+      if(m_fastDIPS_pc) jet.fastDIPS_pc   =m_fastDIPS_pc  ->at(idx);
+      if(m_fastDIPS_pb) jet.fastDIPS_pb   =m_fastDIPS_pb  ->at(idx);
+      if(m_debug) std::cout << "leave flavorTagTLA " << std::endl;
     }
 
   if(m_infoSwitch.m_svDetails){
@@ -1842,6 +1886,11 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<std::vector<float> >(tree,"constituent_e",      m_constituent_e     );
   }
 
+  if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA ) {
+    setBranch<int>(tree,"HadronConeExclTruthLabelID", m_HadronConeExclTruthLabelID);
+    setBranch<int>(tree,"HadronConeExclExtendedTruthLabelID", m_HadronConeExclExtendedTruthLabelID);
+  }
+
   if( m_infoSwitch.m_flavorTag  || m_infoSwitch.m_flavorTagHLT  ) {
 
     setBranch<float>(tree,"DL1r",    m_DL1r);
@@ -1868,8 +1917,6 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"GN2v00NewAliasWP_pu", m_GN2v00NewAliasWP_pu);
     setBranch<float>(tree,"GN2v00NewAliasWP_pc", m_GN2v00NewAliasWP_pc);
     setBranch<float>(tree,"GN2v00NewAliasWP_pb", m_GN2v00NewAliasWP_pb);
-    setBranch<int  >(tree,"HadronConeExclTruthLabelID", m_HadronConeExclTruthLabelID);
-    setBranch<int  >(tree,"HadronConeExclExtendedTruthLabelID", m_HadronConeExclExtendedTruthLabelID);
 
     if( m_infoSwitch.m_jetFitterDetails){
 
@@ -1978,6 +2025,13 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"vtx_online_bkg_y0"  ,m_vtx_online_bkg_y0     );
     setBranch<float>(tree,"vtx_online_bkg_z0"  ,m_vtx_online_bkg_z0     );
 
+  }
+
+  if( m_infoSwitch.m_flavorTagTLA ) {
+    setBranch<float>(tree,"fastDIPS",    m_fastDIPS);
+    setBranch<float>(tree,"fastDIPS_pu", m_fastDIPS_pu);
+    setBranch<float>(tree,"fastDIPS_pc", m_fastDIPS_pc);
+    setBranch<float>(tree,"fastDIPS_pb", m_fastDIPS_pb);
   }
 
   if( !m_infoSwitch.m_jetBTag.empty() || !m_infoSwitch.m_jetBTagCts.empty() ) {
@@ -2289,6 +2343,11 @@ void JetContainer::clear()
     m_constituent_e      ->clear();
   }
 
+  if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA ) {
+    m_HadronConeExclTruthLabelID        ->clear();
+    m_HadronConeExclExtendedTruthLabelID->clear();
+  }
+
   // flavor tag
   if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT  ) {
 
@@ -2316,9 +2375,6 @@ void JetContainer::clear()
     m_GN2v00NewAliasWP_pu               ->clear();
     m_GN2v00NewAliasWP_pc               ->clear();
     m_GN2v00NewAliasWP_pb               ->clear();
-    m_HadronConeExclTruthLabelID        ->clear();
-    m_HadronConeExclExtendedTruthLabelID->clear();
-
 
     if( m_infoSwitch.m_jetFitterDetails){
       m_JetFitter_nVTX             ->clear();
@@ -2422,6 +2478,12 @@ void JetContainer::clear()
 
   }
 
+  if ( m_infoSwitch.m_flavorTagTLA  ) {
+    m_fastDIPS    ->clear();
+    m_fastDIPS_pu ->clear();
+    m_fastDIPS_pc ->clear();
+    m_fastDIPS_pb ->clear();
+  }
 
   if( !m_infoSwitch.m_jetBTag.empty() || !m_infoSwitch.m_jetBTagCts.empty()) { // just clear them all....
     for(auto btag : m_btags)
@@ -3175,6 +3237,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_constituent_e->  push_back( e   );
   }
 
+
+  if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT || m_infoSwitch.m_flavorTagTLA ) {
+    // flavor groups truth definition
+    static SG::AuxElement::ConstAccessor<int> hadConeExclTruthLabel("HadronConeExclTruthLabelID");
+    safeFill<int, int, xAOD::Jet>(jet, hadConeExclTruthLabel, m_HadronConeExclTruthLabelID, -999);
+
+    static SG::AuxElement::ConstAccessor<int> hadConeExclExtendedTruthLabel("HadronConeExclExtendedTruthLabelID");
+    safeFill<int, int, xAOD::Jet>(jet, hadConeExclExtendedTruthLabel, m_HadronConeExclExtendedTruthLabelID, -999);
+  }
+
   if ( m_infoSwitch.m_flavorTag || m_infoSwitch.m_flavorTagHLT ) {
     const xAOD::BTagging * myBTag(0);
 
@@ -3255,13 +3327,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN2v00NewAliasWP_pc->push_back(pc);
     m_GN2v00NewAliasWP_pb->push_back(pb);
     m_GN2v00NewAliasWP->push_back( score );
-
-    // flavor groups truth definition
-    static SG::AuxElement::ConstAccessor<int> hadConeExclTruthLabel("HadronConeExclTruthLabelID");
-    safeFill<int, int, xAOD::Jet>(jet, hadConeExclTruthLabel, m_HadronConeExclTruthLabelID, -999);
-
-    static SG::AuxElement::ConstAccessor<int> hadConeExclExtendedTruthLabel("HadronConeExclExtendedTruthLabelID");
-    safeFill<int, int, xAOD::Jet>(jet, hadConeExclExtendedTruthLabel, m_HadronConeExclExtendedTruthLabelID, -999);
 
     if(m_infoSwitch.m_jetFitterDetails ) {
 
@@ -3562,6 +3627,23 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     if(m_debug) std::cout << "Done m_flavorTagHLT " << std::endl;
   }
 
+  if (m_infoSwitch.m_flavorTagTLA){
+    if(m_debug) std::cout << "Filling m_flavorTagHLT " << std::endl;
+  
+    float  pu=0, pb=0, pc=0, score=0;
+    pu = jet->auxdata<float>( "fastDIPS20211215_pu" );
+    pc = jet->auxdata<float>( "fastDIPS20211215_pc" );
+    pb = jet->auxdata<float>( "fastDIPS20211215_pb" );
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.018*pc+0.982*pu) );
+  
+    m_fastDIPS_pu->push_back( pu );
+    m_fastDIPS_pc->push_back( pc );
+    m_fastDIPS_pb->push_back( pb );
+    m_fastDIPS->push_back( score );
+
+    if(m_debug) std::cout << "Done m_flavorTagTLA " << std::endl;
+  }
 
   if( !m_infoSwitch.m_jetBTag.empty() || !m_infoSwitch.m_jetBTagCts.empty() ) {
     for(auto btag : m_btags)

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -28,8 +28,8 @@ EL::StatusCode TreeAlgo :: setupJob (EL::Job& job)
   job.useXAOD();
   xAOD::Init("TreeAlgo").ignore();
 
-  EL::OutputStream outForTree("tree");
-  job.outputAdd (outForTree);
+  EL::OutputStream outForTree(m_treeStreamName);
+  if(!job.outputHas(m_treeStreamName)) job.outputAdd (outForTree);
 
   return EL::StatusCode::SUCCESS;
 }
@@ -41,7 +41,7 @@ EL::StatusCode TreeAlgo :: initialize ()
   m_store = wk()->xaodStore();
 
   // get the file we created already
-  TFile* treeFile = wk()->getOutputFile ("tree");
+  TFile* treeFile = wk()->getOutputFile (m_treeStreamName);
   treeFile->mkdir(m_name.c_str());
   treeFile->cd(m_name.c_str());
 
@@ -293,7 +293,7 @@ EL::StatusCode TreeAlgo :: execute ()
     }
   }
 
-  TFile* treeFile = wk()->getOutputFile ("tree");
+  TFile* treeFile = wk()->getOutputFile (m_treeStreamName);
 
   // let's make the tdirectory and ttrees
   for(const auto& systName: event_systNames){

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -218,6 +218,9 @@ class BasicEventSelection : public xAH::Algorithm
     /** Check for duplicated events in MC */
     bool m_checkDuplicatesMC = false;
 
+    // determines whether to add additional debugging histograms on data
+    bool m_doRunByRunCutflows = false;
+
   private:
 
     std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
@@ -263,6 +266,10 @@ class BasicEventSelection : public xAH::Algorithm
     int m_cutflow_isbadbatman; //!
     int m_cutflow_npv;        //!
     int m_cutflow_trigger;    //!
+
+    // extra run-by-run event count cutflow
+    TH1D* m_runByrun_beforeCuts = nullptr; //!
+    TH1D* m_runByrun_afterCuts  = nullptr; //!
 
     // object cutflow
     TH1D* m_el_cutflowHist_1 = nullptr;    //!

--- a/xAODAnaHelpers/HelperClasses.h
+++ b/xAODAnaHelpers/HelperClasses.h
@@ -471,6 +471,7 @@ namespace HelperClasses {
         m_constituentAll constituentAll exact
         m_flavorTag      flavorTag      exact
         m_flavorTagHLT   flavorTagHLT   exact
+        m_flavorTagTLA   flavorTagTLA   exact
         m_sfFTagFix      sfFTagFix      partial
         m_sfFTagFlt      sfFTagFlt      partial
         m_sfFTagHyb      sfFTagHyb      partial
@@ -543,6 +544,7 @@ namespace HelperClasses {
     bool m_constituentAll;
     bool m_flavorTag;
     bool m_flavorTagHLT;
+    bool m_flavorTagTLA;
     bool m_btag_jettrk;
     bool m_jetFitterDetails;
     bool m_svDetails;

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -102,6 +102,10 @@ namespace xAH {
       float DL1dv01_pu;
       float DL1dv01_pc;
       float DL1dv01_pb;
+      float fastDIPS;
+      float fastDIPS_pu;
+      float fastDIPS_pc;
+      float fastDIPS_pb;
       float GN1;
       float GN1_pu;
       float GN1_pc;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -213,6 +213,10 @@ namespace xAH {
       std::vector<float> *m_DL1dv01_pu;
       std::vector<float> *m_DL1dv01_pc;
       std::vector<float> *m_DL1dv01_pb;
+      std::vector<float> *m_fastDIPS;
+      std::vector<float> *m_fastDIPS_pu;
+      std::vector<float> *m_fastDIPS_pb;
+      std::vector<float> *m_fastDIPS_pc;
       std::vector<float> *m_GN1;
       std::vector<float> *m_GN1_pu;
       std::vector<float> *m_GN1_pc;

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -15,6 +15,7 @@ class TreeAlgo : public xAH::Algorithm
 public:
   // choose whether the tree gets saved in the same directory as output histograms
   bool m_outHistDir = false;
+  std::string m_treeStreamName = "tree";
 
   // holds bools that control which branches are filled
   std::string m_evtDetailStr = "";


### PR DESCRIPTION
Changes:

1. adding functionality for run-by-run cutflows to BasicEventSelection to help with diagnosing problems when running over period containers containing a large number of runs
2. allowing a modifiable stream name for TreeAlgo 
3. adding additional `flavorTagTLA` detail string for saving HLT jet flavour tagging information on TLA jets including fastDIPS scores