### PR TITLE
Add AB 25.2.64 and 65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         release_version:
           - 25.2.62
           - 25.2.63
+          - 25.2.64
+          - 25.2.65
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
@admins I was hoping this would actually fail :( I am running into errors with 25.2.65 ever since these sort of changes from Nils - https://gitlab.cern.ch/atlas/athena/-/merge_requests/82101. I don't have an easy to share working setup which is lightweight without a FactoryTools/SUSYTools backend. Could I request that someone test this and see if they can find/fix the error? Probably not very useful, but this is the trail of my logs.
```
Package.EventLoop        INFO    created submission directory /direct/usatlas+u/sagar/VLL-DP/FactoryTools/run/submit_dir
Package.EventLoop        INFO    submitting job in /direct/usatlas+u/sagar/VLL-DP/FactoryTools/run/submit_dir
Package.EventLoop        INFO    Running sample: DAOD_LLP1.45973826._000007.pool.root.1
Package.EventLoop        INFO    xAODInput = 1
Package.AsgTools.Compo...ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/Control/AthToolSupport/AsgTools/Root/AsgComponentConfig.cxx:306 (StatusCode asg::{anonymous}::createComponent(std::unique_ptr<asg::AsgComponent>&, const std::string&, const std::string&, const std::string&)): Unable to load class dictionary for type EL::Detail::TreeCacheModule
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:60 (EL::StatusCode EL::{anonymous}::make_module(std::unique_ptr<EL::Detail::Module>&, asg::AsgComponentConfig)): Failed to call "config.makeComponentExpert (module, "new %1% (\"%2%\")", false, "ELModule.")"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:434 (StatusCode EL::Worker::initialize()): Failed to call "make_module (module, config)"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/Worker.cxx:823 (StatusCode EL::Worker::directExecute(const SH::SamplePtr&, const EL::Job&, const std::string&, const SH::MetaObject&)): Failed to call "initialize ()"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/DirectDriver.cxx:81 (StatusCode EL::DirectDriver::doManagerStep(EL::Detail::ManagerData&) const): Failed to call "worker.directExecute (*sample, *data.job, data.submitDir, data.options)"
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/ManagerData.cxx:67 (StatusCode EL::Detail::ManagerData::run()): while performing manager step 14
Package.EventLoop        ERROR   /build/atnight/localbuilds/nightlies/AnalysisBase/main/athena/PhysicsAnalysis/D3PDTools/EventLoop/Root/ManagerData.cxx:68 (StatusCode EL::Detail::ManagerData::run()): on submission directory /direct/usatlas+u/sagar/VLL-DP/FactoryTools/run/submit_dir
Traceback (most recent call last):
  File "/usatlas/u/sagar/VLL-DP/FactoryTools/build/x86_64-el9-gcc14-opt/bin/run_highd0_plusDV.py", line 295, in <module>
    commonOptions.submitJob         ( job , options.driver , options.submitDir , gridUser = options.gridUser , gridTag = options.gridTag, groupRole = options.groupRole, nEvents = options.nevents, skipEvents = options.skipevents, gridOutDSName = options.gridOutDSName)
  File "/direct/usatlas+u/sagar/VLL-DP/FactoryTools/source/FactoryTools/util/commonOptions.py", line 255, in submitJob
    driver.submit(job, submitDir)
cppyy.gbl.std.runtime_error: string EL::Driver::submit(const EL::Job& job, const string& location) =>
    runtime_error: failed to submit job
```
