### PR TITLE
Updates for GN2 and fix to InDetTrackSelectionTool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 25.2.24
+          - 25.2.31
 
     steps:
     - uses: actions/checkout@master

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -230,7 +230,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 		gridName=wk()->metaData()->castString(SH::MetaFields::sampleName);
 		sampleShowerType=HelperFunctions::getMCShowerType(gridName,m_taggerName);
 	      }
-        
+       
         if(m_taggerName=="DL1dv01"){
             if(m_isRun3){
                 switch(sampleShowerType)
@@ -285,18 +285,18 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                     case HelperFunctions::AmcH7:
                         calibration="412116";
                         break;
-	                case HelperFunctions::Unknown:
-                    if (m_allowCalibrationFallback) {
-                      ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
-                      ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
-                      calibration="default";
-                      break;
-                    }
-                    else {
+	                default:
+                        if (m_allowCalibrationFallback) {
+                          ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                          ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                          calibration="default";
+                          break;
+                        }
+                        else {
 		                  ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
 		                  return EL::StatusCode::FAILURE;
 		                  break;
-                    }
+                        }
 	            }
             }
         } else if(m_taggerName=="GN2v01"){
@@ -357,18 +357,18 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                         ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
                         calibration="700660";
                         break;
-                    case HelperFunctions::Unknown:
-                    if (m_allowCalibrationFallback) {
-                      ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
-                      ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
-                      calibration="default";
-                      break;
-                    }
-                    else {
-                          ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-                          return EL::StatusCode::FAILURE;
-                          break;
-                    }
+                    default:
+                      if (m_allowCalibrationFallback) {
+                        ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                        ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                        calibration="default";
+                        break;
+                      }
+                      else {
+                        ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                        return EL::StatusCode::FAILURE;
+                        break;
+                     }
                 }
             }
         } else {

--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -104,7 +104,6 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   m_decorSF = m_decor + "_SF";
   m_decorWeight   = m_decor + "_Weight";
   m_decorQuantile = m_decor + "_Quantile";
-  m_decorInefficiencySF  = m_decor + "_InefficiencySF";
 
   bool opOK(false),taggerOK(false);
   m_getScaleFactors = false;
@@ -148,7 +147,6 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   m_outputSystName      += "_" + m_taggerName + "_" + m_operatingPt;
   m_decorWeight         += "_" + m_taggerName + "_" + m_operatingPt;
   m_decorQuantile       += "_" + m_taggerName + "_" + m_operatingPt;
-  m_decorInefficiencySF += "_" + m_taggerName + "_" + m_operatingPt;
 
   if(!m_useContinuous){
     ANA_MSG_INFO( "Decision Decoration Name     : " << m_decor);
@@ -157,7 +155,6 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     ANA_MSG_INFO( "Weight Decoration Name: "        << m_decorWeight);
     ANA_MSG_INFO( "Quantile Decoration Name: "      << m_decorQuantile);
     ANA_MSG_INFO( "Scale Factor Decoration Name : " << m_decorSF);
-    ANA_MSG_INFO( "Inefficiency Scale Factor Decoration Name : " << m_decorInefficiencySF);
   }
 
   // now take this name and convert it to the cut value for the CDI file
@@ -222,7 +219,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 		std::string sampleName;
 		while(std::getline(ss,sampleName,','))
 		  {
-		    HelperFunctions::ShowerType mySampleShowerType=HelperFunctions::getMCShowerType(sampleName);
+		    HelperFunctions::ShowerType mySampleShowerType=HelperFunctions::getMCShowerType(sampleName,m_taggerName);
 		    if(mySampleShowerType!=sampleShowerType && sampleShowerType!=HelperFunctions::Unknown)
 		      ANA_MSG_ERROR("Cannot have different shower types per grid task.");
 		    sampleShowerType=mySampleShowerType;
@@ -231,22 +228,64 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
 	    else // Use sample name when running locally
 	      {
 		gridName=wk()->metaData()->castString(SH::MetaFields::sampleName);
-		sampleShowerType=HelperFunctions::getMCShowerType(gridName);
+		sampleShowerType=HelperFunctions::getMCShowerType(gridName,m_taggerName);
 	      }
         
-        if(m_isRun3){
-            switch(sampleShowerType)
-            {
-                case HelperFunctions::Pythia8:
-                    calibration="601229";
-                    break;
-                case HelperFunctions::Herwig7p2:
-                    calibration="601414";
-                    break;
-                case HelperFunctions::Sherpa2212:
-                    calibration="700660";
-                    break;
-                default:
+        if(m_taggerName=="DL1dv01"){
+            if(m_isRun3){
+                switch(sampleShowerType)
+                {
+                    case HelperFunctions::Pythia8:
+                        calibration="601229";
+                        break;
+                    case HelperFunctions::Herwig7p2:
+                        calibration="601414";
+                        break;
+                    case HelperFunctions::Sherpa2212:
+                        calibration="700660";
+                        break;
+                    default:
+                        if (m_allowCalibrationFallback) {
+                          ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                          ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                          calibration="default";
+                          break;
+                        }
+                        else {
+                          ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                          return EL::StatusCode::FAILURE;
+                           break;
+                        }
+                }
+            } else {
+
+    	        switch(sampleShowerType)
+	            {
+	                case HelperFunctions::Pythia8:
+		                calibration="410470";
+		                break;
+    	            case HelperFunctions::Herwig7p1:
+	    	            calibration="411233";
+                        break; 
+                    case HelperFunctions::Herwig7p2:
+                        calibration="600666";
+		                break;
+    	            case HelperFunctions::Sherpa221:
+	    	            calibration="410250";
+		                break;
+	                case HelperFunctions::Sherpa2210:
+		                calibration="700122";
+		                break;
+                    case HelperFunctions::Sherpa2212:
+                        calibration="700660";
+                        break;
+                    case HelperFunctions::AmcPy8:
+                        calibration="410464";
+                        break;
+                    case HelperFunctions::AmcH7:
+                        calibration="412116";
+                        break;
+	                case HelperFunctions::Unknown:
                     if (m_allowCalibrationFallback) {
                       ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
                       ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
@@ -254,52 +293,93 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
                       break;
                     }
                     else {
-                      ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-                      return EL::StatusCode::FAILURE;
-                       break;
+		                  ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+		                  return EL::StatusCode::FAILURE;
+		                  break;
                     }
+	            }
+            }
+        } else if(m_taggerName=="GN2v01"){
+            if(m_isRun3){
+                switch(sampleShowerType)
+                {
+                    case HelperFunctions::Pythia8_517:
+                        calibration="601398";
+                        break;
+                    case HelperFunctions::Pythia8:
+                        calibration="601229";
+                        break;
+                    case HelperFunctions::Herwig7p2:
+                        calibration="601414";
+                        break;
+                    case HelperFunctions::Sherpa2214:
+                        calibration="700808";
+                        break;
+                    case HelperFunctions::Sherpa_Unknown:
+                        ANA_MSG_WARNING("Unknown Sherpa version MC shower type for sample " << gridName << ", falling back to MC-MC SFs for Sherpa 2.2.11-2.2.16.");
+                        ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                        calibration="700808";
+                        break;
+                    default:
+                        if (m_allowCalibrationFallback) {
+                          ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                          ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                          calibration="default";
+                          break;
+                        }
+                        else {
+                          ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                          return EL::StatusCode::FAILURE;
+                           break;
+                        }
+                }
+            } else {
+
+                switch(sampleShowerType)
+                {
+                    case HelperFunctions::Pythia8_517:
+                        calibration="410480";
+                        break;
+                    case HelperFunctions::Pythia8:
+                        calibration="410470";
+                        break;
+                    case HelperFunctions::Herwig7p1:
+                        calibration="411233";
+                        break;
+                    case HelperFunctions::Herwig7p2:
+                        calibration="600666";
+                        break;
+                    case HelperFunctions::Sherpa2214:
+                        calibration="700660";
+                        break;
+                    case HelperFunctions::Sherpa_Unknown:
+                        ANA_MSG_WARNING("Unknown Sherpa version MC shower type for sample " << gridName << ", falling back to MC-MC SFs for Sherpa 2.2.11-2.2.16.");
+                        ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                        calibration="700660";
+                        break;
+                    case HelperFunctions::Unknown:
+                    if (m_allowCalibrationFallback) {
+                      ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
+                      ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
+                      calibration="default";
+                      break;
+                    }
+                    else {
+                          ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
+                          return EL::StatusCode::FAILURE;
+                          break;
+                    }
+                }
             }
         } else {
-
-	        switch(sampleShowerType)
-	        {
-	            case HelperFunctions::Pythia8:
-		            calibration="410470";
-		            break;
-	            case HelperFunctions::Herwig7p1:
-		            calibration="411233";
-                    break; 
-                case HelperFunctions::Herwig7p2:
-                    calibration="600666";
-		            break;
-	            case HelperFunctions::Sherpa221:
-		            calibration="410250";
-		            break;
-	            case HelperFunctions::Sherpa2210:
-		            calibration="700122";
-		            break;
-                case HelperFunctions::Sherpa2212:
-                    calibration="700660";
-                    break;
-                case HelperFunctions::AmcPy8:
-                    calibration="410464";
-                    break;
-                case HelperFunctions::AmcH7:
-                    calibration="412116";
-                    break;
-	            case HelperFunctions::Unknown:
-                if (m_allowCalibrationFallback) {
-                  ANA_MSG_WARNING("Cannot determine MC shower type for sample " << gridName << ", falling back to 'default'.");
-                  ANA_MSG_WARNING("Please double-check if this is appropriate for your sample, otherwise you have specify the MC-to-MC calibration manually!");
-                  calibration="default";
-                  break;
-                }
-                else {
-		              ANA_MSG_ERROR("Cannot determine MC shower type for sample " << gridName << ".");
-		              return EL::StatusCode::FAILURE;
-		              break;
-                }
-	        }
+            if (m_allowCalibrationFallback) {
+                ANA_MSG_WARNING("Cannot determine MC shower type for tagger " << m_taggerName << ", only GN2v01 and DL1dv01 are supported. Falling back to 'default'.");
+                ANA_MSG_WARNING("Please double-check if this is appropriate for your sample and tagger, otherwise you have specify the MC-to-MC calibration manually!");
+                calibration="default";
+            } else {
+                ANA_MSG_ERROR("Cannot determine MC shower type for tagger " << m_taggerName << ".");
+                return EL::StatusCode::FAILURE;
+            }
         }
 	  } else { makeMCIndexMap(m_EfficiencyCalibration); }
 	ANA_CHECK( m_BJetEffSFTool_handle.setProperty("EfficiencyBCalibrations"    ,  calibration));
@@ -459,7 +539,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
   // for continuous b-tagging only
   SG::AuxElement::Decorator< float > dec_Weight( m_decorWeight );
   SG::AuxElement::Decorator< int > dec_Quantile( m_decorQuantile );
-  SG::AuxElement::Decorator< std::vector<float> > dec_ineffsfBTag( m_decorInefficiencySF );
 
   //
   // run the btagging decision or get weight and quantile if running continuous
@@ -543,8 +622,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
               if(abs(jet_itr->eta()) > 2.5){
                 if(!dec_sfBTag.isAvailable( *jet_itr ))
 	                dec_sfBTag     ( *jet_itr ) = std::vector<float>({1.});
-                if(m_useContinuous && !dec_ineffsfBTag.isAvailable( *jet_itr ))
-	                dec_ineffsfBTag( *jet_itr ) = std::vector<float>({1.});
                 continue;
               }
               if(m_setMapIndex){ // select an efficiency map for use in MC/MC and inefficiency scale factors, based on user specified selection of efficiency maps
@@ -555,16 +632,13 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
               }
 	      // get the scale factor
 	      float SF(-1.0);
-	      float inefficiencySF(-1.0); // only for continuous b-tagging
 	      CP::CorrectionCode BJetEffCode;
-	      CP::CorrectionCode BJetIneEffCode = CP::CorrectionCode::Ok;
 	      // if passes cut take the efficiency scale factor
 	      // if failed cut take the inefficiency scale factor
-	      // for continuous b-tagging save both
+	      // for continuous take efficiency, as inefficiency should not be used
 	      if(m_useContinuous)
 		{
 		  BJetEffCode = m_BJetEffSFTool_handle->getScaleFactor( *jet_itr, SF );
-		  BJetIneEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, inefficiencySF );
 		}
 	      else
 		{
@@ -574,7 +648,7 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 		    BJetEffCode = m_BJetEffSFTool_handle->getInefficiencyScaleFactor( *jet_itr, SF );
 		}
 
-	      if (BJetEffCode == CP::CorrectionCode::Error || BJetIneEffCode == CP::CorrectionCode::Error)
+	      if (BJetEffCode == CP::CorrectionCode::Error)
 		{
 		  ANA_MSG_ERROR( "Error in getEfficiencyScaleFactor");
 		  return EL::StatusCode::FAILURE;
@@ -587,12 +661,9 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 	      // Save it to the vector
 	      if(                   !dec_sfBTag     .isAvailable( *jet_itr ))
 		dec_sfBTag     ( *jet_itr ) = std::vector<float>();
-	      if(m_useContinuous && !dec_ineffsfBTag.isAvailable( *jet_itr ))
-		dec_ineffsfBTag( *jet_itr ) = std::vector<float>();
 
 
 	      dec_sfBTag( *jet_itr ).push_back(SF);
-	      if(m_useContinuous) dec_ineffsfBTag( *jet_itr ).push_back(inefficiencySF);
       }
     }
   }
@@ -602,8 +673,6 @@ EL::StatusCode BJetEfficiencyCorrector :: executeEfficiencyCorrection(const xAOD
 	{
 	  if(                   !dec_sfBTag     .isAvailable( *jet_itr ))
 	    dec_sfBTag     ( *jet_itr ) = std::vector<float>({1.});
-	  if(m_useContinuous && !dec_ineffsfBTag.isAvailable( *jet_itr ))
-	    dec_ineffsfBTag( *jet_itr ) = std::vector<float>({1.});
 	}
     }
 

--- a/Root/HelperFunctions.cxx
+++ b/Root/HelperFunctions.cxx
@@ -519,7 +519,7 @@ bool HelperFunctions::has_exact(const std::string input, const std::string flag)
   return inputSet.find(flag) != inputSet.end();
 }
 
-HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& sample_name)
+HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& sample_name, const std::string& m_taggerName)
 {
   //
   //pre-process sample name
@@ -534,15 +534,33 @@ HelperFunctions::ShowerType HelperFunctions::getMCShowerType(const std::string& 
 
   //
   // Determine shower type by looking for keywords in name
-  if(tmp_name.Contains("AMCATNLOPY")) return AmcPy8;
-  else if(tmp_name.Contains("AMCATNLOH")) return AmcH7;
-  else if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
-  else if(tmp_name.Contains("HERWIG")) return Herwig7p1;
-  else if(tmp_name.Contains("PHH7EG")) return Herwig7p2;
-  else if(tmp_name.Contains("SHERPA_221_")) return Sherpa221;
-  else if(tmp_name.Contains("SH_221_")) return Sherpa221;
-  else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
-  else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
-  else if(tmp_name.Contains("SH_2212")) return Sherpa2212;
-  else return Unknown;
+  if(m_taggerName=="DL1dv01"){
+    if(tmp_name.Contains("AMCATNLOPY")) return AmcPy8;
+    else if(tmp_name.Contains("AMCATNLOH")) return AmcH7;
+    else if(tmp_name.Contains("PYTHIA8EVTGEN")) return Pythia8;
+    else if(tmp_name.Contains("HERWIG")) return Herwig7p1;
+    else if(tmp_name.Contains("PHH7EG")) return Herwig7p2;
+    else if(tmp_name.Contains("SHERPA_221_")) return Sherpa221;
+    else if(tmp_name.Contains("SH_221_")) return Sherpa221;
+    else if(tmp_name.Contains("SH_2210")) return Sherpa2210;
+    else if(tmp_name.Contains("SH_2211")) return Sherpa2210;
+    else if(tmp_name.Contains("SH_2212")) return Sherpa2212;
+    else return Unknown;
+  } else if(m_taggerName=="GN2v01"){
+    if(tmp_name.Contains("PYTHIA8EVTGEN517")) return Pythia8_517;
+    else if(tmp_name.Contains("PYTHIA8EVTGEN") and !tmp_name.Contains("AMCATNLO")) return Pythia8; //aMcAtNlo not supported for GN2, so don't let it count as Pythia8
+    else if(tmp_name.Contains("HERWIG") and !tmp_name.Contains("AMCATNLO")) return Herwig7p1; 
+    else if(tmp_name.Contains("PHH7EG")) return Herwig7p2;
+    else if(tmp_name.Contains("SH_2210")) return Sherpa2214;//FTAG uses 2.2.14 SFs for 2.2.10
+    else if(tmp_name.Contains("SH_2211")) return Sherpa2214;//MC-to-MC maps for versions of Sherpa between 2.2.11 and 2.2.16 are equivalent.
+    else if(tmp_name.Contains("SH_2212")) return Sherpa2214;
+    else if(tmp_name.Contains("SH_2213")) return Sherpa2214;
+    else if(tmp_name.Contains("SH_2214")) return Sherpa2214;
+    else if(tmp_name.Contains("SH_2215")) return Sherpa2214;
+    else if(tmp_name.Contains("SH_2216")) return Sherpa2214;
+    else if(tmp_name.Contains("SH_") and !tmp_name.Contains("SH_2")) return Sherpa_Unknown;//Unknown Sherpa Version. This is to handle Sh_blank (e.g. DSID 701050). The examples I've found are all 2.2.16, but that's not guaranteed.
+    else return Unknown;
+  } else {
+    return  Unknown;
+  }
 }

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -1889,7 +1889,8 @@ void JetContainer::setBranches(TTree *tree)
     // this applies the JVF/JVT selection cuts
     // https://twiki.cern.ch/twiki/bin/view/AtlasProtected/JvtManualRecalculation
     if( m_infoSwitch.m_allTrackPVSel ) {
-      m_trkSelTool = new InDet::InDetTrackSelectionTool( "JetTrackSelection", "Loose" );
+      m_trkSelTool = new InDet::InDetTrackSelectionTool( "JetTrackSelection");
+      m_trkSelTool->setProperty( "CutLevel", "Loose");
       m_trkSelTool->initialize();
       // to do this need to have AddJets return a status code
       //ANA_CHECK( m_trkSelTool->initialize());

--- a/Root/MuonCalibrator.cxx
+++ b/Root/MuonCalibrator.cxx
@@ -140,6 +140,7 @@ EL::StatusCode MuonCalibrator :: initialize ()
     ANA_CHECK(m_muonCalibrationTool_handle.setProperty("do2StationsHighPt", m_do2StationsHighPt));
   }  
   ANA_CHECK(m_muonCalibrationTool_handle.setProperty( "IsRun3Geo", m_isRun3Geo ));
+  ANA_CHECK(m_muonCalibrationTool_handle.setProperty( "OutputLevel", msg().level()));
   ANA_CHECK(m_muonCalibrationTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_muonCalibrationTool_handle);
 

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -63,7 +63,7 @@ public:
   std::string m_operatingPtCDI = "";
   /// @brief will only get scale factors for calibrated working points
   bool m_getScaleFactors = false;
-  /// @brief will get tagWeight, quantile, SF and InefficiencySF
+  /// @brief will get tagWeight, quantile, and SF
   bool m_useContinuous = false;
   /// @brief The decoration key written to passing objects
   std::string m_decor = "BTag";
@@ -94,7 +94,6 @@ private:
   std::string m_decorSF = "";
   std::string m_decorWeight = ""; // only for continuous b-tagging
   std::string m_decorQuantile = ""; // only for continuous b-tagging
-  std::string m_decorInefficiencySF = ""; // only for continuous b-tagging
 
   std::map<int,std::string> m_DSIDtoGenerator; //!
   std::map<std::string,unsigned int> m_MCIndexes; //!

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -518,7 +518,7 @@ namespace HelperFunctions {
   }
 
   /// @brief The different supported shower types
-  enum ShowerType {Unknown, Pythia8, Herwig7p1, Herwig7p2, Sherpa221, Sherpa2210, Sherpa2212, AmcPy8, AmcH7};
+  enum ShowerType {Unknown, Pythia8, Herwig7p1, Herwig7p2, Sherpa221, Sherpa2210, Sherpa2212, AmcPy8, AmcH7, Pythia8_517, Sherpa2214, Sherpa_Unknown};
 
   /**
     @brief Determines the type of generator used for the shower from the sample name
@@ -533,7 +533,7 @@ namespace HelperFunctions {
      * SHERPA : Sherpa22 (if not Sherpa 21)
     @endrst
    */
-  ShowerType getMCShowerType(const std::string& sample_name);
+  ShowerType getMCShowerType(const std::string& sample_name, const std::string& m_taggerName);
 
 
 } // close namespace HelperFunctions


### PR DESCRIPTION
Updating MC/MC maps to allow for GN2. Removing inefficiency SF tool for PCBT, as this is not recommended to be used. Also updating so InDetTrackSelectionTool is compatible with newer AnalysisBase releases due to changes in https://gitlab.cern.ch/atlas/athena/-/merge_requests/73962. Also updating to allow the output level of the muon calibration tool to be configured. Updating supported releases to AnalysisBase 25.2.31 (needed for GN2).