### PR TITLE
Allow Different Map for Electron Trigger Tool

### DIFF
--- a/Root/ElectronEfficiencyCorrector.cxx
+++ b/Root/ElectronEfficiencyCorrector.cxx
@@ -314,7 +314,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
     } else {
       m_asgElEffCorrTool_elSF_Trig = new AsgElectronEfficiencyCorrectionTool(m_TrigEffSF_tool_name);
       m_asgElEffCorrTool_elSF_Trig->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-      if ( !m_overrideMapFilePath.empty() ) {
+      if ( !m_overrideMapFilePathTrig.empty() ) {
+        ANA_MSG_WARNING( "Overriding MapFilePath for trigger SF only to " << m_overrideMapFilePathTrig );
+        ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("MapFilePath", m_overrideMapFilePathTrig));
+      } else if ( !m_overrideMapFilePath.empty() ) {
         ANA_MSG_WARNING( "Overriding MapFilePath to " << m_overrideMapFilePath );
         ANA_CHECK( m_asgElEffCorrTool_elSF_Trig->setProperty("MapFilePath", m_overrideMapFilePath));
       }
@@ -334,7 +337,10 @@ EL::StatusCode ElectronEfficiencyCorrector :: initialize ()
     } else {
       m_asgElEffCorrTool_elSF_TrigMCEff = new AsgElectronEfficiencyCorrectionTool(m_TrigMCEff_tool_name);
       m_asgElEffCorrTool_elSF_TrigMCEff->msg().setLevel( MSG::ERROR ); // DEBUG, VERBOSE, INFO
-      if ( !m_overrideMapFilePath.empty() ) {
+      if ( !m_overrideMapFilePathTrig.empty() ) {
+        ANA_MSG_WARNING( "Overriding MapFilePath for trigger SF only to " << m_overrideMapFilePathTrig );
+        ANA_CHECK( m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("MapFilePath", m_overrideMapFilePathTrig));
+      } else if ( !m_overrideMapFilePath.empty() ) {
         ANA_MSG_WARNING( "Overriding MapFilePath to " << m_overrideMapFilePath );
         ANA_CHECK( m_asgElEffCorrTool_elSF_TrigMCEff->setProperty("MapFilePath", m_overrideMapFilePath));
       }

--- a/xAODAnaHelpers/ElectronEfficiencyCorrector.h
+++ b/xAODAnaHelpers/ElectronEfficiencyCorrector.h
@@ -87,6 +87,9 @@ public:
   /// @brief Override corrections map file (not recommended)
   std::string m_overrideMapFilePath = "";
 
+  /// @brief Override corrections map file for trigger (needed as Run2 R22 Trigger SF use R21 values)
+  std::string m_overrideMapFilePathTrig = "";
+
 private:
   int m_numEvent;         //!
   int m_numObject;        //!


### PR DESCRIPTION
Allowing the electron trigger efficiency tool to use a different map file than the other electron efficiency tools. This is needed as in R22, the map file for the trigger scale factors is different than the main map file.