### PR TITLE
Fixing types for duplicate check

### DIFF
--- a/Root/BasicEventSelection.cxx
+++ b/Root/BasicEventSelection.cxx
@@ -809,11 +809,11 @@ EL::StatusCode BasicEventSelection :: execute ()
 
   if ( ( !isMC() && m_checkDuplicatesData ) || ( isMC() && m_checkDuplicatesMC ) ) {
 
-    std::pair<uint32_t,uint32_t> thispair = std::make_pair(eventInfo->runNumber(),eventInfo->eventNumber());
+    std::pair<int, Long64_t> thispair = std::make_pair(eventInfo->runNumber(),eventInfo->eventNumber());
 
     if ( m_RunNr_VS_EvtNr.find(thispair) != m_RunNr_VS_EvtNr.end() ) {
 
-      ANA_MSG_WARNING("Found duplicated event! runNumber = " << static_cast<uint32_t>(eventInfo->runNumber()) << ", eventNumber = " << static_cast<uint32_t>(eventInfo->eventNumber()) << ". Skipping this event");
+      ANA_MSG_WARNING("Found duplicated event! runNumber = " << eventInfo->runNumber() << ", eventNumber = " << eventInfo->eventNumber() << ". Skipping this event");
 
       // Bookkeep info in duplicates TTree
       //

--- a/xAODAnaHelpers/BasicEventSelection.h
+++ b/xAODAnaHelpers/BasicEventSelection.h
@@ -227,7 +227,7 @@ class BasicEventSelection : public xAH::Algorithm
 
   private:
 
-    std::set<std::pair<uint32_t,uint32_t> > m_RunNr_VS_EvtNr; //!
+    std::set<std::pair<int, Long64_t> > m_RunNr_VS_EvtNr; //!
     // trigger unprescale chains
     std::vector<std::string> m_triggerUnprescaleList; //!
     // decisions of triggers which are saved but not cut on, converted into a list


### PR DESCRIPTION
Fixing types for duplicate check to match how they are stored in https://github.com/UCATLAS/xAODAnaHelpers/blob/main/xAODAnaHelpers/EventInfo.h#L37-38 . Without this, the duplicate checker can change the eventNumber when casting it to an int32, which can give false positives on the duplicate check.

This should only affect analyses using `m_checkDuplicatesData` and/or `m_checkDuplicatesMC`. Duplicate events (real or false positives) are sent to `<filename>_duplicates_tree.root` files, which can be used to check the impact of this fix.