### PR TITLE
Add distinctions for muon trigger SFs for 2023 and 2024

### DIFF
--- a/Root/MuonEfficiencyCorrector.cxx
+++ b/Root/MuonEfficiencyCorrector.cxx
@@ -705,9 +705,13 @@ EL::StatusCode MuonEfficiencyCorrector :: executeSF ( const xAOD::EventInfo* eve
     for (auto const& trig : m_SingleMuTriggerMap) {
 
       auto trig_it = trig.second;
+      // run numbers from MuonTriggerScaleFactors::getYear()
+      // https://gitlab.cern.ch/atlas/athena/-/blob/main/PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections/Root/MuonTriggerScaleFactors.cxx
       if (trig.first.find("2015")!=std::string::npos && run>284484) continue;
-      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos || trig.first.find("2018")!=std::string::npos) && (run<=284484 || run >400000) ) continue;
-      else if (trig.first.find("2022")!=std::string::npos && run< 400000) continue;
+      else if ((trig.first.find("2016")!=std::string::npos || trig.first.find("2017")!=std::string::npos || trig.first.find("2018")!=std::string::npos) && (run <= 284484 || run > 364292) ) continue;
+      else if (trig.first.find("2022")!=std::string::npos && (run <= 364292 || run > 440613) ) continue;
+      else if (trig.first.find("2023")!=std::string::npos && (run <= 440613 || run > 456749) ) continue;
+      else if (trig.first.find("2024")!=std::string::npos && run <= 456749 ) continue;
 
       std::unique_ptr< std::vector< std::string > > sysVariationNamesTrig = nullptr;
       if ( writeSystNames ) sysVariationNamesTrig = std::make_unique< std::vector< std::string > >();


### PR DESCRIPTION
This pull request adds some distinctions for 2023 and 2024 when evaluating muon triggers SFs. The logic in this block is a bit un-intuitive to me, so a cross check is appreciated.

To my understanding these distinctions are not required but mostly avoid to create unnecessary decorators.

I've slightly changes some of the existing run numbers to be in line with
https://gitlab.cern.ch/atlas/athena/-/blob/main/PhysicsAnalysis/MuonID/MuonIDAnalysis/MuonEfficiencyCorrections/Root/MuonTriggerScaleFactors.cxx
where the values for 2023 originate from this ongoing MR
https://gitlab.cern.ch/atlas/athena/-/merge_requests/73513/diffs