### PR TITLE
Btagging Accessor

### DIFF
--- a/Root/BJetEfficiencyCorrector.cxx
+++ b/Root/BJetEfficiencyCorrector.cxx
@@ -188,6 +188,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("JetAuthor",           m_jetAuthor));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("MinPt", m_minPt));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("ErrorOnTagWeightFailure", m_errorOnTagWeightFailure));
+  ANA_CHECK( m_BJetSelectTool_handle.setProperty("readFromBTaggingObject", m_readFromBTaggingObject));
   ANA_CHECK( m_BJetSelectTool_handle.setProperty("OutputLevel", msg().level() ));
   ANA_CHECK( m_BJetSelectTool_handle.retrieve());
   ANA_MSG_DEBUG("Retrieved tool: " << m_BJetSelectTool_handle);
@@ -204,6 +205,7 @@ EL::StatusCode BJetEfficiencyCorrector :: initialize ()
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("ScaleFactorFileName", m_corrFileName       ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("UseDevelopmentFile",  m_useDevelopmentFile ));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("ConeFlavourLabel",    m_coneFlavourLabel   ));
+    ANA_CHECK( m_BJetEffSFTool_handle.setProperty("readFromBTaggingObject", m_readFromBTaggingObject));
     ANA_CHECK( m_BJetEffSFTool_handle.setProperty("OutputLevel", msg().level() ));
 
     if(!m_EfficiencyCalibration.empty()){

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -227,6 +227,7 @@ EL::StatusCode JetSelector :: initialize ()
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("TaggerName",	      m_taggerName));
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("OperatingPoint",      m_operatingPt));
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("JetAuthor",	      m_jetAuthor));
+    ANA_CHECK( m_BJetSelectTool_handle.setProperty("readFromBTaggingObject", m_readFromBTaggingObject));
     ANA_CHECK( m_BJetSelectTool_handle.setProperty("OutputLevel",  msg().level()));
     ANA_CHECK( m_BJetSelectTool_handle.retrieve());
     ANA_MSG_DEBUG("Retrieved tool: " << m_BJetSelectTool_handle);

--- a/xAODAnaHelpers/BJetEfficiencyCorrector.h
+++ b/xAODAnaHelpers/BJetEfficiencyCorrector.h
@@ -44,6 +44,7 @@ public:
   std::string m_taggerName = "DL1r";
   bool        m_useDevelopmentFile = true;
   bool        m_coneFlavourLabel = true;
+  bool        m_readFromBTaggingObject = false;
   std::string m_systematicsStrategy = "SFEigen";
   /// @brief BTaggingSelectionTool throws an error on missing tagging weights. If false, a warning is given instead
   bool        m_errorOnTagWeightFailure = true;

--- a/xAODAnaHelpers/JetSelector.h
+++ b/xAODAnaHelpers/JetSelector.h
@@ -192,6 +192,7 @@ public:
   std::string m_jetAuthor = "AntiKt4EMPFlowJets";
   std::string m_taggerName = "DL1r";
   std::string m_operatingPt = "FixedCutBEff_70";
+  bool        m_readFromBTaggingObject = false;
   // for BTaggingSelectionTool -- doubles are needed or will crash
   // for the b-tagging tool - these are the b-tagging groups minimums
   // users making tighter cuts can use the selector's parameters to keep


### PR DESCRIPTION
Allow the btagging information to be read from the jet container instead of the btagging object. This is necessary as the latest DAODs no longer have the btagging object.