### PR TITLE
Option to fallback to default calibration in automatic configuration of MC-to-MC b-tagging SFs

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -247,9 +247,16 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                     calibration="700660";
                     break;
                 default:
-                    ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-                    return EL::StatusCode::FAILURE;
-                    break;
+                    if (m_allowCalibrationFallback) {
+                      ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                      calibration="default";
+                      break;
+                    }
+                    else {
+                      ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                      return EL::StatusCode::FAILURE;
+                       break;
+                    }
             }
         } else {
 
@@ -280,9 +287,16 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                     calibration="412116";
                     break;
 	            case HelperFunctions::Unknown:
-		            ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-		            return EL::StatusCode::FAILURE;
-		            break;
+                if (m_allowCalibrationFallback) {
+                  ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                  calibration="default";
+                  break;
+                }
+                else {
+		              ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+		              return EL::StatusCode::FAILURE;
+		              break;
+                }
 	        }
         }
 	  } else { makeMCIndexMap(m_EfficiencyCalibration); }

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -249,6 +249,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                 default:
                     if (m_allowCalibrationFallback) {
                       ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                      ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
                       calibration="default";
                       break;
                     }
@@ -289,6 +290,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	            case HelperFunctions::Unknown:
                 if (m_allowCalibrationFallback) {
                   ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                  ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
                   calibration="default";
                   break;
                 }

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -80,6 +80,8 @@ public:
   /// @brief Calibration to use for MC (EfficiencyB/C/T/LightCalibrations), "auto" to determine from sample name (multiple samples can be provided as long as they are separated by ';')
   /// @brief Example: "410470;410250;410558;410464" (Pythia8,Sherpa22,Herwig7,MG)
   std::string m_EfficiencyCalibration = "";
+  /// @brief Allow to fallback to "default" configuration when the shower type can't be determined automatically
+  bool m_allowCalibrationFallback = false;
 
   /// @brief To change NP scheme for b-tagging systematics - Loose is the default value in athena
   std::string m_EigenvectorReductionB = "Loose";


### PR DESCRIPTION
The "auto" option to configure the b-tagging SFs currently causes failures if a sample isn't covered by the list. This PR gives an option to make this a bit more forgiven by potentially falling back to the default calibration. The default is of course to not use this.