### PR TITLE
Replacing barcodes with UIDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,8 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 25.2.31
-          - 25.2.32
-          - 25.2.33
-          - 25.2.34
-          - 25.2.35
-          - 25.2.36
-          - 25.2.37
-          - 25.2.38
-          - 25.2.39
-          - 25.2.40
-          - 25.2.41
-          - 25.2.42
-          - 25.2.43
+          - 25.2.62
+          - 25.2.63
 
     steps:
     - uses: actions/checkout@master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
-# Set the minimum required CMake version:
-cmake_minimum_required( VERSION 3.6 FATAL_ERROR )
-
 set( release_libs xAODTriggerCnvLib )
 
 if( AnalysisBase_VERSION AND AnalysisBase_VERSION VERSION_GREATER 21.0 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@
 # Declare the package name:
 atlas_subdir( xAODAnaHelpers )
 
+# Set the minimum required CMake version:
+cmake_minimum_required( VERSION 3.6 FATAL_ERROR )
+
 set( release_libs xAODTriggerCnvLib )
 
 if( AnalysisBase_VERSION AND AnalysisBase_VERSION VERSION_GREATER 21.0 )

--- a/Root/TruthContainer.cxx
+++ b/Root/TruthContainer.cxx
@@ -348,7 +348,7 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
   m_pdgId  ->push_back( truth->pdgId() );
   if(!m_infoSwitch.m_pdgIdOnly){
     m_status ->push_back( truth->status() );
-    m_barcode->push_back( truth->barcode() );
+    m_barcode->push_back( truth->uid() );
   }
   if(m_debug)   std::cout << "Filled status " << std::endl;
 
@@ -386,7 +386,7 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
       const xAOD::TruthParticle* parent = truth->parent(iparent);
       if(parent){
 	m_parent_pdgId  ->back().push_back(parent->pdgId());
-	m_parent_barcode->back().push_back(parent->barcode());
+	m_parent_barcode->back().push_back(parent->uid());
 	m_parent_status ->back().push_back(parent->status());
       }else{
 	m_parent_pdgId  ->back().push_back(-99);
@@ -408,7 +408,7 @@ void TruthContainer::FillTruth( const xAOD::IParticle* particle ){
       const xAOD::TruthParticle* child = truth->child(ichild);
       if(child){
 	m_child_pdgId  ->back().push_back(child->pdgId());
-	m_child_barcode->back().push_back(child->barcode());
+	m_child_barcode->back().push_back(child->uid());
 	m_child_status ->back().push_back(child->status());
       }else{
 	m_child_pdgId  ->back().push_back(-99);

--- a/Root/VertexContainer.cxx
+++ b/Root/VertexContainer.cxx
@@ -78,8 +78,8 @@ void VertexContainer::FillTruthVertices( const xAOD::TruthVertexContainer* truth
     int hsBarcode = -999;
     const xAOD::TruthVertex* hsTruthVertex(nullptr);
     for ( auto *truthVertex : *truthVertices ) {
-      if ( truthVertex->barcode()<0 && truthVertex->barcode()>hsBarcode ) {
-        hsBarcode = truthVertex->barcode();
+      if ( truthVertex->uid()<0 && truthVertex->uid()>hsBarcode ) {
+        hsBarcode = truthVertex->uid();
         hsTruthVertex = truthVertex;
       }
     }

--- a/ci/top_CMakeLists.txt
+++ b/ci/top_CMakeLists.txt
@@ -1,7 +1,7 @@
 # Project build configuration.
 
 # Set the minimum required CMake version.
-cmake_minimum_required( VERSION 3.4 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 
 project( xAODAnaHelpers VERSION 1.0.0)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -80,7 +80,7 @@ class ColoredLogger(logging.Logger):
 
 
 # Regular expression for comments
-comment_re = re.compile('(^)?[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
+comment_re = re.compile(r'(^)?[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
                         re.DOTALL | re.MULTILINE)
 
 # http://www.lifl.fr/~damien.riquet/parse-a-json-file-with-comments.html


### PR DESCRIPTION
Replacing barcodes with UIDs as needed due to https://gitlab.cern.ch/atlas/athena/-/merge_requests/76135

Also fixing python syntax warning.

Note that accessing the uid may still fail on older files due to [ATLASRECTS-8264](https://its.cern.ch/jira/browse/ATLASRECTS-8264), but this PR is still necessary to allow xAH to build successfully.