### PR TITLE
Fixing FTAG MCMC SFs

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -226,44 +226,58 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 		gridName=wk()->metaData()->castString(SH::MetaFields::sampleName);
 		sampleShowerType=HelperFunctions::getMCShowerType(gridName);
 	      }
+        
+        if(m_isRun3){
+            switch(sampleShowerType)
+            {
+                case HelperFunctions::Pythia8:
+                    calibration="601229";
+                    break;
+                case HelperFunctions::Herwig7p2:
+                    calibration="601414";
+                    break;
+                case HelperFunctions::Sherpa2212:
+                    calibration="700660";
+                    break;
+                default:
+                    ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                    return EL::StatusCode::FAILURE;
+                    break;
+            }
+        } else {
 
-	    switch(sampleShowerType)
-	      {
-	      case HelperFunctions::Pythia8:
-		calibration="410470";
-        if(m_isRun3){
-            calibration="601129";
+	        switch(sampleShowerType)
+	        {
+	            case HelperFunctions::Pythia8:
+		            calibration="410470";
+		            break;
+	            case HelperFunctions::Herwig7p1:
+		            calibration="411233";
+                    break; 
+                case HelperFunctions::Herwig7p2:
+                    calibration="600666";
+		            break;
+	            case HelperFunctions::Sherpa221:
+		            calibration="410250";
+		            break;
+	            case HelperFunctions::Sherpa2210:
+		            calibration="700122";
+		            break;
+                case HelperFunctions::Sherpa2212:
+                    calibration="700660";
+                    break;
+                case HelperFunctions::AmcPy8:
+                    calibration="410464";
+                    break;
+                case HelperFunctions::AmcH7:
+                    calibration="412116";
+                    break;
+	            case HelperFunctions::Unknown:
+		            ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+		            return EL::StatusCode::FAILURE;
+		            break;
+	        }
         }
-		break;
-	      case HelperFunctions::Herwig7p1:
-		calibration="411233";
-        break; 
-          case HelperFunctions::Herwig7p2:
-        calibration="600666";
-        if(m_isRun3){
-            calibration="601414";
-        }
-		break;
-	      case HelperFunctions::Sherpa221:
-		calibration="410250";
-		break;
-	      case HelperFunctions::Sherpa2210:
-		calibration="700122";
-		break;
-          case HelperFunctions::Sherpa2212:
-        calibration="700660";
-        break;
-          case HelperFunctions::AmcPy8:
-        calibration="410464";
-        break;
-          case HelperFunctions::AmcH7:
-        calibration="412116";
-        break;
-	      case HelperFunctions::Unknown:
-		ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-		return EL::StatusCode::FAILURE;
-		break;
-	      }
 	  } else { makeMCIndexMap(m_EfficiencyCalibration); }
 	ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EfficiencyBCalibrations"    ,  calibration));
 	ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EfficiencyCCalibrations"    ,  calibration));

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -256,6 +256,9 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
           case HelperFunctions::AmcPy8:
         calibration="410464";
         break;
+          case HelperFunctions::AmcH7:
+        calibration="412116";
+        break;
 	      case HelperFunctions::Unknown:
 		ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
 		return EL::StatusCode::FAILURE;

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -231,19 +231,31 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	      {
 	      case HelperFunctions::Pythia8:
 		calibration="410470";
+        if(m_isRun3){
+            calibration="601129";
+        }
 		break;
-	      case HelperFunctions::Herwig7:
-		calibration="410558";
+	      case HelperFunctions::Herwig7p1:
+		calibration="411233";
+        break; 
+          case HelperFunctions::Herwig7p2:
+        calibration="600666";
+        if(m_isRun3){
+            calibration="601414";
+        }
 		break;
-	      case HelperFunctions::Sherpa21:
-		calibration="426131";
-		break;
-	      case HelperFunctions::Sherpa22:
+	      case HelperFunctions::Sherpa221:
 		calibration="410250";
 		break;
 	      case HelperFunctions::Sherpa2210:
 		calibration="700122";
 		break;
+          case HelperFunctions::Sherpa2212:
+        calibration="700660";
+        break;
+          case HelperFunctions::AmcPy8:
+        calibration="410464";
+        break;
 	      case HelperFunctions::Unknown:
 		ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
 		return EL::StatusCode::FAILURE;

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -538,7 +538,7 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   else if(tmp_name.Contains("AMCATNLOH")) return AmcH7;
   else if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
   else if(tmp_name.Contains("HERWIG")) return Herwig7p1;
-  else if(tmp_name.Contains("PHH7EG_H7UE")) return Herwig7p2;
+  else if(tmp_name.Contains("PHH7EG")) return Herwig7p2;
   else if(tmp_name.Contains("SHERPA_221_")) return Sherpa221;
   else if(tmp_name.Contains("SH_221_")) return Sherpa221;
   else if(tmp_name.Contains("SH_2210")) return Sherpa2210;

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -534,14 +534,15 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
 
   //
   // Determine shower type by looking for keywords in name
-  if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
+  if(tmp_name.Contains("AMCATNLOPY")) return AmcPy8;
+  else if(tmp_name.Contains("AMCATNLOH")) return AmcH7;
+  else if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
   else if(tmp_name.Contains("HERWIG")) return Herwig7p1;
-  else if(tmp_name.Contains("PhH7EG_H7UE")) return Herwig7p2;
+  else if(tmp_name.Contains("PHH7EG_H7UE")) return Herwig7p2;
   else if(tmp_name.Contains("SHERPA_221_")) return Sherpa221;
   else if(tmp_name.Contains("SH_221_")) return Sherpa221;
   else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2212")) return Sherpa2212;
-  else if(tmp_name.Contains("aMcAtNloPy8")) return AmcPy8;
   else return Unknown;
 }

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -527,7 +527,6 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   tmp_name.ReplaceAll("Py8EG","PYTHIA8EVTGEN");
   tmp_name.ReplaceAll("Py8EvtGen","PYTHIA8EVTGEN");
   tmp_name.ReplaceAll("Py8","Pythia8");
-  tmp_name.ReplaceAll("H7","HERWIG");
   if(tmp_name.Contains("Pythia") && !tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia","PYTHIA8EVTGEN");
   if(tmp_name.Contains("Pythia8") && !tmp_name.Contains("EvtGen")) tmp_name.ReplaceAll("Pythia8","PYTHIA8EVTGEN");
   //capitalize the entire sample name
@@ -536,12 +535,13 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
   //
   // Determine shower type by looking for keywords in name
   if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
-  else if(tmp_name.Contains("HERWIG")) return Herwig7;
-  else if(tmp_name.Contains("SHERPA_CT")) return Sherpa21;
+  else if(tmp_name.Contains("HERWIG")) return Herwig7p1;
+  else if(tmp_name.Contains("PhH7EG_H7UE")) return Herwig7p2;
+  else if(tmp_name.Contains("SHERPA_221_")) return Sherpa221;
+  else if(tmp_name.Contains("SH_221_")) return Sherpa221;
   else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
   else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
-  else if(tmp_name.Contains("SH_2212")) return Sherpa2210;
-  else if(tmp_name.Contains("SH_2214")) return Sherpa2210;
-  else if(tmp_name.Contains("SHERPA")) return Sherpa22;
+  else if(tmp_name.Contains("SH_2212")) return Sherpa2212;
+  else if(tmp_name.Contains("aMcAtNloPy8")) return AmcPy8;
   else return Unknown;
 }

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -50,6 +50,9 @@ public:
   /// @brief Decorate tag weights even if we're not doing pseudocontinuous b-tagging
   bool        m_alwaysGetTagWeight = false;
 
+  /// @brief Flag to get Run3 MC-MC SFs
+  bool        m_isRun3 = false;
+
   // allowed operating points:
   // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingCalibrationDataInterface#xAOD_interface
   //For the fixed cut, valid options are: [ "FixedCutBEff_60", "FixedCutBEff_70", "FixedCutBEff_77", "FixedCutBEff_85" ]

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -518,7 +518,7 @@ namespace HelperFunctions {
   }
 
   /// @brief The different supported shower types
-  enum ShowerType {Unknown, Pythia8, Herwig7p1, Herwig7p2, Sherpa221, Sherpa2210, Sherpa2212, AmcPy8};
+  enum ShowerType {Unknown, Pythia8, Herwig7p1, Herwig7p2, Sherpa221, Sherpa2210, Sherpa2212, AmcPy8, AmcH7};
 
   /**
     @brief Determines the type of generator used for the shower from the sample name

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -518,7 +518,7 @@ namespace HelperFunctions {
   }
 
   /// @brief The different supported shower types
-  enum ShowerType {Unknown, Pythia8, Herwig7, Sherpa21, Sherpa22, Sherpa2210};
+  enum ShowerType {Unknown, Pythia8, Herwig7p1, Herwig7p2, Sherpa221, Sherpa2210, Sherpa2212, AmcPy8};
 
   /**
     @brief Determines the type of generator used for the shower from the sample name


### PR DESCRIPTION
Updating MC-MC SFs to match https://ftag.docs.cern.ch/algorithms/activities/mcmc/#release-22-supported-generators and the CDI files (with the CDI files given precedence). Note this requires a new option in BJetEfficiencyCorrector, isRun3, which is set to False by default.