### PR TITLE
Draft: Introduce option to run AsgDeadHVCellRemovalTool for electrons

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -151,6 +151,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     m_el_cutflow_all             = m_el_cutflowHist_1->GetXaxis()->FindBin("all");
     m_el_cutflow_author_cut      = m_el_cutflowHist_1->GetXaxis()->FindBin("author_cut");
     m_el_cutflow_OQ_cut          = m_el_cutflowHist_1->GetXaxis()->FindBin("OQ_cut");
+    m_el_cutflow_deadHVCell_cut  = m_el_cutflowHist_1->GetXaxis()->FindBin("deadHVCell_cut");
     m_el_cutflow_ptmax_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmax_cut");
     m_el_cutflow_ptmin_cut       = m_el_cutflowHist_1->GetXaxis()->FindBin("ptmin_cut");
     m_el_cutflow_eta_cut         = m_el_cutflowHist_1->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
@@ -167,6 +168,7 @@ EL::StatusCode ElectronSelector :: initialize ()
       m_el_cutflow_all       = m_el_cutflowHist_2->GetXaxis()->FindBin("all");
       m_el_cutflow_author_cut    = m_el_cutflowHist_2->GetXaxis()->FindBin("author_cut");
       m_el_cutflow_OQ_cut    = m_el_cutflowHist_2->GetXaxis()->FindBin("OQ_cut");
+      m_el_cutflow_deadHVCell_cut  = m_el_cutflowHist_2->GetXaxis()->FindBin("deadHVCell_cut");
       m_el_cutflow_ptmax_cut     = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmax_cut");
       m_el_cutflow_ptmin_cut     = m_el_cutflowHist_2->GetXaxis()->FindBin("ptmin_cut");
       m_el_cutflow_eta_cut     = m_el_cutflowHist_2->GetXaxis()->FindBin("eta_cut"); // including crack veto, if applied
@@ -400,6 +402,15 @@ EL::StatusCode ElectronSelector :: initialize ()
   }
 
   // **********************************************************************************************
+
+
+  // Set up the dead HV Removal Tool
+  m_deadHVTool.setTypeAndName("AsgDeadHVCellRemovalTool/deadHVTool");
+  if (m_deadHVTool.retrieve().isFailure()){
+      ANA_MSG_ERROR("Failed to retrieve DeadHVTool, aborting");
+      return StatusCode::FAILURE;
+  }
+
 
   ANA_MSG_INFO( "ElectronSelector Interface succesfully initialized!" );
 
@@ -859,6 +870,19 @@ int ElectronSelector :: passCuts( const xAOD::Electron* electron, const xAOD::Ve
   }
   if (!m_isUsedBefore && m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_OQ_cut, 1 );
   if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_OQ_cut, 1 ); }
+
+  // *********************************************************************************************************************************************************************
+  //
+  // Dead HV Cell veto (affects only 2016 data)
+  //
+  if ( m_applyDeadHVCellVeto ) {
+    if( !m_deadHVTool->accept(electron) ){
+      ANA_MSG_DEBUG( "Electron failed dead HV cell veto." );
+      return 0;
+    }
+  }
+  if (!m_isUsedBefore && m_useCutFlow) m_el_cutflowHist_1->Fill( m_el_cutflow_deadHVCell_cut, 1 );
+  if ( m_isUsedBefore && m_useCutFlow ) { m_el_cutflowHist_2->Fill( m_el_cutflow_deadHVCell_cut, 1 ); }
 
   // *********************************************************************************************************************************************************************
   //

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -405,10 +405,14 @@ EL::StatusCode ElectronSelector :: initialize ()
 
 
   // Set up the dead HV Removal Tool
-  m_deadHVTool.setTypeAndName("AsgDeadHVCellRemovalTool/deadHVTool");
-  if (m_deadHVTool.retrieve().isFailure()){
+  if (m_applyDeadHVCellVeto)
+    m_deadHVTool.setTypeAndName("AsgDeadHVCellRemovalTool/deadHVTool");
+    if (m_deadHVTool.retrieve().isFailure()){
       ANA_MSG_ERROR("Failed to retrieve DeadHVTool, aborting");
       return StatusCode::FAILURE;
+  }
+  else {
+      ANA_MSG_WARNING("Not applying veto of dead HV cells although it's recommended - please double check!");
   }
 
 

--- a/xAODAnaHelpers/ElectronSelector.h
+++ b/xAODAnaHelpers/ElectronSelector.h
@@ -11,6 +11,7 @@
 // EDM include(s):
 #include "xAODEgamma/ElectronContainer.h"
 #include "xAODTracking/Vertex.h"
+#include "EgammaAnalysisInterfaces/IAsgDeadHVCellRemovalTool.h"
 
 // package include(s):
 #include "xAODAnaHelpers/ParticlePIDManager.h"
@@ -128,6 +129,8 @@ public:
   bool           m_doAuthorCut = true;
   /// @brief Perform object quality cut
   bool           m_doOQCut = true;
+  /// @brief Apply veto dead HV cells, affects only 2016 data
+  bool m_applyDeadHVCellVeto = false;
 
   ///// electron PID /////
 
@@ -199,6 +202,7 @@ public:
 
   std::string    m_isoDecSuffix = "";
 
+
 private:
 
   /**
@@ -247,6 +251,7 @@ private:
   int   m_el_cutflow_all;              //!
   int   m_el_cutflow_author_cut;       //!
   int   m_el_cutflow_OQ_cut;           //!
+  int   m_el_cutflow_deadHVCell_cut;   //!
   int   m_el_cutflow_ptmax_cut;        //!
   int   m_el_cutflow_ptmin_cut;        //!
   int   m_el_cutflow_eta_cut;          //!
@@ -258,6 +263,8 @@ private:
   int   m_el_cutflow_iso_cut;          //!
 
   std::vector<std::string> m_IsoKeys;  //!
+
+
 
   /* tools */
 
@@ -277,6 +284,9 @@ private:
   ElectronLHPIDManager*                    m_el_LH_PIDManager = nullptr;        //!
   /// @brief class to manage cut-based PID selection/decorations - see ISSUE for explaination
   ElectronCutBasedPIDManager*              m_el_CutBased_PIDManager = nullptr;  //!
+
+  /// @brief tool that selects on dead HV from the 2016 run, according to https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EGammaIdentificationRun2#Removal_of_Electron_Photon_clust
+  asg::AnaToolHandle<IAsgDeadHVCellRemovalTool> m_deadHVTool;
 
   /* other private members */
 


### PR DESCRIPTION
Following the egamma twiki here, we should to an additional veto for electrons in data 2016:
https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EGammaIdentificationRun2#Removal_of_Electron_Photon_clust

It's also done in the CP algs here
https://gitlab.cern.ch/atlas/athena/-/blob/main/PhysicsAnalysis/Algorithms/EgammaAnalysisAlgorithms/Root/EgammaIsGoodOQSelectionTool.cxx
so I more or less just copied the implementation.

The only question I'd have is if we even may want to run this veto as default because it seems to be recommended?