### PR TITLE
Adding support for GN2v01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
           - 25.2.2
           - 25.2.3
           - 25.2.4
-
+          - 25.2.5
+          - 25.2.6    
+    
     steps:
     - uses: actions/checkout@master
     - name: build ${{ env['RELEASE'] }}

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -134,7 +134,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if (m_taggerName == "GN120220509")   { taggerOK = true; m_getScaleFactors =  false; }
   if (m_taggerName == "GN2v00LegacyWP")   { taggerOK = true; m_getScaleFactors =  false; }
   if (m_taggerName == "GN2v00NewAliasWP")   { taggerOK = true; m_getScaleFactors =  false; }
-  if (m_taggerName == "GN2v01")   { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "GN2v01")   { taggerOK = true; m_getScaleFactors =  true; }
 
   if( !opOK || !taggerOK ) {
     ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -129,6 +129,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if (m_taggerName == "GN120220509")   { taggerOK = true; m_getScaleFactors =  false; }
   if (m_taggerName == "GN2v00LegacyWP")   { taggerOK = true; m_getScaleFactors =  false; }
   if (m_taggerName == "GN2v00NewAliasWP")   { taggerOK = true; m_getScaleFactors =  false; }
+  if (m_taggerName == "GN2v01")   { taggerOK = true; m_getScaleFactors =  false; }
 
   if( !opOK || !taggerOK ) {
     ANA_MSG_ERROR( "Requested tagger/operating point is not known to xAH. Arrow v Indian? " << m_taggerName << "/" << m_operatingPt);

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -114,7 +114,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   // https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/BTaggingBenchmarksRelease21
 
   // All working points are calibrated (but not all taggers, see next check)
-  if (m_operatingPt == "FixedCutBEff_60") { opOK = true; m_getScaleFactors =  true; }
+  if (m_operatingPt == "FixedCutBEff_60" and (m_taggerName != "GN2v01")) { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "FixedCutBEff_65") {
     if(m_taggerName == "GN2v01"){
         opOK = true; m_getScaleFactors =  true;

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -123,6 +123,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   if (m_operatingPt == "FixedCutBEff_70") { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "FixedCutBEff_77") { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "FixedCutBEff_85") { opOK = true; m_getScaleFactors =  true; }
+  if (m_operatingPt == "FixedCutBEff_90" and (m_taggerName == "GN2v01")) { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "Continuous"     ) { opOK = true; m_getScaleFactors =  true;
     m_useContinuous = true;
     ANA_MSG_DEBUG(" Using continuous b-tagging"); }

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -115,6 +115,11 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 
   // All working points are calibrated (but not all taggers, see next check)
   if (m_operatingPt == "FixedCutBEff_60") { opOK = true; m_getScaleFactors =  true; }
+  if (m_operatingPt == "FixedCutBEff_65") {
+    if(m_taggerName == "GN2v01"){
+        opOK = true; m_getScaleFactors =  true;
+    }
+  }
   if (m_operatingPt == "FixedCutBEff_70") { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "FixedCutBEff_77") { opOK = true; m_getScaleFactors =  true; }
   if (m_operatingPt == "FixedCutBEff_85") { opOK = true; m_getScaleFactors =  true; }

--- a/Root/Jet.cxx
+++ b/Root/Jet.cxx
@@ -90,6 +90,24 @@ int Jet::is_btag(BTaggerOP op) const
     case Jet::BTaggerOP::GN2v00NewAliasWP_FixedCutBEff_85:
       return is_GN2v00NewAliasWP_FixedCutBEff_85;
       break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_65:
+      return is_GN2v01_FixedCutBEff_65;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_70:
+      return is_GN2v01_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_77:
+      return is_GN2v01_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_85:
+      return is_GN2v01_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_90:
+      return is_GN2v01_FixedCutBEff_90;
+      break;
+    case Jet::BTaggerOP::GN2v01_Continuous:
+      return is_GN2v01_Continuous;
+      break;
     default:
       return 0;
       break;
@@ -183,6 +201,24 @@ const std::vector<float>& Jet::SF_btag(BTaggerOP op) const
       break;
     case Jet::BTaggerOP::GN2v00NewAliasWP_FixedCutBEff_85:
       return SF_GN2v00NewAliasWP_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_65:
+      return SF_GN2v01_FixedCutBEff_65;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_70:
+      return SF_GN2v01_FixedCutBEff_70;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_77:
+      return SF_GN2v01_FixedCutBEff_77;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_85:
+      return SF_GN2v01_FixedCutBEff_85;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_90:
+      return SF_GN2v01_FixedCutBEff_90;
+      break;
+    case Jet::BTaggerOP::GN2v01_Continuous:
+      return SF_GN2v01_Continuous;
       break;
     default:
       static const std::vector<float> dummySF = {1.};

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -285,6 +285,11 @@ JetContainer::JetContainer(const std::string& name, const std::string& detailStr
     m_GN2v00NewAliasWP_pu               =new std::vector<float>();
     m_GN2v00NewAliasWP_pc               =new std::vector<float>();
     m_GN2v00NewAliasWP_pb               =new std::vector<float>();
+    m_GN2v01                            =new std::vector<float>();
+    m_GN2v01_pu                         =new std::vector<float>();
+    m_GN2v01_pc                         =new std::vector<float>();
+    m_GN2v01_pb                         =new std::vector<float>();
+    m_GN2v01_ptau                       =new std::vector<float>();
 
     // Jet Fitter
     if( m_infoSwitch.m_jetFitterDetails){
@@ -765,6 +770,11 @@ JetContainer::~JetContainer()
     delete m_GN2v00NewAliasWP_pu;
     delete m_GN2v00NewAliasWP_pc;
     delete m_GN2v00NewAliasWP_pb;
+    delete m_GN2v01;
+    delete m_GN2v01_pu;
+    delete m_GN2v01_pc;
+    delete m_GN2v01_pb;
+    delete m_GN2v01_ptau;
 
     // Jet Fitter
     if( m_infoSwitch.m_jetFitterDetails){
@@ -1089,6 +1099,11 @@ void JetContainer::setTree(TTree *tree)
       connectBranch<float>(tree,"GN2v00NewAliasWP_pu"               ,&m_GN2v00NewAliasWP_pu  );
       connectBranch<float>(tree,"GN2v00NewAliasWP_pc"               ,&m_GN2v00NewAliasWP_pc  );
       connectBranch<float>(tree,"GN2v00NewAliasWP_pb"               ,&m_GN2v00NewAliasWP_pb  );
+      connectBranch<float>(tree,"GN2v01"                            ,&m_GN2v01     );
+      connectBranch<float>(tree,"GN2v01_pu"                         ,&m_GN2v01_pu  );
+      connectBranch<float>(tree,"GN2v01_pc"                         ,&m_GN2v01_pc  );
+      connectBranch<float>(tree,"GN2v01_pb"                         ,&m_GN2v01_pb  );
+      connectBranch<float>(tree,"GN2v01_ptau"                       ,&m_GN2v01_ptau);
     }
 
   if(m_infoSwitch.m_flavorTagHLT)
@@ -1368,6 +1383,11 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
       if(m_GN2v00NewAliasWP_pu) jet.GN2v00NewAliasWP_pu =m_GN2v00NewAliasWP_pu ->at(idx);
       if(m_GN2v00NewAliasWP_pc) jet.GN2v00NewAliasWP_pc =m_GN2v00NewAliasWP_pc ->at(idx);
       if(m_GN2v00NewAliasWP_pb) jet.GN2v00NewAliasWP_pb =m_GN2v00NewAliasWP_pb ->at(idx);
+      if(m_GN2v01)       jet.GN2v01       =m_GN2v01       ->at(idx);
+      if(m_GN2v01_pu)    jet.GN2v01_pu    =m_GN2v01_pu    ->at(idx);
+      if(m_GN2v01_pc)    jet.GN2v01_pc    =m_GN2v01_pc    ->at(idx);
+      if(m_GN2v01_pb)    jet.GN2v01_pb    =m_GN2v01_pb    ->at(idx);
+      if(m_GN2v01_ptau)  jet.GN2v01_ptau  =m_GN2v01_ptau  ->at(idx);
 
       //std::cout << m_HadronConeExclTruthLabelID->size() << std::endl;
       if(m_debug) std::cout << "leave flavorTag " << std::endl;
@@ -1602,6 +1622,30 @@ void JetContainer::updateParticle(uint idx, Jet& jet)
 	  jet.is_GN2v00NewAliasWP_FixedCutBEff_85=       btag->m_isTag->at(idx);
 	  jet.SF_GN2v00NewAliasWP_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
 	  break;
+        case Jet::BTaggerOP::GN2v01_FixedCutBEff_65:
+      jet.is_GN2v01_FixedCutBEff_65=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_FixedCutBEff_65=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_70:
+      jet.is_GN2v01_FixedCutBEff_70=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_FixedCutBEff_70=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_77:
+      jet.is_GN2v01_FixedCutBEff_77=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_FixedCutBEff_77=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_85:
+      jet.is_GN2v01_FixedCutBEff_85=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_FixedCutBEff_85=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
+    case Jet::BTaggerOP::GN2v01_FixedCutBEff_90:
+      jet.is_GN2v01_FixedCutBEff_90=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_FixedCutBEff_90=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
+    case Jet::BTaggerOP::GN2v01_Continuous:
+      jet.is_GN2v01_Continuous=       btag->m_isTag->at(idx);
+      jet.SF_GN2v01_Continuous=(m_mc)?btag->m_sf   ->at(idx):dummy1;
+      break;
 
 	default:
 	  throw std::domain_error(
@@ -1917,6 +1961,11 @@ void JetContainer::setBranches(TTree *tree)
     setBranch<float>(tree,"GN2v00NewAliasWP_pu", m_GN2v00NewAliasWP_pu);
     setBranch<float>(tree,"GN2v00NewAliasWP_pc", m_GN2v00NewAliasWP_pc);
     setBranch<float>(tree,"GN2v00NewAliasWP_pb", m_GN2v00NewAliasWP_pb);
+    setBranch<float>(tree,"GN2v01",    m_GN2v01);
+    setBranch<float>(tree,"GN2v01_pu", m_GN2v01_pu);
+    setBranch<float>(tree,"GN2v01_pc", m_GN2v01_pc);
+    setBranch<float>(tree,"GN2v01_pb", m_GN2v01_pb);
+    setBranch<float>(tree,"GN2v01_ptau", m_GN2v01_ptau);
 
     if( m_infoSwitch.m_jetFitterDetails){
 
@@ -2375,6 +2424,11 @@ void JetContainer::clear()
     m_GN2v00NewAliasWP_pu               ->clear();
     m_GN2v00NewAliasWP_pc               ->clear();
     m_GN2v00NewAliasWP_pb               ->clear();
+    m_GN2v01                            ->clear();
+    m_GN2v01_pu                         ->clear();
+    m_GN2v01_pc                         ->clear();
+    m_GN2v01_pb                         ->clear();
+    m_GN2v01_ptau                       ->clear();
 
     if( m_infoSwitch.m_jetFitterDetails){
       m_JetFitter_nVTX             ->clear();
@@ -3261,7 +3315,7 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
       safeFill<double, double, xAOD::BTagging>(myBTag, JetVertexCharge_discriminant, m_JetVertexCharge_discriminant, -999);
     }
 
-    float pu, pb, pc, score;
+    float pu, pb, pc, ptau, score;
 
     pu=0; pb=0; pc=0;
     myBTag->variable<float>("DL1r" , "pu", pu);
@@ -3327,6 +3381,19 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN2v00NewAliasWP_pc->push_back(pc);
     m_GN2v00NewAliasWP_pb->push_back(pb);
     m_GN2v00NewAliasWP->push_back( score );
+
+    pu=0; pb=0; pc=0; ptau=0;
+    myBTag->variable<float>("GN2v01" , "pu", pu);
+    myBTag->variable<float>("GN2v01" , "pc", pc);
+    myBTag->variable<float>("GN2v01" , "pb", pb);
+    myBTag->variable<float>("GN2v01" , "ptau", ptau);
+    //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
+    score=log( pb / (0.20*pc+0.01*ptau+0.79*pu) ); // GN2v01 uses a different f_c value than DL1dv01 which is 0.018
+    m_GN2v01_pu->push_back(pu);
+    m_GN2v01_pc->push_back(pc);
+    m_GN2v01_pb->push_back(pb);
+    m_GN2v01_ptau->push_back(ptau);
+    m_GN2v01->push_back( score );
 
     if(m_infoSwitch.m_jetFitterDetails ) {
 

--- a/xAODAnaHelpers/Jet.h
+++ b/xAODAnaHelpers/Jet.h
@@ -19,6 +19,8 @@ namespace xAH {
 	DL1dv00_Continuous, DL1r_Continuous, DL1dv01_Continuous, GN120220509_Continuous , // Continuous
   GN2v00LegacyWP_FixedCutBEff_60  , GN2v00LegacyWP_FixedCutBEff_70  , GN2v00LegacyWP_FixedCutBEff_77  , GN2v00LegacyWP_FixedCutBEff_85  ,
   GN2v00NewAliasWP_FixedCutBEff_60  , GN2v00NewAliasWP_FixedCutBEff_70  , GN2v00NewAliasWP_FixedCutBEff_77  , GN2v00NewAliasWP_FixedCutBEff_85  ,
+  GN2v01_FixedCutBEff_65  , GN2v01_FixedCutBEff_70  , GN2v01_FixedCutBEff_77  , GN2v01_FixedCutBEff_85  , GN2v01_FixedCutBEff_90  ,
+    GN2v01_Continuous , // Continuous 
       };
 
       float rapidity;
@@ -118,6 +120,11 @@ namespace xAH {
       float GN2v00NewAliasWP_pu;
       float GN2v00NewAliasWP_pc;
       float GN2v00NewAliasWP_pb;
+      float GN2v01;
+      float GN2v01_pu;
+      float GN2v01_pc;
+      float GN2v01_pb;
+      float GN2v01_ptau;
       int  HadronConeExclTruthLabelID;
       int  HadronConeExclExtendedTruthLabelID;
 
@@ -254,6 +261,16 @@ namespace xAH {
       std::vector<float> SF_GN2v00NewAliasWP_FixedCutBEff_77;
       int is_GN2v00NewAliasWP_FixedCutBEff_85;
       std::vector<float> SF_GN2v00NewAliasWP_FixedCutBEff_85;
+      int is_GN2v01_FixedCutBEff_65;
+      std::vector<float> SF_GN2v01_FixedCutBEff_65;
+      int is_GN2v01_FixedCutBEff_70;
+      std::vector<float> SF_GN2v01_FixedCutBEff_70;
+      int is_GN2v01_FixedCutBEff_77;
+      std::vector<float> SF_GN2v01_FixedCutBEff_77;
+      int is_GN2v01_FixedCutBEff_85;
+      std::vector<float> SF_GN2v01_FixedCutBEff_85;
+      int is_GN2v01_FixedCutBEff_90;
+      std::vector<float> SF_GN2v01_FixedCutBEff_90;
 
       // Continuous
       int is_DL1r_Continuous;
@@ -274,6 +291,9 @@ namespace xAH {
       int is_GN2v00NewAliasWP_Continuous;
       std::vector<float> SF_GN2v00NewAliasWP_Continuous;
       std::vector<float> inEffSF_GN2v00NewAliasWP_Continuous;
+      int is_GN2v01_Continuous;
+      std::vector<float> SF_GN2v01_Continuous;
+      std::vector<float> inEffSF_GN2v01_Continuous;
 
       // truth
       int   ConeTruthLabelID;

--- a/xAODAnaHelpers/JetContainer.h
+++ b/xAODAnaHelpers/JetContainer.h
@@ -229,6 +229,11 @@ namespace xAH {
       std::vector<float> *m_GN2v00NewAliasWP_pu;
       std::vector<float> *m_GN2v00NewAliasWP_pc;
       std::vector<float> *m_GN2v00NewAliasWP_pb;
+      std::vector<float> *m_GN2v01;
+      std::vector<float> *m_GN2v01_pu;
+      std::vector<float> *m_GN2v01_pc;
+      std::vector<float> *m_GN2v01_pb;
+      std::vector<float> *m_GN2v01_ptau;
 
       // Jet Fitter
       std::vector<float>  *m_JetFitter_nVTX           ;
@@ -398,6 +403,18 @@ namespace xAH {
 	    m_op=Jet::BTaggerOP::GN2v00NewAliasWP_FixedCutBEff_77;
 	  else if(m_accessorName=="GN2v00NewAliasWP_FixedCutBEff_85")
 	    m_op=Jet::BTaggerOP::GN2v00NewAliasWP_FixedCutBEff_85;
+
+          else if(m_accessorName=="GN2v01_FixedCutBEff_65")
+        m_op=Jet::BTaggerOP::GN2v01_FixedCutBEff_65;
+      else if(m_accessorName=="GN2v01_FixedCutBEff_70")
+        m_op=Jet::BTaggerOP::GN2v01_FixedCutBEff_70;
+      else if(m_accessorName=="GN2v01_FixedCutBEff_77")
+        m_op=Jet::BTaggerOP::GN2v01_FixedCutBEff_77;
+      else if(m_accessorName=="GN2v01_FixedCutBEff_85")
+        m_op=Jet::BTaggerOP::GN2v01_FixedCutBEff_85;
+      else if(m_accessorName=="GN2v01_FixedCutBEff_90")
+        m_op=Jet::BTaggerOP::GN2v01_FixedCutBEff_90;
+
   }
 
         ~btagOpPoint()


### PR DESCRIPTION
Adding support for GN2v01 to xAH. This requires AnalysisBase >=25.2.2. Note that SFs may require AnalysisBase >=25.2.6. This isn't nominally supported yet by xAH, but it still worked in my tests. Input files must also have p-tags p5980 or higher. It should also be noted that MC-MC SFs do not exist for different generators, only for "default".