### PR TITLE
Implementing option for deadHV photon veto

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -413,7 +413,7 @@ EL::StatusCode ElectronSelector :: initialize ()
     }
   }
   else {
-      ANA_MSG_WARNING("Not applying veto of dead HV cells although it's recommended - please double check!");
+      ANA_MSG_WARNING("Not applying veto of dead HV cells on electrons although it's recommended - please double check!");
   }
 
 

--- a/xAODAnaHelpers/PhotonSelector.h
+++ b/xAODAnaHelpers/PhotonSelector.h
@@ -5,6 +5,7 @@
 #include <xAODAnaHelpers/Algorithm.h>
 #include <xAODTracking/VertexContainer.h>
 #include <xAODEgamma/PhotonContainer.h>
+#include <EgammaAnalysisInterfaces/IAsgDeadHVCellRemovalTool.h>
 
 namespace CP {
   class IsolationSelectionTool;
@@ -46,6 +47,8 @@ public:
   bool	     	 m_vetoCrack = true;
   bool           m_doAuthorCut = true;
   bool           m_doOQCut = true;
+  /// @brief Apply veto dead HV cells, affects only 2016 data
+  bool m_applyDeadHVCellVeto = false;
   /** read object quality from derivation, rather than calculating it on the fly */
   bool           m_readOQFromDerivation = false;
 
@@ -82,6 +85,7 @@ private:
   int   m_ph_cutflow_author_cut;       //!
   int   m_ph_cutflow_OQ_cut;           //!
   int   m_ph_cutflow_PID_cut;          //!
+  int   m_ph_cutflow_deadHVCell_cut;   //!
   int   m_ph_cutflow_ptmax_cut;        //!
   int   m_ph_cutflow_ptmin_cut;        //!
   int   m_ph_cutflow_eta_cut;          //!
@@ -92,6 +96,9 @@ private:
 
   /* tools */
   CP::IsolationSelectionTool* m_IsolationSelectionTool = nullptr; //!
+
+  /// @brief tool that selects on dead HV from the 2016 run, according to https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EGammaIdentificationRun2#Removal_of_Electron_Photon_clust
+  asg::AnaToolHandle<IAsgDeadHVCellRemovalTool> m_deadHVTool; //!
 
 public:
 


### PR DESCRIPTION
This implements the option for the deadHV photon veto. According to the twiki https://twiki.cern.ch/twiki/bin/view/AtlasProtected/EGammaIdentificationRun2#Removal_of_Electron_Photon_clust, this should remove some photons in 2016.

Small local tests showed this removed 17/21560 photons (0.08%) in an mc20a sample, 0/24941 photons in an mc20e samples, 1/257 photons (0.4%) in a data16 sample, and 0/3248 photons in a data18 sample.

A corresponding PR for electrons was merged in https://github.com/UCATLAS/xAODAnaHelpers/pull/1706.