### PR TITLE
Updating to run with AnalysisBase 25.2.94

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - analysisbase
         release_version:
           - 25.2.94
+          - 25.2.95
+          - 25.2.96
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
         release_type:
           - analysisbase
         release_version:
-          - 25.2.62
-          - 25.2.63
+          - 25.2.94
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.20]
+        python-version: [3.10.21]
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10.20
+    - name: Set up Python 3.10.21
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}

--- a/Root/EventInfo.cxx
+++ b/Root/EventInfo.cxx
@@ -283,7 +283,7 @@ void EventInfo::clear()
   return;
 }
 
-void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event, const xAOD::VertexContainer* vertices) {
+void EventInfo::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::Event* event, const xAOD::VertexContainer* vertices) {
 
   if (!m_infoSwitch.m_noDataInfo){ // saved always (unless specifically requiring not to)
     m_runNumber             = eventInfo->runNumber();

--- a/Root/HelpTreeBase.cxx
+++ b/Root/HelpTreeBase.cxx
@@ -29,7 +29,7 @@ using std::vector;
 #pragma link C++ class vector<float>+;
 #endif
 
-HelpTreeBase::HelpTreeBase(xAOD::TEvent* event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store, std::string nominalTreeName):
+HelpTreeBase::HelpTreeBase(xAOD::Event* event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store, std::string nominalTreeName):
   m_trigInfoSwitch(nullptr),
   m_trigConfTool(nullptr),
   m_trigDecTool(nullptr),
@@ -110,7 +110,7 @@ HelpTreeBase::~HelpTreeBase() {
 }
 
 
-HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent* event, xAOD::TStore* store, const float units, bool debug, std::string nominalTreeName):
+HelpTreeBase::HelpTreeBase(TTree* tree, TFile* file, xAOD::Event* event, xAOD::TStore* store, const float units, bool debug, std::string nominalTreeName):
   HelpTreeBase(event, tree, file, units, debug, store, nominalTreeName)
 {
   // use the other constructor for everything
@@ -143,7 +143,7 @@ void HelpTreeBase::AddEvent( const std::string& detailStr ) {
   this->AddEventUser(detailStr);
 }
 
-void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* /*event*/, const xAOD::VertexContainer* vertices ) {
+void HelpTreeBase::FillEvent( const xAOD::EventInfo* eventInfo, xAOD::Event* /*event*/, const xAOD::VertexContainer* vertices ) {
 
   this->ClearEvent();
 

--- a/Root/JetContainer.cxx
+++ b/Root/JetContainer.cxx
@@ -3319,9 +3319,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     float pu, pb, pc, ptau, score;
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1r" , "pu", pu);
-    myBTag->variable<float>("DL1r" , "pc", pc);
-    myBTag->variable<float>("DL1r" , "pb", pb);
+    std::string actualTagger = "DL1r";
+    SG::ConstAccessor<float> pbTaggerAcc_dl1r (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_dl1r (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_dl1r (actualTagger+"_pu");
+    if (pbTaggerAcc_dl1r.isAvailable(*jet) && pcTaggerAcc_dl1r.isAvailable(*jet)
+        && puTaggerAcc_dl1r.isAvailable(*jet)) {
+      pb = pbTaggerAcc_dl1r(*jet);
+      pc = pcTaggerAcc_dl1r(*jet);
+      pu = puTaggerAcc_dl1r(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.018*pc+0.982*pu) );
     m_DL1r_pu->push_back(pu);
@@ -3330,9 +3337,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1r->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1dv00" , "pu", pu);
-    myBTag->variable<float>("DL1dv00" , "pc", pc);
-    myBTag->variable<float>("DL1dv00" , "pb", pb);
+    actualTagger = "DL1dv00";
+    SG::ConstAccessor<float> pbTaggerAcc_dl1dv00 (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_dl1dv00 (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_dl1dv00 (actualTagger+"_pu");
+    if (pbTaggerAcc_dl1dv00.isAvailable(*jet) && pcTaggerAcc_dl1dv00.isAvailable(*jet)
+        && puTaggerAcc_dl1dv00.isAvailable(*jet)) {
+      pb = pbTaggerAcc_dl1dv00(*jet);
+      pc = pcTaggerAcc_dl1dv00(*jet);
+      pu = puTaggerAcc_dl1dv00(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.018*pc+0.982*pu) );
     m_DL1dv00_pu->push_back(pu);
@@ -3340,9 +3354,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1dv00_pb->push_back(pb);
     m_DL1dv00->push_back( score );
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("DL1dv01" , "pu", pu);
-    myBTag->variable<float>("DL1dv01" , "pc", pc);
-    myBTag->variable<float>("DL1dv01" , "pb", pb);
+    actualTagger = "DL1dv01";
+    SG::ConstAccessor<float> pbTaggerAcc_dl1dv01 (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_dl1dv01 (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_dl1dv01 (actualTagger+"_pu");
+    if (pbTaggerAcc_dl1dv01.isAvailable(*jet) && pcTaggerAcc_dl1dv01.isAvailable(*jet)
+        && puTaggerAcc_dl1dv01.isAvailable(*jet)) {
+      pb = pbTaggerAcc_dl1dv01(*jet);
+      pc = pcTaggerAcc_dl1dv01(*jet);
+      pu = puTaggerAcc_dl1dv01(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.018*pc+0.982*pu) );
     m_DL1dv01_pu->push_back(pu);
@@ -3351,9 +3372,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_DL1dv01->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("GN120220509" , "pu", pu);
-    myBTag->variable<float>("GN120220509" , "pc", pc);
-    myBTag->variable<float>("GN120220509" , "pb", pb);
+    actualTagger = "GN120220509";
+    SG::ConstAccessor<float> pbTaggerAcc_GN120220509 (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_GN120220509 (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_GN120220509 (actualTagger+"_pu");
+    if (pbTaggerAcc_GN120220509.isAvailable(*jet) && pcTaggerAcc_GN120220509.isAvailable(*jet)
+        && puTaggerAcc_GN120220509.isAvailable(*jet)) {
+      pb = pbTaggerAcc_GN120220509(*jet);
+      pc = pcTaggerAcc_GN120220509(*jet);
+      pu = puTaggerAcc_GN120220509(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.05*pc+0.95*pu) ); // GN1 uses a different f_c value than DL1d which is 0.05
     m_GN1_pu->push_back(pu);
@@ -3362,9 +3390,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN1->push_back( score );
 
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("GN2v00LegacyWP" , "pu", pu);
-    myBTag->variable<float>("GN2v00LegacyWP" , "pc", pc);
-    myBTag->variable<float>("GN2v00LegacyWP" , "pb", pb);
+    actualTagger = "GN2v00LegacyWP";
+    SG::ConstAccessor<float> pbTaggerAcc_GN2v00LegacyWP (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_GN2v00LegacyWP (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_GN2v00LegacyWP (actualTagger+"_pu");
+    if (pbTaggerAcc_GN2v00LegacyWP.isAvailable(*jet) && pcTaggerAcc_GN2v00LegacyWP.isAvailable(*jet)
+        && puTaggerAcc_GN2v00LegacyWP.isAvailable(*jet)) {
+      pb = pbTaggerAcc_GN2v00LegacyWP(*jet);
+      pc = pcTaggerAcc_GN2v00LegacyWP(*jet);
+      pu = puTaggerAcc_GN2v00LegacyWP(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.10*pc+0.90*pu) ); // GN2 uses a different f_c value than DL1d which is 0.01
     m_GN2v00LegacyWP_pu->push_back(pu);
@@ -3373,9 +3408,16 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN2v00LegacyWP->push_back( score );
     
     pu=0; pb=0; pc=0;
-    myBTag->variable<float>("GN2v00NewAliasWP" , "pu", pu);
-    myBTag->variable<float>("GN2v00NewAliasWP" , "pc", pc);
-    myBTag->variable<float>("GN2v00NewAliasWP" , "pb", pb);
+    actualTagger = "GN2v00NewAliasWP";
+    SG::ConstAccessor<float> pbTaggerAcc_GN2v00NewAliasWP (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_GN2v00NewAliasWP (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_GN2v00NewAliasWP (actualTagger+"_pu");
+    if (pbTaggerAcc_GN2v00NewAliasWP.isAvailable(*jet) && pcTaggerAcc_GN2v00NewAliasWP.isAvailable(*jet)
+        && puTaggerAcc_GN2v00NewAliasWP.isAvailable(*jet)) {
+      pb = pbTaggerAcc_GN2v00NewAliasWP(*jet);
+      pc = pcTaggerAcc_GN2v00NewAliasWP(*jet);
+      pu = puTaggerAcc_GN2v00NewAliasWP(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.10*pc+0.90*pu) ); // GN2 uses a different f_c value than DL1d which is 0.01
     m_GN2v00NewAliasWP_pu->push_back(pu);
@@ -3384,10 +3426,18 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN2v00NewAliasWP->push_back( score );
 
     pu=0; pb=0; pc=0; ptau=0;
-    myBTag->variable<float>("GN2v01" , "pu", pu);
-    myBTag->variable<float>("GN2v01" , "pc", pc);
-    myBTag->variable<float>("GN2v01" , "pb", pb);
-    myBTag->variable<float>("GN2v01" , "ptau", ptau);
+    actualTagger = "GN2v01";
+    SG::ConstAccessor<float> pbTaggerAcc_GN2v01 (actualTagger+"_pb");
+    SG::ConstAccessor<float> pcTaggerAcc_GN2v01 (actualTagger+"_pc");
+    SG::ConstAccessor<float> puTaggerAcc_GN2v01 (actualTagger+"_pu");
+    SG::ConstAccessor<float> ptauTaggerAcc_GN2v01 (actualTagger+"_ptau");
+    if (pbTaggerAcc_GN2v01.isAvailable(*jet) && pcTaggerAcc_GN2v01.isAvailable(*jet)
+        && puTaggerAcc_GN2v01.isAvailable(*jet) && ptauTaggerAcc_GN2v01.isAvailable(*jet)) {
+      pb = pbTaggerAcc_GN2v01(*jet);
+      pc = pcTaggerAcc_GN2v01(*jet);
+      pu = puTaggerAcc_GN2v01(*jet);
+      ptau = ptauTaggerAcc_GN2v01(*jet);
+    }
     //FixMe: Retrieve the correct f_c value from the CDI file would be the best approach
     score=log( pb / (0.20*pc+0.01*ptau+0.79*pu) ); // GN2v01 uses a different f_c value than DL1dv01 which is 0.018
     m_GN2v01_pu->push_back(pu);
@@ -3395,7 +3445,6 @@ void JetContainer::FillJet( const xAOD::IParticle* particle, const xAOD::Vertex*
     m_GN2v01_pb->push_back(pb);
     m_GN2v01_ptau->push_back(ptau);
     m_GN2v01->push_back( score );
-
     if(m_infoSwitch.m_jetFitterDetails ) {
 
       static SG::AuxElement::ConstAccessor< int   > jf_nVTXAcc       ("JetFitter_nVTX");

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -267,6 +267,7 @@ EL::StatusCode JetSelector :: initialize ()
     ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("JetContainer", m_outContainerName) );
     ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("WorkingPoint", m_WorkingPointJVT) );
     ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("OutputLevel", msg().level()) );
+    ATH_CHECK( m_jetNNJvtSelectionTool.setProperty("JvtMomentName", "NNJvt") );
     ATH_CHECK( m_jetNNJvtSelectionTool.retrieve() );
     ANA_MSG_DEBUG("Retrieved tool: " << m_jetNNJvtSelectionTool);
 

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -116,6 +116,7 @@ EL::StatusCode METConstructor :: initialize ()
   ANA_MSG_DEBUG( "Is MC? " << isMC() );
 
   //////////// IMETMaker ////////////////
+  ATH_CHECK( m_metmaker_handle.setProperty("JetContainer", "AntiKt4EMPFlowJets") );
   if ( m_dofJVTCut ) {
     ANA_CHECK(m_metmaker_handle.setProperty("JetRejectionDec", m_fJVTdecorName));
   }

--- a/Root/METConstructor.cxx
+++ b/Root/METConstructor.cxx
@@ -146,6 +146,14 @@ EL::StatusCode METConstructor :: initialize ()
   if ( m_calculateSignificance ) {
     ANA_CHECK( m_metSignificance_handle.setProperty("TreatPUJets", m_significanceTreatPUJets) );
     ANA_CHECK( m_metSignificance_handle.setProperty("SoftTermReso", m_significanceSoftTermReso) );
+    ANA_CHECK( m_metSignificance_handle.setProperty("EgammaESModel", m_significanceESModel) );
+    ANA_CHECK( m_metSignificance_handle.setProperty("EgammaDecorrelationModel", "1NP_v1") );
+    // This is the only recommended set of jet resolutions for use with R22+ MET Significance until "Consolidated" recommendations are available
+    ANA_CHECK( m_metSignificance_handle.setProperty("JetCalibConfig", "JES_data2017_2016_2015_Recommendation_PFlow_Aug2018_rel21.config") );
+    ANA_CHECK( m_metSignificance_handle.setProperty("JetCalibSequence", "JetArea_Residual_EtaJES_GSC_Smear") );
+    ATH_CHECK( m_metSignificance_handle.setProperty("JetCalibArea", "00-04-81") );
+
+    ANA_CHECK( m_metSignificance_handle.setProperty("MuonCalibMode", m_significanceMuonCalibMode) );
 
     // For AFII samples
     if ( isFastSim() ){

--- a/Root/MinixAOD.cxx
+++ b/Root/MinixAOD.cxx
@@ -115,7 +115,7 @@ EL::StatusCode MinixAOD :: initialize ()
 
   // always do this, obviously
   TFile *file_xAOD = wk()->getOutputFile(m_outputFileName);
-  ANA_CHECK( m_event->writeTo(file_xAOD));
+  ANA_CHECK( m_event->writeTo(*file_xAOD));
 
   if(m_copyFileMetaData){
     m_fileMetaDataTool = new xAODMaker::FileMetaDataTool();
@@ -330,7 +330,7 @@ EL::StatusCode MinixAOD :: finalize () {
   //
   // Close file
   TFile *file_xAOD = wk()->getOutputFile(m_outputFileName);
-  ANA_CHECK( m_event->finishWritingTo(file_xAOD));
+  ANA_CHECK( m_event->finishWritingTo(*file_xAOD));
 
   if(m_fileMetaDataTool) delete m_fileMetaDataTool;
   // if(m_trigMetaDataTool) delete m_trigMetaDataTool;

--- a/Root/TreeAlgo.cxx
+++ b/Root/TreeAlgo.cxx
@@ -715,6 +715,6 @@ EL::StatusCode TreeAlgo :: finalize () {
 
 EL::StatusCode TreeAlgo :: histFinalize () { return EL::StatusCode::SUCCESS; }
 
-HelpTreeBase* TreeAlgo :: createTree(xAOD::TEvent *event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store) {
+HelpTreeBase* TreeAlgo :: createTree(xAOD::Event *event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store) {
     return new HelpTreeBase( event, tree, file, units, debug, store );
 }

--- a/Root/Writer.cxx
+++ b/Root/Writer.cxx
@@ -98,7 +98,7 @@ EL::StatusCode Writer :: initialize ()
 
   // output xAOD
   TFile * file = wk()->getOutputFile (m_outputLabel.Data());
-  ANA_CHECK( m_event->writeTo(file));
+  ANA_CHECK( m_event->writeTo(*file));
 
   //FIXME add this as well
 // Set which variables not to write out:
@@ -204,7 +204,7 @@ EL::StatusCode Writer :: finalize ()
 
   // finalize and close our output xAOD file ( and write MetaData tree )
   TFile * file = wk()->getOutputFile(m_outputLabel.Data());
-  ANA_CHECK( m_event->finishWritingTo( file ));
+  ANA_CHECK( m_event->finishWritingTo( *file ));
 
   return EL::StatusCode::SUCCESS;
 }

--- a/scripts/xAH_run.py
+++ b/scripts/xAH_run.py
@@ -453,17 +453,6 @@ if __name__ == "__main__":
       job.options().setDouble(ROOT.EL.Job.optXAODPerfStats, 1)
       job.options().setDouble(ROOT.EL.Job.optPrintPerFileStats, 1)
 
-    # access mode branch
-    if args.access_mode == 'branch':
-      xAH_logger.info("\tusing branch access mode: ROOT.EL.Job.optXaodAccessMode_branch")
-      job.options().setString( ROOT.EL.Job.optXaodAccessMode, ROOT.EL.Job.optXaodAccessMode_branch )
-    elif args.access_mode == 'athena':
-      xAH_logger.info("\tusing branch access mode: ROOT.EL.Job.optXaodAccessMode_athena")
-      job.options().setString (ROOT.EL.Job.optXaodAccessMode, ROOT.EL.Job.optXaodAccessMode_athena)
-    else:
-      xAH_logger.info("\tusing class access mode: ROOT.EL.Job.optXaodAccessMode_class")
-      job.options().setString( ROOT.EL.Job.optXaodAccessMode, ROOT.EL.Job.optXaodAccessMode_class )
-
     # formatted string
     algorithmConfiguration_string = []
 

--- a/xAODAnaHelpers/Algorithm.h
+++ b/xAODAnaHelpers/Algorithm.h
@@ -209,7 +209,7 @@ namespace xAH {
         std::string m_className = "Algorithm"; //!
 
         /** The TEvent object */
-        xAOD::TEvent* m_event = nullptr; //!
+        xAOD::Event* m_event = nullptr; //!
         /** The TStore object */
         xAOD::TStore* m_store = nullptr; //!
 

--- a/xAODAnaHelpers/EventInfo.h
+++ b/xAODAnaHelpers/EventInfo.h
@@ -20,7 +20,7 @@ namespace xAH {
     void setTree    (TTree *tree);
     void setBranches(TTree *tree);
     void clear();
-    void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event = nullptr, const xAOD::VertexContainer* vertices = nullptr);
+    void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::Event* event = nullptr, const xAOD::VertexContainer* vertices = nullptr);
     template <typename T_BR>
       void connectBranch(TTree *tree, std::string name, T_BR *variable);
 

--- a/xAODAnaHelpers/HelpTreeBase.h
+++ b/xAODAnaHelpers/HelpTreeBase.h
@@ -67,8 +67,8 @@ class HelpTreeBase {
 
 public:
 
-  HelpTreeBase(xAOD::TEvent *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, xAOD::TStore* store = nullptr, std::string nominalTreeName = "nominal" );
-  HelpTreeBase(TTree* tree, TFile* file, xAOD::TEvent *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false, std::string nominalTreeName = "nominal" );
+  HelpTreeBase(xAOD::Event *event, TTree* tree, TFile* file, const float units = 1e3, bool debug = false, xAOD::TStore* store = nullptr, std::string nominalTreeName = "nominal" );
+  HelpTreeBase(TTree* tree, TFile* file, xAOD::Event *event = nullptr, xAOD::TStore* store = nullptr, const float units = 1e3, bool debug = false, std::string nominalTreeName = "nominal" );
   virtual ~HelpTreeBase();
 
   void AddEvent         (const std::string& detailStr = "");
@@ -110,7 +110,7 @@ public:
    **/
   static std::string FatJetCollectionName(const std::string& fatjetName = "fatjet", const std::string& suffix = "");
 
-  xAOD::TEvent* m_event;
+  xAOD::Event* m_event;
   xAOD::TStore* m_store;
 
   /// @brief Name of vertex container
@@ -124,7 +124,7 @@ public:
   TrigConf::xAODConfigTool*    m_trigConfTool;
   Trig::TrigDecisionTool*      m_trigDecTool;
 
-  void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::TEvent* event = nullptr, const xAOD::VertexContainer* vertices = nullptr );
+  void FillEvent( const xAOD::EventInfo* eventInfo, xAOD::Event* event = nullptr, const xAOD::VertexContainer* vertices = nullptr );
 
   void FillTrigger( const xAOD::EventInfo* eventInfo );
   void FillJetTrigger();

--- a/xAODAnaHelpers/HelperFunctions.h
+++ b/xAODAnaHelpers/HelperFunctions.h
@@ -234,10 +234,10 @@ namespace HelperFunctions {
   template< typename T1, typename T2 >
   StatusCode makeSubsetCont( T1*& intCont, T2*& outCont, const std::string& flagSelect = "", HelperClasses::ToolName tool_name = HelperClasses::ToolName::DEFAULT) { return makeSubsetCont<T1, T2>(intCont, outCont, msg(), flagSelect, tool_name); }
 
-  /** @brief Retrieve an arbitrary object from TStore / TEvent
+  /** @brief Retrieve an arbitrary object from TStore / Event
     @param cont  pass in a pointer to the object to store the retrieved container in
     @param name  the name of the object to look up
-    @param event the TEvent, usually wk()->xaodEvent(). Set to 0 to not search TEvent.
+    @param event the Event, usually wk()->xaodEvent(). Set to 0 to not search Event.
     @param store the TStore, usually wk()->xaodStore(). Set to 0 to not search TStore.
     @param msg   the MsgStream object with appropriate level for debugging
 
@@ -247,11 +247,11 @@ namespace HelperFunctions {
       Example Usage::
 
         const xAOD::JetContainer* jets(0);
-        // look for "AntiKt10LCTopoJets" in both TEvent and TStore
+        // look for "AntiKt10LCTopoJets" in both Event and TStore
         ANA_CHECK( HelperFunctions::retrieve(jets, "AntiKt10LCTopoJets", m_event, m_store) );
         // look for "AntiKt10LCTopoJets" in only TStore
         ANA_CHECK( HelperFunctions::retrieve(jets, "AntiKt10LCTopoJets", 0, m_store) );
-        // look for "AntiKt10LCTopoJets" in only TEvent, enable verbose output
+        // look for "AntiKt10LCTopoJets" in only Event, enable verbose output
         ANA_CHECK( HelperFunctions::retrieve(jets, "AntiKt10LCTopoJets", m_event, 0, msg()) );
 
       Checking Order:
@@ -263,7 +263,7 @@ namespace HelperFunctions {
           - attempt to retrieve from store
           - return if failure
 
-      - next check TEvent
+      - next check Event
 
         - check if event contains 'xAOD::JetContainer' named 'name'
 
@@ -277,24 +277,24 @@ namespace HelperFunctions {
     @endrst
   */
   template <typename T>
-  StatusCode retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store, MsgStream& msg){
+  StatusCode retrieve(T*& cont, std::string name, xAOD::Event* event, xAOD::TStore* store, MsgStream& msg){
     std::string funcName{"in retrieve<"+type_name<T>()+">(" + name + "): "};
     if((event == NULL) && (store == NULL)){
-      msg << MSG::ERROR << funcName << "Both TEvent and TStore objects are null. Cannot retrieve anything." << endmsg;
+      msg << MSG::ERROR << funcName << "Both Event and TStore objects are null. Cannot retrieve anything." << endmsg;
       return StatusCode::FAILURE;
     }
     msg << MSG::DEBUG << funcName << "\tAttempting to retrieve " << name << " of type " << type_name<T>() << endmsg;
-    if((event != NULL) && (store == NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TEvent" << endmsg;
+    if((event != NULL) && (store == NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::Event" << endmsg;
     if((event == NULL) && (store != NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore" << endmsg;
-    if((event != NULL) && (store != NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore, xAOD::TEvent" << endmsg;
+    if((event != NULL) && (store != NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore, xAOD::Event" << endmsg;
     if((store != NULL) && (store->contains<T>(name))){
       msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::TStore" << endmsg;
       if(!store->retrieve( cont, name ).isSuccess()) return StatusCode::FAILURE;
       msg << MSG::DEBUG << funcName << "\t\t\tRetrieved from xAOD::TStore" << endmsg;
     } else if((event != NULL) && (event->contains<T>(name))){
-      msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::TEvent" << endmsg;
+      msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::Event" << endmsg;
       if(!event->retrieve( cont, name ).isSuccess()) return StatusCode::FAILURE;
-      msg << MSG::DEBUG << funcName << "\t\t\tRetrieved from xAOD::TEvent" << endmsg;
+      msg << MSG::DEBUG << funcName << "\t\t\tRetrieved from xAOD::Event" << endmsg;
     } else {
       msg << MSG::DEBUG << funcName << "\t\tNot found at all" << endmsg;
       return StatusCode::FAILURE;
@@ -303,13 +303,13 @@ namespace HelperFunctions {
   }
   /* retrieve() overload for no msgStream object passed in */
   template <typename T>
-  StatusCode retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return retrieve<T>(cont, name, event, store, msg()); }
+  StatusCode retrieve(T*& cont, std::string name, xAOD::Event* event, xAOD::TStore* store) { return retrieve<T>(cont, name, event, store, msg()); }
   template <typename T>
-  StatusCode __attribute__((deprecated("retrieve<T>(..., bool) is deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882"))) retrieve(T*& cont, std::string name, xAOD::TEvent* event, xAOD::TStore* store, bool debug) { return retrieve<T>(cont, name, event, store, msg()); }
+  StatusCode __attribute__((deprecated("retrieve<T>(..., bool) is deprecated. See https://github.com/UCATLAS/xAODAnaHelpers/pull/882"))) retrieve(T*& cont, std::string name, xAOD::Event* event, xAOD::TStore* store, bool debug) { return retrieve<T>(cont, name, event, store, msg()); }
 
-  /** @brief Return true if an arbitrary object from TStore / TEvent is available
+  /** @brief Return true if an arbitrary object from TStore / Event is available
     @param name  the name of the object to look up
-    @param event the TEvent, usually wk()->xaodEvent(). Set to 0 to not search TEvent.
+    @param event the Event, usually wk()->xaodEvent(). Set to 0 to not search Event.
     @param store the TStore, usually wk()->xaodStore(). Set to 0 to not search TStore.
     @param msg   the MsgStream object with appropriate level for debugging
 
@@ -320,17 +320,17 @@ namespace HelperFunctions {
       Example Usage::
 
         const xAOD::JetContainer* jets(0);
-        // look for "AntiKt10LCTopoJets" in both TEvent and TStore
+        // look for "AntiKt10LCTopoJets" in both Event and TStore
         HelperFunctions::isAvailable<xAOD::JetContainer>("AntiKt10LCTopoJets", m_event, m_store)
         // look for "AntiKt10LCTopoJets" in only TStore
         HelperFunctions::isAvailable<xAOD::JetContainer>("AntiKt10LCTopoJets", 0, m_store)
-        // look for "AntiKt10LCTopoJets" in only TEvent, enable verbose output
+        // look for "AntiKt10LCTopoJets" in only Event, enable verbose output
         HelperFunctions::isAvailable<xAOD::JetContainer>("AntiKt10LCTopoJets", m_event, 0, MSG::VERBOSE)
 
     @endrst
   */
   template <typename T>
-  bool isAvailable(std::string name, xAOD::TEvent* event, xAOD::TStore* store, MsgStream& msg){
+  bool isAvailable(std::string name, xAOD::Event* event, xAOD::TStore* store, MsgStream& msg){
     /* Checking Order:
         - check if store contains 'xAOD::JetContainer' named 'name'
         --- checkstore store
@@ -339,14 +339,14 @@ namespace HelperFunctions {
     */
     std::string funcName{"in isAvailable<"+type_name<T>()+">(" + name + "): "};
     msg << MSG::DEBUG << funcName << "\tAttempting to retrieve " << name << " of type " << type_name<T>() << endmsg;
-    if(store == NULL)                      msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TEvent" << endmsg;
+    if(store == NULL)                      msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::Event" << endmsg;
     if(event == NULL)                      msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore" << endmsg;
-    if((event != NULL) && (store != NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore, xAOD::TEvent" << endmsg;
+    if((event != NULL) && (store != NULL)) msg << MSG::DEBUG << funcName << "\t\tLooking inside: xAOD::TStore, xAOD::Event" << endmsg;
     if((store != NULL) && (store->contains<T>(name))){
       msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::TStore" << endmsg;;
       return true;
     } else if((event != NULL) && (event->contains<T>(name))){
-      msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::TEvent" << endmsg;
+      msg << MSG::DEBUG << funcName << "\t\t\tFound inside xAOD::Event" << endmsg;
       return true;
     } else {
       msg << MSG::DEBUG << funcName << "\t\tNot found at all" << endmsg;
@@ -356,7 +356,7 @@ namespace HelperFunctions {
   }
   /* isAvailable() overload for no msgStream object passed in */
   template <typename T>
-  bool isAvailable(std::string name, xAOD::TEvent* event, xAOD::TStore* store) { return isAvailable<T>(name, event, store, msg()); }
+  bool isAvailable(std::string name, xAOD::Event* event, xAOD::TStore* store) { return isAvailable<T>(name, event, store, msg()); }
 
   // stolen from here
   // https://svnweb.cern.ch/trac/atlasoff/browser/Event/xAOD/xAODEgamma/trunk/xAODEgamma/EgammaTruthxAODHelpers.h#L20
@@ -474,12 +474,12 @@ namespace HelperFunctions {
   }
 
   /**
-    @brief Copy a container from the TStore to be recorded in the TEvent (eg: to an output)
+    @brief Copy a container from the TStore to be recorded in the Event (eg: to an output)
     @tparam T1              The type of the container you're going to record
     @tparam T2              The type of the aux container you're going to record
-    @param m_event          A pointer to the TEvent object
+    @param m_event          A pointer to the Event object
     @param m_store          A pointer to the TStore object
-    @param containerName    The name of the container in the TStore to record to TEvent
+    @param containerName    The name of the container in the TStore to record to Event
 
     @rst
       If you have a container in the TStore, this function will record it into the output for you without an issue. As an example::
@@ -490,7 +490,7 @@ namespace HelperFunctions {
     @endrst
    */
   template <typename T1, typename T2>
-  StatusCode recordOutput(xAOD::TEvent* m_event, xAOD::TStore* m_store, std::string containerName){
+  StatusCode recordOutput(xAOD::Event* m_event, xAOD::TStore* m_store, std::string containerName){
     T1* cont(nullptr);
     T2* auxcont(nullptr);
 

--- a/xAODAnaHelpers/METConstructor.h
+++ b/xAODAnaHelpers/METConstructor.h
@@ -75,6 +75,10 @@ public:
   bool m_significanceTreatPUJets = true;
   /// @brief Set soft term resolution
   double m_significanceSoftTermReso = 10.0;
+  /// @brief Set EGamma model
+  std::string m_significanceESModel = "";
+  /// @brief set muon calib mode
+  int m_significanceMuonCalibMode = -1;
 
   // used for systematics
   /// @brief set to false if you want to run met systematics

--- a/xAODAnaHelpers/MuonEfficiencyCorrector_AnaToolHandle.txt
+++ b/xAODAnaHelpers/MuonEfficiencyCorrector_AnaToolHandle.txt
@@ -77,7 +77,7 @@ public:
 
 private:
 
-  xAOD::TEvent *m_event;  //!
+  xAOD::Event *m_event;  //!
   xAOD::TStore *m_store;  //!
 
   int m_numEvent;         //!

--- a/xAODAnaHelpers/TreeAlgo.h
+++ b/xAODAnaHelpers/TreeAlgo.h
@@ -125,7 +125,7 @@ public:
   virtual EL::StatusCode histFinalize ();                   //!
 
   // Help tree creator function
-  virtual HelpTreeBase* createTree(xAOD::TEvent *event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store); //!
+  virtual HelpTreeBase* createTree(xAOD::Event *event, TTree* tree, TFile* file, const float units, bool debug, xAOD::TStore* store); //!
 
   /// @cond
   // this is needed to distribute the algorithm to the workers


### PR DESCRIPTION
Updating to run with AnalysisBase 25.2.94. Migrate TEvent to Event, update JVT and MET configurations. Update b-tagging detail information retrieval and MET significance tool configuration.