### PR TITLE
Move to new set of refactored Jvt-related tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 25.2.17
-          - 25.2.18
-          - 25.2.19
-          - 25.2.20
-          - 25.2.21
+          - 25.2.24
 
     steps:
     - uses: actions/checkout@master

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -498,22 +498,6 @@ EL::StatusCode JetSelector :: execute ()
     // this will be the collection processed - no matter what!!
     ANA_CHECK( HelperFunctions::retrieve(inJets, m_inContainerName, m_event, m_store, msg()) );
 
-    // decorate inJets with truth info
-    if ( isMC() && m_doJVT && m_haveTruthJets ) {
-      static SG::AuxElement::Decorator<char>  isHS("isJvtHS");
-      static SG::AuxElement::Decorator<char>  isPU("isJvtPU");
-      for(const auto& jet : *inJets) {
-        bool ishs = false;
-        bool ispu = true;
-        for(const auto& tjet : *truthJets) {
-          if (tjet->p4().DeltaR(jet->p4())<0.3 && tjet->pt()>10e3) ishs = true;
-          if (tjet->p4().DeltaR(jet->p4())<0.6) ispu = false;
-        }
-        isHS(*jet)=ishs;
-        isPU(*jet)=ispu;
-      }
-    }
-
     // Check against pile-up only jets:
     if ( isMC() && m_doMCCleaning && m_haveTruthJets ){
       float pTAvg = (inJets->size() > 0) ? inJets->at(0)->pt() : 0;
@@ -546,22 +530,6 @@ EL::StatusCode JetSelector :: execute ()
         if ( inJets->size() > 1 ) pTAvg = ( inJets->at(0)->pt() + inJets->at(1)->pt() ) / 2.0;
         if( truthJets->size() == 0 || ( pTAvg / truthJets->at(0)->pt() ) > m_mcCleaningCut ) {
           passMCcleaning = false;
-        }
-      }
-
-      // decorate inJets with truth info
-      if ( isMC() && (m_doJVT || m_dofJVT) && m_haveTruthJets ) {
-        static SG::AuxElement::Decorator<char>  isHS("isJvtHS");
-        static SG::AuxElement::Decorator<char>  isPU("isJvtPU");
-        for(const auto& jet : *inJets) {
-          bool ishs = false;
-          bool ispu = true;
-          for(const auto& tjet : *truthJets) {
-            if (tjet->p4().DeltaR(jet->p4())<0.3 && tjet->pt()>10e3) ishs = true;
-            if (tjet->p4().DeltaR(jet->p4())<0.6) ispu = false;
-          }
-          isHS(*jet)=ishs;
-          isPU(*jet)=ispu;
         }
       }
 
@@ -931,7 +899,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           //
           if (m_jetfJvtEfficiencyTool->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS)
           {
-            ANA_MSG_ERROR("Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
+            ANA_MSG_ERROR("Failed to configure CP::FJvtEfficiencyTool for systematic " << syst_it.name());
             return EL::StatusCode::FAILURE;
           }
           ANA_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -234,35 +234,68 @@ EL::StatusCode JetSelector :: initialize ()
 
   }
 
-  //init fJVT
-  if (m_dofJVT) {
-    // initialize the CP::JetJvtEfficiency Tool for fJVT
-    ANA_CHECK( ASG_MAKE_ANA_TOOL(m_fJVT_eff_tool_handle, CP::JetJvtEfficiency));
-    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("WorkingPoint", m_WorkingPointfJVT ));
-    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("TaggingAlg", CP::JvtTagger::fJvt ));
-    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("SFFile",       m_SFFilefJVT ));
-    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("ScaleFactorDecorationName", "fJVTSF"));
-    ANA_CHECK( m_fJVT_eff_tool_handle.setProperty("OutputLevel",  msg().level()));
-    ANA_CHECK( m_fJVT_eff_tool_handle.retrieve());
-    ANA_MSG_DEBUG("Retrieved tool: " << m_fJVT_eff_tool_handle);
+  // initialize the JetPileupLabelingTool to (re-)evaluate decorators using in Jvt efficiency tools
+  if ( m_doPileupLabel ) {
+    m_jetPileupLabelingTool.setTypeAndName("JetPileupLabelingTool/PileupLabelingTool");
+    ATH_CHECK( m_jetPileupLabelingTool.setProperty("RecoJetContainer", m_outContainerName) );
+    ATH_CHECK( m_jetPileupLabelingTool.setProperty("TruthJetContainer", m_truthJetContainer) );
+  #ifndef XAOD_STANDALONE
+    ATH_CHECK( m_jetPileupLabelingTool.setProperty("SuppressInputDependence", true) );
+    ATH_CHECK( m_jetPileupLabelingTool.setProperty("SuppressOutputDependence", true) );
+  #endif
+    ATH_CHECK( m_jetPileupLabelingTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetPileupLabelingTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetPileupLabelingTool);
+  }
+
+  // initialize CP tools related to NNJvt
+  if (m_doJVT) {
+
+    // initialize jet NNJvt moment tool
+    m_jetNNJvtMomentTool.setTypeAndName("JetPileupTag::JetVertexNNTagger/NNJvtMomentTool");
+    ATH_CHECK( m_jetNNJvtMomentTool.setProperty("JetContainer", m_outContainerName) );
+  #ifndef XAOD_STANDALONE
+    ATH_CHECK( m_jetNNJvtMomentTool.setProperty("SuppressInputDependence", true) );
+    ATH_CHECK( m_jetNNJvtMomentTool.setProperty("SuppressOutputDependence", true) );
+  #endif
+    ATH_CHECK( m_jetNNJvtMomentTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetNNJvtMomentTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetNNJvtMomentTool);
+
+    // initialize jet NNJvt selection tool
+    m_jetNNJvtSelectionTool.setTypeAndName("CP::NNJvtSelectionTool/NNJvtSelectionTool");
+    ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("JetContainer", m_outContainerName) );
+    ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("WorkingPoint", m_WorkingPointJVT) );
+    ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetNNJvtSelectionTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetNNJvtSelectionTool);
+
+    // initialize jet NNJvt efficiency tool (scale factors)
+    m_jetNNJvtEfficiencyTool.setTypeAndName("CP::NNJvtEfficiencyTool/NNJvtEfficiencyTool");
+    ATH_CHECK( m_jetNNJvtEfficiencyTool.setProperty("JetContainer", m_outContainerName) );
+    ATH_CHECK( m_jetNNJvtEfficiencyTool.setProperty("WorkingPoint", m_WorkingPointJVT) );
+    ATH_CHECK( m_jetNNJvtEfficiencyTool.setProperty("SFFile", m_SFFileJVT) );
+    ATH_CHECK( m_jetNNJvtEfficiencyTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetNNJvtEfficiencyTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetNNJvtEfficiencyTool);
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
-    m_outputSystNamesfJVT = m_outputSystNamesfJVT + "_fJVT_" + m_WorkingPointfJVT;
+    m_outputSystNamesJVT = m_outputSystNamesJVT + "_JVT_" + m_WorkingPointJVT;
     //  Create a passed label for JVT cut
-    m_outputfJVTPassed = m_outputfJVTPassed + "_" + m_WorkingPointfJVT;
+    m_outputJVTPassed = m_outputJVTPassed + "_" + m_WorkingPointJVT;
 
-    CP::SystematicSet affectSystsfJVT = m_fJVT_eff_tool_handle->affectingSystematics();
-    for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
+    CP::SystematicSet affectSystsJVT = m_jetNNJvtEfficiencyTool->affectingSystematics();
+    for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("NNJvtEfficiencyTool tool can be affected by NNJvt efficiency systematic: " << syst_it.name()); }
 
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
 
-    const CP::SystematicSet recSystsfJVT = m_fJVT_eff_tool_handle->recommendedSystematics();
-    m_systListfJVT = HelperFunctions::getListofSystematics( recSystsfJVT, m_systNamefJVT, m_systValfJVT, msg() );
+    const CP::SystematicSet recSystsJVT = m_jetNNJvtEfficiencyTool->recommendedSystematics();
+    m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, msg() );
 
-    ANA_MSG_INFO("Will be using JetJvtEfficiency tool fJVT efficiency systematic:");
-    for ( const auto& syst_it : m_systListfJVT ) {
-      if ( m_systNamefJVT.empty() ) {
+    ANA_MSG_INFO("Will be using JetJvtEfficiency tool JVT efficiency systematic:");
+    for ( const auto& syst_it : m_systListJVT ) {
+      if ( m_systNameJVT.empty() ) {
         ANA_MSG_INFO("\t Running w/ nominal configuration only!");
         break;
       }
@@ -270,33 +303,44 @@ EL::StatusCode JetSelector :: initialize ()
     }
   }
 
-  // initialize the CP::JetJvtEfficiency Tool for JVT
-  if (m_doJVT) {
-    ANA_CHECK( ASG_MAKE_ANA_TOOL(m_JVT_tool_handle, CP::JetJvtEfficiency));
-    ANA_CHECK( m_JVT_tool_handle.setProperty("WorkingPoint", m_WorkingPointJVT ));
-    ANA_CHECK( m_JVT_tool_handle.setProperty("TaggingAlg", m_JvtTaggingAlg ));
-    ANA_CHECK( m_JVT_tool_handle.setProperty("SFFile",       m_SFFileJVT ));
-    ANA_CHECK( m_JVT_tool_handle.setProperty("OutputLevel",  msg().level()));
-    ANA_CHECK( m_JVT_tool_handle.retrieve());
-    ANA_MSG_DEBUG("Retrieved tool: " << m_JVT_tool_handle);
+  // initialize CP tools related to NNJvt
+  if (m_dofJVT) {
+
+    // initialize jet fJvt selection tool
+    m_jetfJvtSelectionTool.setTypeAndName("CP::FJvtSelectionTool/fJvtSelectionTool");
+    ATH_CHECK( m_jetfJvtSelectionTool.setProperty("JetContainer", m_outContainerName) );
+    ATH_CHECK( m_jetfJvtSelectionTool.setProperty("WorkingPoint", m_WorkingPointfJVT) );
+    ATH_CHECK( m_jetfJvtSelectionTool.setProperty("JvtMomentName", "DFCommonJets_fJvt") );
+    ATH_CHECK( m_jetfJvtSelectionTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetfJvtSelectionTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetfJvtSelectionTool);
+
+    // initialize jet fJvt efficiency tool (scale factors)
+    m_jetfJvtEfficiencyTool.setTypeAndName("CP::FJvtEfficiencyTool/fJvtEfficiencyTool");
+    ATH_CHECK( m_jetfJvtEfficiencyTool.setProperty("JetContainer", m_outContainerName) );
+    ATH_CHECK( m_jetfJvtEfficiencyTool.setProperty("WorkingPoint", m_WorkingPointfJVT) );
+    ATH_CHECK( m_jetfJvtEfficiencyTool.setProperty("SFFile", m_SFFilefJVT) );
+    ATH_CHECK( m_jetfJvtEfficiencyTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetfJvtEfficiencyTool.retrieve() );
+    ANA_MSG_DEBUG("Retrieved tool: " << m_jetfJvtEfficiencyTool);
 
     //  Add the chosen WP to the string labelling the vector<SF> decoration
-    m_outputSystNamesJVT = m_outputSystNamesJVT + "_JVT_" + m_WorkingPointJVT;
+    m_outputSystNamesfJVT = m_outputSystNamesfJVT + "_fJVT_" + m_WorkingPointfJVT;
     //  Create a passed label for JVT cut
-    m_outputJVTPassed = m_outputJVTPassed + "_" + m_WorkingPointJVT;
+    m_outputfJVTPassed = m_outputfJVTPassed + "_" + m_WorkingPointfJVT;
 
-    CP::SystematicSet affectSystsJVT = m_JVT_tool_handle->affectingSystematics();
-    for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by JVT efficiency systematic: " << syst_it.name()); }
+    CP::SystematicSet affectSystsfJVT = m_jetfJvtEfficiencyTool->affectingSystematics();
+    for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
 
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
 
-    const CP::SystematicSet recSystsJVT = m_JVT_tool_handle->recommendedSystematics();
-    m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, msg() );
+    const CP::SystematicSet recSystsfJVT = m_jetfJvtEfficiencyTool->recommendedSystematics();
+    m_systListfJVT = HelperFunctions::getListofSystematics( recSystsfJVT, m_systNamefJVT, m_systValfJVT, msg() );
 
-    ANA_MSG_INFO("Will be using JetJvtEfficiency tool JVT efficiency systematic:");
-    for ( const auto& syst_it : m_systListJVT ) {
-      if ( m_systNameJVT.empty() ) {
+    ANA_MSG_INFO("Will be using FJvtEfficiencyTool tool fJvt efficiency systematic:");
+    for ( const auto& syst_it : m_systListfJVT ) {
+      if ( m_systNamefJVT.empty() ) {
         ANA_MSG_INFO("\t Running w/ nominal configuration only!");
         break;
       }
@@ -636,9 +680,14 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
       m_count_events_with_duplicates++;
   }
 
+  // add isHS labels to jets (required for Jvt efficiency tools)
+  if (m_doPileupLabel && isMC()) {
+    ATH_CHECK(m_jetPileupLabelingTool->decorate(*inJets));
+  }
+
   // recalculate the NNJvt scores and decisions
   if (m_doJVT && m_recalculateJvtScores) {
-    ANA_CHECK(m_JVT_tool_handle->recalculateScores(*inJets));
+    ATH_CHECK(m_jetNNJvtMomentTool->decorate(*inJets));
   }
 
   i_jet = 0;
@@ -702,6 +751,9 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
     }
   }
 
+  // decorator with flag if it is a hard-scatter jet
+  static const SG::AuxElement::Decorator<char> isJvtHS("isJvtHS");
+
   // Loop over selected jets and decorate with JVT efficiency SF
   // Do it only for MC
   //
@@ -715,7 +767,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
     // Do it only if a tool with *this* name hasn't already been used
     //
-    if ( m_JVT_tool_handle.isInitialized() && !m_jvtUsedBefore) {
+    if ( m_jetNNJvtSelectionTool.isInitialized() && !m_jvtUsedBefore) {
       //
       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* jet)
       //
@@ -746,8 +798,8 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
 	  // apply syst
 
-	  if ( m_JVT_tool_handle->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS ) {
-	    ANA_MSG_ERROR( "Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
+	  if ( m_jetNNJvtEfficiencyTool->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS ) {
+	    ANA_MSG_ERROR( "Failed to configure CP::NNJvtEfficiencyTool for systematic " << syst_it.name());
 	    return EL::StatusCode::FAILURE;
 	  }
 	  ANA_MSG_DEBUG("Successfully applied systematic: " << syst_it.name());
@@ -765,16 +817,16 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           float jvtSF(1.0);
           CP::CorrectionCode result_code;
           // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
-          if ( m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) {
+          if ( m_noJVTVeto && !bool(m_jetNNJvtSelectionTool->accept(jet)) ) {
             if ( syst_it.name().empty() ) {
               passedJVT( *jet ) = 0; // mark as not passed
             }
             if ( m_getJVTSF ){
-              result_code = m_JVT_tool_handle->getInefficiencyScaleFactor( *jet, jvtSF );
+              result_code = m_jetNNJvtEfficiencyTool->getInefficiencyScaleFactor( *jet, jvtSF );
               if (result_code == CP::CorrectionCode::OutOfValidityRange) {
                   jvtSF = 1;
               } else if (result_code != CP::CorrectionCode::Ok and result_code != CP::CorrectionCode::OutOfValidityRange) {
-                  ANA_MSG_ERROR( "Error in JVT Tool getInefficiencyScaleFactor");
+                  ANA_MSG_ERROR( "Error in JNNJvtEfficiencyTool getInefficiencyScaleFactor");
                   return EL::StatusCode::FAILURE;
               }
             }
@@ -783,11 +835,11 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               passedJVT( *jet ) = 1;
             }
             if ( m_getJVTSF ){
-              result_code = m_JVT_tool_handle->getEfficiencyScaleFactor( *jet, jvtSF );
+              result_code = m_jetNNJvtEfficiencyTool->getEfficiencyScaleFactor( *jet, jvtSF );
               if (result_code == CP::CorrectionCode::OutOfValidityRange) {
                   jvtSF = 1;
               } else if (result_code != CP::CorrectionCode::Ok and result_code != CP::CorrectionCode::OutOfValidityRange) {
-                  ANA_MSG_ERROR( "Error in JVT Tool getEfficiencyScaleFactor");
+                  ANA_MSG_ERROR( "Error in NNJvtEfficiencyTool getEfficiencyScaleFactor");
                   return EL::StatusCode::FAILURE;
               }
             }
@@ -795,7 +847,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 	      sfVecJVT.push_back(jvtSF);
 
           ANA_MSG_DEBUG( "===>>>");
-          ANA_MSG_DEBUG( "Jet " << idx << ", pt = " << jet->pt()*1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) );
+          ANA_MSG_DEBUG( "Jet " << idx << ", pt = " << jet->pt()*1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) << " isJvtHS " << bool(isJvtHS(*jet)) );
           ANA_MSG_DEBUG( "JVT SF decoration: " << m_outputSystNamesJVT );
           ANA_MSG_DEBUG( "Systematic: " << syst_it.name() );
           ANA_MSG_DEBUG( "JVT SF:");
@@ -824,7 +876,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
       static const SG::AuxElement::Decorator<char> passedJVT( m_outputJVTPassed );
       passedJVT( *jet ) = 1; // passes by default
 
-      if ( m_noJVTVeto && !m_JVT_tool_handle->passesJvtCut(*jet) ) {
+      if ( m_noJVTVeto && !bool(m_jetNNJvtSelectionTool->accept(jet)) ) {
         passedJVT( *jet ) = 0; // mark as not passed
       } else {
         passedJVT( *jet ) = 1;
@@ -841,7 +893,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
     // Do it only if a tool with *this* name hasn't already been used
     //
-    if (m_fJVT_eff_tool_handle.isInitialized() && !m_fjvtUsedBefore)
+    if (m_jetfJvtEfficiencyTool.isInitialized() && !m_fjvtUsedBefore)
     {
       //
       //  If SF decoration vector doesn't exist, create it (will be done only for the 1st systematic for *this* jet)
@@ -877,7 +929,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
 
           // apply syst
           //
-          if (m_fJVT_eff_tool_handle->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS)
+          if (m_jetfJvtEfficiencyTool->applySystematicVariation(syst_it) != EL::StatusCode::SUCCESS)
           {
             ANA_MSG_ERROR("Failed to configure CP::JetJvtEfficiency for systematic " << syst_it.name());
             return EL::StatusCode::FAILURE;
@@ -891,14 +943,14 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           static const SG::AuxElement::Decorator<char> passedfJVT(m_outputfJVTPassed);
           if (syst_it.name().empty())
           {
-            passedfJVT(*jet) = m_fJVT_eff_tool_handle->passesJvtCut(*jet);
+            passedfJVT(*jet) = bool(m_jetfJvtSelectionTool->accept(jet));
           }
 
           float fjvtSF(1.0);
           CP::CorrectionCode result_code;
           // If we do not enforce JVT veto and the jet hasn't passed the JVT cut, we need to calculate the inefficiency scale factor for it
-          if ( !m_dofJVTVeto && !m_fJVT_eff_tool_handle->passesJvtCut(*jet)) {
-            result_code = m_fJVT_eff_tool_handle->getInefficiencyScaleFactor( *jet, fjvtSF );
+          if ( !m_dofJVTVeto && !bool(m_jetfJvtSelectionTool->accept(jet)) ) {
+            result_code = m_jetfJvtEfficiencyTool->getInefficiencyScaleFactor( *jet, fjvtSF );
             if ( result_code == CP::CorrectionCode::OutOfValidityRange) {
                 fjvtSF = 1;
             } else if ( result_code != CP::CorrectionCode::Ok ) {
@@ -906,10 +958,10 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
               return EL::StatusCode::FAILURE;
             }
           } else { // otherwise classic efficiency scale factor
-            result_code = m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF );
+            result_code = m_jetfJvtEfficiencyTool->getEfficiencyScaleFactor( *jet, fjvtSF );
             if ( result_code == CP::CorrectionCode::OutOfValidityRange) {
                 fjvtSF = 1;
-            } else if ( m_fJVT_eff_tool_handle->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
+            } else if ( m_jetfJvtEfficiencyTool->getEfficiencyScaleFactor( *jet, fjvtSF ) != CP::CorrectionCode::Ok ) {
               ANA_MSG_ERROR( "Error in fJVT Tool getEfficiencyScaleFactor");
               return EL::StatusCode::FAILURE;
             }
@@ -917,7 +969,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
           sfVecfJVT.push_back(fjvtSF);
 
           ANA_MSG_DEBUG("===>>>");
-          ANA_MSG_DEBUG("Jet " << idx << ", pt = " << jet->pt() * 1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()));
+          ANA_MSG_DEBUG("Jet " << idx << ", pt = " << jet->pt() * 1e-3 << " GeV, |eta| = " << std::fabs(jet->eta()) << " isJvtHS " << bool(isJvtHS(*jet)) );
           ANA_MSG_DEBUG("fJVT SF decoration: " << m_outputSystNamesfJVT);
           ANA_MSG_DEBUG("Systematic: " << syst_it.name());
           ANA_MSG_DEBUG("fJVT SF:");
@@ -949,7 +1001,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
       {
         // create passed fJVT decorator
         static const SG::AuxElement::Decorator<char> passedfJVT(m_outputfJVTPassed);
-        passedfJVT(*jet) = m_fJVT_eff_tool_handle->passesJvtCut(*jet);
+        passedfJVT(*jet) = bool(m_jetfJvtSelectionTool->accept(jet));
       }
     }
   }
@@ -1276,7 +1328,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
   } // m_doJVF
 
   if(m_dofJVT){
-    if (!m_fJVT_eff_tool_handle->passesJvtCut(*jet)){
+    if (!bool(m_jetfJvtSelectionTool->accept(jet))){
       ANA_MSG_DEBUG("jet pt = "<<jetPt<<",eta = "<<jetEta<<",phi = "<<jetPhi);
       ANA_MSG_DEBUG("Failed forward JVT");
       if(m_dofJVTVeto)return 0;
@@ -1306,7 +1358,7 @@ int JetSelector :: PassCuts( const xAOD::Jet* jet ) {
         result = true;
       }
     } else {
-      result = m_JVT_tool_handle->passesJvtCut(*jet);
+      result = bool(m_jetNNJvtSelectionTool->accept(jet));
     }
 
     if(result) ANA_MSG_DEBUG(" ... jet passes Jvt cut");

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -24,7 +24,6 @@
 #include "xAODAnaHelpers/HelperFunctions.h"
 
 // external tools include(s):
-#include "JetJvtEfficiency/JetJvtEfficiency.h"
 #include "JetMomentTools/JetForwardJvtTool.h"
 #include "xAODBTaggingEfficiency/BTaggingSelectionTool.h"
 #include "TriggerMatchingTool/MatchingTool.h"

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -235,7 +235,7 @@ EL::StatusCode JetSelector :: initialize ()
   }
 
   // initialize the JetPileupLabelingTool to (re-)evaluate decorators using in Jvt efficiency tools
-  if ( m_doPileupLabel ) {
+  if ( m_doTruthJetTagging ) {
     m_jetPileupLabelingTool.setTypeAndName("JetPileupLabelingTool/PileupLabelingTool");
     ATH_CHECK( m_jetPileupLabelingTool.setProperty("RecoJetContainer", m_outContainerName) );
     ATH_CHECK( m_jetPileupLabelingTool.setProperty("TruthJetContainer", m_truthJetContainer) );
@@ -681,7 +681,7 @@ bool JetSelector :: executeSelection ( const xAOD::JetContainer* inJets,
   }
 
   // add isHS labels to jets (required for Jvt efficiency tools)
-  if (m_doPileupLabel && isMC()) {
+  if (m_doTruthJetTagging && isMC()) {
     ATH_CHECK(m_jetPileupLabelingTool->decorate(*inJets));
   }
 

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -285,7 +285,7 @@ EL::StatusCode JetSelector :: initialize ()
     m_outputJVTPassed = m_outputJVTPassed + "_" + m_WorkingPointJVT;
 
     CP::SystematicSet affectSystsJVT = m_jetNNJvtEfficiencyTool->affectingSystematics();
-    for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("NNJvtEfficiencyTool tool can be affected by NNJvt efficiency systematic: " << syst_it.name()); }
+    for ( const auto& syst_it : affectSystsJVT ) { ANA_MSG_DEBUG("NNJvtEfficiencyTool can be affected by NNJvt efficiency systematic: " << syst_it.name()); }
 
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!
@@ -293,7 +293,7 @@ EL::StatusCode JetSelector :: initialize ()
     const CP::SystematicSet recSystsJVT = m_jetNNJvtEfficiencyTool->recommendedSystematics();
     m_systListJVT = HelperFunctions::getListofSystematics( recSystsJVT, m_systNameJVT, m_systValJVT, msg() );
 
-    ANA_MSG_INFO("Will be using JetJvtEfficiency tool JVT efficiency systematic:");
+    ANA_MSG_INFO("Will be using NNJvtEfficiencyTool tool JVT efficiency systematic:");
     for ( const auto& syst_it : m_systListJVT ) {
       if ( m_systNameJVT.empty() ) {
         ANA_MSG_INFO("\t Running w/ nominal configuration only!");
@@ -303,7 +303,7 @@ EL::StatusCode JetSelector :: initialize ()
     }
   }
 
-  // initialize CP tools related to NNJvt
+  // initialize CP tools related to fJvt
   if (m_dofJVT) {
 
     // initialize jet fJvt selection tool
@@ -330,7 +330,7 @@ EL::StatusCode JetSelector :: initialize ()
     m_outputfJVTPassed = m_outputfJVTPassed + "_" + m_WorkingPointfJVT;
 
     CP::SystematicSet affectSystsfJVT = m_jetfJvtEfficiencyTool->affectingSystematics();
-    for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("JetJvtEfficiency tool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
+    for ( const auto& syst_it : affectSystsfJVT ) { ANA_MSG_DEBUG("FJvtSelectionTool can be affected by fJVT efficiency systematic: " << syst_it.name()); }
 
     // Make a list of systematics to be used, based on configuration input
     // Use HelperFunctions::getListofSystematics() for this!

--- a/Root/TauCalibrator.cxx
+++ b/Root/TauCalibrator.cxx
@@ -131,7 +131,7 @@ EL::StatusCode TauCalibrator :: initialize ()
   if (!m_RecommendationTag.empty()) ANA_CHECK(m_tauSmearingTool_handle.setProperty("RecommendationTag",m_RecommendationTag));
   if (!m_generator.empty()) ANA_CHECK(m_tauSmearingTool_handle.setProperty("Generator",m_generator));
   if (!m_campaign.empty()) ANA_CHECK(m_tauSmearingTool_handle.setProperty("Campaign",m_campaign));
-  ANA_CHECK(m_tauSmearingTool_handle.setProperty("ApplyMVATESQualityCheck",m_applyMVATESQualityCheck));
+  ANA_CHECK(m_tauSmearingTool_handle.setProperty("MVATESQualityCheck",m_applyMVATESQualityCheck));
   ANA_CHECK(m_tauSmearingTool_handle.setProperty("SkipTruthMatchCheck",m_skipTruthMatchCheck));
   ANA_CHECK(m_tauSmearingTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_tauSmearingTool_handle);

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -127,8 +127,8 @@ public:
   float m_eta_max_JVF = 2.4;
   /// @brief cut value
   float m_JVFCut = 0.5;
-  /// @brief (re-)evaluate jet pile-up labels required for Jvt efficiency tools
-  bool m_doPileupLabel = false;
+  /// @brief (re-)evaluate the hard-scatter jet label (isJvtHS) required for Jvt efficiency tools
+  bool m_doTruthJetTagging = false;
   /// @brief check JVT
   bool m_doJVT = false;
   /// @brief keep JVT-rejected jets and decorate passing status

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -128,7 +128,7 @@ public:
   /// @brief cut value
   float m_JVFCut = 0.5;
   /// @brief (re-)evaluate the hard-scatter jet label (isJvtHS) required for Jvt efficiency tools
-  bool m_doTruthJetTagging = false;
+  bool m_doTruthJetTagging = true;
   /// @brief check JVT
   bool m_doJVT = false;
   /// @brief keep JVT-rejected jets and decorate passing status

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -25,7 +25,10 @@
 
 // external tools include(s):
 #include "AsgTools/AnaToolHandle.h"
-#include "JetAnalysisInterfaces/IJetJvtEfficiency.h"
+#include "ParticleJetTools/JetPileupLabelingTool.h"
+#include "JetMomentTools/JetVertexNNTagger.h"
+#include "JetAnalysisInterfaces/IJvtEfficiencyTool.h"
+#include "PATCore/IAsgSelectionTool.h"
 #include "JetInterface/IJetModifier.h"
 #include "FTagAnalysisInterfaces/IBTaggingSelectionTool.h"
 #include "TriggerMatchingTool/IMatchingTool.h"
@@ -124,6 +127,8 @@ public:
   float m_eta_max_JVF = 2.4;
   /// @brief cut value
   float m_JVFCut = 0.5;
+  /// @brief (re-)evaluate jet pile-up labels required for Jvt efficiency tools
+  bool m_doPileupLabel = false;
   /// @brief check JVT
   bool m_doJVT = false;
   /// @brief keep JVT-rejected jets and decorate passing status
@@ -152,73 +157,23 @@ public:
   */
   float m_JVTCut = -1.0;
 
-  /**
-    @rst
-        Available working points for JVT cut from the ``CP::IJetJvtEfficiency`` tool.
-
-        The corresponding data/MC SF will be saved as a ``std::vector<float>`` decoration (for MC only), for nominal WP and the available systematics.
-
-        ======== ================= =============
-        Value    JVT Cut           Efficiency
-        ======== ================= =============
-        "Medium"  (Default) 0.59    92%
-        "Loose"   0.11              97%
-        "Tight"   0.91              85%
-        ======== ================= =============
-
-    @endrst
-  */
+  /// @brief WP for NNJvt
   std::string m_WorkingPointJVT = "FixedEffPt";
 
-  /**
-     @brief Configuration containting JVT scale factors.
-
-     @rst
-     The configuration file with the scale factors calculated by the ``CP::IJetJvtEfficiency``.
-
-     See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JVTCalibration for latest recommendation.
-     @endrst
-  */
-  std::string m_SFFileJVT = "DummySFs.root"; // Due to a recent change in the JetJvtEfficiency tool, we need to explicitly turn on the dummy SF mode by given this string 
+ /// @brief SF file for NNJvtEfficiencyTool
+  std::string m_SFFileJVT = ""; // empty string means to apply dummy SFs
   std::string m_outputSystNamesJVT = "JetJvtEfficiency_JVTSyst";
-  /// @brief Tagging algorithm to be used to veto PU jets in central region - default in R22 is NNJvt. If another algorithm is needed, use corresponding index for the enum here: https://acode-browser1.usatlas.bnl.gov/lxr/source/athena/PhysicsAnalysis/Interfaces/JetAnalysisInterfaces/JetAnalysisInterfaces/IJetJvtEfficiency.h#0022 (note: this link points to the latest r22 version, i.e. master, if a release is used, please check the corresponding enum for the given release: https://gitlab.cern.ch/atlas/athena/-/tags?search=release%2F22.2&sort=updated_desc)
-  int m_JvtTaggingAlg = CP::JvtTagger::NNJvt;
   /// @brief Do re-calculation of NNJvt - scores need to be re-evaluated in case jet pt changed w.r.t. derivation
   bool m_recalculateJvtScores = true;
 
   float         m_systValJVT = 0.0;
   std::string   m_systNameJVT = "";
 
-  /**
-    @rst
-        Available working points for fJVT cut from the ``CP::IJetJvtEfficiency`` tool.
-
-        The corresponding data/MC SF will be saved as a ``std::vector<float>`` decoration (for MC only), for nominal WP and the available systematics.
-
-        ======== ============== =============
-        Value    HS Efficiency  PU Fake Rate
-        ======== ============== =============
-        "Medium"  87.1-97.0%     53.4-60.9%
-        "Tight"   79.9-95.6%     45.4-50.3%
-        ======== ============== =============
-
-        See :https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/FJVTCalibration for more information.
-    @endrst
-  */
+  /// @brief WP for fJvt
   std::string m_WorkingPointfJVT = "Loose";
 
-  /**
-     @brief Configuration containting fJVT scale factors.
-
-     @rst
-        The configuration file with the scale factors calculated by the ``CP::IJetJvtEfficiency``.
-
-        See :https://twiki.cern.ch/twiki/bin/view/AtlasProtected/FJVTCalibration for latest recommendation.
-     @endrst
-  */
-
-  // Set the correct SF file and format
-  std::string m_SFFilefJVT = ""; // JetJvtEfficiency tool will use latest recommendation per default
+  /// @brief SF file for fJvtEfficiencyTool 
+  std::string m_SFFilefJVT = ""; // empty string means to apply dummy SFs
 
   std::string m_outputSystNamesfJVT = "JetJvtEfficiency_fJVTSyst";
 
@@ -307,8 +262,13 @@ private:
   std::vector<std::string>            m_singleJetTrigChainsList; //!  /* contains all the HLT trigger chains tokens extracted from m_singleJetTrigChains */
   std::vector<std::string>            m_diJetTrigChainsList;     //!  /* contains all the HLT trigger chains tokens extracted from m_diJetTrigChains */
 
-  asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_JVT_tool_handle{"CP::IJetJvtEfficiency/JVT"}; //!
-  asg::AnaToolHandle<CP::IJetJvtEfficiency>  m_fJVT_eff_tool_handle{"CP::JetJvtEfficiency/fJVT"}; //!
+  asg::AnaToolHandle<JetPileupLabelingTool>  m_jetPileupLabelingTool;  //!
+  asg::AnaToolHandle<JetPileupTag::JetVertexNNTagger>  m_jetNNJvtMomentTool;  //!
+  asg::AnaToolHandle<IAsgSelectionTool> m_jetNNJvtSelectionTool;  //!
+  asg::AnaToolHandle<CP::IJvtEfficiencyTool> m_jetNNJvtEfficiencyTool;  //!
+  asg::AnaToolHandle<IAsgSelectionTool> m_jetfJvtSelectionTool;  //!
+  asg::AnaToolHandle<CP::IJvtEfficiencyTool> m_jetfJvtEfficiencyTool;  //!
+
   asg::AnaToolHandle<IBTaggingSelectionTool> m_BJetSelectTool_handle{"BTaggingSelectionTool"};  //!
 
   asg::AnaToolHandle<Trig::IMatchingTool>    m_trigJetMatchTool_handle; //!


### PR DESCRIPTION
From the jet pile-up tagging side the old and overloaded `JetJvtEfficiency` tool has been deprecated now since nearly a year in favor of a new set of refactored tools (where each does more or less only one things and are hence simpler to maintain).

This PR now finally also makes this migration within xAH.